### PR TITLE
Fix AVX2 dispatch in parallel GEMV for Q5_0

### DIFF
--- a/src/kernels/gemm_kernels_q5_0.c
+++ b/src/kernels/gemm_kernels_q5_0.c
@@ -649,6 +649,8 @@ void gemv_q5_0_parallel_simd(float *y,
 #if defined(__AVX512F__)
         /* Call single-row AVX512 implementation */
         gemv_q5_0_avx512(&y[row], (const char *)blocks + row * blocks_per_row * sizeof(block_q5_0), x, 1, K);
+#elif defined(__AVX2__)
+        gemv_q5_0_avx2(&y[row], (const char *)blocks + row * blocks_per_row * sizeof(block_q5_0), x, 1, K);
 #elif defined(__AVX__)
         gemv_q5_0_avx(&y[row], (const char *)blocks + row * blocks_per_row * sizeof(block_q5_0), x, 1, K);
 #else


### PR DESCRIPTION
## Summary
Fix undefined symbol error for `gemv_q5_0_avx` on AVX2 machines.

The parallel version of `gemv_q5_0_parallel_prefetch` was directly calling `gemv_q5_0_avx()` which doesn't exist on AVX2 machines (where the guard condition excludes AVX when AVX2 is defined).

## Changes
Add proper AVX2 dispatch in the parallel version to call `gemv_q5_0_avx2()`.

## Test plan
- [x] Build passes locally
- [x] Parity tests pass locally
- [ ] CI passes (will verify)

🤖 Generated with [Claude Code](https://claude.ai/code)