### PR TITLE
Add Gemma4 and Qwen3.5 v8 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,7 @@ SRCS    := src/backend_native.c \
 	           src/kernels/recurrent_qk_norm_kernels.c \
 	           src/kernels/recurrent_norm_kernels.c \
 	           src/kernels/deltanet_kernels.c \
+	           src/kernels/gemma4_per_layer_embed.c \
 	           src/kernels/attention_decode_fused.c \
 	           src/kernels/embedding_kernels.c \
 	           src/kernels/embedding_kernels_bf16.c \

--- a/docs/QWEN35_CK_LLAMA_PARITY_WORKLOG.md
+++ b/docs/QWEN35_CK_LLAMA_PARITY_WORKLOG.md
@@ -102,3 +102,843 @@ projection ordering after layer 0 and final-head ranking.
 .venv/bin/python unittest/test_q6k_q8k_parity.py
 make build/libckernel_engine.so
 ```
+
+## Post-PR #24 pull verification and scoped recurrent probes
+
+After pulling `origin/main` at `53839e89`, the tree was clean and the quick
+validation set passed:
+
+```bash
+.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py version/v8/scripts/codegen_core_v8.py version/v8/scripts/compare_multitoken_logits_v8.py
+.venv/bin/python unittest/test_q8_k_quantize_parity.py
+.venv/bin/python unittest/test_q6k_q8k_parity.py
+```
+
+The regenerated Qwen3.5 `libmodel.so` still has the same production baseline:
+
+```text
+status=fail step=2 prefix_len=33 ck_next=42726 llama_next=8755 cosine=0.999169 rmse=0.136147 topk_overlap=16/16
+```
+
+Scoped recurrent projection probes were added as disabled-by-default codegen
+instrumentation:
+
+```bash
+CK_V8_DEBUG_RECURRENT_PROJ_FP32_LAYER=<layer>
+CK_V8_DEBUG_RECURRENT_PROJ_FP32_OP=recurrent_gate_proj|recurrent_alpha_proj|recurrent_beta_proj|all
+```
+
+Probe results on the step-2 prefix:
+
+- Layer-0 `recurrent_gate_proj` FP32 input fallback regressed to step 0:
+  `ck_next=4434`, `llama_next=14542`, cosine `0.998873`, RMSE `0.167207`,
+  top-k overlap `14/16`.
+- Layer-0 `recurrent_alpha_proj` FP32 input fallback regressed to step 0:
+  cosine `0.999044`, RMSE `0.152741`, top-k overlap `16/16`.
+- Layer-0 `recurrent_beta_proj` kept step 2 but worsened RMSE to `0.167373`.
+- Layer-1 recurrent projection fallback with `OP=all` regressed to step 0:
+  cosine `0.999032`, RMSE `0.153540`, top-k overlap `14/16`.
+- `CK_DEBUG_Q5K_FP32_FALLBACK=1` regressed to step 0.
+- `CK_DEBUG_Q5K_GENERIC_DOT=1` regressed to step 0.
+- `CK_DEBUG_Q5K_SHARED_Q8_QUANT=1` was identical to baseline.
+- Fresh `CK_DEBUG_Q8_0_Q8_0_REF=1` regressed to step 0.
+
+Conclusion: the production path remains the best tested path. The remaining
+step-2 mismatch is not fixed by broad recurrent FP32 fallback, Q5_K FP32/generic
+fallback, or Q8_0 reference mode. The next useful probe should be a narrower
+layer/op output attribution around layer-0 residual/MLP/final logits, not a
+broader reference fallback.
+
+## Narrower layer-0/final-head attribution
+
+The multi-token parity runner now records margin fields for borderline top-1
+cases:
+
+- `ck_top1_margin`
+- `llama_top1_margin`
+- `ck_llama_winner_delta_in_ck`
+- `llama_winner_delta_in_llama`
+
+Fresh baseline with margin reporting:
+
+```text
+status=fail step=2 prefix_len=33 ck_next=42726 llama_next=8755 cosine=0.999169 rmse=0.136147 ck_margin=0.050137 llama_margin=0.014244 topk_overlap=16/16
+```
+
+This confirms the failure is a swapped top-2 ranking. CK prefers `42726` over
+`8755` by about `0.050`, while llama prefers `8755` over `42726` by only about
+`0.014`.
+
+Additional targeted probes:
+
+- `CK_V8_DEBUG_LM_HEAD_FP32=1` improves global RMSE to about `0.132172`, but
+  still fails at step 2 and increases CK's wrong top-1 margin to about
+  `0.053362`. Final-head Q8_K activation quantization is not the whole issue.
+- `CK_V8_DEBUG_LM_HEAD_FP32=1 CK_DEBUG_Q5K_SHARED_Q8_QUANT=1` is identical to
+  final-head FP32 alone.
+- `CK_V8_DEBUG_LM_HEAD_FP32=1 CK_DEBUG_Q6K_Q8K_SIMD=1` is identical to
+  final-head FP32 alone because the final-head debug path uses `gemv_q6_k`.
+- First full-attention layer `CK_V8_DEBUG_ATTN_PROJ_FP32_LAYER=3
+  CK_V8_DEBUG_ATTN_PROJ_FP32_OP=q_gate_proj` is unchanged at step 2.
+- First full-attention layer `OP=out_proj` regresses to step 0.
+- First full-attention layer `OP=all` regresses to step 0.
+- Extending the layer-0 MLP gate/up FP32 treatment to layer 1 with
+  `CK_V8_DEBUG_MLP_GATE_UP_FP32_LAYER=1` regresses to step 0.
+
+Conclusion: do not generalize the layer-0 MLP gate/up FP32 default, do not make
+full-attention projection FP32 by default, and do not switch final-head logits
+to FP32 input as a correctness fix. The remaining drift is already present in
+the final hidden vector, but the tested broad layer-1/full-attention/final-head
+knobs either do nothing or make the earlier step-0 ranking worse.
+
+## Hidden/layer boundary attribution
+
+Added disabled-by-default CK hidden export instrumentation:
+
+```bash
+CK_DEBUG_EXPORT_HIDDEN=/tmp/qwen35_ck_hidden_prefix31
+```
+
+The generated model now writes raw float32 dumps for:
+
+- `after_attn`: after the attention residual add.
+- `layer_out`: after the MLP residual add.
+- `final_hidden`: after final RMSNorm.
+
+The dump naming convention is:
+
+```text
+tok_<token_index>_layer_<layer>_<name>.f32
+```
+
+Added helper scripts:
+
+- `version/v8/scripts/export_ck_hidden_v8.py`
+- `version/v8/scripts/export_llama_hidden_v8.py`
+- `version/v8/scripts/compare_hidden_vectors_v8.py`
+
+For the 31-token Qwen3.5 replay prefix, llama.cpp `result_norm` and CK
+`final_hidden` have matching shape (`1024` float32 values) but still differ:
+
+```text
+cosine=0.998619420 rmse=0.228622310 mean_abs=0.180518913 max_abs=0.967097282
+```
+
+Layer boundary comparison against llama.cpp `l_out-N` shows the residual stream
+is still close before final norm, but drift accumulates through the stack:
+
+```text
+layer=00 layer_rmse=0.000584642
+layer=08 layer_rmse=0.003003950
+layer=16 layer_rmse=0.005816995
+layer=23 layer_rmse=0.015478137
+final    final_rmse=0.228622310
+```
+
+The final RMSNorm ratio check shows the norm itself is consistent: the
+CK/llama scale ratio is effectively constant (`1.0027507`, std about
+`5e-8`). The apparent final-hidden jump is the expected amplification of the
+layer-23 residual drift by the final RMSNorm scale, not a separate final-norm
+layout bug.
+
+Splitting each layer into attention residual and MLP residual at the same
+prefix shows the first drift starts in layer-0 MLP, while attention is initially
+essentially exact:
+
+```text
+layer=00 attn_rmse=0.000000294 layer_rmse=0.000584642 mlp_delta_rmse=0.000584625
+layer=01 attn_rmse=0.001277270 layer_rmse=0.001718792 mlp_delta_rmse=0.001613365
+layer=16 attn_rmse=0.005361738 layer_rmse=0.005816995 mlp_delta_rmse=0.003202434
+layer=23 attn_rmse=0.013048312 layer_rmse=0.015478137 mlp_delta_rmse=0.007171859
+```
+
+Conclusion: the next probe should instrument MLP internals (`attn_post_norm`,
+gate/up projections, SwiGLU output, and down projection) rather than KV cache,
+template handling, final RMSNorm, or broad FP32 fallbacks.
+
+## MLP internal attribution
+
+Extended `CK_DEBUG_EXPORT_HIDDEN` to also dump:
+
+- `post_attn_norm`
+- `mlp_gate`
+- `mlp_up`
+- `mlp_swiglu`
+
+At the same 31-token prefix, layer 0 now isolates the first meaningful drift to
+the Q4_K x Q8_K gate/up projection feeding SwiGLU:
+
+```text
+layer=00 post_attn_norm_rmse=0.000007283
+layer=00 gate_rmse=0.006835827
+layer=00 up_rmse=0.004497923
+layer=00 swiglu_rmse=0.000858409
+layer=00 ffn_out_rmse=0.000584625
+```
+
+Selected later-layer gate/up/SwiGLU drift:
+
+```text
+layer=01 gate_rmse=0.016662135 up_rmse=0.010981179 swiglu_rmse=0.002851053
+layer=03 gate_rmse=0.040134239 up_rmse=0.018443348 swiglu_rmse=0.005236901
+layer=16 gate_rmse=0.024762276 up_rmse=0.014746895 swiglu_rmse=0.005745402
+layer=23 gate_rmse=0.032057280 up_rmse=0.019168103 swiglu_rmse=0.012375210
+```
+
+Conclusion: the remaining Qwen3.5 long-generation drift is now narrowed to
+quantized MLP gate/up projection accumulation/layout, with SwiGLU mostly
+amplifying that input difference. The next corrective patch should target
+`gemv_q4_k_q8_k`/Q8_K activation quantization parity for the gate/up path, not
+KV cache or final RMSNorm.
+
+## Scoped MLP gate/up Q8_K contract probe
+
+Added a scoped codegen probe for the MLP gate/up projection:
+
+```bash
+CK_V8_DEBUG_MLP_GATE_UP_Q8_CONTRACT_LAYER=0
+CK_V8_DEBUG_MLP_GATE_UP_Q8_CONTRACT=1
+```
+
+This lets the generated `mlp_gate_up` path quantize the saved FP32 activation
+to Q8_K and call `gemv_q4_k_q8_k`/`gemv_q6_k_q8_k`, even when the layer is
+otherwise covered by the FP32 adapter. It is intentionally opt-in and is not a
+production default.
+
+At the 31-token prefix, forcing only layer 0 through the Q8_K contract improves
+local hidden parity:
+
+```text
+baseline layer=00 gate_rmse=0.006835827 up_rmse=0.004497923 swiglu_rmse=0.000858409 layer_out_rmse=0.000584642
+layer0-q8 layer=00 gate_rmse=0.000001400 up_rmse=0.000000987 swiglu_rmse=0.000000201 layer_out_rmse=0.000000302
+
+baseline layer=01 gate_rmse=0.016782489 up_rmse=0.011081605 swiglu_rmse=0.002876791 layer_out_rmse=0.001725532
+layer0-q8 layer=01 gate_rmse=0.009773169 up_rmse=0.006565175 swiglu_rmse=0.001707974 layer_out_rmse=0.001080668
+```
+
+But it does not improve production greedy parity. It regresses the multi-token
+runner from the current step-2 divergence back to step 0:
+
+```text
+baseline: status=fail step=2 ck_next=42726 llama_next=8755 cosine=0.999169 rmse=0.136147 topk_overlap=16/16
+layer0-q8: status=fail step=0 ck_next=4434 llama_next=14542 cosine=0.999011 rmse=0.157136 topk_overlap=15/16
+```
+
+The final-head probe gives the same warning: `CK_V8_DEBUG_LM_HEAD_FP32=1`
+slightly improves RMSE at the current step-2 divergence (`0.132172`) but does
+not recover top-1 parity, and combining it with the layer-0 Q8_K contract still
+fails at step 0.
+
+Conclusion: Q8_K gate/up contract is useful attribution instrumentation, but it
+should not be made a default yet. The next target is the later-layer/final-head
+borderline ranking drift after the improved layer-0 hidden parity, not a broad
+gate/up fallback.
+
+## Llama replay contract attribution
+
+The earlier step-2 divergence was partly a parity-harness contract mismatch.
+For recurrent Qwen3.5, llama.cpp chat behavior is best approximated by batching
+the initial prompt/prefix and then decoding generated continuation tokens
+sequentially. The old runner only supported full-batched or full-sequential
+replay:
+
+```text
+full-batched:    status=fail step=2 prefix_len=33 ck_next=42726 llama_next=8755 rmse=0.136147 topk_overlap=16/16
+full-sequential: status=fail step=0 prefix_len=31 ck_next=14542 llama_next=4434 rmse=0.134203 topk_overlap=16/16
+hybrid:          status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791 rmse=0.167313 topk_overlap=15/16
+```
+
+The helper now uses `--prefix-decode-mode` for `--tokens-before`, and the
+multi-token runner supports `--llama-decode-mode hybrid`. In `auto` mode,
+`sequential_decode` CK contracts use hybrid llama replay.
+
+The remaining mismatch is still real. At the step-5 hybrid divergence, the
+competing logits are:
+
+```text
+id=1791  ck=20.545345 llama=20.547802 diff=-0.002457
+id=11290 ck=20.693890 llama=20.240915 diff=+0.452974
+```
+
+Final hidden at the same prefix remains directionally close but numerically
+different enough to flip that borderline final-head ranking:
+
+```text
+final_hidden cosine=0.998118609 rmse=0.260651554 mean_abs=0.202567363 max_abs=0.879841700
+```
+
+Conclusion: do not treat the old step-2 failure as a kernel regression by
+itself. The next real fix target is the hidden-stream accumulation before the
+step-5 hybrid divergence, then final-head/logit attribution on that corrected
+contract.
+
+## Step-5 recurrent attribution
+
+Added `CK_DEBUG_EXPORT_HIDDEN` coverage for recurrent internals in generated
+v8 decode code. This is diagnostic only: runtime math is unchanged unless the
+environment variable is set.
+
+At the step-5 hybrid divergence prefix, layer-boundary drift is gradual rather
+than a KV-position or recurrent-state collapse. Exact RMSNorm does not move the
+result:
+
+```text
+CK_RMSNORM_EXACT=1:
+status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+cosine=0.998818 rmse=0.167313 topk_overlap=15/16
+```
+
+Layer 0 recurrent internals are essentially exact until the SSM output
+projection:
+
+```text
+layer 0 linear_attn_qkv_mixed rmse=2.05e-7
+layer 0 conv_output_silu      rmse=1.89e-8
+layer 0 q_conv_predelta       rmse=1.19e-6
+layer 0 k_conv_predelta       rmse=2.53e-6
+layer 0 gate                  rmse=6.67e-8
+layer 0 attn_output           rmse=6.97e-8
+layer 0 final_output          rmse=1.45e-6
+layer 0 linear_attn_out       rmse=1.10e-4
+layer 0 layer_out             rmse=6.72e-4
+```
+
+The first nontrivial jump is therefore `recurrent_out_proj` (`ssm_out`), which
+currently lowers to `gemv_q5_k` with Q5_K weights and FP32 activation adapter.
+Debug variants show this is not solved by broad fallbacks:
+
+```text
+normal Q5_K:       L0 linear_attn_out rmse=0.000109637
+shared Q8 quant:   L0 linear_attn_out rmse=0.000109637
+generic Q5 dot:    L0 linear_attn_out rmse=0.000109633
+FP32 dequant path: L0 linear_attn_out rmse=0.001397091
+```
+
+Conclusion: DeltaNet/state update is not the source of the current step-5
+drift. The next focused target is Q5_K `ssm_out` projection parity against
+llama.cpp's production CPU path, then re-run the hybrid multi-token runner.
+
+## Step-5 Q5 ssm_out and all-layer attribution
+
+Added a diagnostic-only `CK_DEBUG_EXPORT_HIDDEN` export for the special
+`mlp_down` Q4/Q6 x Q8 generated branch. This branch returned before the generic
+hidden export, so previous layer scans could not directly compare CK
+`mlp_down` with llama.cpp `ffn_out`.
+
+Q5_K `ssm_out` was tested against llama.cpp with production repack enabled and
+disabled. The layer-0 `linear_attn_out` mismatch is effectively unchanged by
+repack mode:
+
+```text
+llama repack:    L0 linear_attn_out rmse=0.000109637074
+llama no-repack: L0 linear_attn_out rmse=0.000109637936
+```
+
+CK Q5_K debug variants also do not materially improve `ssm_out`; broad FP32
+dequant is worse:
+
+```text
+normal Q5_K:       L0 linear_attn_out rmse=0.000109637
+shared Q8 quant:   L0 linear_attn_out rmse=0.000109637
+generic Q5 dot:    L0 linear_attn_out rmse=0.000109633
+FP32 dequant path: L0 linear_attn_out rmse=0.001397091
+```
+
+All-layer boundary comparison at the step-5 prefix shows gradual accumulation
+rather than a single early recurrent-state failure. Representative layers:
+
+```text
+layer 0  mlp_down rmse=0.000666019 layer_out rmse=0.000671901
+layer 1  mlp_down rmse=0.001783894 layer_out rmse=0.001823632
+layer 14 mlp_down rmse=0.003055496 layer_out rmse=0.005089171
+layer 20 mlp_down rmse=0.004561305 layer_out rmse=0.012175406
+layer 23 mlp_down rmse=0.010093235 layer_out rmse=0.019746876
+```
+
+Layer-scoped FP32 for layer-23 `mlp_down` does not fix final hidden/logit drift:
+
+```text
+layer 23 mlp_down FP32: rmse=0.009868351 max_abs=0.148512125
+layer 23 layer_out FP32: rmse=0.019657867 max_abs=0.157317400
+final_hidden FP32: cosine=0.998114085 rmse=0.260965042
+```
+
+The 100-token hybrid runner still diverges at the same point:
+
+```text
+status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+cosine=0.998818 rmse=0.167313 ck_margin=0.129669 llama_margin=0.123436
+topk_overlap=15/16
+```
+
+Conclusion: the next target is no longer broad Q5_K `ssm_out`. The remaining
+failure is accumulated hidden-stream drift amplified by final norm/final-head
+borderline ranking. Next useful probes are final RMSNorm/logit attribution and
+layer-scoped quantized projection parity where the drift grows late, especially
+the Q4/Q6 MLP/output projections, without making broad FP32 fallbacks default.
+
+Follow-up diagnostics:
+
+```text
+all MLP-down FP32:
+  layer 23 layer_out rmse=0.018691192 max_abs=0.073951483
+  final_hidden rmse=0.253469587
+  token parity worsens to step=0 ck_next=4434 llama_next=14542
+
+LM-head FP32:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998821 rmse=0.167931 topk_overlap=15/16
+```
+
+Conclusion: broad MLP-down FP32 and final-head FP32 are not production fixes.
+The remaining mismatch is a hidden-stream numerical accumulation issue. The
+next patch should attribute the recurrent/full-attention block inputs and the
+Q4/Q6 MLP gate/up/down projections around the late layers, then tighten only
+the kernel/order that demonstrably moves the hybrid step-5 logits closer.
+
+Cross-model smoke checks after diagnostic changes:
+
+```text
+Qwen3-0.6B cached v8:
+  prompt: "Hello! Give one short sentence."
+  response: "Hello, how can I assist you today?"
+  prompt eval: 237.18 tok/s, decode: 39.03 tok/s, stop=eos
+
+Gemma-3-270m-it cached v8:
+  prompt: "Hello! Give one short sentence."
+  response: "Hi there! How can I help you today?"
+  prompt eval: 26.75 tok/s, decode: 27.37 tok/s, stop=eos
+
+Qwen3.5-0.8B cached v8:
+  prompt: "Hello! Give one short sentence."
+  response is coherent and stops on eos, but decode remains slower
+  prompt eval: 20.23 tok/s, decode: 18.14 tok/s
+```
+
+Qwen2 and Nanbeige were not present in the local v8 cache during this pass, so
+they were not re-run without triggering downloads.
+
+Layer-23 full-attention projection FP32 was also tested:
+
+```text
+CK_V8_DEBUG_ATTN_PROJ_FP32_LAYER=23 CK_V8_DEBUG_ATTN_PROJ_FP32_OP=all:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998637 rmse=0.184371 topk_overlap=15/16
+```
+
+This worsens the metric relative to baseline, so full-attention projection FP32
+is not a fix.
+
+## Step-5 late-layer Q4/Q6 projection attribution
+
+Added diagnostic-only exports for the special generated full-attention
+`q_proj`/`k_proj`/`v_proj`/`out_proj` branches and added
+`version/v8/scripts/compare_hidden_dirs_v8.py` so CK hidden dumps can be
+compared against llama.cpp graph dumps without one-off scripts.
+
+At the current step-5 divergent prefix, Q4 and Q8 reference modes do not move
+the failure:
+
+```text
+CK_DEBUG_Q4K_Q8_REF=1:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998818 rmse=0.167313
+
+CK_DEBUG_Q8K_REF=1:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998818 rmse=0.167313
+```
+
+The Q6_K x Q8_K standalone parity harness now compiles and passes:
+
+```text
+vec_dot_q6_k_q8_k: PASS
+gemv_q6_k_q8_k: PASS
+gemm_nt_q6_k_q8_k: PASS
+vs_fp32_accuracy: PASS
+```
+
+Layer-output drift grows gradually across the model and then jumps most at the
+last layer:
+
+```text
+layer 0  layer_out rmse=0.000671901
+layer 14 layer_out rmse=0.005089171
+layer 19 layer_out rmse=0.011063572
+layer 22 layer_out rmse=0.015108324
+layer 23 layer_out rmse=0.019746876 max_abs=0.176826477
+```
+
+Exact layer-23 sub-tensor attribution:
+
+```text
+after_attn      rmse=0.015569128 max_abs=0.054430604
+post_attn_norm  rmse=0.064206322 max_abs=0.224881053
+mlp_down/ffn_out rmse=0.010093235 max_abs=0.168021202
+layer_out       rmse=0.019746876 max_abs=0.176826477
+final_hidden    rmse=0.260651554 max_abs=0.879841700
+```
+
+The large final-hidden RMSE is not a separate final RMSNorm bug. CK and
+llama.cpp both amplify layer-23 output by about 13x through final RMSNorm, so
+the `0.0197` layer-output drift naturally becomes about `0.26` at
+`result_norm`.
+
+llama.cpp no-repack mode does not explain the mismatch. It changes borderline
+logits but does not make CK match the no-repack hidden stream:
+
+```text
+llama repack:    layer23 layer_out rmse=0.019746876
+llama no-repack: layer23 layer_out rmse=0.019932953
+```
+
+Current conclusion: the remaining step-5 mismatch is not Q4 SIMD/VNNI, not
+Q8_K SIMD quantization, not Q6_K SIMD, not final head, and not final RMSNorm.
+It is accumulated hidden-stream drift that becomes borderline-logit-visible.
+The next useful target is a controlled cross-input projection probe: run CK
+layer-23 Q6_K `ffn_down` with llama's `ffn_swiglu` input, and conversely compare
+CK's `ffn_swiglu` input against llama's, so we can separate upstream
+hidden-stream drift from Q6_K down-projection math without making broad FP32
+fallbacks.
+
+## Layer-23 controlled projection probes
+
+Added `version/v8/scripts/probe_ck_q6_projection_v8.py`, a diagnostic-only
+external-input projection probe. It initializes the generated CK model, resolves
+generated weight offsets such as `W_LAYER_23_FFN_DOWN`, quantizes a supplied
+FP32 input vector to Q8_K with CK's own `quantize_row_q8_k`, and runs the CK
+Q4_K/Q6_K x Q8_K GEMV kernel against the loaded CK weights.
+
+Probe self-checks against CK's own hidden dumps reproduce generated-model
+outputs to float noise:
+
+```text
+CK post_attn_norm -> CK layer23 ffn_gate:
+  rmse=0.000000268 max_abs=0.000001907
+
+CK post_attn_norm -> CK layer23 ffn_up:
+  rmse=0.000000119 max_abs=0.000000954
+
+CK ffn_swiglu -> CK layer23 ffn_down:
+  rmse=0.000000000 max_abs=0.000000000
+```
+
+The cross-input probes also match llama.cpp when using llama.cpp's exact inputs:
+
+```text
+llama attn_post_norm -> CK layer23 Q4_K ffn_gate vs llama ffn_gate:
+  rmse=0.000000218 max_abs=0.000001907
+
+llama attn_post_norm -> CK layer23 Q4_K ffn_up vs llama ffn_up:
+  rmse=0.000000090 max_abs=0.000000954
+
+llama ffn_swiglu -> CK layer23 Q6_K ffn_down vs llama ffn_out:
+  rmse=0.000000040 max_abs=0.000000238
+```
+
+Conclusion: layer-23 Q4_K gate/up projection math and Q6_K down-projection math
+are not the source of the current user-visible divergence. When controlled with
+llama's inputs, CK matches llama. The remaining drift is already present in the
+incoming hidden stream before layer-23 FFN. The next target should move one
+stage earlier: layer-22 recurrent output/state update or the residual stream
+entering layer 23, not Q4/Q6 projection accumulation.
+
+## Layer-18..22 recurrent attribution
+
+Added recurrent-label support to `version/v8/scripts/compare_hidden_dirs_v8.py`
+and compared CK hidden dumps against llama.cpp dumps for token 35 at layers
+18..22. The important result is that no single recurrent block creates a large
+new jump. Recurrent core outputs remain close, while the residual stream drift
+is already present and grows gradually:
+
+```text
+layer 18 attn_output rmse=0.000189929 final_output rmse=0.005203748 layer_out rmse=0.009478236
+layer 20 attn_output rmse=0.000254188 final_output rmse=0.005859494 layer_out rmse=0.012175406
+layer 21 attn_output rmse=0.000147115 final_output rmse=0.004915851 layer_out rmse=0.013586523
+layer 22 attn_output rmse=0.000073131 final_output rmse=0.006740517 layer_out rmse=0.015108324
+```
+
+Layer 22 token 31..35 is internally close to llama.cpp:
+
+```text
+token 31 layer22 layer_out rmse=0.015393589
+token 32 layer22 layer_out rmse=0.014333183
+token 33 layer22 layer_out rmse=0.016999627
+token 34 layer22 layer_out rmse=0.015404123
+token 35 layer22 layer_out rmse=0.015108324
+```
+
+This clears layer-22 recurrent core/state update as a standalone large-error
+source for the current step-5 divergence. It is still part of the accumulated
+hidden stream, but the evidence now points to many small residual/projection
+differences rather than one broken recurrent op.
+
+Additional attribution checks:
+
+```text
+CK_DELTANET_FORCE_REF=1:
+  worsens to step=0 divergence, ck_next=4434, llama_next=14542
+
+CK_V8_DEBUG_LM_HEAD_FP32=1:
+  still step=5 divergence, ck_next=11290, llama_next=1791
+
+llama.cpp --no-repack:
+  still prefers token 1791 at step 5, with a smaller llama margin
+```
+
+The parity runners now expose `--llama-no-repack` so no-repack comparisons can
+be reproduced directly instead of requiring a hand-written helper command.
+
+Current conclusion: Qwen3.5 step-5 mismatch is still real, but the latest
+evidence clears layer-22 recurrent math, layer-23 Q4/Q6 projections, final
+RMSNorm, final head, DeltaNet reference-vs-AVX, and llama CPU repack as single
+smoking guns. The next useful fix target is earlier gradual residual-stream
+drift, starting from the first layers where layer-output RMSE begins to grow,
+with scoped projection/norm probes rather than broad FP32 fallbacks.
+
+## Layer-0 attribution
+
+Moved the comparison earlier than layer 18. At token 35, the residual drift
+starts in layer 0 and then grows gradually across later layers:
+
+```text
+layer 0 layer_out rmse=0.000671901
+layer 1 layer_out rmse=0.001823632
+layer 2 layer_out rmse=0.002421916
+layer 17 layer_out rmse=0.008501958
+```
+
+Layer-0 projection probes with llama.cpp inputs clear the quantized projection
+paths:
+
+```text
+llama ffn_swiglu -> CK W_LAYER_0_FFN_DOWN Q6_K:
+  rmse=0.000000007 max_abs=0.000000060
+
+llama attn_post_norm -> CK W_LAYER_0_FFN_GATE Q4_K:
+  rmse=0.000000072 max_abs=0.000000477
+
+llama attn_post_norm -> CK W_LAYER_0_FFN_UP Q4_K:
+  rmse=0.000000039 max_abs=0.000000179
+
+llama final_output -> CK W_LAYER_0_SSM_OUT Q5_K:
+  rmse=0.000000026 max_abs=0.000000060
+```
+
+Added Q5_K support to `probe_ck_q6_projection_v8.py` so recurrent `SSM_OUT`
+can be checked directly.
+
+Layer-0 recurrent internals are also very close before the final residual:
+
+```text
+z rmse=0.000000184 max_abs=0.000001431
+alpha rmse=0.000000242 max_abs=0.000000477
+gate rmse=0.000000067 max_abs=0.000000238
+attn_output rmse=0.000000070 max_abs=0.000002246
+final_output rmse=0.000001453 max_abs=0.000051141
+```
+
+Added `probe_ck_recurrent_norm_gate_v8.py` and verified CK gated RMSNorm with
+llama `attn_output` and llama `z` reproduces llama `final_output`:
+
+```text
+recurrent_norm_gate_forward:
+  rmse=0.000000012 max_abs=0.000000238
+```
+
+A narrow AVX-512 DeltaNet FMA experiment was tested and then reverted because
+the multi-token parity result was unchanged:
+
+```text
+status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+cosine=0.998818 rmse=0.167313 topk_overlap=15/16
+```
+
+Current conclusion: the old hard corruption loop is not back. The remaining
+Qwen3.5 issue is a small recurrent hidden-stream numerical drift that appears
+from layer 0 and is amplified by normal downstream projections/norms. The
+quantized Q4/Q5/Q6 projection kernels checked so far match llama.cpp with
+controlled inputs. Next target should be a more direct DeltaNet fused-vs-CK
+probe, especially comparing llama's fused `__fgdn_ar__` result layout/state
+against CK's `attn_output`/state, rather than changing projection kernels.
+
+## DeltaNet state and q/k norm probe
+
+Added diagnostic state export for CK `recurrent_core` and added
+`probe_ck_deltanet_v8.py` for direct CK DeltaNet calls with external tensors.
+
+The raw CK state dump does not match llama's raw `new_state` dump because the
+state layout is transposed by row/column per head:
+
+```text
+raw state compare:
+  cosine=0.005202360 rmse=0.041935225 max_abs=3.336471231
+
+CK [head,row,col] transposed to llama [head,col,row]:
+  cosine=0.999999940 rmse=0.000002794 max_abs=0.000334039
+```
+
+With llama's q/k/v/g/beta and previous state fed directly into CK
+`gated_deltanet_autoregressive_forward`, CK reproduces llama's layer-0
+DeltaNet output and state:
+
+```text
+out:
+  rmse=0.000000001 max_abs=0.000000045
+
+state_llama_layout:
+  rmse=0.000000001 max_abs=0.000000238
+```
+
+This clears CK DeltaNet math and state update for the tested layer-0 token.
+
+The first visible upstream growth point is recurrent q/k L2 normalization:
+
+```text
+conv_output_silu:
+  rmse=0.000000019 max_abs=0.000000477
+q_conv:
+  rmse=0.000000023 max_abs=0.000000477
+k_conv:
+  rmse=0.000000016 max_abs=0.000000238
+q_conv_predelta:
+  rmse=0.000001194 max_abs=0.000029743
+k_conv_predelta:
+  rmse=0.000002527 max_abs=0.000044525
+```
+
+I tested changing CK recurrent q/k L2 norm from `sqrt(sum_sq + eps)` to
+llama.cpp's `max(sqrt(sum_sq), eps)` semantics. That matched llama's fully
+sequential replay better, but it regressed the production-like hybrid target
+from the known step-5 mismatch back to step 0:
+
+```text
+unsafe q/k norm experiment:
+  status=fail step=0 ck_next=4434 llama_next=14542
+```
+
+That runtime change was reverted. The baseline production-like result is back
+to the prior state:
+
+```text
+status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+cosine=0.998818 rmse=0.167313 topk_overlap=15/16
+```
+
+Current conclusion: this does not look like a restored hard-corruption bug.
+It looks like an old, small decode-vs-prefill/hybrid numerical mismatch in
+Qwen3.5 recurrent q/k normalization or its interaction with llama's chunked
+prefill path. The next safe target is to compare CK production prefill, not
+only sequential `ck_model_decode`, against llama hybrid before changing q/k
+norm math.
+
+## CK replay mode attribution
+
+Added explicit CK replay modes to `compare_multitoken_logits_v8.py`:
+
+- `--ck-prefill-mode auto`: follows the model runtime contract.
+- `--ck-prefill-mode sequential`: feeds all tokens through `ck_model_decode`.
+- `--ck-prefill-mode batched`: feeds the full prefix through
+  `ck_model_embed_tokens` + `ck_model_forward`.
+- `--ck-prefill-mode hybrid`: batches the initial prompt and decodes generated
+  tokens one at a time.
+
+For Qwen3.5, the runtime contract currently reports
+`prefill_policy=sequential_decode`, but all three CK modes produced the same
+production-like result against llama hybrid:
+
+```text
+auto:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998818 rmse=0.167313 topk_overlap=15/16
+
+batched:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998818 rmse=0.167313 topk_overlap=15/16
+
+hybrid:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998818 rmse=0.167313 topk_overlap=15/16
+```
+
+llama sequential still diverges immediately from the production-like llama
+hybrid target:
+
+```text
+llama sequential:
+  status=fail step=0 prefix_len=31 ck_next=14542 llama_next=4434
+  cosine=0.999262 rmse=0.134203 topk_overlap=16/16
+```
+
+Disabling llama CPU tensor repacking did not move the first production-like
+divergence:
+
+```text
+llama hybrid --llama-no-repack:
+  status=fail step=5 prefix_len=36 ck_next=11290 llama_next=1791
+  cosine=0.998772 rmse=0.169180 topk_overlap=15/16
+```
+
+I also tried making llama-style q/k L2 norm a runtime env switch. Even with the
+environment unset, the extra branch changed the hot kernel enough to flip a
+borderline step-0 token after rebuild, so that diagnostic branch was removed.
+The default rebuilt engine is back to the known step-5 baseline above.
+
+Current conclusion: the remaining Qwen3.5 issue is not caused by comparing the
+wrong CK prefill path. It is a shared CK numerical drift visible in sequential,
+batched, and hybrid CK replay. The next safe target is narrower hidden-stream
+attribution around the step-5 prefix, with attention to recurrent q/k norm
+interaction and layer-0/layer-1 residual drift, but without adding branches to
+hot math kernels or changing the default q/k norm formula.
+
+## Step-5 hidden attribution
+
+Generated a richer llama hidden dump for the step-5 prefix and compared layers
+0-1 against CK hidden exports. Layer 0 shows the first measurable difference at
+q/k L2 normalization:
+
+```text
+layer 0 linear_attn_qkv_mixed:
+  rmse=0.000000205 max_abs=0.000002384
+layer 0 q_conv:
+  rmse=0.000000023 max_abs=0.000000477
+layer 0 k_conv:
+  rmse=0.000000016 max_abs=0.000000238
+layer 0 q_conv_predelta:
+  rmse=0.000001194 max_abs=0.000029743
+layer 0 k_conv_predelta:
+  rmse=0.000002527 max_abs=0.000044525
+layer 0 attn_output:
+  rmse=0.000000070 max_abs=0.000002246
+layer 0 final_output:
+  rmse=0.000001453 max_abs=0.000051141
+layer 0 linear_attn_out:
+  rmse=0.000109637 max_abs=0.000807405
+layer 0 layer_out:
+  rmse=0.000671901 max_abs=0.002632155
+```
+
+Offline formula check using CK `q_conv`/`k_conv` inputs confirms llama's q/k
+norm output is reproduced by `x / max(sqrt(sum_sq), eps)`, while CK's default
+`x / sqrt(sum_sq + eps)` accounts for the observed q/k predelta delta:
+
+```text
+q default formula vs llama:
+  rmse=0.000001198 max_abs=0.000029862
+q llama formula vs llama:
+  rmse=0.000000020 max_abs=0.000000238
+
+k default formula vs llama:
+  rmse=0.000002527 max_abs=0.000044495
+k llama formula vs llama:
+  rmse=0.000000023 max_abs=0.000000209
+```
+
+However, switching the hot kernel to llama's formula globally still regresses
+the prompt boundary to step 0. This means q/k norm semantics are a real local
+parity difference, but changing them globally is not yet a safe production fix.
+The likely explanation is that CK's sequential prompt-state evolution and
+llama's hybrid/chunked prompt-state evolution currently have compensating
+differences. The next safe target is to compare recurrent state and q/k norm
+across the prompt boundary, especially token 30 -> generated token 31, before
+applying any formula change.

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -826,6 +826,20 @@ void rmsnorm_forward(const float *input,
                      int d_model,
                      int aligned_embed_dim,
                      float eps);
+void rmsnorm_forward_no_weight(const float *input,
+                               float *output,
+                               float *rstd_cache,
+                               int tokens,
+                               int d_model,
+                               int aligned_embed_dim,
+                               float eps);
+void gemma4_v_norm_forward(const float *input,
+                           float *output,
+                           float *rstd_cache,
+                           int tokens,
+                           int num_kv_heads,
+                           int head_dim,
+                           float eps);
 
 void rmsnorm_backward(const float *d_output,
                       const float *input,
@@ -848,6 +862,37 @@ void qk_norm_forward(float *q,
                      int head_dim,
                      float eps);
 
+
+void gemma4_per_layer_prepare_forward(float *per_layer_input,
+                                      const float *hidden,
+                                      const int32_t *token_ids,
+                                      const void *per_layer_token_emb,
+                                      const uint16_t *per_layer_model_proj,
+                                      const float *per_layer_proj_norm,
+                                      int tokens,
+                                      int num_layers,
+                                      int embed_dim,
+                                      int per_layer_dim,
+                                      int vocab_size,
+                                      float eps);
+
+void gemma4_per_layer_embed_forward(float *hidden,
+                                    const float *per_layer_input,
+                                    const float *inp_gate,
+                                    const float *proj,
+                                    const float *post_norm,
+                                    const float *out_scale,
+                                    int tokens,
+                                    int layer,
+                                    int num_layers,
+                                    int embed_dim,
+                                    int per_layer_dim,
+                                    float eps);
+
+void gemma4_final_logit_softcap_forward(float *logits,
+                                        int tokens,
+                                        int vocab_size,
+                                        float cap);
 void qk_norm_backward(const float *d_q_out,
                       const float *d_k_out,
                       const float *q_in,
@@ -1162,6 +1207,28 @@ void attention_forward_full_head_major_gqa_flash_strided(const float *q,
                                                          int aligned_head_dim,
                                                          int kv_stride_tokens);
 
+void attention_forward_causal_head_major_gqa_flash_strided_gemma4(const float *q,
+                                                                  const float *k,
+                                                                  const float *v,
+                                                                  float *output,
+                                                                  int num_heads,
+                                                                  int num_kv_heads,
+                                                                  int num_tokens,
+                                                                  int head_dim,
+                                                                  int aligned_head_dim,
+                                                                  int kv_stride_tokens);
+
+void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q,
+                                                                const float *k,
+                                                                const float *v,
+                                                                float *output,
+                                                                int num_heads,
+                                                                int num_kv_heads,
+                                                                int num_tokens,
+                                                                int head_dim,
+                                                                int aligned_head_dim,
+                                                                int kv_stride_tokens);
+
 // Regular exact full / bidirectional attention for encoder-style prefill.
 // This matches the non-flash CPU reference path more closely than the online
 // flash reduction used by the causal kernels.
@@ -1217,6 +1284,17 @@ void attention_forward_decode_head_major_gqa_flash(const float *q_token,
                                                   int head_dim,
                                                   int aligned_head_dim);
 
+void attention_forward_decode_head_major_gqa_flash_gemma4(const float *q_token,
+                                                          const float *k_cache,
+                                                          const float *v_cache,
+                                                          float *out_token,
+                                                          int num_heads,
+                                                          int num_kv_heads,
+                                                          int kv_tokens,
+                                                          int cache_capacity,
+                                                          int head_dim,
+                                                          int aligned_head_dim);
+
 // Llama-parity decode flash attention variant that rounds K/V through FP16 before use.
 void attention_forward_decode_head_major_gqa_flash_f16kv(const float *q_token,
                                                          const float *k_cache,
@@ -1260,6 +1338,19 @@ void attention_forward_decode_head_major_gqa_regular(const float *q_token,
 // Each token attends to the last `sliding_window` tokens.
 //   sliding_window: window size (0 or negative = no limit, like regular causal)
 void attention_forward_causal_head_major_gqa_flash_strided_sliding(
+    const float *q,
+    const float *k,
+    const float *v,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens,
+    int sliding_window);
+
+void attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(
     const float *q,
     const float *k,
     const float *v,
@@ -1610,6 +1701,19 @@ void gated_deltanet_autoregressive_backward(const float *d_out,
 // Sliding-window attention forward (decode, flash-style)
 // Single query token attends to the last `sliding_window` tokens in KV cache.
 void attention_forward_decode_head_major_gqa_flash_sliding(
+    const float *q_token,
+    const float *k_cache,
+    const float *v_cache,
+    float *out_token,
+    int num_heads,
+    int num_kv_heads,
+    int kv_tokens,
+    int cache_capacity,
+    int head_dim,
+    int aligned_head_dim,
+    int sliding_window);
+
+void attention_forward_decode_head_major_gqa_flash_sliding_gemma4(
     const float *q_token,
     const float *k_cache,
     const float *v_cache,
@@ -2152,6 +2256,31 @@ void rope_forward_qk_with_rotary_dim(float *q,
                                      int aligned_head_dim,
                                      int pos_offset,
                                      int rotary_dim);
+
+void rope_forward_qk_gemma4_direct(float *q,
+                                   float *k,
+                                   const float *freq_factors,
+                                   int use_freq_factors,
+                                   int num_heads,
+                                   int num_kv_heads,
+                                   int num_tokens,
+                                   int head_dim,
+                                   int aligned_head_dim,
+                                   int pos_offset,
+                                   int rotary_dim,
+                                   float freq_base);
+void rope_forward_qk_with_rotary_dim_cache_stride(float *q,
+                                                  float *k,
+                                                  const float *cos_cache,
+                                                  const float *sin_cache,
+                                                  int num_heads,
+                                                  int num_kv_heads,
+                                                  int num_tokens,
+                                                  int head_dim,
+                                                  int aligned_head_dim,
+                                                  int pos_offset,
+                                                  int rotary_dim,
+                                                  int cache_rotary_dim);
 
 void rope_forward_qk_pairwise_with_rotary_dim(float *q,
                                               float *k,

--- a/scripts/ck_chat.py
+++ b/scripts/ck_chat.py
@@ -2365,7 +2365,7 @@ def main():
                        help="Stop generation when '<eos>' appears in decoded text")
     parser.add_argument("--stop-on-text", action="append", default=[],
                        help="Stop generation when this decoded text marker appears (repeatable)")
-    parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen3", "qwen35", "gemma"], default="auto",
+    parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen3", "qwen35", "gemma", "gemma3", "gemma4"], default="auto",
                        help="Chat template mode: auto (from GGUF), none, qwen, qwen3, qwen35, or gemma")
     parser.add_argument("--no-chat-template", action="store_true",
                        help="Disable chat template formatting (same as --chat-template=none)")

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -2859,7 +2859,8 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
                                                         int head_dim,
                                                         int aligned_head_dim,
                                                         int kv_stride_tokens,
-                                                        int causal)
+                                                        int causal,
+                                                        float scale)
 {
     if (!q || !k || !v || !output) {
         return;
@@ -2871,7 +2872,6 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
         return;
     }
 
-    const float scale = 1.0f / sqrtf((float)head_dim);
     const int T = num_tokens;
     const size_t kv_head_stride = (size_t)kv_stride_tokens * (size_t)aligned_head_dim;
 
@@ -2939,7 +2939,8 @@ void attention_forward_causal_head_major_gqa_flash(const float *q,
                                                 num_tokens, head_dim,
                                                 aligned_head_dim,
                                                 /*kv_stride_tokens=*/num_tokens,
-                                                /*causal=*/1);
+                                                /*causal=*/1,
+                                                1.0f / sqrtf((float)head_dim));
 }
 
 void attention_forward_full_head_major_gqa_flash(const float *q,
@@ -2957,7 +2958,8 @@ void attention_forward_full_head_major_gqa_flash(const float *q,
                                                 num_tokens, head_dim,
                                                 aligned_head_dim,
                                                 /*kv_stride_tokens=*/num_tokens,
-                                                /*causal=*/0);
+                                                /*causal=*/0,
+                                                1.0f / sqrtf((float)head_dim));
 }
 
 /**
@@ -2986,7 +2988,8 @@ void attention_forward_causal_head_major_gqa_flash_strided(const float *q,
                                                 num_tokens, head_dim,
                                                 aligned_head_dim,
                                                 kv_stride_tokens,
-                                                /*causal=*/1);
+                                                /*causal=*/1,
+                                                1.0f / sqrtf((float)head_dim));
 }
 
 void attention_forward_full_head_major_gqa_flash_strided(const float *q,
@@ -3005,7 +3008,51 @@ void attention_forward_full_head_major_gqa_flash_strided(const float *q,
                                                 num_tokens, head_dim,
                                                 aligned_head_dim,
                                                 kv_stride_tokens,
-                                                /*causal=*/0);
+                                                /*causal=*/0,
+                                                1.0f / sqrtf((float)head_dim));
+}
+
+
+void attention_forward_causal_head_major_gqa_flash_strided_gemma4(const float *q,
+                                                                  const float *k,
+                                                                  const float *v,
+                                                                  float *output,
+                                                                  int num_heads,
+                                                                  int num_kv_heads,
+                                                                  int num_tokens,
+                                                                  int head_dim,
+                                                                  int aligned_head_dim,
+                                                                  int kv_stride_tokens)
+{
+    (void)head_dim;
+    attention_forward_head_major_gqa_flash_impl(q, k, v, output,
+                                                num_heads, num_kv_heads,
+                                                num_tokens, head_dim,
+                                                aligned_head_dim,
+                                                kv_stride_tokens,
+                                                /*causal=*/1,
+                                                1.0f);
+}
+
+void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q,
+                                                                const float *k,
+                                                                const float *v,
+                                                                float *output,
+                                                                int num_heads,
+                                                                int num_kv_heads,
+                                                                int num_tokens,
+                                                                int head_dim,
+                                                                int aligned_head_dim,
+                                                                int kv_stride_tokens)
+{
+    (void)head_dim;
+    attention_forward_head_major_gqa_flash_impl(q, k, v, output,
+                                                num_heads, num_kv_heads,
+                                                num_tokens, head_dim,
+                                                aligned_head_dim,
+                                                kv_stride_tokens,
+                                                /*causal=*/0,
+                                                1.0f);
 }
 
 void attention_forward_causal_head_major_gqa_flash_strided_f16kv(const float *q,
@@ -3389,6 +3436,50 @@ void attention_forward_decode_head_major_gqa_flash(const float *q_token,
     }
 
     const float scale = 1.0f / sqrtf((float)head_dim);
+    const size_t head_stride = (size_t)cache_capacity * (size_t)aligned_head_dim;
+
+    for (int h = 0; h < num_heads; ++h) {
+        int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+        const float *q_head = q_token + (size_t)h * (size_t)aligned_head_dim;
+        const float *k_head = k_cache + (size_t)kv_head * head_stride;
+        const float *v_head = v_cache + (size_t)kv_head * head_stride;
+        float *out_head = out_token + (size_t)h * (size_t)aligned_head_dim;
+
+        attention_flash_decode(out_head,
+                               q_head,
+                               k_head,
+                               v_head,
+                               1,
+                               kv_tokens,
+                               1,
+                               aligned_head_dim,
+                               scale);
+    }
+}
+
+
+void attention_forward_decode_head_major_gqa_flash_gemma4(const float *q_token,
+                                                          const float *k_cache,
+                                                          const float *v_cache,
+                                                          float *out_token,
+                                                          int num_heads,
+                                                          int num_kv_heads,
+                                                          int kv_tokens,
+                                                          int cache_capacity,
+                                                          int head_dim,
+                                                          int aligned_head_dim)
+{
+    if (!q_token || !k_cache || !v_cache || !out_token) {
+        return;
+    }
+    if (num_heads <= 0 || num_kv_heads <= 0 || kv_tokens <= 0 || cache_capacity <= 0) {
+        return;
+    }
+    if (kv_tokens > cache_capacity || head_dim <= 0 || aligned_head_dim <= 0) {
+        return;
+    }
+
+    const float scale = 1.0f;
     const size_t head_stride = (size_t)cache_capacity * (size_t)aligned_head_dim;
 
     for (int h = 0; h < num_heads; ++h) {

--- a/src/kernels/attention_kernels_sliding.c
+++ b/src/kernels/attention_kernels_sliding.c
@@ -525,6 +525,71 @@ void attention_forward_causal_head_major_gqa_flash_strided_sliding(
  *
  * After changes: make test
  */
+void attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(
+    const float *q,
+    const float *k,
+    const float *v,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens,
+    int sliding_window)
+{
+    if (!q || !k || !v || !output) {
+        return;
+    }
+    if (num_heads <= 0 || num_kv_heads <= 0 || num_tokens <= 0) {
+        return;
+    }
+    if (kv_stride_tokens < num_tokens) {
+        return;
+    }
+
+    if (getenv("CK_FORCE_NONSLIDING_ATTN")) {
+        attention_forward_causal_head_major_gqa_flash_strided_gemma4(
+            q, k, v, output, num_heads, num_kv_heads, num_tokens,
+            head_dim, aligned_head_dim, kv_stride_tokens
+        );
+        return;
+    }
+
+    const float scale = 1.0f;
+    const int T = num_tokens;
+    const size_t kv_head_stride = (size_t)kv_stride_tokens * (size_t)aligned_head_dim;
+
+#if defined(__AVX512F__)
+    #define SLIDING_FLASH_IMPL_GEMMA4 attention_flash_query_sliding_avx512
+#elif defined(__AVX2__)
+    #define SLIDING_FLASH_IMPL_GEMMA4 attention_flash_query_sliding_avx2
+#elif defined(__AVX__)
+    #define SLIDING_FLASH_IMPL_GEMMA4 attention_flash_query_sliding_avx
+#else
+    #define SLIDING_FLASH_IMPL_GEMMA4 attention_flash_query_sliding
+#endif
+
+    for (int h = 0; h < num_heads; ++h) {
+        int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+        const float *k_head = k + (size_t)kv_head * kv_head_stride;
+        const float *v_head = v + (size_t)kv_head * kv_head_stride;
+
+        for (int i = 0; i < T; ++i) {
+            const float *q_vec = q + qkv_index(h, i, 0, T, aligned_head_dim);
+            float *out_vec = output + qkv_index(h, i, 0, T, aligned_head_dim);
+            SLIDING_FLASH_IMPL_GEMMA4(q_vec, k_head, v_head,
+                                      /*query_pos=*/i,
+                                      /*kv_tokens=*/T,
+                                      head_dim, aligned_head_dim,
+                                      scale, out_vec,
+                                      sliding_window);
+        }
+    }
+
+#undef SLIDING_FLASH_IMPL_GEMMA4
+}
+
 void attention_forward_decode_head_major_gqa_flash_sliding(
     const float *q_token,
     const float *k_cache,
@@ -609,4 +674,77 @@ void attention_forward_decode_head_major_gqa_flash_sliding(
     }
 
 #undef SLIDING_DECODE_IMPL
+}
+
+void attention_forward_decode_head_major_gqa_flash_sliding_gemma4(
+    const float *q_token,
+    const float *k_cache,
+    const float *v_cache,
+    float *out_token,
+    int num_heads,
+    int num_kv_heads,
+    int kv_tokens,
+    int cache_capacity,
+    int head_dim,
+    int aligned_head_dim,
+    int sliding_window)
+{
+    if (!q_token || !k_cache || !v_cache || !out_token) {
+        return;
+    }
+    if (num_heads <= 0 || num_kv_heads <= 0 || cache_capacity <= 0) {
+        return;
+    }
+    if (kv_tokens <= 0 || kv_tokens > cache_capacity || head_dim <= 0 || aligned_head_dim <= 0) {
+        return;
+    }
+
+    if (getenv("CK_FORCE_NONSLIDING_ATTN")) {
+        attention_forward_decode_head_major_gqa_flash_gemma4(
+            q_token, k_cache, v_cache, out_token,
+            num_heads, num_kv_heads, kv_tokens, cache_capacity,
+            head_dim, aligned_head_dim
+        );
+        return;
+    }
+
+    const float scale = 1.0f;
+    const size_t head_stride = (size_t)cache_capacity * (size_t)aligned_head_dim;
+    int effective_kv_tokens = kv_tokens;
+    if (sliding_window > 0 && sliding_window < kv_tokens) {
+        effective_kv_tokens = sliding_window;
+    }
+    if (effective_kv_tokens <= 0) {
+        return;
+    }
+    int kv_start_offset = kv_tokens - effective_kv_tokens;
+
+#if defined(__AVX512F__)
+    #define SLIDING_DECODE_IMPL_GEMMA4 attention_flash_query_sliding_avx512
+#elif defined(__AVX2__)
+    #define SLIDING_DECODE_IMPL_GEMMA4 attention_flash_query_sliding_avx2
+#elif defined(__AVX__)
+    #define SLIDING_DECODE_IMPL_GEMMA4 attention_flash_query_sliding_avx
+#else
+    #define SLIDING_DECODE_IMPL_GEMMA4 attention_flash_query_sliding
+#endif
+
+    for (int h = 0; h < num_heads; ++h) {
+        int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+        const float *q_head = q_token + (size_t)h * (size_t)aligned_head_dim;
+        const float *k_head = k_cache + (size_t)kv_head * head_stride
+                            + (size_t)kv_start_offset * (size_t)aligned_head_dim;
+        const float *v_head = v_cache + (size_t)kv_head * head_stride
+                            + (size_t)kv_start_offset * (size_t)aligned_head_dim;
+        float *out_head = out_token + (size_t)h * (size_t)aligned_head_dim;
+
+        SLIDING_DECODE_IMPL_GEMMA4(q_head, k_head, v_head,
+                                   /*query_pos=*/effective_kv_tokens - 1,
+                                   /*kv_tokens=*/effective_kv_tokens,
+                                   head_dim, aligned_head_dim,
+                                   scale, out_head,
+                                   /*sliding_window=*/0);
+    }
+
+#undef SLIDING_DECODE_IMPL_GEMMA4
 }

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -16,6 +16,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "ckernel_quant.h"
@@ -94,10 +95,33 @@ void gemv_q4_k_q8_k_vnni(float *y,
                          const void *x_q8,
                          int M, int K)
 {
-    /* Correctness first: the previous VNNI path changed the float accumulation
+    const char *fast_env = getenv("CK_ENABLE_Q4K_Q8K_VNNI_FAST");
+    if (fast_env && fast_env[0] && fast_env[0] != '0') {
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+        if (!y || !W || !x_q8 || M <= 0 || K <= 0) {
+            return;
+        }
+
+        const block_q4_K *blocks = (const block_q4_K *)W;
+        const block_q8_K *x = (const block_q8_K *)x_q8;
+        const int blocks_per_row = K / QK_K;
+
+        for (int row = 0; row < M; ++row) {
+            const block_q4_K *w_row = blocks + (size_t)row * (size_t)blocks_per_row;
+            float sum = 0.0f;
+            for (int b = 0; b < blocks_per_row; ++b) {
+                sum += dot_q4_k_q8_k_vnni_block(&w_row[b], &x[b]);
+            }
+            y[row] = sum;
+        }
+        return;
+#endif
+    }
+
+    /* Correctness first: the fast VNNI path changes the float accumulation
      * order enough to move borderline Qwen3.5 logits. Keep production on the
-     * llama-style scalar accumulation until the VNNI kernel preserves that
-     * contract exactly.
+     * llama-style scalar accumulation unless explicitly benchmarking the fast
+     * path with CK_ENABLE_Q4K_Q8K_VNNI_FAST=1.
      */
     gemv_q4_k_q8_k_ref(y, W, x_q8, M, K);
 }

--- a/src/kernels/gemma4_per_layer_embed.c
+++ b/src/kernels/gemma4_per_layer_embed.c
@@ -1,0 +1,217 @@
+#include <math.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "ckernel_quant.h"
+
+typedef struct {
+    ck_half d;
+    ck_half dmin;
+    uint8_t scales[K_SCALE_SIZE];
+    uint8_t qh[QK_K / 8];
+    uint8_t qs[QK_K / 2];
+} ck_gemma4_block_q5_K;
+
+static inline float ck_bf16_to_f32(uint16_t v)
+{
+    uint32_t bits = ((uint32_t)v) << 16;
+    float out;
+    memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+static inline float ck_gemma4_gelu(float x)
+{
+    const float c0 = 0.7978845608028654f;
+    const float c1 = 0.044715f;
+    return 0.5f * x * (1.0f + tanhf(c0 * x * (1.0f + c1 * x * x)));
+}
+
+static inline void ck_gemma4_unpack_q5_k_scales(const uint8_t *scales, uint8_t *sc, uint8_t *m)
+{
+    sc[0] = scales[0] & 0x3F;
+    sc[1] = scales[1] & 0x3F;
+    sc[2] = scales[2] & 0x3F;
+    sc[3] = scales[3] & 0x3F;
+
+    m[0] = scales[4] & 0x3F;
+    m[1] = scales[5] & 0x3F;
+    m[2] = scales[6] & 0x3F;
+    m[3] = scales[7] & 0x3F;
+
+    sc[4] = (scales[8]  & 0x0F) | ((scales[0] >> 6) << 4);
+    sc[5] = (scales[9]  & 0x0F) | ((scales[1] >> 6) << 4);
+    sc[6] = (scales[10] & 0x0F) | ((scales[2] >> 6) << 4);
+    sc[7] = (scales[11] & 0x0F) | ((scales[3] >> 6) << 4);
+
+    m[4] = (scales[8]  >> 4) | ((scales[4] >> 6) << 4);
+    m[5] = (scales[9]  >> 4) | ((scales[5] >> 6) << 4);
+    m[6] = (scales[10] >> 4) | ((scales[6] >> 6) << 4);
+    m[7] = (scales[11] >> 4) | ((scales[7] >> 6) << 4);
+}
+
+static inline uint8_t ck_gemma4_q5_k_value(const ck_gemma4_block_q5_K *block, int subblock, int i)
+{
+    const uint8_t *ql = block->qs + (subblock / 2) * 32;
+    const uint8_t low = (subblock & 1) ? (uint8_t)(ql[i] >> 4) : (uint8_t)(ql[i] & 0x0F);
+    const uint8_t high = (block->qh[i] & (uint8_t)(1u << subblock)) ? 16u : 0u;
+    return (uint8_t)(low | high);
+}
+
+static void ck_gemma4_dequant_q5_k_block(const ck_gemma4_block_q5_K *block, float *out)
+{
+    uint8_t sc[8];
+    uint8_t m[8];
+    ck_gemma4_unpack_q5_k_scales(block->scales, sc, m);
+    const float d = CK_FP16_TO_FP32(block->d);
+    const float dmin = CK_FP16_TO_FP32(block->dmin);
+    for (int s = 0; s < 8; ++s) {
+        const float scale = d * (float)sc[s];
+        const float minv = dmin * (float)m[s];
+        for (int i = 0; i < 32; ++i) {
+            out[s * 32 + i] = scale * (float)ck_gemma4_q5_k_value(block, s, i) - minv;
+        }
+    }
+}
+
+static void ck_gemma4_rmsnorm_tmp(const float *x, const float *gamma, float *out, int n, float eps)
+{
+    double ss = 0.0;
+    for (int i = 0; i < n; ++i) {
+        ss += (double)x[i] * (double)x[i];
+    }
+    const float scale = 1.0f / sqrtf((float)(ss / (double)n) + eps);
+    for (int i = 0; i < n; ++i) {
+        out[i] = x[i] * scale * gamma[i];
+    }
+}
+
+void gemma4_per_layer_prepare_forward(float *per_layer_input,
+                                      const float *hidden,
+                                      const int32_t *token_ids,
+                                      const void *per_layer_token_emb,
+                                      const uint16_t *per_layer_model_proj,
+                                      const float *per_layer_proj_norm,
+                                      int tokens,
+                                      int num_layers,
+                                      int embed_dim,
+                                      int per_layer_dim,
+                                      int vocab_size,
+                                      float eps)
+{
+    if (!per_layer_input || !hidden || !token_ids || !per_layer_token_emb ||
+        !per_layer_model_proj || !per_layer_proj_norm || tokens <= 0 ||
+        num_layers <= 0 || embed_dim <= 0 || per_layer_dim != QK_K || vocab_size <= 0) {
+        return;
+    }
+
+    const ck_gemma4_block_q5_K *token_blocks = (const ck_gemma4_block_q5_K *)per_layer_token_emb;
+    const size_t token_blocks_per_row = (size_t)num_layers;
+    const float token_scale = sqrtf((float)per_layer_dim);
+    const float model_scale = 1.0f / sqrtf((float)embed_dim);
+    const float mix_scale = 0.7071067811865475f;
+
+    float token_vec[QK_K];
+    float proj_vec[QK_K];
+    float proj_normed[QK_K];
+
+    for (int t = 0; t < tokens; ++t) {
+        const int token = token_ids[t];
+        if (token < 0 || token >= vocab_size) {
+            continue;
+        }
+        const float *h = hidden + (size_t)t * (size_t)embed_dim;
+        for (int layer = 0; layer < num_layers; ++layer) {
+            float *dst = per_layer_input + ((size_t)t * (size_t)num_layers + (size_t)layer) * (size_t)per_layer_dim;
+            const ck_gemma4_block_q5_K *tok_block = token_blocks + (size_t)token * token_blocks_per_row + (size_t)layer;
+            ck_gemma4_dequant_q5_k_block(tok_block, token_vec);
+            for (int i = 0; i < per_layer_dim; ++i) {
+                token_vec[i] *= token_scale;
+            }
+
+            const uint16_t *model_proj_base = per_layer_model_proj + (size_t)layer * (size_t)per_layer_dim * (size_t)embed_dim;
+            for (int i = 0; i < per_layer_dim; ++i) {
+                const uint16_t *row = model_proj_base + (size_t)i * (size_t)embed_dim;
+                float acc = 0.0f;
+                for (int j = 0; j < embed_dim; ++j) {
+                    acc += ck_bf16_to_f32(row[j]) * h[j];
+                }
+                proj_vec[i] = acc * model_scale;
+            }
+            ck_gemma4_rmsnorm_tmp(proj_vec, per_layer_proj_norm, proj_normed, per_layer_dim, eps);
+            for (int i = 0; i < per_layer_dim; ++i) {
+                dst[i] = (token_vec[i] + proj_normed[i]) * mix_scale;
+            }
+        }
+    }
+}
+
+void gemma4_per_layer_embed_forward(float *hidden,
+                                    const float *per_layer_input,
+                                    const float *inp_gate,
+                                    const float *proj,
+                                    const float *post_norm,
+                                    const float *out_scale,
+                                    int tokens,
+                                    int layer,
+                                    int num_layers,
+                                    int embed_dim,
+                                    int per_layer_dim,
+                                    float eps)
+{
+    if (!hidden || !per_layer_input || !inp_gate || !proj || !post_norm ||
+        tokens <= 0 || layer < 0 || layer >= num_layers || embed_dim <= 0 || per_layer_dim != QK_K) {
+        return;
+    }
+
+    float gate_vec[QK_K];
+    float branch[4096];
+    float branch_normed[4096];
+    if (embed_dim > (int)(sizeof(branch) / sizeof(branch[0]))) {
+        return;
+    }
+
+    for (int t = 0; t < tokens; ++t) {
+        float *h = hidden + (size_t)t * (size_t)embed_dim;
+        const float *inp_vec = per_layer_input + ((size_t)t * (size_t)num_layers + (size_t)layer) * (size_t)per_layer_dim;
+
+        for (int i = 0; i < per_layer_dim; ++i) {
+            const float *row = inp_gate + (size_t)i * (size_t)embed_dim;
+            float acc = 0.0f;
+            for (int j = 0; j < embed_dim; ++j) {
+                acc += row[j] * h[j];
+            }
+            gate_vec[i] = ck_gemma4_gelu(acc) * inp_vec[i];
+        }
+
+        for (int j = 0; j < embed_dim; ++j) {
+            const float *row = proj + (size_t)j * (size_t)per_layer_dim;
+            float acc = 0.0f;
+            for (int i = 0; i < per_layer_dim; ++i) {
+                acc += row[i] * gate_vec[i];
+            }
+            branch[j] = acc;
+        }
+        ck_gemma4_rmsnorm_tmp(branch, post_norm, branch_normed, embed_dim, eps);
+        const float layer_scale = out_scale ? out_scale[0] : 1.0f;
+        for (int j = 0; j < embed_dim; ++j) {
+            h[j] = (h[j] + branch_normed[j]) * layer_scale;
+        }
+    }
+}
+
+void gemma4_final_logit_softcap_forward(float *logits,
+                                        int tokens,
+                                        int vocab_size,
+                                        float cap)
+{
+    if (!logits || tokens <= 0 || vocab_size <= 0 || cap <= 0.0f) {
+        return;
+    }
+    const float inv_cap = 1.0f / cap;
+    const size_t total = (size_t)tokens * (size_t)vocab_size;
+    for (size_t i = 0; i < total; ++i) {
+        logits[i] = tanhf(logits[i] * inv_cap) * cap;
+    }
+}

--- a/src/kernels/rmsnorm_kernels.c
+++ b/src/kernels/rmsnorm_kernels.c
@@ -251,6 +251,54 @@ void rmsnorm_forward(const float *input,
     }
 }
 
+void rmsnorm_forward_no_weight(const float *input,
+                               float *output,
+                               float *rstd_cache,
+                               int tokens,
+                               int d_model,
+                               int aligned_embed_dim,
+                               float eps)
+{
+    if (!input || !output || tokens <= 0 || d_model <= 0 || aligned_embed_dim <= 0) {
+        return;
+    }
+    const float inv_d = 1.0f / (float)d_model;
+    for (int t = 0; t < tokens; ++t) {
+        const float *x = input + (size_t)t * (size_t)aligned_embed_dim;
+        float *y = output + (size_t)t * (size_t)aligned_embed_dim;
+        double sum_sq = 0.0;
+        for (int d = 0; d < d_model; ++d) {
+            sum_sq += (double)x[d] * (double)x[d];
+        }
+        const float rstd = 1.0f / sqrtf((float)(sum_sq * (double)inv_d) + eps);
+        if (rstd_cache) {
+            rstd_cache[t] = rstd;
+        }
+        for (int d = 0; d < d_model; ++d) {
+            y[d] = x[d] * rstd;
+        }
+        for (int d = d_model; d < aligned_embed_dim; ++d) {
+            y[d] = 0.0f;
+        }
+    }
+}
+
+void gemma4_v_norm_forward(const float *input,
+                           float *output,
+                           float *rstd_cache,
+                           int tokens,
+                           int num_kv_heads,
+                           int head_dim,
+                           float eps)
+{
+    if (!input || !output || tokens <= 0 || num_kv_heads <= 0 || head_dim <= 0) {
+        return;
+    }
+    rmsnorm_forward_no_weight(input, output, rstd_cache,
+                              tokens * num_kv_heads, head_dim, head_dim, eps);
+}
+
+
 /**
  * RMSNorm backward pass
  * @test test_rmsnorm.py::TestRMSNormBackward::test_backward_tokens

--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -836,6 +836,135 @@ void rope_forward_qk_with_rotary_dim(float *q,
                                 head_dim, aligned_head_dim, pos_offset, rotary_dim);
 }
 
+
+void rope_forward_qk_gemma4_direct(float *q,
+                                   float *k,
+                                   const float *freq_factors,
+                                   int use_freq_factors,
+                                   int num_heads,
+                                   int num_kv_heads,
+                                   int num_tokens,
+                                   int head_dim,
+                                   int aligned_head_dim,
+                                   int pos_offset,
+                                   int rotary_dim,
+                                   float freq_base)
+{
+    if (rotary_dim <= 0 || rotary_dim > head_dim) {
+        rotary_dim = head_dim;
+    }
+    if (freq_base <= 0.0f) {
+        freq_base = 10000.0f;
+    }
+    const int rotary_half = rotary_dim / 2;
+    const size_t head_stride = (size_t)num_tokens * (size_t)aligned_head_dim;
+    const float theta_scale = powf(freq_base, -2.0f / (float)rotary_dim);
+
+    for (int h = 0; h < num_heads; ++h) {
+        float *head = q + (size_t)h * head_stride;
+        for (int t = 0; t < num_tokens; ++t) {
+            const float pos = (float)(pos_offset + t);
+            float *x_row = head + (size_t)t * (size_t)aligned_head_dim;
+            for (int i = 0; i < rotary_half; ++i) {
+                const int idx0 = 2 * i;
+                const int idx1 = idx0 + 1;
+                const float ff = (use_freq_factors && freq_factors) ? freq_factors[i] : 1.0f;
+                const float theta = pos * powf(theta_scale, (float)i) / ff;
+                const float c = cosf(theta);
+                const float sv = sinf(theta);
+                const float x0 = x_row[idx0];
+                const float x1 = x_row[idx1];
+                x_row[idx0] = x0 * c - x1 * sv;
+                x_row[idx1] = x0 * sv + x1 * c;
+            }
+        }
+    }
+
+    for (int h = 0; h < num_kv_heads; ++h) {
+        float *head = k + (size_t)h * head_stride;
+        for (int t = 0; t < num_tokens; ++t) {
+            const float pos = (float)(pos_offset + t);
+            float *x_row = head + (size_t)t * (size_t)aligned_head_dim;
+            for (int i = 0; i < rotary_half; ++i) {
+                const int idx0 = 2 * i;
+                const int idx1 = idx0 + 1;
+                const float ff = (use_freq_factors && freq_factors) ? freq_factors[i] : 1.0f;
+                const float theta = pos * powf(theta_scale, (float)i) / ff;
+                const float c = cosf(theta);
+                const float sv = sinf(theta);
+                const float x0 = x_row[idx0];
+                const float x1 = x_row[idx1];
+                x_row[idx0] = x0 * c - x1 * sv;
+                x_row[idx1] = x0 * sv + x1 * c;
+            }
+        }
+    }
+}
+
+void rope_forward_qk_with_rotary_dim_cache_stride(float *q,
+                                                  float *k,
+                                                  const float *cos_cache,
+                                                  const float *sin_cache,
+                                                  int num_heads,
+                                                  int num_kv_heads,
+                                                  int num_tokens,
+                                                  int head_dim,
+                                                  int aligned_head_dim,
+                                                  int pos_offset,
+                                                  int rotary_dim,
+                                                  int cache_rotary_dim)
+{
+    if (rotary_dim <= 0 || rotary_dim > head_dim) {
+        rotary_dim = head_dim;
+    }
+    if (cache_rotary_dim < rotary_dim) {
+        cache_rotary_dim = rotary_dim;
+    }
+    const int rotary_half = rotary_dim / 2;
+    const int cache_half = cache_rotary_dim / 2;
+    const size_t head_stride = (size_t)num_tokens * (size_t)aligned_head_dim;
+
+    for (int h = 0; h < num_heads; ++h) {
+        float *head = q + (size_t)h * head_stride;
+        for (int t = 0; t < num_tokens; ++t) {
+            const int pos = pos_offset + t;
+            const float *cos_row = cos_cache + (size_t)pos * (size_t)cache_half;
+            const float *sin_row = sin_cache + (size_t)pos * (size_t)cache_half;
+            float *x_row = head + (size_t)t * (size_t)aligned_head_dim;
+            for (int i = 0; i < rotary_half; ++i) {
+                const int idx0 = 2 * i;
+                const int idx1 = idx0 + 1;
+                const float x0 = x_row[idx0];
+                const float x1 = x_row[idx1];
+                const float c = cos_row[i];
+                const float sv = sin_row[i];
+                x_row[idx0] = x0 * c - x1 * sv;
+                x_row[idx1] = x0 * sv + x1 * c;
+            }
+        }
+    }
+
+    for (int h = 0; h < num_kv_heads; ++h) {
+        float *head = k + (size_t)h * head_stride;
+        for (int t = 0; t < num_tokens; ++t) {
+            const int pos = pos_offset + t;
+            const float *cos_row = cos_cache + (size_t)pos * (size_t)cache_half;
+            const float *sin_row = sin_cache + (size_t)pos * (size_t)cache_half;
+            float *x_row = head + (size_t)t * (size_t)aligned_head_dim;
+            for (int i = 0; i < rotary_half; ++i) {
+                const int idx0 = 2 * i;
+                const int idx1 = idx0 + 1;
+                const float x0 = x_row[idx0];
+                const float x1 = x_row[idx1];
+                const float c = cos_row[i];
+                const float sv = sin_row[i];
+                x_row[idx0] = x0 * c - x1 * sv;
+                x_row[idx1] = x0 * sv + x1 * c;
+            }
+        }
+    }
+}
+
 void rope_forward_qk_pairwise_with_rotary_dim(float *q,
                                               float *k,
                                               const float *cos_cache,

--- a/tests/test_build_ir_v8_scaffold.py
+++ b/tests/test_build_ir_v8_scaffold.py
@@ -37,6 +37,15 @@ def _normalized_template_doc(doc: dict) -> dict:
     attention_contract = normalized.get("contract", {}).get("attention_contract")
     if isinstance(attention_contract, dict):
         attention_contract.pop("train_runtime_contract", None)
+        for key in (
+            "layer_policy_config_key",
+            "layer_kind_config_key",
+            "state_policy_config_key",
+            "attention_policy_config_key",
+            "recurrent_policy_config_key",
+            "kv_policy_config_key",
+        ):
+            attention_contract.pop(key, None)
     return normalized
 
 

--- a/tests/test_v8_gemma4_scaffold.py
+++ b/tests/test_v8_gemma4_scaffold.py
@@ -8,7 +8,13 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str((REPO_ROOT / "version" / "v8" / "scripts").resolve()))
 
 from scripts.chat_contract import build_chat_contract, load_template_chat_contract  # type: ignore
-from convert_gguf_to_bump_v8 import TensorInfo, classify_layer_contract, describe_layer_contract  # type: ignore
+from convert_gguf_to_bump_v8 import (  # type: ignore
+    TensorInfo,
+    build_gemma4_attention_plan,
+    classify_layer_contract,
+    describe_layer_contract,
+    _inject_runtime_config_defaults,
+)
 
 
 def _tensor(name: str, dims: tuple[int, ...]) -> TensorInfo:
@@ -23,6 +29,13 @@ class V8Gemma4ScaffoldTests(unittest.TestCase):
         self.assertEqual(contract["turn_suffix"], "<turn|>\n")
         self.assertEqual(contract["assistant_generation_prefix"], "<|turn>model\n")
         self.assertEqual(contract["token_stop_markers"], ["<turn|>"])
+
+    def test_gemma4_uses_q8_activation_logits_by_default(self) -> None:
+        gemma4 = _inject_runtime_config_defaults({}, "gemma4")
+        gemma3 = _inject_runtime_config_defaults({}, "gemma3")
+        self.assertFalse(gemma4["prefer_fp32_logits"])
+        self.assertTrue(gemma4["prefer_q8_0_contract"])
+        self.assertTrue(gemma3["prefer_fp32_logits"])
 
     def test_build_chat_contract_detects_gemma4_markers(self) -> None:
         chat_template = "<|turn>user\nHello<turn|>\n<|turn>model\n"
@@ -76,6 +89,111 @@ class V8Gemma4ScaffoldTests(unittest.TestCase):
         self.assertIsNotNone(detail)
         self.assertIn("Gemma4 hybrid block", detail)
         self.assertIn("per-layer projection lowering", detail)
+
+    def test_build_gemma4_attention_plan_makes_shared_kv_explicit(self) -> None:
+        plan = build_gemma4_attention_plan(
+            {
+                "gemma4.attention.sliding_window_pattern": [True, False, True, False],
+                "gemma4.attention.shared_kv_layers": 2,
+                "gemma4.attention.sliding_window": 1024,
+                "gemma4.attention.head_count": 16,
+                "gemma4.attention.head_count_kv": 4,
+                "gemma4.attention.key_length": 256,
+                "gemma4.attention.value_length": 256,
+                "gemma4.attention.key_length_swa": 128,
+                "gemma4.attention.value_length_swa": 128,
+                "gemma4.rope.dimension_count": 512,
+                "gemma4.rope.dimension_count_swa": 256,
+            },
+            4,
+        )
+        self.assertEqual(
+            plan["layer_kinds"],
+            [
+                "sliding_attention_kv",
+                "full_attention_kv",
+                "sliding_attention_shared_kv",
+                "full_attention_shared_kv",
+            ],
+        )
+        self.assertEqual(plan["layer_kv_policy"], ["produce", "produce", "reuse", "reuse"])
+        self.assertEqual(plan["layer_kv_source"], [0, 1, 0, 1])
+        self.assertEqual(plan["layer_sliding_window"], [1024, 0, 1024, 0])
+        self.assertEqual(plan["layer_rope_kind"], ["swa", "full", "swa", "full"])
+        self.assertEqual(plan["layer_q_head_dim"], [128, 256, 128, 256])
+        self.assertEqual(plan["layer_k_head_dim"], [128, 256, 128, 256])
+        self.assertEqual(plan["layer_v_head_dim"], [128, 256, 128, 256])
+        self.assertEqual(plan["layer_rotary_dim"], [256, 512, 256, 512])
+        self.assertEqual(plan["layer_q_dim"], [2048, 4096, 2048, 4096])
+        self.assertEqual(plan["layer_kv_dim"], [512, 1024, 512, 1024])
+
+    def test_gemma4_template_declares_q_only_shared_kv_kinds(self) -> None:
+        template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4.json"
+        import json
+
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        body = template["block_types"]["decoder"]["body"]
+        self.assertEqual(body["kind_config_key"], "layer_kinds")
+        self.assertIn("sliding_attention_shared_kv", body["ops_by_kind"])
+        self.assertIn("full_attention_shared_kv", body["ops_by_kind"])
+        shared_ops = body["ops_by_kind"]["sliding_attention_shared_kv"]
+        self.assertIn("q_proj", shared_ops)
+        self.assertIn("q_norm", shared_ops)
+        self.assertIn("rope_q", shared_ops)
+        self.assertIn("attn_sliding_shared_kv", shared_ops)
+        self.assertNotIn("k_proj", shared_ops)
+        self.assertNotIn("v_proj", shared_ops)
+
+    def test_gemma4_kv_layers_use_supported_paired_qk_ops_for_first_bringup(self) -> None:
+        template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4.json"
+        import json
+
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        body = template["block_types"]["decoder"]["body"]
+        for kind in ("sliding_attention_kv", "full_attention_kv"):
+            ops = body["ops_by_kind"][kind]
+            self.assertIn("qk_norm", ops)
+            self.assertIn("rope_qk", ops)
+            self.assertNotIn("q_norm", ops)
+            self.assertNotIn("rope_q", ops)
+
+    def test_gemma4_v_norm_is_unweighted_rmsnorm(self) -> None:
+        import json
+
+        template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4.json"
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        body = template["block_types"]["decoder"]["body"]
+        for kind in ("sliding_attention_kv", "full_attention_kv"):
+            ops = body["ops_by_kind"][kind]
+            self.assertIn("v_norm", ops)
+            self.assertLess(ops.index("v_proj"), ops.index("v_norm"))
+            self.assertLess(ops.index("v_norm"), ops.index("qk_norm"))
+
+        overlay_path = REPO_ROOT / "version" / "v8" / "kernel_maps" / "kernel_bindings.overlay.json"
+        overlay = json.loads(overlay_path.read_text(encoding="utf-8"))
+        binding = overlay["bindings"]["rmsnorm_forward_no_weight"]
+        self.assertNotIn("gamma", {param["name"] for param in binding["params"]})
+        self.assertNotIn("v_norm_gamma", json.dumps(binding))
+
+    def test_gemma4_template_runs_per_layer_embedding_after_ffn_residual(self) -> None:
+        import json
+
+        template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4.json"
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        body = template["block_types"]["decoder"]["body"]
+        for ops in body["ops_by_kind"].values():
+            self.assertIn("gemma4_per_layer_embed", ops)
+            self.assertLess(ops.index("post_ffn_norm"), ops.index("gemma4_per_layer_embed"))
+
+        kernel_map = json.loads(
+            (REPO_ROOT / "version" / "v8" / "kernel_maps" / "gemma4_per_layer_embed_forward.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(kernel_map["op"], "gemma4_per_layer_embed")
+        self.assertEqual(kernel_map["impl"]["function"], "gemma4_per_layer_embed_forward")
+        prepare_map = json.loads(
+            (REPO_ROOT / "version" / "v8" / "kernel_maps" / "gemma4_per_layer_prepare_forward.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(prepare_map["op"], "gemma4_per_layer_prepare")
 
 
 if __name__ == "__main__":

--- a/tests/test_v8_qwen35_policy.py
+++ b/tests/test_v8_qwen35_policy.py
@@ -1,0 +1,50 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str((REPO_ROOT / "version" / "v8" / "scripts").resolve()))
+
+from convert_gguf_to_bump_v8 import build_qwen35_execution_plan  # type: ignore
+
+
+class V8Qwen35PolicyTests(unittest.TestCase):
+    def test_build_qwen35_execution_plan_makes_state_ownership_explicit(self) -> None:
+        plan = build_qwen35_execution_plan(
+            ["recurrent", "recurrent", "recurrent", "full_attention"]
+        )
+        self.assertEqual(
+            plan["layer_state_policy"],
+            ["recurrent_state", "recurrent_state", "recurrent_state", "kv_cache"],
+        )
+        self.assertEqual(plan["layer_attention_policy"], ["none", "none", "none", "full"])
+        self.assertEqual(plan["layer_recurrent_policy"], ["deltanet", "deltanet", "deltanet", "none"])
+        self.assertEqual(plan["layer_kv_policy"], ["none", "none", "none", "produce"])
+        self.assertEqual(
+            plan["layer_execution_plan"][3],
+            {
+                "layer": 3,
+                "kind": "full_attention",
+                "state_policy": "kv_cache",
+                "attention_policy": "full",
+                "recurrent_policy": "none",
+                "kv_policy": "produce",
+            },
+        )
+
+    def test_qwen35_template_declares_policy_config_keys(self) -> None:
+        template_path = REPO_ROOT / "version" / "v8" / "templates" / "qwen35.json"
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        contract = template["contract"]["attention_contract"]
+        self.assertEqual(contract["layer_policy_config_key"], "layer_execution_plan")
+        self.assertEqual(contract["state_policy_config_key"], "layer_state_policy")
+        self.assertEqual(contract["attention_policy_config_key"], "layer_attention_policy")
+        self.assertEqual(contract["recurrent_policy_config_key"], "layer_recurrent_policy")
+        self.assertEqual(contract["kv_policy_config_key"], "layer_kv_policy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -3,15 +3,15 @@
     "description": "Kernel registry generated from v8 kernel maps",
     "version": "v8",
     "generated_by": "ck_run_v8.py",
-    "source_dir": "/home/root/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
+    "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 132,
+      "total": 142,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
-        "attention": 10,
+        "attention": 13,
         "attention_projection": 1,
-        "attention_sliding": 2,
+        "attention_sliding": 4,
         "attn_gate_sigmoid_mul": 1,
         "attn_gate_sigmoid_mul_backward": 1,
         "bias_add": 1,
@@ -19,6 +19,7 @@
         "embedding_backward": 1,
         "feature_concat": 1,
         "feature_slice_copy": 1,
+        "final_logit_softcap": 1,
         "fused_attention_block": 3,
         "fused_linear_bias": 3,
         "fused_mlp_block": 1,
@@ -28,6 +29,8 @@
         "gelu": 3,
         "gemm": 14,
         "gemm_backward": 1,
+        "gemma4_per_layer_embed": 1,
+        "gemma4_per_layer_prepare": 1,
         "gemv": 13,
         "kv_cache_store": 2,
         "layernorm": 2,
@@ -52,7 +55,7 @@
         "residual_add": 1,
         "residual_save": 1,
         "rmsnorm": 2,
-        "rope": 5,
+        "rope": 6,
         "rope_backward": 2,
         "rope_init": 2,
         "rowwise_bias_add": 1,
@@ -65,6 +68,7 @@
         "ssm_conv1d_backward": 1,
         "swiglu": 3,
         "tokenizer": 1,
+        "v_norm": 1,
         "vision_patchify": 1
       }
     }
@@ -643,6 +647,76 @@
       "_source_file": "attention_decode_flash_f16kv.json"
     },
     {
+      "id": "attention_forward_decode_head_major_gqa_flash_gemma4",
+      "op": "attention",
+      "variant": "decode_head_major_gqa_flash_gemma4_noscale",
+      "mode": "decode",
+      "quant": {
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q_token",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "head_dim"
+          ],
+          "desc": "Query for single token [num_heads, head_dim]"
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp32",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ],
+          "desc": "K cache [num_kv_heads, max_seq_len, head_dim]"
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp32",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ],
+          "desc": "V cache [num_kv_heads, max_seq_len, head_dim]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out_token",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "head_dim"
+          ],
+          "desc": "Output for single token [num_heads, head_dim]"
+        }
+      ],
+      "dims": [
+        "num_heads",
+        "num_kv_heads",
+        "kv_tokens",
+        "cache_capacity",
+        "head_dim",
+        "aligned_head_dim"
+      ],
+      "impl": {
+        "function": "attention_forward_decode_head_major_gqa_flash_gemma4",
+        "c_declaration": "void attention_forward_decode_head_major_gqa_flash_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int num_kv_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim);",
+        "sources": [
+          "src/kernels/attention_kernels.c"
+        ]
+      },
+      "notes": "Gemma4 no-scale decode attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+      "name": "attention_forward_decode_head_major_gqa_flash_gemma4",
+      "_source_file": "attention_decode_flash_gemma4.json"
+    },
+    {
       "id": "attention_forward_causal_head_major_gqa_flash_strided",
       "op": "attention",
       "variant": "causal_flash_fp32",
@@ -979,6 +1053,191 @@
       "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_f16kv.json"
     },
     {
+      "id": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+      "op": "attention",
+      "variant": "causal_flash_fp32_gemma4_noscale",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [heads, tokens, head_dim]"
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "runtime_buffers": [
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "Key tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+        },
+        {
+          "name": "v",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "Value tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Attention output [heads, tokens, head_dim]"
+        }
+      ],
+      "scratch": [
+        {
+          "name": "qkv_scratch",
+          "dtype": "fp32",
+          "size_bytes": "H * T * D * 4",
+          "desc": "QKV tiles for flash attention"
+        },
+        {
+          "name": "attn_scratch",
+          "dtype": "fp32",
+          "size_bytes": "H * T * T * 4",
+          "desc": "Attention scores [heads, T, T]"
+        }
+      ],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "S",
+        "D"
+      ],
+      "params": [
+        {
+          "name": "kv_stride_tokens",
+          "dtype": "int32",
+          "desc": "Stride in tokens for KV cache layout"
+        },
+        {
+          "name": "head_dim",
+          "dtype": "int32",
+          "desc": "Head dimension (unpadded)"
+        },
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Aligned head dimension for SIMD"
+        }
+      ],
+      "parallelization": {
+        "supported": [
+          "head"
+        ],
+        "preferred": {
+          "prefill": "head",
+          "decode": "head"
+        },
+        "strategies": [
+          {
+            "name": "head",
+            "partition_dim": "H",
+            "param_style": "ith_nth",
+            "notes": "Parallelize across heads; each thread handles one or more heads."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "D": 64,
+          "T": 32
+        },
+        "notes": "Flash attention uses SIMD paths when available. T should be multiple of 32 for optimal tile sizes."
+      },
+      "impl": {
+        "function": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+        "c_declaration": "void attention_forward_causal_head_major_gqa_flash_strided_gemma4(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+        "sources": [
+          "src/kernels/attention_kernels.c",
+          "src/kernels/softmax_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "avx512",
+            "requires": [
+              "avx512f",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx512f",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx2",
+            "requires": [
+              "avx2",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx2",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx",
+            "requires": [
+              "avx"
+            ],
+            "compile_flags": [
+              "-mavx"
+            ]
+          },
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_attention.py"
+        ],
+        "bench": [
+          "scripts/bench_attention.py"
+        ],
+        "parity": [
+          {
+            "kind": "llamacpp",
+            "command": "python test_mega_fusion_parity.py",
+            "tolerance": "1e-4",
+            "notes": "Compare against llama.cpp ggml_flash_attn_ext"
+          }
+        ]
+      },
+      "notes": "Gemma4 no-scale causal multi-head attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+      "name": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+      "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_gemma4.json"
+    },
+    {
       "id": "attention_forward_causal_head_major_gqa_flash_strided_sliding",
       "op": "attention_sliding",
       "variant": "causal_flash_fp32_sliding",
@@ -1169,6 +1428,196 @@
       "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_sliding.json"
     },
     {
+      "id": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+      "op": "attention_sliding",
+      "variant": "causal_flash_fp32_sliding_gemma4_noscale",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [heads, tokens, head_dim]"
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "runtime_buffers": [
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "Key tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+        },
+        {
+          "name": "v",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "Value tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Attention output [heads, tokens, head_dim]"
+        }
+      ],
+      "scratch": [
+        {
+          "name": "qkv_scratch",
+          "dtype": "fp32",
+          "size_bytes": "H * T * D * 4",
+          "desc": "QKV tiles for flash attention"
+        },
+        {
+          "name": "attn_scratch",
+          "dtype": "fp32",
+          "size_bytes": "H * T * T * 4",
+          "desc": "Attention scores [heads, T, T]"
+        }
+      ],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "S",
+        "D"
+      ],
+      "params": [
+        {
+          "name": "kv_stride_tokens",
+          "dtype": "int32",
+          "desc": "Stride in tokens for KV cache layout"
+        },
+        {
+          "name": "head_dim",
+          "dtype": "int32",
+          "desc": "Head dimension (unpadded)"
+        },
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Aligned head dimension for SIMD"
+        },
+        {
+          "name": "sliding_window",
+          "dtype": "int32",
+          "desc": "Sliding window size (0 = no limit)"
+        }
+      ],
+      "parallelization": {
+        "supported": [
+          "head"
+        ],
+        "preferred": {
+          "prefill": "head",
+          "decode": "head"
+        },
+        "strategies": [
+          {
+            "name": "head",
+            "partition_dim": "H",
+            "param_style": "ith_nth",
+            "notes": "Parallelize across heads; each thread handles one or more heads."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "D": 64,
+          "T": 32
+        },
+        "notes": "Flash attention uses SIMD paths when available. T should be multiple of 32 for optimal tile sizes."
+      },
+      "impl": {
+        "function": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+        "c_declaration": "void attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens, int sliding_window);",
+        "sources": [
+          "src/kernels/attention_kernels_sliding.c",
+          "src/kernels/softmax_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "avx512",
+            "requires": [
+              "avx512f",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx512f",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx2",
+            "requires": [
+              "avx2",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx2",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx",
+            "requires": [
+              "avx"
+            ],
+            "compile_flags": [
+              "-mavx"
+            ]
+          },
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_attention_sliding.py"
+        ],
+        "bench": [
+          "scripts/bench_attention.py"
+        ],
+        "parity": [
+          {
+            "kind": "llamacpp",
+            "command": "python test_mega_fusion_parity.py",
+            "tolerance": "1e-4",
+            "notes": "Compare against llama.cpp ggml_flash_attn_ext with sliding window"
+          }
+        ]
+      },
+      "notes": "Gemma4 no-scale causal sliding-window attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+      "name": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+      "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4.json"
+    },
+    {
       "id": "attention_forward_decode_head_major_gqa_flash_f16cache",
       "op": "attention",
       "variant": "decode_head_major_gqa_flash_f16cache",
@@ -1340,6 +1789,109 @@
       "notes": "Flash attention for decode mode with sliding window: single query token attends to the last W KV cache entries.",
       "name": "attention_forward_decode_head_major_gqa_flash_sliding",
       "_source_file": "attention_forward_decode_head_major_gqa_flash_sliding.json"
+    },
+    {
+      "id": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4",
+      "op": "attention_sliding",
+      "variant": "decode_flash_fp32_sliding_gemma4_noscale",
+      "mode": "decode",
+      "quant": {
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q_token",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "head_dim"
+          ],
+          "desc": "Query for single token [num_heads, head_dim]"
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp32",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ],
+          "desc": "K cache [num_kv_heads, max_seq_len, head_dim]"
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp32",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ],
+          "desc": "V cache [num_kv_heads, max_seq_len, head_dim]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out_token",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "head_dim"
+          ],
+          "desc": "Output for single token [num_heads, head_dim]"
+        }
+      ],
+      "dims": [
+        "num_heads",
+        "num_kv_heads",
+        "kv_tokens",
+        "cache_capacity",
+        "head_dim",
+        "aligned_head_dim"
+      ],
+      "params": [
+        {
+          "name": "head_dim",
+          "dtype": "int32",
+          "desc": "Head dimension (unpadded)"
+        },
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Aligned head dimension for SIMD"
+        },
+        {
+          "name": "sliding_window",
+          "dtype": "int32",
+          "desc": "Sliding window size (0 = no limit)"
+        }
+      ],
+      "impl": {
+        "function": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4",
+        "c_declaration": "void attention_forward_decode_head_major_gqa_flash_sliding_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int num_kv_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim, int sliding_window);",
+        "sources": [
+          "src/kernels/attention_kernels_sliding.c"
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_attention_sliding.py"
+        ],
+        "bench": [
+          "scripts/bench_attention.py"
+        ],
+        "parity": [
+          {
+            "kind": "llamacpp",
+            "command": "python test_mega_fusion_parity.py",
+            "tolerance": "1e-4",
+            "notes": "Compare against llama.cpp with sliding window"
+          }
+        ]
+      },
+      "notes": "Gemma4 no-scale decode sliding-window attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+      "name": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4",
+      "_source_file": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4.json"
     },
     {
       "id": "attention_forward_decode_head_major_gqa_regular",
@@ -1746,6 +2298,182 @@
       "notes": "Full / bidirectional multi-head attention with GQA support. Intended for encoder-style prefill where every token attends to the full sequence.",
       "name": "attention_forward_full_head_major_gqa_flash_strided",
       "_source_file": "attention_forward_full_head_major_gqa_flash_strided.json"
+    },
+    {
+      "id": "attention_forward_full_head_major_gqa_flash_strided_gemma4",
+      "op": "attention",
+      "variant": "full_flash_fp32_gemma4_noscale",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [heads, tokens, head_dim]"
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "runtime_buffers": [
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "Key tensor [kv_heads, seq_len, head_dim], strided layout"
+        },
+        {
+          "name": "v",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "Value tensor [kv_heads, seq_len, head_dim], strided layout"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Attention output [heads, tokens, head_dim]"
+        }
+      ],
+      "scratch": [
+        {
+          "name": "qkv_scratch",
+          "dtype": "fp32",
+          "size_bytes": "H * T * D * 4",
+          "desc": "QKV tiles for flash attention"
+        },
+        {
+          "name": "attn_scratch",
+          "dtype": "fp32",
+          "size_bytes": "H * T * T * 4",
+          "desc": "Attention scores [heads, T, T]"
+        }
+      ],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "S",
+        "D"
+      ],
+      "params": [
+        {
+          "name": "kv_stride_tokens",
+          "dtype": "int32",
+          "desc": "Stride in tokens for KV layout"
+        },
+        {
+          "name": "head_dim",
+          "dtype": "int32",
+          "desc": "Head dimension (unpadded)"
+        },
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Aligned head dimension for SIMD"
+        }
+      ],
+      "parallelization": {
+        "supported": [
+          "head"
+        ],
+        "preferred": {
+          "prefill": "head"
+        },
+        "strategies": [
+          {
+            "name": "head",
+            "partition_dim": "H",
+            "param_style": "ith_nth",
+            "notes": "Parallelize across heads; each thread handles one or more heads."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "D": 64,
+          "T": 32
+        },
+        "notes": "Flash attention uses SIMD paths when available. This variant is full / bidirectional and applies no causal mask."
+      },
+      "impl": {
+        "function": "attention_forward_full_head_major_gqa_flash_strided_gemma4",
+        "c_declaration": "void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+        "sources": [
+          "src/kernels/attention_kernels.c",
+          "src/kernels/softmax_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "avx512",
+            "requires": [
+              "avx512f",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx512f",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx2",
+            "requires": [
+              "avx2",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx2",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx",
+            "requires": [
+              "avx"
+            ],
+            "compile_flags": [
+              "-mavx"
+            ]
+          },
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_attention_full.py"
+        ],
+        "bench": [
+          "unittest/test_attention.py"
+        ]
+      },
+      "notes": "Gemma4 no-scale full multi-head attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+      "name": "attention_forward_full_head_major_gqa_flash_strided_gemma4",
+      "_source_file": "attention_forward_full_head_major_gqa_flash_strided_gemma4.json"
     },
     {
       "id": "attention_forward_full_head_major_gqa_ggml_strided",
@@ -6043,6 +6771,267 @@
       "notes": "Opt-in contract path: internally quantizes FP32 activations to Q8_0 before compute.",
       "name": "gemm_nt_q8_0_q8_0_contract",
       "_source_file": "gemm_nt_q8_0_q8_0_contract.json"
+    },
+    {
+      "id": "gemma4_final_logit_softcap_forward",
+      "op": "final_logit_softcap",
+      "variant": "gemma4_scalar_correctness",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "logits",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "V"
+          ],
+          "desc": "Logits buffer updated in-place"
+        }
+      ],
+      "weights": [],
+      "outputs": [
+        {
+          "name": "logits",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "V"
+          ],
+          "desc": "Softcapped logits"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "seq_len",
+        "vocab_size"
+      ],
+      "params": [
+        {
+          "name": "cap",
+          "dtype": "float32",
+          "desc": "Softcap value; <=0 disables"
+        }
+      ],
+      "impl": {
+        "function": "gemma4_final_logit_softcap_forward",
+        "c_declaration": "void gemma4_final_logit_softcap_forward(float *logits, int tokens, int vocab_size, float cap);",
+        "sources": [
+          "src/kernels/gemma4_per_layer_embed.c"
+        ]
+      },
+      "notes": "Gemma4 final logit softcapping matching llama.cpp: tanh(logit / cap) * cap.",
+      "name": "gemma4_final_logit_softcap_forward",
+      "_source_file": "gemma4_final_logit_softcap_forward.json"
+    },
+    {
+      "id": "gemma4_per_layer_embed_forward",
+      "op": "gemma4_per_layer_embed",
+      "variant": "gemma4_scalar_correctness",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Main hidden stream, updated in-place"
+        },
+        {
+          "name": "per_layer_input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "L",
+            "P"
+          ],
+          "desc": "Prepared Gemma4 per-layer input stream"
+        }
+      ],
+      "weights": [
+        {
+          "name": "inp_gate",
+          "dtype": "fp32",
+          "shape": [
+            "P",
+            "E"
+          ],
+          "desc": "Layer input gate projection"
+        },
+        {
+          "name": "proj",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "P"
+          ],
+          "desc": "Layer projection back to model stream"
+        },
+        {
+          "name": "post_norm",
+          "dtype": "fp32",
+          "shape": [
+            "E"
+          ],
+          "desc": "Layer post projection RMSNorm scale"
+        },
+        {
+          "name": "out_scale",
+          "dtype": "fp32",
+          "shape": [
+            1
+          ],
+          "desc": "Optional Gemma4 layer output scale"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Updated hidden stream"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "seq_len",
+        "num_layers",
+        "embed_dim",
+        "per_layer_dim"
+      ],
+      "params": [
+        {
+          "name": "eps",
+          "dtype": "float32",
+          "desc": "RMSNorm epsilon"
+        }
+      ],
+      "impl": {
+        "function": "gemma4_per_layer_embed_forward",
+        "c_declaration": "void gemma4_per_layer_embed_forward(float *hidden, const float *per_layer_input, const float *inp_gate, const float *proj, const float *post_norm, const float *out_scale, int tokens, int layer, int num_layers, int embed_dim, int per_layer_dim, float eps);",
+        "sources": [
+          "src/kernels/gemma4_per_layer_embed.c"
+        ]
+      },
+      "notes": "First-pass correctness implementation of llama.cpp Gemma4 per-layer embedding branch.",
+      "name": "gemma4_per_layer_embed_forward",
+      "_source_file": "gemma4_per_layer_embed_forward.json"
+    },
+    {
+      "id": "gemma4_per_layer_prepare_forward",
+      "op": "gemma4_per_layer_prepare",
+      "variant": "gemma4_scalar_correctness",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "q5_k",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ]
+        },
+        {
+          "name": "tokens",
+          "dtype": "i32",
+          "shape": [
+            "T"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "per_layer_token_emb",
+          "dtype": "q5_k",
+          "shape": [
+            "V",
+            "L",
+            "P"
+          ]
+        },
+        {
+          "name": "per_layer_model_proj",
+          "dtype": "bf16",
+          "shape": [
+            "L",
+            "P",
+            "E"
+          ]
+        },
+        {
+          "name": "per_layer_proj_norm",
+          "dtype": "fp32",
+          "shape": [
+            "P"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "per_layer_input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "L",
+            "P"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "seq_len",
+        "num_layers",
+        "embed_dim",
+        "per_layer_dim",
+        "vocab_size"
+      ],
+      "params": [
+        {
+          "name": "eps",
+          "dtype": "float32"
+        }
+      ],
+      "impl": {
+        "function": "gemma4_per_layer_prepare_forward",
+        "c_declaration": "void gemma4_per_layer_prepare_forward(float *per_layer_input, const float *hidden, const int32_t *token_ids, const void *per_layer_token_emb, const uint16_t *per_layer_model_proj, const float *per_layer_proj_norm, int tokens, int num_layers, int embed_dim, int per_layer_dim, int vocab_size, float eps);",
+        "sources": [
+          "src/kernels/gemma4_per_layer_embed.c"
+        ]
+      },
+      "notes": "Prepare Gemma4 per-layer input stream once from original token embedding stream.",
+      "name": "gemma4_per_layer_prepare_forward",
+      "_source_file": "gemma4_per_layer_prepare_forward.json"
     },
     {
       "id": "gemv_fused_q5_0_bias",
@@ -12585,6 +13574,59 @@
       "_source_file": "rmsnorm_forward.json"
     },
     {
+      "id": "v_norm",
+      "op": "v_norm",
+      "variant": "fp32_no_gamma",
+      "quant": {
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "D"
+          ],
+          "desc": "Input [tokens, dim]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "D"
+          ],
+          "desc": "RMS-normalized output without learned scale"
+        }
+      ],
+      "dims": [
+        "tokens",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "params": [
+        {
+          "name": "eps",
+          "dtype": "float",
+          "default": 1e-06
+        }
+      ],
+      "impl": {
+        "function": "gemma4_v_norm_forward",
+        "c_declaration": "void gemma4_v_norm_forward(const float *input, float *output, float *rstd_cache, int tokens, int num_kv_heads, int head_dim, float eps);",
+        "sources": [
+          "src/kernels/rmsnorm_kernels.c"
+        ]
+      },
+      "notes": "Gemma4 V RMSNorm without gamma. Normalizes each [head_dim] V head independently, matching llama.cpp ggml_rms_norm after reshape.",
+      "name": "v_norm",
+      "_source_file": "rmsnorm_no_weight.json"
+    },
+    {
       "id": "rope_backward_qk_f32",
       "op": "rope_backward",
       "variant": "fp32_qk",
@@ -13064,6 +14106,208 @@
       "notes": "Rotary Position Embedding (RoPE) for queries and keys. Applies rotation in complex plane: x_rot = x * cos(theta) + rotate_half(x) * sin(theta). Only rotates first rotary_dim channels; remaining channels pass through unchanged.",
       "name": "rope_forward_qk",
       "_source_file": "rope_forward_qk.json"
+    },
+    {
+      "id": "rope_forward_qk_gemma4",
+      "op": "rope",
+      "variant": "fp32_head_major",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [heads, tokens, head_dim] to be rotated in-place"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ],
+          "desc": "Key tensor [kv_heads, tokens, head_dim] to be rotated in-place"
+        }
+      ],
+      "weights": [
+        {
+          "name": "rope_freqs",
+          "dtype": "fp32",
+          "shape": [
+            "rotary_dim/2"
+          ],
+          "desc": "Gemma4 full-attention proportional RoPE frequency factors; ignored for sliding layers"
+        }
+      ],
+      "activations": [],
+      "runtime_buffers": [
+        {
+          "name": "cos_cache",
+          "dtype": "fp32",
+          "shape": [
+            "max_T",
+            "rotary_dim",
+            2
+          ],
+          "desc": "RoPE cos cache [max_seq, rotary_dim/2]"
+        },
+        {
+          "name": "sin_cache",
+          "dtype": "fp32",
+          "shape": [
+            "max_T",
+            "rotary_dim",
+            2
+          ],
+          "desc": "RoPE sin cache [max_seq, rotary_dim/2]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor after RoPE application (in-place)"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ],
+          "desc": "Key tensor after RoPE application (in-place)"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "D",
+        "rotary_dim"
+      ],
+      "params": [
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Aligned head dimension for SIMD"
+        },
+        {
+          "name": "pos_offset",
+          "dtype": "int32",
+          "desc": "Position offset for cos/sin cache lookup"
+        },
+        {
+          "name": "rotary_dim",
+          "dtype": "int32",
+          "desc": "RoPE rotary dimensions (only rotate first rotary_dim channels)"
+        },
+        {
+          "name": "cache_rotary_dim",
+          "dtype": "int32",
+          "source": "dim:max_rotary_dim",
+          "desc": "RoPE cache row width for mixed Gemma4 rotary dimensions"
+        }
+      ],
+      "parallelization": {
+        "supported": [
+          "head",
+          "token"
+        ],
+        "preferred": {
+          "prefill": "head",
+          "decode": "head"
+        },
+        "strategies": [
+          {
+            "name": "head",
+            "partition_dim": "H",
+            "param_style": "ith_nth",
+            "notes": "Parallelize across heads; each thread handles one or more heads."
+          },
+          {
+            "name": "token",
+            "partition_dim": "T",
+            "param_style": "ith_nth",
+            "notes": "Parallelize across tokens; each thread handles one or more tokens."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "D": 64,
+          "T": 32
+        },
+        "notes": "D should be multiple of 64 for optimal SIMD. D is the unpadded dimension; AD is used for alignment."
+      },
+      "impl": {
+        "function": "rope_forward_qk_gemma4_direct",
+        "c_declaration": "void rope_forward_qk_gemma4_direct(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+        "sources": [
+          "src/kernels/rope_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "avx512",
+            "requires": [
+              "avx512f",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx512f",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx",
+            "requires": [
+              "avx"
+            ],
+            "compile_flags": [
+              "-mavx"
+            ]
+          },
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_rope.py"
+        ],
+        "bench": [
+          "scripts/bench_rope.py"
+        ],
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": "python unittest/test_rope.py --compare-numpy",
+            "tolerance": "1e-5",
+            "notes": "Verify RoPE rotation matches numpy reference"
+          }
+        ]
+      },
+      "notes": "Rotary Position Embedding (RoPE) for queries and keys. Applies rotation in complex plane: x_rot = x * cos(theta) + rotate_half(x) * sin(theta). Only rotates first rotary_dim channels; remaining channels pass through unchanged. Gemma4 variant uses max_rotary_dim as cache row stride so sliding/full layers can share one RoPE cache.",
+      "name": "rope_forward_qk_gemma4",
+      "_source_file": "rope_forward_qk_gemma4.json"
     },
     {
       "id": "rope_forward_qk_pairwise",

--- a/version/v8/kernel_maps/attention_decode_flash_gemma4.json
+++ b/version/v8/kernel_maps/attention_decode_flash_gemma4.json
@@ -1,0 +1,70 @@
+{
+  "id": "attention_forward_decode_head_major_gqa_flash_gemma4",
+  "op": "attention",
+  "variant": "decode_head_major_gqa_flash_gemma4_noscale",
+  "mode": "decode",
+  "quant": {
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q_token",
+      "dtype": "fp32",
+      "shape": [
+        "num_heads",
+        "head_dim"
+      ],
+      "desc": "Query for single token [num_heads, head_dim]"
+    },
+    {
+      "name": "k_cache",
+      "dtype": "fp32",
+      "shape": [
+        "num_kv_heads",
+        "cache_capacity",
+        "head_dim"
+      ],
+      "desc": "K cache [num_kv_heads, max_seq_len, head_dim]"
+    },
+    {
+      "name": "v_cache",
+      "dtype": "fp32",
+      "shape": [
+        "num_kv_heads",
+        "cache_capacity",
+        "head_dim"
+      ],
+      "desc": "V cache [num_kv_heads, max_seq_len, head_dim]"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out_token",
+      "dtype": "fp32",
+      "shape": [
+        "num_heads",
+        "head_dim"
+      ],
+      "desc": "Output for single token [num_heads, head_dim]"
+    }
+  ],
+  "dims": [
+    "num_heads",
+    "num_kv_heads",
+    "kv_tokens",
+    "cache_capacity",
+    "head_dim",
+    "aligned_head_dim"
+  ],
+  "impl": {
+    "function": "attention_forward_decode_head_major_gqa_flash_gemma4",
+    "c_declaration": "void attention_forward_decode_head_major_gqa_flash_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int num_kv_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim);",
+    "sources": [
+      "src/kernels/attention_kernels.c"
+    ]
+  },
+  "notes": "Gemma4 no-scale decode attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+  "name": "attention_forward_decode_head_major_gqa_flash_gemma4",
+  "_source_file": "attention_decode_flash_gemma4.json"
+}

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_gemma4.json
@@ -1,0 +1,185 @@
+{
+  "id": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+  "op": "attention",
+  "variant": "causal_flash_fp32_gemma4_noscale",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor [heads, tokens, head_dim]"
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "runtime_buffers": [
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "S",
+        "D"
+      ],
+      "desc": "Key tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+    },
+    {
+      "name": "v",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "S",
+        "D"
+      ],
+      "desc": "Value tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Attention output [heads, tokens, head_dim]"
+    }
+  ],
+  "scratch": [
+    {
+      "name": "qkv_scratch",
+      "dtype": "fp32",
+      "size_bytes": "H * T * D * 4",
+      "desc": "QKV tiles for flash attention"
+    },
+    {
+      "name": "attn_scratch",
+      "dtype": "fp32",
+      "size_bytes": "H * T * T * 4",
+      "desc": "Attention scores [heads, T, T]"
+    }
+  ],
+  "dims": [
+    "H",
+    "KV",
+    "T",
+    "S",
+    "D"
+  ],
+  "params": [
+    {
+      "name": "kv_stride_tokens",
+      "dtype": "int32",
+      "desc": "Stride in tokens for KV cache layout"
+    },
+    {
+      "name": "head_dim",
+      "dtype": "int32",
+      "desc": "Head dimension (unpadded)"
+    },
+    {
+      "name": "aligned_head_dim",
+      "dtype": "int32",
+      "desc": "Aligned head dimension for SIMD"
+    }
+  ],
+  "parallelization": {
+    "supported": [
+      "head"
+    ],
+    "preferred": {
+      "prefill": "head",
+      "decode": "head"
+    },
+    "strategies": [
+      {
+        "name": "head",
+        "partition_dim": "H",
+        "param_style": "ith_nth",
+        "notes": "Parallelize across heads; each thread handles one or more heads."
+      }
+    ]
+  },
+  "constraints": {
+    "alignment": {
+      "D": 64,
+      "T": 32
+    },
+    "notes": "Flash attention uses SIMD paths when available. T should be multiple of 32 for optimal tile sizes."
+  },
+  "impl": {
+    "function": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+    "c_declaration": "void attention_forward_causal_head_major_gqa_flash_strided_gemma4(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+    "sources": [
+      "src/kernels/attention_kernels.c",
+      "src/kernels/softmax_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "avx512",
+        "requires": [
+          "avx512f",
+          "fma"
+        ],
+        "compile_flags": [
+          "-mavx512f",
+          "-mfma"
+        ]
+      },
+      {
+        "name": "avx2",
+        "requires": [
+          "avx2",
+          "fma"
+        ],
+        "compile_flags": [
+          "-mavx2",
+          "-mfma"
+        ]
+      },
+      {
+        "name": "avx",
+        "requires": [
+          "avx"
+        ],
+        "compile_flags": [
+          "-mavx"
+        ]
+      },
+      {
+        "name": "ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_attention.py"
+    ],
+    "bench": [
+      "scripts/bench_attention.py"
+    ],
+    "parity": [
+      {
+        "kind": "llamacpp",
+        "command": "python test_mega_fusion_parity.py",
+        "tolerance": "1e-4",
+        "notes": "Compare against llama.cpp ggml_flash_attn_ext"
+      }
+    ]
+  },
+  "notes": "Gemma4 no-scale causal multi-head attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+  "name": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+  "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_gemma4.json"
+}

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4.json
@@ -1,0 +1,190 @@
+{
+  "id": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+  "op": "attention_sliding",
+  "variant": "causal_flash_fp32_sliding_gemma4_noscale",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor [heads, tokens, head_dim]"
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "runtime_buffers": [
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "S",
+        "D"
+      ],
+      "desc": "Key tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+    },
+    {
+      "name": "v",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "S",
+        "D"
+      ],
+      "desc": "Value tensor [kv_heads, seq_len, head_dim], strided layout (KV cache)"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Attention output [heads, tokens, head_dim]"
+    }
+  ],
+  "scratch": [
+    {
+      "name": "qkv_scratch",
+      "dtype": "fp32",
+      "size_bytes": "H * T * D * 4",
+      "desc": "QKV tiles for flash attention"
+    },
+    {
+      "name": "attn_scratch",
+      "dtype": "fp32",
+      "size_bytes": "H * T * T * 4",
+      "desc": "Attention scores [heads, T, T]"
+    }
+  ],
+  "dims": [
+    "H",
+    "KV",
+    "T",
+    "S",
+    "D"
+  ],
+  "params": [
+    {
+      "name": "kv_stride_tokens",
+      "dtype": "int32",
+      "desc": "Stride in tokens for KV cache layout"
+    },
+    {
+      "name": "head_dim",
+      "dtype": "int32",
+      "desc": "Head dimension (unpadded)"
+    },
+    {
+      "name": "aligned_head_dim",
+      "dtype": "int32",
+      "desc": "Aligned head dimension for SIMD"
+    },
+    {
+      "name": "sliding_window",
+      "dtype": "int32",
+      "desc": "Sliding window size (0 = no limit)"
+    }
+  ],
+  "parallelization": {
+    "supported": [
+      "head"
+    ],
+    "preferred": {
+      "prefill": "head",
+      "decode": "head"
+    },
+    "strategies": [
+      {
+        "name": "head",
+        "partition_dim": "H",
+        "param_style": "ith_nth",
+        "notes": "Parallelize across heads; each thread handles one or more heads."
+      }
+    ]
+  },
+  "constraints": {
+    "alignment": {
+      "D": 64,
+      "T": 32
+    },
+    "notes": "Flash attention uses SIMD paths when available. T should be multiple of 32 for optimal tile sizes."
+  },
+  "impl": {
+    "function": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+    "c_declaration": "void attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens, int sliding_window);",
+    "sources": [
+      "src/kernels/attention_kernels_sliding.c",
+      "src/kernels/softmax_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "avx512",
+        "requires": [
+          "avx512f",
+          "fma"
+        ],
+        "compile_flags": [
+          "-mavx512f",
+          "-mfma"
+        ]
+      },
+      {
+        "name": "avx2",
+        "requires": [
+          "avx2",
+          "fma"
+        ],
+        "compile_flags": [
+          "-mavx2",
+          "-mfma"
+        ]
+      },
+      {
+        "name": "avx",
+        "requires": [
+          "avx"
+        ],
+        "compile_flags": [
+          "-mavx"
+        ]
+      },
+      {
+        "name": "ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_attention_sliding.py"
+    ],
+    "bench": [
+      "scripts/bench_attention.py"
+    ],
+    "parity": [
+      {
+        "kind": "llamacpp",
+        "command": "python test_mega_fusion_parity.py",
+        "tolerance": "1e-4",
+        "notes": "Compare against llama.cpp ggml_flash_attn_ext with sliding window"
+      }
+    ]
+  },
+  "notes": "Gemma4 no-scale causal sliding-window attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+  "name": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+  "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4.json"
+}

--- a/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_sliding_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_sliding_gemma4.json
@@ -1,0 +1,103 @@
+{
+  "id": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4",
+  "op": "attention_sliding",
+  "variant": "decode_flash_fp32_sliding_gemma4_noscale",
+  "mode": "decode",
+  "quant": {
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q_token",
+      "dtype": "fp32",
+      "shape": [
+        "num_heads",
+        "head_dim"
+      ],
+      "desc": "Query for single token [num_heads, head_dim]"
+    },
+    {
+      "name": "k_cache",
+      "dtype": "fp32",
+      "shape": [
+        "num_kv_heads",
+        "cache_capacity",
+        "head_dim"
+      ],
+      "desc": "K cache [num_kv_heads, max_seq_len, head_dim]"
+    },
+    {
+      "name": "v_cache",
+      "dtype": "fp32",
+      "shape": [
+        "num_kv_heads",
+        "cache_capacity",
+        "head_dim"
+      ],
+      "desc": "V cache [num_kv_heads, max_seq_len, head_dim]"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out_token",
+      "dtype": "fp32",
+      "shape": [
+        "num_heads",
+        "head_dim"
+      ],
+      "desc": "Output for single token [num_heads, head_dim]"
+    }
+  ],
+  "dims": [
+    "num_heads",
+    "num_kv_heads",
+    "kv_tokens",
+    "cache_capacity",
+    "head_dim",
+    "aligned_head_dim"
+  ],
+  "params": [
+    {
+      "name": "head_dim",
+      "dtype": "int32",
+      "desc": "Head dimension (unpadded)"
+    },
+    {
+      "name": "aligned_head_dim",
+      "dtype": "int32",
+      "desc": "Aligned head dimension for SIMD"
+    },
+    {
+      "name": "sliding_window",
+      "dtype": "int32",
+      "desc": "Sliding window size (0 = no limit)"
+    }
+  ],
+  "impl": {
+    "function": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4",
+    "c_declaration": "void attention_forward_decode_head_major_gqa_flash_sliding_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int num_kv_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim, int sliding_window);",
+    "sources": [
+      "src/kernels/attention_kernels_sliding.c"
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_attention_sliding.py"
+    ],
+    "bench": [
+      "scripts/bench_attention.py"
+    ],
+    "parity": [
+      {
+        "kind": "llamacpp",
+        "command": "python test_mega_fusion_parity.py",
+        "tolerance": "1e-4",
+        "notes": "Compare against llama.cpp with sliding window"
+      }
+    ]
+  },
+  "notes": "Gemma4 no-scale decode sliding-window attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+  "name": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4",
+  "_source_file": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4.json"
+}

--- a/version/v8/kernel_maps/attention_forward_full_head_major_gqa_flash_strided_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_full_head_major_gqa_flash_strided_gemma4.json
@@ -1,0 +1,176 @@
+{
+  "id": "attention_forward_full_head_major_gqa_flash_strided_gemma4",
+  "op": "attention",
+  "variant": "full_flash_fp32_gemma4_noscale",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor [heads, tokens, head_dim]"
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "runtime_buffers": [
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "S",
+        "D"
+      ],
+      "desc": "Key tensor [kv_heads, seq_len, head_dim], strided layout"
+    },
+    {
+      "name": "v",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "S",
+        "D"
+      ],
+      "desc": "Value tensor [kv_heads, seq_len, head_dim], strided layout"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Attention output [heads, tokens, head_dim]"
+    }
+  ],
+  "scratch": [
+    {
+      "name": "qkv_scratch",
+      "dtype": "fp32",
+      "size_bytes": "H * T * D * 4",
+      "desc": "QKV tiles for flash attention"
+    },
+    {
+      "name": "attn_scratch",
+      "dtype": "fp32",
+      "size_bytes": "H * T * T * 4",
+      "desc": "Attention scores [heads, T, T]"
+    }
+  ],
+  "dims": [
+    "H",
+    "KV",
+    "T",
+    "S",
+    "D"
+  ],
+  "params": [
+    {
+      "name": "kv_stride_tokens",
+      "dtype": "int32",
+      "desc": "Stride in tokens for KV layout"
+    },
+    {
+      "name": "head_dim",
+      "dtype": "int32",
+      "desc": "Head dimension (unpadded)"
+    },
+    {
+      "name": "aligned_head_dim",
+      "dtype": "int32",
+      "desc": "Aligned head dimension for SIMD"
+    }
+  ],
+  "parallelization": {
+    "supported": [
+      "head"
+    ],
+    "preferred": {
+      "prefill": "head"
+    },
+    "strategies": [
+      {
+        "name": "head",
+        "partition_dim": "H",
+        "param_style": "ith_nth",
+        "notes": "Parallelize across heads; each thread handles one or more heads."
+      }
+    ]
+  },
+  "constraints": {
+    "alignment": {
+      "D": 64,
+      "T": 32
+    },
+    "notes": "Flash attention uses SIMD paths when available. This variant is full / bidirectional and applies no causal mask."
+  },
+  "impl": {
+    "function": "attention_forward_full_head_major_gqa_flash_strided_gemma4",
+    "c_declaration": "void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+    "sources": [
+      "src/kernels/attention_kernels.c",
+      "src/kernels/softmax_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "avx512",
+        "requires": [
+          "avx512f",
+          "fma"
+        ],
+        "compile_flags": [
+          "-mavx512f",
+          "-mfma"
+        ]
+      },
+      {
+        "name": "avx2",
+        "requires": [
+          "avx2",
+          "fma"
+        ],
+        "compile_flags": [
+          "-mavx2",
+          "-mfma"
+        ]
+      },
+      {
+        "name": "avx",
+        "requires": [
+          "avx"
+        ],
+        "compile_flags": [
+          "-mavx"
+        ]
+      },
+      {
+        "name": "ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_attention_full.py"
+    ],
+    "bench": [
+      "unittest/test_attention.py"
+    ]
+  },
+  "notes": "Gemma4 no-scale full multi-head attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
+  "name": "attention_forward_full_head_major_gqa_flash_strided_gemma4",
+  "_source_file": "attention_forward_full_head_major_gqa_flash_strided_gemma4.json"
+}

--- a/version/v8/kernel_maps/gemma4_final_logit_softcap_forward.json
+++ b/version/v8/kernel_maps/gemma4_final_logit_softcap_forward.json
@@ -1,0 +1,58 @@
+{
+  "id": "gemma4_final_logit_softcap_forward",
+  "op": "final_logit_softcap",
+  "variant": "gemma4_scalar_correctness",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "logits",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "V"
+      ],
+      "desc": "Logits buffer updated in-place"
+    }
+  ],
+  "weights": [],
+  "outputs": [
+    {
+      "name": "logits",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "V"
+      ],
+      "desc": "Softcapped logits"
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "seq_len",
+    "vocab_size"
+  ],
+  "params": [
+    {
+      "name": "cap",
+      "dtype": "float32",
+      "desc": "Softcap value; <=0 disables"
+    }
+  ],
+  "impl": {
+    "function": "gemma4_final_logit_softcap_forward",
+    "c_declaration": "void gemma4_final_logit_softcap_forward(float *logits, int tokens, int vocab_size, float cap);",
+    "sources": [
+      "src/kernels/gemma4_per_layer_embed.c"
+    ]
+  },
+  "notes": "Gemma4 final logit softcapping matching llama.cpp: tanh(logit / cap) * cap."
+}

--- a/version/v8/kernel_maps/gemma4_per_layer_embed_forward.json
+++ b/version/v8/kernel_maps/gemma4_per_layer_embed_forward.json
@@ -1,0 +1,105 @@
+{
+  "id": "gemma4_per_layer_embed_forward",
+  "op": "gemma4_per_layer_embed",
+  "variant": "gemma4_scalar_correctness",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Main hidden stream, updated in-place"
+    },
+    {
+      "name": "per_layer_input",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "L",
+        "P"
+      ],
+      "desc": "Prepared Gemma4 per-layer input stream"
+    }
+  ],
+  "weights": [
+    {
+      "name": "inp_gate",
+      "dtype": "fp32",
+      "shape": [
+        "P",
+        "E"
+      ],
+      "desc": "Layer input gate projection"
+    },
+    {
+      "name": "proj",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "P"
+      ],
+      "desc": "Layer projection back to model stream"
+    },
+    {
+      "name": "post_norm",
+      "dtype": "fp32",
+      "shape": [
+        "E"
+      ],
+      "desc": "Layer post projection RMSNorm scale"
+    },
+    {
+      "name": "out_scale",
+      "dtype": "fp32",
+      "shape": [
+        1
+      ],
+      "desc": "Optional Gemma4 layer output scale"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Updated hidden stream"
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "seq_len",
+    "num_layers",
+    "embed_dim",
+    "per_layer_dim"
+  ],
+  "params": [
+    {
+      "name": "eps",
+      "dtype": "float32",
+      "desc": "RMSNorm epsilon"
+    }
+  ],
+  "impl": {
+    "function": "gemma4_per_layer_embed_forward",
+    "c_declaration": "void gemma4_per_layer_embed_forward(float *hidden, const float *per_layer_input, const float *inp_gate, const float *proj, const float *post_norm, const float *out_scale, int tokens, int layer, int num_layers, int embed_dim, int per_layer_dim, float eps);",
+    "sources": [
+      "src/kernels/gemma4_per_layer_embed.c"
+    ]
+  },
+  "notes": "First-pass correctness implementation of llama.cpp Gemma4 per-layer embedding branch."
+}

--- a/version/v8/kernel_maps/gemma4_per_layer_prepare_forward.json
+++ b/version/v8/kernel_maps/gemma4_per_layer_prepare_forward.json
@@ -1,0 +1,92 @@
+{
+  "id": "gemma4_per_layer_prepare_forward",
+  "op": "gemma4_per_layer_prepare",
+  "variant": "gemma4_scalar_correctness",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "q5_k",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ]
+    },
+    {
+      "name": "tokens",
+      "dtype": "i32",
+      "shape": [
+        "T"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "per_layer_token_emb",
+      "dtype": "q5_k",
+      "shape": [
+        "V",
+        "L",
+        "P"
+      ]
+    },
+    {
+      "name": "per_layer_model_proj",
+      "dtype": "bf16",
+      "shape": [
+        "L",
+        "P",
+        "E"
+      ]
+    },
+    {
+      "name": "per_layer_proj_norm",
+      "dtype": "fp32",
+      "shape": [
+        "P"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "per_layer_input",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "L",
+        "P"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "seq_len",
+    "num_layers",
+    "embed_dim",
+    "per_layer_dim",
+    "vocab_size"
+  ],
+  "params": [
+    {
+      "name": "eps",
+      "dtype": "float32"
+    }
+  ],
+  "impl": {
+    "function": "gemma4_per_layer_prepare_forward",
+    "c_declaration": "void gemma4_per_layer_prepare_forward(float *per_layer_input, const float *hidden, const int32_t *token_ids, const void *per_layer_token_emb, const uint16_t *per_layer_model_proj, const float *per_layer_proj_norm, int tokens, int num_layers, int embed_dim, int per_layer_dim, int vocab_size, float eps);",
+    "sources": [
+      "src/kernels/gemma4_per_layer_embed.c"
+    ]
+  },
+  "notes": "Prepare Gemma4 per-layer input stream once from original token embedding stream."
+}

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -117,6 +117,7 @@
             "ln2_gamma",
             "post_attention_norm",
             "post_ffn_norm",
+            "v_norm_gamma",
             "final_ln_weight"
           ]
         },
@@ -1098,6 +1099,517 @@
         {
           "name": "aligned_head_dim",
           "source": "dim:head_dim"
+        }
+      ]
+    },
+    "gemma4_per_layer_embed_forward": {
+      "note": "Apply Gemma4 per-layer residual branch using prepared per-layer input stream.",
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "float*"
+        },
+        {
+          "name": "per_layer_input",
+          "source": "activation:per_layer_input",
+          "cast": "const float*"
+        },
+        {
+          "name": "inp_gate",
+          "source": "weight_f:per_layer_inp_gate"
+        },
+        {
+          "name": "proj",
+          "source": "weight_f:per_layer_proj"
+        },
+        {
+          "name": "post_norm",
+          "source": "weight_f:per_layer_post_norm"
+        },
+        {
+          "name": "out_scale",
+          "source": "weight_f:layer_output_scale"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "layer",
+          "source": "runtime:layer"
+        },
+        {
+          "name": "num_layers",
+          "source": "dim:num_layers"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "per_layer_dim",
+          "source": "dim:per_layer_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "gemma4_per_layer_prepare_forward": {
+      "note": "Prepare Gemma4 per-layer input stream from original embeddings.",
+      "params": [
+        {
+          "name": "per_layer_input",
+          "source": "output:per_layer_input",
+          "cast": "float*"
+        },
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "token_ids",
+          "source": "activation:tokens",
+          "cast": "const int32_t*"
+        },
+        {
+          "name": "per_layer_token_emb",
+          "source": "weight:per_layer_token_emb"
+        },
+        {
+          "name": "per_layer_model_proj",
+          "source": "weight:per_layer_model_proj",
+          "cast": "const uint16_t*"
+        },
+        {
+          "name": "per_layer_proj_norm",
+          "source": "weight_f:per_layer_proj_norm"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "num_layers",
+          "source": "dim:num_layers"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "per_layer_dim",
+          "source": "dim:per_layer_dim"
+        },
+        {
+          "name": "vocab_size",
+          "source": "dim:vocab_size"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "gemma4_final_logit_softcap_forward": {
+      "note": "Apply Gemma4 final logit softcapping in-place: tanh(logit / cap) * cap.",
+      "params": [
+        {
+          "name": "logits",
+          "source": "activation:logits",
+          "cast": "float*"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "vocab_size",
+          "source": "dim:vocab_size"
+        },
+        {
+          "name": "cap",
+          "source": "dim:final_logit_softcapping"
+        }
+      ]
+    },
+    "attention_forward_causal_head_major_gqa_flash_strided_gemma4": {
+      "note": "Prefill: all tokens process together with causal mask Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "name": "q",
+          "source": "scratch:q_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "v",
+          "source": "scratch:v_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "output",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        }
+      ]
+    },
+    "attention_forward_full_head_major_gqa_flash_strided_gemma4": {
+      "note": "Prefill: full / bidirectional attention across the entire sequence Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "name": "q",
+          "source": "scratch:q_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "v",
+          "source": "scratch:v_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "output",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        }
+      ]
+    },
+    "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4": {
+      "note": "Prefill: sliding window attention with causal mask Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "name": "q",
+          "source": "scratch:q_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "v",
+          "source": "scratch:v_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "output",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "sliding_window",
+          "source": "dim:sliding_window"
+        }
+      ]
+    },
+    "attention_forward_decode_head_major_gqa_flash_gemma4": {
+      "note": "Decode: single query token attends to KV cache (positions 0..pos) Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "name": "q_token",
+          "source": "scratch:q_scratch",
+          "cast": "const float*"
+        },
+        {
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer",
+          "cast": "const float*"
+        },
+        {
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer",
+          "cast": "const float*"
+        },
+        {
+          "name": "out_token",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "kv_tokens",
+          "source": "runtime:kv_tokens"
+        },
+        {
+          "name": "cache_capacity",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        }
+      ]
+    },
+    "attention_forward_decode_head_major_gqa_flash_sliding_gemma4": {
+      "note": "Decode: sliding window attention - single query token attends to last W KV cache entries Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "name": "q_token",
+          "source": "scratch:q_scratch",
+          "cast": "const float*"
+        },
+        {
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer",
+          "cast": "const float*"
+        },
+        {
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer",
+          "cast": "const float*"
+        },
+        {
+          "name": "out_token",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "kv_tokens",
+          "source": "runtime:kv_tokens"
+        },
+        {
+          "name": "cache_capacity",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "sliding_window",
+          "source": "dim:sliding_window"
+        }
+      ]
+    },
+    "rope_forward_qk_gemma4_direct": {
+      "note": "Gemma4 RoPE uses per-layer frequency base and optional full-attention frequency factors.",
+      "params": [
+        {
+          "name": "q",
+          "source": "scratch:q_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "freq_factors",
+          "source": "weight_f:rope_freqs",
+          "cast": "const float*"
+        },
+        {
+          "name": "use_freq_factors",
+          "source": "dim:use_rope_freq_factors"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "pos_offset",
+          "source": "runtime:pos"
+        },
+        {
+          "name": "rotary_dim",
+          "source": "dim:rotary_dim"
+        },
+        {
+          "name": "freq_base",
+          "source": "dim:rope_freq_base"
+        }
+      ]
+    },
+    "gemma4_v_norm_forward": {
+      "params": [
+        {
+          "name": "input",
+          "source": "activation:input",
+          "cast": "const float*"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rstd_cache",
+          "source": "null"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "rmsnorm_forward_no_weight": {
+      "params": [
+        {
+          "name": "input",
+          "source": "activation:input",
+          "cast": "const float*"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rstd_cache",
+          "source": "null"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "d_model",
+          "source": "dim:_output_dim"
+        },
+        {
+          "name": "aligned_embed_dim",
+          "source": "dim:_output_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
         }
       ]
     }

--- a/version/v8/kernel_maps/rmsnorm_no_weight.json
+++ b/version/v8/kernel_maps/rmsnorm_no_weight.json
@@ -1,0 +1,22 @@
+{
+  "id": "v_norm",
+  "op": "v_norm",
+  "variant": "fp32_no_gamma",
+  "quant": {"activation": "fp32", "output": "fp32"},
+  "inputs": [
+    {"name": "input", "dtype": "fp32", "shape": ["T", "D"], "desc": "Input [tokens, dim]"}
+  ],
+  "outputs": [
+    {"name": "output", "dtype": "fp32", "shape": ["T", "D"], "desc": "RMS-normalized output without learned scale"}
+  ],
+  "dims": ["tokens", "num_kv_heads", "head_dim"],
+  "params": [
+    {"name": "eps", "dtype": "float", "default": 1e-6}
+  ],
+  "impl": {
+    "function": "gemma4_v_norm_forward",
+    "c_declaration": "void gemma4_v_norm_forward(const float *input, float *output, float *rstd_cache, int tokens, int num_kv_heads, int head_dim, float eps);",
+    "sources": ["src/kernels/rmsnorm_kernels.c"]
+  },
+  "notes": "Gemma4 V RMSNorm without gamma. Normalizes each [head_dim] V head independently, matching llama.cpp ggml_rms_norm after reshape."
+}

--- a/version/v8/kernel_maps/rope_forward_qk_gemma4.json
+++ b/version/v8/kernel_maps/rope_forward_qk_gemma4.json
@@ -1,0 +1,191 @@
+{
+  "id": "rope_forward_qk_gemma4",
+  "op": "rope",
+  "variant": "fp32_head_major",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor [heads, tokens, head_dim] to be rotated in-place"
+    },
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "D"
+      ],
+      "desc": "Key tensor [kv_heads, tokens, head_dim] to be rotated in-place"
+    }
+  ],
+  "weights": [{"name": "rope_freqs", "dtype": "fp32", "shape": ["rotary_dim/2"], "desc": "Gemma4 full-attention proportional RoPE frequency factors; ignored for sliding layers"}],
+  "activations": [],
+  "runtime_buffers": [
+    {
+      "name": "cos_cache",
+      "dtype": "fp32",
+      "shape": [
+        "max_T",
+        "rotary_dim",
+        2
+      ],
+      "desc": "RoPE cos cache [max_seq, rotary_dim/2]"
+    },
+    {
+      "name": "sin_cache",
+      "dtype": "fp32",
+      "shape": [
+        "max_T",
+        "rotary_dim",
+        2
+      ],
+      "desc": "RoPE sin cache [max_seq, rotary_dim/2]"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor after RoPE application (in-place)"
+    },
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "D"
+      ],
+      "desc": "Key tensor after RoPE application (in-place)"
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "H",
+    "KV",
+    "T",
+    "D",
+    "rotary_dim"
+  ],
+  "params": [
+    {
+      "name": "aligned_head_dim",
+      "dtype": "int32",
+      "desc": "Aligned head dimension for SIMD"
+    },
+    {
+      "name": "pos_offset",
+      "dtype": "int32",
+      "desc": "Position offset for cos/sin cache lookup"
+    },
+    {
+      "name": "rotary_dim",
+      "dtype": "int32",
+      "desc": "RoPE rotary dimensions (only rotate first rotary_dim channels)"
+    },
+    {
+      "name": "cache_rotary_dim",
+      "dtype": "int32",
+      "source": "dim:max_rotary_dim",
+      "desc": "RoPE cache row width for mixed Gemma4 rotary dimensions"
+    }
+  ],
+  "parallelization": {
+    "supported": [
+      "head",
+      "token"
+    ],
+    "preferred": {
+      "prefill": "head",
+      "decode": "head"
+    },
+    "strategies": [
+      {
+        "name": "head",
+        "partition_dim": "H",
+        "param_style": "ith_nth",
+        "notes": "Parallelize across heads; each thread handles one or more heads."
+      },
+      {
+        "name": "token",
+        "partition_dim": "T",
+        "param_style": "ith_nth",
+        "notes": "Parallelize across tokens; each thread handles one or more tokens."
+      }
+    ]
+  },
+  "constraints": {
+    "alignment": {
+      "D": 64,
+      "T": 32
+    },
+    "notes": "D should be multiple of 64 for optimal SIMD. D is the unpadded dimension; AD is used for alignment."
+  },
+  "impl": {
+    "function": "rope_forward_qk_gemma4_direct",
+    "c_declaration": "void rope_forward_qk_gemma4_direct(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+    "sources": [
+      "src/kernels/rope_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "avx512",
+        "requires": [
+          "avx512f",
+          "fma"
+        ],
+        "compile_flags": [
+          "-mavx512f",
+          "-mfma"
+        ]
+      },
+      {
+        "name": "avx",
+        "requires": [
+          "avx"
+        ],
+        "compile_flags": [
+          "-mavx"
+        ]
+      },
+      {
+        "name": "ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_rope.py"
+    ],
+    "bench": [
+      "scripts/bench_rope.py"
+    ],
+    "parity": [
+      {
+        "kind": "numpy",
+        "command": "python unittest/test_rope.py --compare-numpy",
+        "tolerance": "1e-5",
+        "notes": "Verify RoPE rotation matches numpy reference"
+      }
+    ]
+  },
+  "notes": "Rotary Position Embedding (RoPE) for queries and keys. Applies rotation in complex plane: x_rot = x * cos(theta) + rotate_half(x) * sin(theta). Only rotates first rotary_dim channels; remaining channels pass through unchanged. Gemma4 variant uses max_rotary_dim as cache row stride so sliding/full layers can share one RoPE cache."
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -348,6 +348,10 @@ OP_DATAFLOW = {
         "inputs": {"token_ids": "external:token_ids"},
         "outputs": {"out": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "gemma4_per_layer_prepare": {
+        "inputs": {"input": "main_stream", "tokens": "external:token_ids"},
+        "outputs": {"per_layer_input": {"slot": "gemma4_per_layer_stream", "dtype": "fp32"}},
+    },
     "patchify": {
         "inputs": {"image": "external:image_input"},
         "outputs": {"patches": {"slot": "patch_scratch", "dtype": "fp32"}},
@@ -409,9 +413,21 @@ OP_DATAFLOW = {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "gemma4_per_layer_embed": {
+        "inputs": {"hidden": "main_stream", "per_layer_input": "gemma4_per_layer_stream"},
+        "outputs": {"hidden": {"slot": "main_stream", "dtype": "fp32"}},
+    },
+    "v_norm": {
+        "inputs": {"input": "v_scratch"},
+        "outputs": {"output": {"slot": "v_scratch", "dtype": "fp32"}},
+    },
     "final_rmsnorm": {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
+    },
+    "final_logit_softcap": {
+        "inputs": {"logits": "logits"},
+        "outputs": {"logits": {"slot": "logits", "dtype": "fp32"}},
     },
     "quantize_input_0": {
         "inputs": {"input": "main_stream"},
@@ -1206,8 +1222,8 @@ def generate_init_ops(manifest: Dict, config: Dict) -> List[Dict]:
     if rope_type in ("rope", "rope_qk", True):
         # Get config values
         rope_theta = config["rope_theta"]
-        head_dim = config["head_dim"]
-        rotary_dim = config["rotary_dim"]
+        head_dim = max(int(config["head_dim"]), int(config.get("max_rotary_dim", config["rotary_dim"]) or config["rotary_dim"]))
+        rotary_dim = int(config.get("max_rotary_dim", config["rotary_dim"]) or config["rotary_dim"])
         max_seq_len = config["context_length"]
 
         # RoPE scaling (for extended context models like Llama 3.1)
@@ -1577,6 +1593,24 @@ def build_activation_specs(config: Dict[str, Any], mode: str, context_len: int, 
     kv_cache_dtype = "fp16" if mode == "decode" and decode_kv_cache_dtype in {"fp16", "f16"} else "fp32"
     kv_elem_bytes = _dtype_size_bytes(kv_cache_dtype)
 
+    def _positive_int_config(name: str, default: int) -> int:
+        try:
+            value = int(config.get(name, default) or default)
+        except Exception:
+            value = default
+        return value if value > 0 else default
+
+    max_q_head_dim = max(head_dim, _positive_int_config("max_q_head_dim", head_dim))
+    max_k_head_dim = max(head_dim, _positive_int_config("max_k_head_dim", head_dim))
+    max_v_head_dim = max(head_dim, _positive_int_config("max_v_head_dim", head_dim))
+    kv_cache_head_dim = max(
+        max_k_head_dim,
+        max_v_head_dim,
+        _positive_int_config("kv_cache_head_dim", head_dim),
+    )
+    max_attn_head_dim = max(max_q_head_dim, max_k_head_dim, max_v_head_dim, kv_cache_head_dim)
+    kv_cache_token_stride_total = int(config.get("kv_cache_token_stride_total", 0) or 0)
+
     max_context = int(config.get("context_length", 32768))
     if context_len is None:
         context_len = max_context
@@ -1633,38 +1667,51 @@ def build_activation_specs(config: Dict[str, Any], mode: str, context_len: int, 
 
     # KV cache + RoPE
     if uses_kv_cache:
-        kv_per_layer = num_kv_heads * context_len * head_dim * kv_elem_bytes
-        total_kv_size = num_layers * 2 * kv_per_layer
-        add("kv_cache", total_kv_size, f"[{num_layers}, 2, {num_kv_heads}, {context_len}, {head_dim}]", kv_cache_dtype)
+        if kv_cache_token_stride_total > 0:
+            total_kv_size = context_len * kv_cache_token_stride_total * kv_elem_bytes
+            add("kv_cache", total_kv_size, f"[variable_kv, {context_len}, mixed_head_dim]", kv_cache_dtype)
+        else:
+            kv_per_layer = num_kv_heads * context_len * kv_cache_head_dim * kv_elem_bytes
+            total_kv_size = num_layers * 2 * kv_per_layer
+            add("kv_cache", total_kv_size, f"[{num_layers}, 2, {num_kv_heads}, {context_len}, {kv_cache_head_dim}]", kv_cache_dtype)
 
-    rotary_dim = config.get("rotary_dim", head_dim)
+    rotary_dim = int(config.get("rotary_dim", head_dim) or head_dim)
+    layer_rotary = config.get("layer_rotary_dim")
+    if isinstance(layer_rotary, list) and layer_rotary:
+        rotary_dim = max(rotary_dim, max(int(v or 0) for v in layer_rotary))
     rope_half = int(rotary_dim) // 2
     if uses_rope:
         rope_size = context_len * rope_half * 4 * 2
         add("rope_cache", rope_size, f"[2, {context_len}, {rope_half}]")
 
     # Scratch buffers
-    q_size = num_heads * seq_len * head_dim * 4
-    k_size = num_kv_heads * seq_len * head_dim * 4
-    v_size = num_kv_heads * seq_len * head_dim * 4
-    attn_out_size = num_heads * seq_len * head_dim * 4
+    q_size = num_heads * seq_len * max_q_head_dim * 4
+    k_size = num_kv_heads * seq_len * max_k_head_dim * 4
+    v_size = num_kv_heads * seq_len * max_v_head_dim * 4
+    attn_out_size = num_heads * seq_len * max_q_head_dim * 4
     q_gate_proj_dim = int(config.get("q_gate_proj_dim", config.get("attn_q_gate_proj_dim", 0)) or 0)
     if q_gate_proj_dim <= 0:
-        q_gate_proj_dim = 2 * num_heads * head_dim
-    attn_gate_dim = int(config.get("attn_gate_dim", max(q_gate_proj_dim - (num_heads * head_dim), 0)) or 0)
+        q_gate_proj_dim = 2 * num_heads * max_q_head_dim
+    attn_gate_dim = int(config.get("attn_gate_dim", max(q_gate_proj_dim - (num_heads * max_q_head_dim), 0)) or 0)
     if attn_gate_dim <= 0:
-        attn_gate_dim = num_heads * head_dim
+        attn_gate_dim = num_heads * max_q_head_dim
     attn_q_gate_packed_size = seq_len * q_gate_proj_dim * 4
     attn_gate_size = seq_len * attn_gate_dim * 4
-    add("q_scratch", q_size, f"[{num_heads}, {seq_len}, {head_dim}]")
-    add("k_scratch", k_size, f"[{num_kv_heads}, {seq_len}, {head_dim}]")
-    add("v_scratch", v_size, f"[{num_kv_heads}, {seq_len}, {head_dim}]")
+    add("q_scratch", q_size, f"[{num_heads}, {seq_len}, {max_q_head_dim}]")
+    add("k_scratch", k_size, f"[{num_kv_heads}, {seq_len}, {max_k_head_dim}]")
+    add("v_scratch", v_size, f"[{num_kv_heads}, {seq_len}, {max_v_head_dim}]")
     add("attn_q_gate_packed", attn_q_gate_packed_size, f"[{seq_len}, {q_gate_proj_dim}]")
     add("attn_gate", attn_gate_size, f"[{seq_len}, {attn_gate_dim}]")
-    add("attn_scratch", attn_out_size, f"[{num_heads}, {seq_len}, {head_dim}]")
+    add("attn_scratch", attn_out_size, f"[{num_heads}, {seq_len}, {max_q_head_dim}]")
+
+    if bool(config.get("gemma4_per_layer_embedding", False)):
+        per_layer_dim = int(config.get("per_layer_dim", 0) or 0)
+        if per_layer_dim > 0 and num_layers > 0:
+            per_layer_size = seq_len * num_layers * per_layer_dim * 4
+            add("gemma4_per_layer_stream", per_layer_size, f"[{seq_len}, {num_layers}, {per_layer_dim}]")
 
     mlp_size = seq_len * intermediate_size * 2 * 4
-    fused_attn_scratch = max(350 * 1024, 3 * num_heads * seq_len * head_dim * 4 + embed_dim * 4 * seq_len * 4)
+    fused_attn_scratch = max(350 * 1024, 3 * num_heads * seq_len * max_attn_head_dim * 4 + embed_dim * 4 * seq_len * 4)
     # BF16 GeGLU needs 3 * seq_len * dim * 4 (input [a,b] + output)
     geglu_bf16_scratch = seq_len * intermediate_size * 3 * 4
     scratch_size = max(mlp_size, fused_attn_scratch, geglu_bf16_scratch)
@@ -1772,6 +1819,10 @@ TEMPLATE_TO_KERNEL_OP = {
     "post_attention_norm": "rmsnorm",
     "ffn_norm": "rmsnorm",
     "post_ffn_norm": "rmsnorm",
+    "gemma4_per_layer_prepare": "gemma4_per_layer_prepare",
+    "gemma4_per_layer_embed": "gemma4_per_layer_embed",
+    "final_logit_softcap": "final_logit_softcap",
+    "v_norm": "v_norm",
     "qkv_proj": "qkv_projection",  # Or fallback to 3x matmul
     "qkv_packed_proj": "matmul",
     "q_proj": "matmul",
@@ -2644,6 +2695,77 @@ def compute_matmul_dims(op_name: str, config: Dict) -> Tuple[Optional[int], Opti
     if op_name in ("quantize_mlp_down_input",):
         return inter, inter  # _input_dim = intermediate_size
     return None, None
+
+
+def _config_layer_int(config: Dict, key: str, layer: int, default: int) -> int:
+    vals = config.get(key)
+    if isinstance(vals, list) and 0 <= layer < len(vals):
+        try:
+            return int(vals[layer])
+        except (TypeError, ValueError):
+            return int(default)
+    return int(default)
+
+
+def apply_layer_attention_dims(op_name: str, params: Dict, layer: int, config: Dict) -> None:
+    """Apply explicit per-layer attention dimensions for architectures that need them."""
+    if str(config.get("model", "")).lower() != "gemma4" or layer < 0:
+        return
+
+    embed_dim = int(config.get("embed_dim", 0) or 0)
+    num_kv_heads = int(config.get("num_kv_heads", config.get("num_heads", 1)) or 1)
+    q_head_dim = _config_layer_int(config, "layer_q_head_dim", layer, int(config.get("head_dim", 0) or 0))
+    k_head_dim = _config_layer_int(config, "layer_k_head_dim", layer, q_head_dim)
+    v_head_dim = _config_layer_int(config, "layer_v_head_dim", layer, k_head_dim)
+    q_dim = _config_layer_int(config, "layer_q_dim", layer, int(config.get("num_heads", 1) or 1) * q_head_dim)
+    k_dim = num_kv_heads * k_head_dim
+    v_dim = num_kv_heads * v_head_dim
+    rotary_dim = _config_layer_int(config, "layer_rotary_dim", layer, int(config.get("rotary_dim", q_head_dim) or q_head_dim))
+    sliding_window = _config_layer_int(config, "layer_sliding_window", layer, int(config.get("sliding_window", 0) or 0))
+    rope_kinds = config.get("layer_rope_kind")
+    rope_kind = str(rope_kinds[layer]) if isinstance(rope_kinds, list) and 0 <= layer < len(rope_kinds) else ("swa" if sliding_window > 0 else "full")
+    rope_freq_base = float(config.get("rope_theta_swa" if rope_kind == "swa" else "rope_theta", config.get("rope_theta", 10000.0)) or 10000.0)
+
+    if op_name == "q_proj":
+        params["_output_dim"] = q_dim
+        params["_input_dim"] = embed_dim
+        params["output_dim"] = q_dim
+    elif op_name == "k_proj":
+        params["_output_dim"] = k_dim
+        params["_input_dim"] = embed_dim
+        params["output_dim"] = k_dim
+    elif op_name == "v_proj":
+        params["_output_dim"] = v_dim
+        params["_input_dim"] = embed_dim
+        params["output_dim"] = v_dim
+    elif op_name == "out_proj":
+        params["_output_dim"] = embed_dim
+        params["_input_dim"] = q_dim
+        params["input_dim"] = q_dim
+    elif op_name == "quantize_out_proj_input":
+        params["_output_dim"] = q_dim
+        params["_input_dim"] = q_dim
+        params["input_dim"] = q_dim
+    elif op_name in ("qk_norm", "rope_qk", "kv_cache_store", "attn", "attn_sliding"):
+        params["head_dim"] = q_head_dim
+        params["q_head_dim"] = q_head_dim
+        params["k_head_dim"] = k_head_dim
+        params["v_head_dim"] = v_head_dim
+        params["q_dim"] = q_dim
+        params["k_dim"] = k_dim
+        params["v_dim"] = v_dim
+        params["rotary_dim"] = rotary_dim
+        params["n_dims"] = rotary_dim
+        params["rope_freq_base"] = rope_freq_base
+        params["use_rope_freq_factors"] = 1 if (op_name == "rope_qk" and rope_kind == "full") else 0
+        if sliding_window > 0:
+            params["sliding_window"] = sliding_window
+    elif op_name == "v_norm":
+        params["embed_dim"] = v_dim
+        params["d_model"] = v_dim
+        params["aligned_embed_dim"] = v_dim
+        params["_input_dim"] = v_dim
+        params["_output_dim"] = v_dim
 
 
 def _align_up(value: int, alignment: int) -> int:
@@ -4105,6 +4227,19 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "post_attention_norm": None,
         "ffn_norm": None,
         "post_ffn_norm": None,
+        "gemma4_per_layer_prepare": [
+            "per_layer_token_emb",
+            "per_layer_model_proj",
+            "per_layer_proj_norm",
+        ],
+        "gemma4_per_layer_embed": [
+            "per_layer_inp_gate",
+            "per_layer_proj",
+            "per_layer_post_norm",
+            "layer_output_scale",
+        ],
+        "final_logit_softcap": None,
+        "v_norm": [],
         "final_rmsnorm": None,
         "qk_norm": None,  # Per-head RMSNorm gamma is always fp32
 
@@ -4207,6 +4342,20 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         # Metadata ops - no kernel
         if weight_info == "metadata":
             return []
+
+        # Explicit no-weight math ops. These are real kernels, but they must not
+        # flow through the header/footer weighted path below, which would invent
+        # a q8_0 weight requirement and fail to bind kernels such as Gemma4 V RMSNorm.
+        if op in {"v_norm"}:
+            kernel_id = find_kernel(
+                registry,
+                op=kernel_op,
+                quant={},
+                mode=mode,
+                prefer_q8_activation=prefer_q8_activation,
+                prefer_parallel=use_parallel,
+            )
+            return [kernel_id] if kernel_id else []
 
         # Ops with quantized weights
         if isinstance(weight_info, list) and weight_info:
@@ -4840,6 +4989,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         ("ffn_norm", 0): ["ln2_gamma"],     # Pre-MLP norm (Gemma)
         ("post_attention_norm", 0): ["post_attention_norm"],
         ("post_ffn_norm", 0): ["post_ffn_norm"],
+        ("v_norm", 0): [],
         # residual_add: both instances use same weights (none), but tracked for consistency
         ("residual_add", 0): [],            # Post-attention residual
         ("residual_add", 1): [],            # Post-MLP residual
@@ -4928,6 +5078,8 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                 weight_keys = list(explicit_refs.keys())
         elif section == "body" and (op, instance_idx) in REPEATED_OP_WEIGHTS:
             weight_keys = REPEATED_OP_WEIGHTS[(op, instance_idx)]
+        elif section == "body" and op == "rope_qk" and str(config.get("model", "")).lower() == "gemma4":
+            weight_keys = ["rope_freqs"]
         elif section == "header":
             weight_keys = _header_weight_keys(op)
         elif section == "footer":
@@ -5422,7 +5574,22 @@ def insert_bias_add_ops(
         if isinstance(bias_weight_name, str) and is_zero_bias_tensor(bias_weight_name):
             skipped_zero += 1
             continue
-        if kernel_supports_bias(op.get("kernel", "")):
+
+        # Prefill GEMM kernels bind optional bias directly, but decode lowering
+        # rewrites these projection ops to GEMV kernels that do not take bias.
+        # Keep Gemma4/Qwen-style projection biases explicit in decode so the
+        # later GEMV specialization cannot silently drop them.
+        decode_needs_explicit_bias = mode == "decode" and op_type in {
+            "q_proj",
+            "q_gate_proj",
+            "k_proj",
+            "v_proj",
+            "out_proj",
+            "mlp_gate_up",
+            "mlp_up",
+            "mlp_down",
+        }
+        if kernel_supports_bias(op.get("kernel", "")) and not decode_needs_explicit_bias:
             continue
 
         out_dim, _ = compute_matmul_dims(op_type, config)
@@ -5661,6 +5828,15 @@ def generate_ir_lower_1(
     force_decode_attn_regular = str(os.environ.get("CK_V7_DECODE_ATTN_REGULAR", "")).strip().lower() in ("1", "true", "yes", "on")
     decode_kv_cache_dtype = str(config.get("decode_kv_cache_dtype", "fp32") or "fp32").strip().lower()
     decode_uses_fp16_kv = decode_kv_cache_dtype in {"fp16", "f16"}
+    layer_kv_source_cfg = config.get("layer_kv_source") if isinstance(config.get("layer_kv_source"), list) else []
+
+    def _kv_read_layer_for(layer: int) -> int:
+        try:
+            if 0 <= int(layer) < len(layer_kv_source_cfg):
+                return int(layer_kv_source_cfg[int(layer)])
+        except (TypeError, ValueError):
+            pass
+        return int(layer)
 
     for i, op in enumerate(lowered_ops):
         final_ops.append(op)
@@ -5685,6 +5861,7 @@ def generate_ir_lower_1(
                         "kv_cache_k": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
                         "kv_cache_v": {"type": "kv_cache", "buffer": f"kv_cache_v_L{layer}"},
                     },
+                    "params": copy.deepcopy(op.get("params", {})),
                     "scratch": [],
                     "_auto_inserted": True,
                 }
@@ -5705,10 +5882,12 @@ def generate_ir_lower_1(
                         decode_kernel = "attention_forward_decode_head_major_gqa_flash_f16cache"
                 op["kernel"] = decode_kernel
                 op["function"] = decode_kernel
+                kv_read_layer = _kv_read_layer_for(int(op.get("layer", 0)))
+                op["_kv_cache_read_layer"] = kv_read_layer
                 # Update inputs to use KV cache instead of scratch
                 op.setdefault("inputs", {})
-                op["inputs"]["k_cache"] = {"type": "kv_cache", "source": f"kv_cache_k_L{op['layer']}"}
-                op["inputs"]["v_cache"] = {"type": "kv_cache", "source": f"kv_cache_v_L{op['layer']}"}
+                op["inputs"]["k_cache"] = {"type": "kv_cache", "source": f"kv_cache_k_L{kv_read_layer}"}
+                op["inputs"]["v_cache"] = {"type": "kv_cache", "source": f"kv_cache_v_L{kv_read_layer}"}
                 # Remove scratch K/V references if present
                 op["inputs"].pop("k", None)
                 op["inputs"].pop("v", None)
@@ -5914,6 +6093,7 @@ WEIGHT_PATTERNS = {
 
     # QK norm weights (per-head RMSNorm gamma for Q and K)
     "q_norm": ["layer.{L}.q_norm", "layers.{L}.attention.q_norm", "layer.{L}.attn_q_norm"],
+    "rope_freqs": ["rope_freqs"],
     "k_norm": ["layer.{L}.k_norm", "layers.{L}.attention.k_norm", "layer.{L}.attn_k_norm"],
 
     # Recurrent hybrid block weights
@@ -5945,6 +6125,12 @@ WEIGHT_PATTERNS = {
     "ln2_beta": ["layer.{L}.ln2_beta", "layers.{L}.ffn_norm.bias", "v.blk.{L}.ln2.bias"],
     "post_attention_norm": ["layer.{L}.post_attention_norm", "layers.{L}.post_attention_norm.weight"],
     "post_ffn_norm": ["layer.{L}.post_ffn_norm", "layer.{L}.post_ffw_norm", "layers.{L}.post_ffn_norm.weight"],
+    "per_layer_token_emb": ["per_layer_token_emb"],
+    "per_layer_model_proj": ["per_layer_model_proj"],
+    "per_layer_proj_norm": ["per_layer_proj_norm"],
+    "per_layer_inp_gate": ["layer.{L}.per_layer_inp_gate"],
+    "per_layer_proj": ["layer.{L}.per_layer_proj"],
+    "per_layer_post_norm": ["layer.{L}.per_layer_post_norm"],
     "patch_emb": [
         "patch_emb.weight",
         "patch_embeddings.weight",
@@ -6027,6 +6213,19 @@ TEMPLATE_OP_WEIGHTS = {
     "post_attention_norm": ["post_attention_norm"],
     "ffn_norm": ["ln2_gamma"],
     "post_ffn_norm": ["post_ffn_norm"],
+    "gemma4_per_layer_prepare": [
+        "per_layer_token_emb",
+        "per_layer_model_proj",
+        "per_layer_proj_norm",
+    ],
+    "gemma4_per_layer_embed": [
+        "per_layer_inp_gate",
+        "per_layer_proj",
+        "per_layer_post_norm",
+        "layer_output_scale",
+    ],
+    "final_logit_softcap": [],
+    "v_norm": [],
     "final_rmsnorm": ["final_ln_weight", "final_ln_bias"],
     "qkv_proj": ["wq", "wk", "wv", "bq", "bk", "bv"],  # QKV + optional biases (for fused kernel)
     "qkv_packed_proj": ["attn_qkv", "bqkv"],
@@ -6294,6 +6493,23 @@ def generate_memory_layout(
             non_model_weights.add(v)
     model_weights = all_weight_names - non_model_weights
 
+    template_family = str(template.get("family", "") or template.get("name", "") or "").strip().lower()
+    model_family = str(config.get("model", "") or config.get("model_type", "") or "").strip().lower()
+    if template_family == "gemma4" or model_family == "gemma4":
+        # Gemma4 GGUFs may carry layer.*.v_norm_gamma tensors, but llama.cpp
+        # applies V RMSNorm as an unweighted ggml_rms_norm. Treat these as
+        # intentionally ignored only for the explicit Gemma4 template.
+        ignored_v_norm_gamma = {
+            w for w in model_weights
+            if w.startswith("layer.") and w.endswith(".v_norm_gamma")
+        }
+        if ignored_v_norm_gamma:
+            model_weights -= ignored_v_norm_gamma
+            print(
+                f"  Ignoring {len(ignored_v_norm_gamma)} Gemma4 v_norm_gamma tensors "
+                "because V RMSNorm is unweighted"
+            )
+
     # Weights expected but not used by IR1
     unused_by_ir1 = expected_weights - ir1_used_weights
 
@@ -6413,6 +6629,27 @@ def generate_memory_layout(
     kv_cache_dtype = "fp16" if mode == "decode" and decode_kv_cache_dtype in {"fp16", "f16"} else "fp32"
     kv_elem_bytes = _dtype_size_bytes(kv_cache_dtype)
 
+    head_dim = int(head_dim)
+    num_heads = int(num_heads)
+    num_kv_heads = int(num_kv_heads)
+    def _positive_int_config(name: str, default: int) -> int:
+        try:
+            value = int(config.get(name, default) or default)
+        except Exception:
+            value = default
+        return value if value > 0 else default
+
+    max_q_head_dim = max(head_dim, _positive_int_config("max_q_head_dim", head_dim))
+    max_k_head_dim = max(head_dim, _positive_int_config("max_k_head_dim", head_dim))
+    max_v_head_dim = max(head_dim, _positive_int_config("max_v_head_dim", head_dim))
+    kv_cache_head_dim = max(
+        max_k_head_dim,
+        max_v_head_dim,
+        _positive_int_config("kv_cache_head_dim", head_dim),
+    )
+    max_attn_head_dim = max(max_q_head_dim, max_k_head_dim, max_v_head_dim, kv_cache_head_dim)
+    kv_cache_token_stride_total = int(config.get("kv_cache_token_stride_total", 0) or 0)
+
     # Use provided context_len or default from config
     max_context = config.get("context_length", 32768)
     if context_len is None:
@@ -6495,12 +6732,19 @@ def generate_memory_layout(
     # KV cache: [num_layers, 2, num_kv_heads, context_len, head_dim]
     # Stores K and V for all layers, indexed by position
     if uses_kv_cache:
-        kv_per_layer = num_kv_heads * context_len * head_dim * kv_elem_bytes
-        total_kv_size = num_layers * 2 * kv_per_layer
-        add_buffer("kv_cache", total_kv_size, f"[{num_layers}, 2, {num_kv_heads}, {context_len}, {head_dim}]", kv_cache_dtype)
+        if kv_cache_token_stride_total > 0:
+            total_kv_size = context_len * kv_cache_token_stride_total * kv_elem_bytes
+            add_buffer("kv_cache", total_kv_size, f"[variable_kv, {context_len}, mixed_head_dim]", kv_cache_dtype)
+        else:
+            kv_per_layer = num_kv_heads * context_len * kv_cache_head_dim * kv_elem_bytes
+            total_kv_size = num_layers * 2 * kv_per_layer
+            add_buffer("kv_cache", total_kv_size, f"[{num_layers}, 2, {num_kv_heads}, {context_len}, {kv_cache_head_dim}]", kv_cache_dtype)
 
     # RoPE tables: precomputed cos/sin [2, context_len, rotary_dim/2]
-    rotary_dim = config.get("rotary_dim", head_dim)
+    rotary_dim = int(config.get("rotary_dim", head_dim) or head_dim)
+    layer_rotary = config.get("layer_rotary_dim")
+    if isinstance(layer_rotary, list) and layer_rotary:
+        rotary_dim = max(rotary_dim, max(int(v or 0) for v in layer_rotary))
     rope_half = int(rotary_dim) // 2
     if uses_rope:
         rope_size = context_len * rope_half * 4 * 2
@@ -6508,35 +6752,41 @@ def generate_memory_layout(
 
     # Layer scratch buffers (reused across layers)
     # Q output: [num_heads, seq_len, head_dim]
-    q_size = num_heads * seq_len * head_dim * 4
-    add_buffer("q_scratch", q_size, f"[{num_heads}, {seq_len}, {head_dim}]")
+    q_size = num_heads * seq_len * max_q_head_dim * 4
+    add_buffer("q_scratch", q_size, f"[{num_heads}, {seq_len}, {max_q_head_dim}]")
 
-    # K output: [num_kv_heads, seq_len, head_dim]
-    k_size = num_kv_heads * seq_len * head_dim * 4
-    add_buffer("k_scratch", k_size, f"[{num_kv_heads}, {seq_len}, {head_dim}]")
+    # K output: [num_kv_heads, seq_len, max_k_head_dim]
+    k_size = num_kv_heads * seq_len * max_k_head_dim * 4
+    add_buffer("k_scratch", k_size, f"[{num_kv_heads}, {seq_len}, {max_k_head_dim}]")
 
-    # V output: [num_kv_heads, seq_len, head_dim]
-    v_size = num_kv_heads * seq_len * head_dim * 4
-    add_buffer("v_scratch", v_size, f"[{num_kv_heads}, {seq_len}, {head_dim}]")
+    # V output: [num_kv_heads, seq_len, max_v_head_dim]
+    v_size = num_kv_heads * seq_len * max_v_head_dim * 4
+    add_buffer("v_scratch", v_size, f"[{num_kv_heads}, {seq_len}, {max_v_head_dim}]")
 
-    # Attention output: [num_heads, seq_len, head_dim]
-    attn_out_size = num_heads * seq_len * head_dim * 4
+    # Attention output: [num_heads, seq_len, max_q_head_dim]
+    attn_out_size = num_heads * seq_len * max_q_head_dim * 4
     q_gate_proj_dim = int(config.get("q_gate_proj_dim", config.get("attn_q_gate_proj_dim", 0)) or 0)
     if q_gate_proj_dim <= 0:
-        q_gate_proj_dim = 2 * num_heads * head_dim
-    attn_gate_dim = int(config.get("attn_gate_dim", max(q_gate_proj_dim - (num_heads * head_dim), 0)) or 0)
+        q_gate_proj_dim = 2 * num_heads * max_q_head_dim
+    attn_gate_dim = int(config.get("attn_gate_dim", max(q_gate_proj_dim - (num_heads * max_q_head_dim), 0)) or 0)
     if attn_gate_dim <= 0:
-        attn_gate_dim = num_heads * head_dim
+        attn_gate_dim = num_heads * max_q_head_dim
     add_buffer("attn_q_gate_packed", seq_len * q_gate_proj_dim * 4, f"[{seq_len}, {q_gate_proj_dim}]")
     add_buffer("attn_gate", seq_len * attn_gate_dim * 4, f"[{seq_len}, {attn_gate_dim}]")
-    add_buffer("attn_scratch", attn_out_size, f"[{num_heads}, {seq_len}, {head_dim}]")
+    add_buffer("attn_scratch", attn_out_size, f"[{num_heads}, {seq_len}, {max_q_head_dim}]")
+
+    if bool(config.get("gemma4_per_layer_embedding", False)):
+        per_layer_dim = int(config.get("per_layer_dim", 0) or 0)
+        if per_layer_dim > 0 and num_layers > 0:
+            per_layer_size = seq_len * num_layers * per_layer_dim * 4
+            add_buffer("gemma4_per_layer_stream", per_layer_size, f"[{seq_len}, {num_layers}, {per_layer_dim}]")
 
     # MLP scratch: [seq_len, intermediate_size * 2]
     mlp_size = seq_len * intermediate_size * 2 * 4
     # Fused attention scratch needs more space (Q, attn_out, proj, qkv_scratch)
     # Formula: 3 * num_heads * seq_len * head_dim * 4 + qkv_scratch (embed_dim * 4 * tokens + overhead)
     # For safety, use at least 350KB for decode fused attention
-    fused_attn_scratch = max(350 * 1024, 3 * num_heads * seq_len * head_dim * 4 + embed_dim * 4 * seq_len * 4)
+    fused_attn_scratch = max(350 * 1024, 3 * num_heads * seq_len * max_attn_head_dim * 4 + embed_dim * 4 * seq_len * 4)
     # BF16 GeGLU needs 3 * seq_len * dim * 4 (input [a,b] + output)
     geglu_bf16_scratch = seq_len * intermediate_size * 3 * 4
     scratch_size = max(mlp_size, fused_attn_scratch, geglu_bf16_scratch)
@@ -7062,10 +7312,17 @@ def generate_ir_lower_2(
     kv_cache_dtype = str(config.get("decode_kv_cache_dtype", "fp32") or "fp32").strip().lower()
     kv_elem_bytes = _dtype_size_bytes(kv_cache_dtype if kv_cache_dtype in {"fp16", "f16"} else "fp32")
 
+    layer_k_cache_offset = config.get("layer_k_cache_offset") if isinstance(config.get("layer_k_cache_offset"), list) else []
+    layer_v_cache_offset = config.get("layer_v_cache_offset") if isinstance(config.get("layer_v_cache_offset"), list) else []
+
     def kv_layer_offsets(layer: int) -> Optional[Tuple[int, int]]:
         kv_buf = activation_buffers.get("kv_cache")
         if not kv_buf or not context_len or not num_kv_heads or not head_dim:
             return None
+        if 0 <= int(layer) < len(layer_k_cache_offset) and 0 <= int(layer) < len(layer_v_cache_offset):
+            k_base = kv_buf["offset"] + int(layer_k_cache_offset[int(layer)]) * int(context_len) * kv_elem_bytes
+            v_base = kv_buf["offset"] + int(layer_v_cache_offset[int(layer)]) * int(context_len) * kv_elem_bytes
+            return k_base, v_base
         kv_per_layer = num_kv_heads * context_len * head_dim * kv_elem_bytes
         base = kv_buf["offset"] + layer * 2 * kv_per_layer
         return base, base + kv_per_layer
@@ -7146,6 +7403,8 @@ def generate_ir_lower_2(
             "outputs": {},
             "params": {},
         }
+        if "_kv_cache_read_layer" in ir_op:
+            lowered_op["_kv_cache_read_layer"] = int(ir_op["_kv_cache_read_layer"])
 
         # Process weights - add concrete bump offsets
         for wkey, winfo in ir_op.get("weights", {}).items():
@@ -7702,6 +7961,30 @@ def generate_ir_lower_2(
                             }
                             continue
 
+                if ir_op.get("op") == "gemma4_per_layer_prepare" and input_name in ("tokens", "token_ids"):
+                    buf = activation_buffers.get("token_ids")
+                    if buf:
+                        lowered_op["activations"][input_name] = {
+                            "buffer": "token_ids",
+                            "activation_offset": buf["offset"],
+                            "dtype": "i32",
+                            "ptr_expr": f"activations + {buf['offset']}",
+                        }
+                        continue
+
+                declared_slot = input_info.get("slot")
+                declared_from = input_info.get("from")
+                if declared_slot == "external:token_ids" or declared_from == "external:token_ids":
+                    buf = activation_buffers.get("token_ids")
+                    if buf:
+                        lowered_op["activations"][input_name] = {
+                            "buffer": "token_ids",
+                            "activation_offset": buf["offset"],
+                            "dtype": "i32",
+                            "ptr_expr": f"activations + {buf['offset']}",
+                        }
+                        continue
+
                 # Special case: embedding operation reads from token_ids, not layer_input
                 if "embedding" in ir_op.get("kernel", "").lower() and "token" in input_name.lower():
                     buf = activation_buffers.get("token_ids")
@@ -7709,7 +7992,7 @@ def generate_ir_lower_2(
                         lowered_op["activations"][input_name] = {
                             "buffer": "token_ids",
                             "activation_offset": buf["offset"],
-                            "dtype": "int32",
+                            "dtype": "i32",
                             "ptr_expr": f"activations + {buf['offset']}",
                         }
                         continue
@@ -7983,7 +8266,7 @@ def generate_ir_lower_2(
                 # For DECODE mode, use KV cache offsets for K and V (they're read from cache)
                 # For PREFILL mode, use scratch buffers (K/V are computed fresh each time)
                 if mode == "decode" and scratch_name in ("k_scratch", "v_scratch"):
-                    layer_idx = int(ir_op.get("layer", 0))
+                    layer_idx = int(ir_op.get("_kv_cache_read_layer", ir_op.get("layer", 0)))
                     kv_offs = kv_layer_offsets(layer_idx)
                     if kv_offs:
                         k_off, v_off = kv_offs
@@ -8203,6 +8486,7 @@ def generate_ir_lower_2(
             params["_output_dim"] = out_dim
         if in_dim is not None and "_input_dim" not in params:
             params["_input_dim"] = in_dim
+        apply_layer_attention_dims(op_type, params, int(lowered_op.get("layer", -1)), config)
 
         if op_type == "bias_add" and "_output_dim" not in params:
             for w in lowered_op.get("weights", {}).values():
@@ -8817,17 +9101,50 @@ def generate_ir_lower_3(lowered_ir: Dict, mode: str) -> Dict:
                     op_errors.append(f"{func}.{name}: missing param '{key}'")
                     expr = "0"
 
+            elif src.startswith("config:"):
+                key = src.split(":", 1)[1]
+                if key in config:
+                    val = config[key]
+                    if isinstance(val, str):
+                        expr = f'"{val}"'
+                    elif isinstance(val, bool):
+                        expr = "1" if val else "0"
+                    else:
+                        expr = str(val)
+                else:
+                    op_errors.append(f"{func}.{name}: missing config '{key}'")
+                    expr = "0"
+
             elif src.startswith("runtime:"):
                 key = src.split(":", 1)[1]
                 layer = op.get("layer", 0)
+                kv_layer = int(op.get("_kv_cache_read_layer", layer))
+                try:
+                    kv_cache_head_dim = int(config.get("kv_cache_head_dim", config.get("head_dim", 1)) or config.get("head_dim", 1) or 1)
+                except Exception:
+                    kv_cache_head_dim = int(config.get("head_dim", 1) or 1)
+                if kv_cache_head_dim <= 0:
+                    kv_cache_head_dim = 1
+                layer_k_offsets = config.get("layer_k_cache_offset") if isinstance(config.get("layer_k_cache_offset"), list) else []
+                layer_v_offsets = config.get("layer_v_cache_offset") if isinstance(config.get("layer_v_cache_offset"), list) else []
+                if 0 <= kv_layer < len(layer_k_offsets) and 0 <= kv_layer < len(layer_v_offsets):
+                    k_expr = f"(model->kv_cache + {int(layer_k_offsets[kv_layer])}ULL*MAX_SEQ_LEN)"
+                    v_expr = f"(model->kv_cache + {int(layer_v_offsets[kv_layer])}ULL*MAX_SEQ_LEN)"
+                    k_expr_f16 = f"(model->kv_cache_f16 + {int(layer_k_offsets[kv_layer])}ULL*MAX_SEQ_LEN)"
+                    v_expr_f16 = f"(model->kv_cache_f16 + {int(layer_v_offsets[kv_layer])}ULL*MAX_SEQ_LEN)"
+                else:
+                    k_expr = f"(model->kv_cache + ({kv_layer}*2)*NUM_KV_HEADS*MAX_SEQ_LEN*{kv_cache_head_dim})"
+                    v_expr = f"(model->kv_cache + ({kv_layer}*2+1)*NUM_KV_HEADS*MAX_SEQ_LEN*{kv_cache_head_dim})"
+                    k_expr_f16 = f"(model->kv_cache_f16 + ({kv_layer}*2)*NUM_KV_HEADS*MAX_SEQ_LEN*{kv_cache_head_dim})"
+                    v_expr_f16 = f"(model->kv_cache_f16 + ({kv_layer}*2+1)*NUM_KV_HEADS*MAX_SEQ_LEN*{kv_cache_head_dim})"
                 if key in ("kv_cache_k_layer", "kv_k"):
-                    expr = f"(model->kv_cache + ({layer}*2)*NUM_KV_HEADS*MAX_SEQ_LEN*HEAD_DIM)"
+                    expr = k_expr
                 elif key in ("kv_cache_v_layer", "kv_v"):
-                    expr = f"(model->kv_cache + ({layer}*2+1)*NUM_KV_HEADS*MAX_SEQ_LEN*HEAD_DIM)"
+                    expr = v_expr
                 elif key == "kv_cache_k_layer_f16":
-                    expr = f"(model->kv_cache_f16 + ({layer}*2)*NUM_KV_HEADS*MAX_SEQ_LEN*HEAD_DIM)"
+                    expr = k_expr_f16
                 elif key == "kv_cache_v_layer_f16":
-                    expr = f"(model->kv_cache_f16 + ({layer}*2+1)*NUM_KV_HEADS*MAX_SEQ_LEN*HEAD_DIM)"
+                    expr = v_expr_f16
                 elif key == "rope_cos":
                     expr = "model->rope_cos"
                 elif key == "rope_sin":
@@ -9097,11 +9414,13 @@ def generate_init_ir_lower_3(init_ir: Dict, layout: Dict) -> Dict:
                 "expr": f"(float*)(g_model->bump + {rope_cache_define})",
             })
 
-            # sin_cache output buffer (offset by head_dim/2)
+            head_dim = int(params.get("head_dim", {}).get("value", op_config.get("head_dim", config["head_dim"])))
+
+            # sin_cache output buffer (offset by the init cache row width)
             args.append({
                 "name": "sin_cache",
                 "source": "output:rope_sin",
-                "expr": f"(float*)(g_model->bump + {rope_cache_define}) + MAX_SEQ_LEN * HEAD_DIM / 2",
+                "expr": f"(float*)(g_model->bump + {rope_cache_define}) + MAX_SEQ_LEN * {head_dim} / 2",
             })
 
             # max_seq_len
@@ -9115,7 +9434,7 @@ def generate_init_ir_lower_3(init_ir: Dict, layout: Dict) -> Dict:
             args.append({
                 "name": "head_dim",
                 "source": "dim:head_dim",
-                "expr": "HEAD_DIM",
+                "expr": str(head_dim),
             })
 
             # base (rope_theta)

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -270,12 +270,15 @@ def _compiler_supports_openmp(compiler: str, omp_flag: str) -> bool:
         probe.close()
         out_path = probe.name + ".out"
         cmd = [compiler, probe.name, omp_flag, "-o", out_path]
-        proc = subprocess.run(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
+        try:
+            proc = subprocess.run(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        except FileNotFoundError:
+            return bool(shutil.which(compiler))
         try:
             if os.path.exists(out_path):
                 os.unlink(out_path)
@@ -966,8 +969,9 @@ def step_run_chat(work_dir: Path, args: argparse.Namespace, *, gguf_path: Path |
         cmd.extend(["--repeat-penalty", str(float(args.repeat_penalty))])
     if args.repeat_last_n is not None:
         cmd.extend(["--repeat-last-n", str(int(args.repeat_last_n))])
-    if args.no_repeat_ngram_size is not None:
-        cmd.extend(["--no-repeat-ngram-size", str(int(args.no_repeat_ngram_size))])
+    no_repeat_ngram_size = getattr(args, "no_repeat_ngram_size", None)
+    if no_repeat_ngram_size is not None:
+        cmd.extend(["--no-repeat-ngram-size", str(int(no_repeat_ngram_size))])
     if args.prompt:
         cmd.extend(["--prompt", args.prompt])
     if args.no_chat_template:
@@ -1083,8 +1087,9 @@ def run_pipeline(args: argparse.Namespace) -> int:
             cmd.extend(["--repeat-penalty", str(float(args.repeat_penalty))])
         if args.repeat_last_n is not None:
             cmd.extend(["--repeat-last-n", str(int(args.repeat_last_n))])
-        if args.no_repeat_ngram_size is not None:
-            cmd.extend(["--no-repeat-ngram-size", str(int(args.no_repeat_ngram_size))])
+        no_repeat_ngram_size = getattr(args, "no_repeat_ngram_size", None)
+        if no_repeat_ngram_size is not None:
+            cmd.extend(["--no-repeat-ngram-size", str(int(no_repeat_ngram_size))])
         for override in list(getattr(args, "vision_activation_pref", []) or []):
             cmd.extend(["--vision-activation-pref", str(override)])
         if args.no_chat_template:
@@ -1195,7 +1200,7 @@ Examples:
     run_parser.add_argument("--repeat-last-n", type=int, default=None)
     run_parser.add_argument("--no-repeat-ngram-size", type=int, default=None)
     run_parser.add_argument("--prompt", default=None, help="Single prompt (non-interactive if set)")
-    run_parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen2", "qwen3", "qwen35", "qwen3vl", "gemma", "gemma3", "llama"], default="auto")
+    run_parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen2", "qwen3", "qwen35", "qwen3vl", "gemma", "gemma3", "gemma4", "llama"], default="auto")
     run_parser.add_argument("--no-chat-template", action="store_true")
     run_parser.add_argument("--allow-raw-prompt", action="store_true")
     run_parser.add_argument("--thinking-mode", choices=["auto", "visible", "suppressed"], default="auto")

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -622,6 +622,7 @@ def emit_op(
     force_outproj_fp32_layers: set[int] | None = None,
     force_attn_proj_fp32_layers: set[int] | None = None,
     force_mlp_gate_up_fp32_layers: set[int] | None = None,
+    force_mlp_gate_up_q8_contract_layers: set[int] | None = None,
 ) -> str:
     """Emit a single function call from an IR operation.
 
@@ -640,6 +641,7 @@ def emit_op(
     force_outproj_fp32 = int(layer) in (force_outproj_fp32_layers or set())
     force_attn_proj_fp32 = int(layer) in (force_attn_proj_fp32_layers or set())
     force_mlp_gate_up_fp32 = int(layer) in (force_mlp_gate_up_fp32_layers or set())
+    force_mlp_gate_up_q8_contract = int(layer) in (force_mlp_gate_up_q8_contract_layers or set())
 
     lines = []
     lines.append(f"    /* Op {idx}: {function} ({op_name}) layer={layer} section={section} */")
@@ -738,6 +740,7 @@ def emit_op(
         k_expr = arg_expr_by_name.get("k")
         if x_expr and y_expr and k_expr:
             lines.append(f"    ck_debug_attn_proj_fp32_input = {x_expr};")
+            lines.append(f"    ck_debug_recurrent_proj_fp32_input = {x_expr};")
             if profile:
                 lines.append("    CK_PROFILE_BEGIN();")
             lines.append("    quantize_row_q8_k(")
@@ -747,6 +750,76 @@ def emit_op(
             lines.append("    );")
             if profile:
                 lines.append(f'    CK_PROFILE_END("decode", "{function}", "{op_name}", {layer});')
+            if seq_idx is not None:
+                lines.append(f"    if (stop_seq == {seq_idx}) return;")
+            return "\n".join(lines)
+
+    if op_name in {"recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj"} and function in {"gemv_q4_k_q8_k", "gemv_q8_0_q8_0_contract"}:
+        arg_expr_by_name = {}
+        for arg in args:
+            nm = str(arg.get("name", "")).lower()
+            ex = str(arg.get("expr", ""))
+            if nm and ex and nm not in arg_expr_by_name:
+                arg_expr_by_name[nm] = ex
+
+        y_expr = arg_expr_by_name.get("y")
+        w_expr = arg_expr_by_name.get("w")
+        x_q8_expr = arg_expr_by_name.get("x_q8")
+        x_expr = arg_expr_by_name.get("x")
+        m_expr = arg_expr_by_name.get("m")
+        k_expr = arg_expr_by_name.get("k")
+        fp32_function = "gemv_q4_k" if function == "gemv_q4_k_q8_k" else "gemv_q8_0"
+        q8_call_input = x_q8_expr if function == "gemv_q4_k_q8_k" else x_expr
+        if y_expr and w_expr and q8_call_input and m_expr and k_expr:
+            active_name = f"ck_debug_recurrent_proj_fp32_active_{seq_idx if seq_idx is not None else idx}"
+            lines.append(
+                f"    const int {active_name} = "
+                f"((debug_recurrent_proj_fp32_layer == {layer}) && "
+                f"(!debug_recurrent_proj_op_env || debug_recurrent_proj_op_env[0] == '\\0' || "
+                f"strcmp(debug_recurrent_proj_op_env, \"all\") == 0 || "
+                f"strcmp(debug_recurrent_proj_op_env, \"{op_name}\") == 0));"
+            )
+            lines.append(f"    if ({active_name} && ck_debug_recurrent_proj_fp32_input != NULL) {{")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.append(f"        {fp32_function}(")
+            lines.append(f"            {y_expr},")
+            lines.append(f"            {w_expr},")
+            lines.append("            ck_debug_recurrent_proj_fp32_input,")
+            lines.append(f"            {m_expr},")
+            lines.append(f"            {k_expr}")
+            lines.append("        );")
+            if profile:
+                lines.append(f'        CK_PROFILE_END("decode", "{fp32_function}", "{op_name}", {layer});')
+            lines.append("    } else {")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.append(f"        {function}(")
+            lines.append(f"            {y_expr},")
+            lines.append(f"            {w_expr},")
+            lines.append(f"            {q8_call_input},")
+            lines.append(f"            {m_expr},")
+            lines.append(f"            {k_expr}")
+            lines.append("        );")
+            if profile:
+                lines.append(f'        CK_PROFILE_END("decode", "{function}", "{op_name}", {layer});')
+            lines.append("    }")
+            if dump:
+                raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+                lines.append("    #ifdef CK_PARITY_DUMP")
+                lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "{op_name}", {m_expr});')
+                lines.append("    #endif")
+            hidden_label = {
+                "recurrent_gate_proj": "z",
+                "recurrent_alpha_proj": "alpha",
+                "recurrent_beta_proj": "beta",
+            }.get(op_name)
+            if hidden_label:
+                raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+                lines.append(
+                    f'    ck_debug_export_hidden(model, {layer}, "{hidden_label}", '
+                    f'(const float*){raw_expr}, {m_expr});'
+                )
             if seq_idx is not None:
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
@@ -806,6 +879,12 @@ def emit_op(
                 lines.append("    #ifdef CK_PARITY_DUMP")
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "{dump_label}", {m_expr});')
                 lines.append("    #endif")
+            raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            hidden_label = "q_proj" if op_name == "q_gate_proj" else op_name
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "{hidden_label}", '
+                f'(const float*){raw_expr}, {m_expr});'
+            )
             if seq_idx is not None:
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
@@ -985,6 +1064,11 @@ def emit_op(
                 lines.append("    #ifdef CK_PARITY_DUMP")
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "attn_output", {m_expr});')
                 lines.append("    #endif")
+            raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "out_proj", '
+                f'(const float*){raw_expr}, {m_expr});'
+            )
             if seq_idx is not None:
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
@@ -1080,6 +1164,11 @@ def emit_op(
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "down_proj", {m_expr});')
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "ffn_down", {m_expr});')
                 lines.append("    #endif")
+            raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "mlp_down", '
+                f'(const float*){raw_expr}, {m_expr});'
+            )
             if seq_idx is not None:
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
@@ -1112,6 +1201,8 @@ def emit_op(
             up_w_expr = f"((const void*)((const uint8_t*)({w_expr}) + ((size_t)({half_expr}) * {row_bytes_expr})))"
             fp32_function = "gemv_q4_k" if function in {"gemv_q4_k", "gemv_q4_k_q8_k"} else "gemv_q6_k"
             active_name = f"ck_debug_mlp_gate_up_fp32_active_{seq_idx if seq_idx is not None else idx}"
+            q8_contract_name = f"ck_debug_mlp_gate_up_q8_contract_active_{seq_idx if seq_idx is not None else idx}"
+            q8_contract_supported = function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}
 
             if profile:
                 lines.append("    CK_PROFILE_BEGIN();")
@@ -1120,7 +1211,30 @@ def emit_op(
                 f"(debug_mlp_gate_up_fp32_layer == {layer}) || "
                 f"{1 if force_mlp_gate_up_fp32 else 0};"
             )
-            lines.append(f"    if ({active_name} && ck_debug_mlp_gate_up_fp32_input != NULL) {{")
+            lines.append(
+                f"    const int {q8_contract_name} = "
+                f"({1 if q8_contract_supported else 0}) && "
+                f"(debug_mlp_gate_up_q8_contract || "
+                f"(debug_mlp_gate_up_q8_contract_layer == {layer}) || "
+                f"{1 if force_mlp_gate_up_q8_contract else 0});"
+            )
+            lines.append(f"    if ({q8_contract_name} && ck_debug_mlp_gate_up_fp32_input != NULL) {{")
+            lines.append(f"    quantize_row_q8_k(ck_debug_mlp_gate_up_fp32_input, {x_expr}, {k_expr});")
+            lines.append(f"    {function}(")
+            lines.append(f"        {gate_y_expr},")
+            lines.append(f"        {gate_w_expr},")
+            lines.append(f"        {x_expr},")
+            lines.append(f"        {half_expr},")
+            lines.append(f"        {k_expr}")
+            lines.append("    );")
+            lines.append(f"    {function}(")
+            lines.append(f"        {up_y_expr},")
+            lines.append(f"        {up_w_expr},")
+            lines.append(f"        {x_expr},")
+            lines.append(f"        {half_expr},")
+            lines.append(f"        {k_expr}")
+            lines.append("    );")
+            lines.append(f"    }} else if ({active_name} && ck_debug_mlp_gate_up_fp32_input != NULL) {{")
             lines.append(f"    {fp32_function}(")
             lines.append(f"        {gate_y_expr},")
             lines.append(f"        {gate_w_expr},")
@@ -1154,14 +1268,19 @@ def emit_op(
             if profile:
                 lines.append(f'    CK_PROFILE_END("decode", "{function}", "{op_name}", {layer});')
 
+            raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_gate", (const float*){raw_expr}, {half_expr});')
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "mlp_up", '
+                f'(const float*)(((const float*){raw_expr}) + {half_expr}), {half_expr});'
+            )
+
             if debug:
-                raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
                 lines.append(f'    {{ float *_dbg = (float*){raw_expr}; '
                             f'printf("[Op {idx} {op_name} L{layer}] out[0..4]: %f %f %f %f %f\\n", '
                             f'_dbg[0], _dbg[1], _dbg[2], _dbg[3], _dbg[4]); }}')
 
             if dump:
-                raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
                 lines.append("    #ifdef CK_PARITY_DUMP")
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "ffn_gate_up", {m_expr});')
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "gate_proj", {half_expr});')
@@ -1235,6 +1354,161 @@ def emit_op(
     lines.append("    );")
     if profile:
         lines.append(f'    CK_PROFILE_END("decode", "{function}", "{op_name}", {layer});')
+
+    arg_expr_by_name_for_hidden: Dict[str, str] = {}
+    for arg in args:
+        nm = str(arg.get("name", "")).lower()
+        ex = str(arg.get("expr", ""))
+        if nm and ex and nm not in arg_expr_by_name_for_hidden:
+            arg_expr_by_name_for_hidden[nm] = ex
+
+    def _hidden_arg(*names: str) -> str | None:
+        for nm in names:
+            ex = arg_expr_by_name_for_hidden.get(nm.lower())
+            if ex:
+                return ex
+        return None
+
+    def _hidden_raw(expr: str | None) -> str | None:
+        if not expr:
+            return None
+        return expr.replace("(float*)", "").replace("(void*)", "").strip()
+
+    def _mul_expr(*terms: str | None) -> str | None:
+        non_empty = [t for t in terms if t and str(t) != "0"]
+        if not non_empty:
+            return None
+        return " * ".join(f"({t})" for t in non_empty)
+
+    def _hidden_count(*names: str, default: str = "EMBED_DIM") -> str:
+        for nm in names:
+            ex = arg_expr_by_name_for_hidden.get(nm.lower())
+            if ex:
+                return ex
+        return default
+
+    def _emit_hidden_export(expr: str | None, label: str, count_expr: str | None) -> None:
+        raw_expr = _hidden_raw(expr)
+        if raw_expr and count_expr:
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "{label}", '
+                f'(const float*){raw_expr}, {count_expr});'
+            )
+
+    if op_name == "residual_add":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
+        if out_expr:
+            if op_instance_idx == 0:
+                lines.append(f'    ck_debug_export_hidden(model, {layer}, "after_attn", (const float*){out_expr}, EMBED_DIM);')
+            elif op_instance_idx == 1:
+                lines.append(f'    ck_debug_export_hidden(model, {layer}, "layer_out", (const float*){out_expr}, EMBED_DIM);')
+    elif op_name == "post_attention_norm":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y"))
+        if out_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "post_attn_norm", (const float*){out_expr}, EMBED_DIM);')
+    elif op_name in ("silu_mul", "swiglu"):
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y", "data"))
+        if out_expr:
+            count_expr = _hidden_count("dim", "n", "intermediate_dim", default="INTERMEDIATE_DIM")
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_swiglu", (const float*){out_expr}, {count_expr});')
+    elif op_name == "mlp_down":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
+        if out_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_down", (const float*){out_expr}, EMBED_DIM);')
+    elif op_name == "recurrent_qkv_proj":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "linear_attn_qkv_mixed",
+            _hidden_count("m", "n", "rows", "dim", default="0"),
+        )
+    elif op_name == "recurrent_gate_proj":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "z",
+            _hidden_count("m", "n", "rows", "dim", default="0"),
+        )
+    elif op_name == "recurrent_alpha_proj":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "alpha",
+            _hidden_count("m", "n", "rows", "dim", default="0"),
+        )
+    elif op_name == "recurrent_beta_proj":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "beta",
+            _hidden_count("m", "n", "rows", "dim", default="0"),
+        )
+    elif op_name == "recurrent_dt_gate":
+        _emit_hidden_export(
+            _hidden_arg("gate", "output", "out"),
+            "gate",
+            _mul_expr(_hidden_arg("rows"), _hidden_arg("dim")),
+        )
+    elif op_name == "recurrent_conv_state_update":
+        q_dim = _hidden_arg("q_dim")
+        k_dim = _hidden_arg("k_dim")
+        v_dim = _hidden_arg("v_dim")
+        history_len = _hidden_arg("history_len")
+        num_tokens = _hidden_arg("num_tokens")
+        width_expr = f"({history_len}) + ({num_tokens})" if history_len and num_tokens else None
+        channel_expr = f"({q_dim}) + ({k_dim}) + ({v_dim})" if q_dim and k_dim and v_dim else None
+        _emit_hidden_export(
+            _hidden_arg("conv_x"),
+            "conv_input",
+            _mul_expr(_hidden_arg("num_seqs"), channel_expr, width_expr),
+        )
+    elif op_name == "recurrent_ssm_conv":
+        _emit_hidden_export(
+            _hidden_arg("out", "output"),
+            "conv_output_raw",
+            _mul_expr(_hidden_arg("num_tokens"), _hidden_arg("num_channels")),
+        )
+    elif op_name == "recurrent_silu":
+        _emit_hidden_export(
+            _hidden_arg("out", "output"),
+            "conv_output_silu",
+            _mul_expr(_hidden_arg("rows"), _hidden_arg("dim")),
+        )
+    elif op_name == "recurrent_split_conv_qkv":
+        rows_expr = _hidden_arg("rows")
+        q_dim = _hidden_arg("q_dim")
+        k_dim = _hidden_arg("k_dim")
+        v_dim = _hidden_arg("v_dim")
+        _emit_hidden_export(_hidden_arg("q"), "q_conv", _mul_expr(rows_expr, q_dim))
+        _emit_hidden_export(_hidden_arg("k"), "k_conv", _mul_expr(rows_expr, k_dim))
+        _emit_hidden_export(_hidden_arg("v"), "v_conv_predelta", _mul_expr(rows_expr, v_dim))
+    elif op_name == "recurrent_qk_l2_norm":
+        rows_expr = _hidden_arg("rows")
+        _emit_hidden_export(_hidden_arg("q"), "q_conv_predelta", _mul_expr(rows_expr, _hidden_arg("q_dim")))
+        _emit_hidden_export(_hidden_arg("k"), "k_conv_predelta", _mul_expr(rows_expr, _hidden_arg("k_dim")))
+    elif op_name == "recurrent_core":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "attn_output",
+            _mul_expr(_hidden_arg("tokens", "num_tokens", "rows"), _hidden_arg("num_heads", "groups"), _hidden_arg("state_dim", "head_dim")),
+        )
+        _emit_hidden_export(
+            _hidden_arg("state_out"),
+            "new_state",
+            _mul_expr(_hidden_arg("num_heads", "groups"), _hidden_arg("state_dim", "head_dim"), _hidden_arg("state_dim", "head_dim")),
+        )
+    elif op_name == "recurrent_norm_gate":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "final_output",
+            _mul_expr(_hidden_arg("rows", "tokens"), _hidden_arg("num_heads", "groups"), _hidden_arg("head_dim", "state_dim")),
+        )
+    elif op_name == "recurrent_out_proj":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "linear_attn_out",
+            _hidden_count("m", "n", "rows", "dim", default="EMBED_DIM"),
+        )
+    elif op_name == "final_rmsnorm":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y"))
+        if out_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "final_hidden", (const float*){out_expr}, EMBED_DIM);')
 
     # Add debug output if enabled
     if debug:
@@ -1619,11 +1893,19 @@ static void ck_decode(CKModel *model, int32_t token) {
     int debug_mlp_gate_up_fp32 = debug_mlp_gate_up_env ? (atoi(debug_mlp_gate_up_env) != 0) : 0;
     const char *debug_mlp_gate_up_layer_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_FP32_LAYER");
     int debug_mlp_gate_up_fp32_layer = debug_mlp_gate_up_layer_env ? atoi(debug_mlp_gate_up_layer_env) : -1;
+    const char *debug_mlp_gate_up_q8_contract_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_Q8_CONTRACT");
+    int debug_mlp_gate_up_q8_contract = debug_mlp_gate_up_q8_contract_env ? (atoi(debug_mlp_gate_up_q8_contract_env) != 0) : 0;
+    const char *debug_mlp_gate_up_q8_contract_layer_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_Q8_CONTRACT_LAYER");
+    int debug_mlp_gate_up_q8_contract_layer = debug_mlp_gate_up_q8_contract_layer_env ? atoi(debug_mlp_gate_up_q8_contract_layer_env) : -1;
     const float *ck_debug_mlp_gate_up_fp32_input = NULL;
     const char *debug_attn_proj_layer_env = getenv("CK_V8_DEBUG_ATTN_PROJ_FP32_LAYER");
     int debug_attn_proj_fp32_layer = debug_attn_proj_layer_env ? atoi(debug_attn_proj_layer_env) : -1;
     const char *debug_attn_proj_op_env = getenv("CK_V8_DEBUG_ATTN_PROJ_FP32_OP");
     const float *ck_debug_attn_proj_fp32_input = NULL;
+    const char *debug_recurrent_proj_layer_env = getenv("CK_V8_DEBUG_RECURRENT_PROJ_FP32_LAYER");
+    int debug_recurrent_proj_fp32_layer = debug_recurrent_proj_layer_env ? atoi(debug_recurrent_proj_layer_env) : -1;
+    const char *debug_recurrent_proj_op_env = getenv("CK_V8_DEBUG_RECURRENT_PROJ_FP32_OP");
+    const float *ck_debug_recurrent_proj_fp32_input = NULL;
     const char *debug_lm_head_env = getenv("CK_V8_DEBUG_LM_HEAD_FP32");
     int debug_lm_head_fp32 = debug_lm_head_env ? (atoi(debug_lm_head_env) != 0) : 0;
     const float *ck_debug_lm_head_fp32_input = NULL;
@@ -1683,6 +1965,21 @@ static void ck_decode(CKModel *model, int32_t token) {
             force_mlp_gate_up_fp32_layers.add(int(raw_mlp_gate_up_layers))
         except Exception:
             pass
+    force_mlp_gate_up_q8_contract_layers: set[int] = set()
+    raw_mlp_gate_up_q8_contract_layers = config.get("mlp_gate_up_q8_contract_layers")
+    if raw_mlp_gate_up_q8_contract_layers is None:
+        raw_mlp_gate_up_q8_contract_layers = config.get("mlp_gate_up_q8_contract_layer")
+    if isinstance(raw_mlp_gate_up_q8_contract_layers, (list, tuple, set)):
+        for raw_layer in raw_mlp_gate_up_q8_contract_layers:
+            try:
+                force_mlp_gate_up_q8_contract_layers.add(int(raw_layer))
+            except Exception:
+                pass
+    elif raw_mlp_gate_up_q8_contract_layers is not None:
+        try:
+            force_mlp_gate_up_q8_contract_layers.add(int(raw_mlp_gate_up_q8_contract_layers))
+        except Exception:
+            pass
     if profile:
         lines.append("    CK_PROFILE_VARS();")
     lines.append(f"    /* Store token at offset {token_offset} (from layout) */")
@@ -1723,6 +2020,7 @@ static void ck_decode(CKModel *model, int32_t token) {
                 force_outproj_fp32_layers=force_outproj_fp32_layers,
                 force_attn_proj_fp32_layers=force_attn_proj_fp32_layers,
                 force_mlp_gate_up_fp32_layers=force_mlp_gate_up_fp32_layers,
+                force_mlp_gate_up_q8_contract_layers=force_mlp_gate_up_q8_contract_layers,
             )
         )
         if (scale_embeddings_sqrt_dim
@@ -2040,6 +2338,19 @@ static void ck_decode(CKModel *model, int32_t token);
 static void ck_prefill(CKModel *model, const int32_t *tokens, int count);
 static int ck_trace_pos_enabled(void);
 static void ck_trace_pos(const char *stage, int32_t token, int count, int before_pos, int after_pos);
+
+static void ck_debug_export_hidden(CKModel *model, int layer, const char *name, const float *data, int count) {{
+    const char *dir = getenv("CK_DEBUG_EXPORT_HIDDEN");
+    if (!dir || !dir[0] || !model || !name || !data || count <= 0) return;
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/tok_%04d_layer_%03d_%s.f32",
+                     dir, model->pos, layer, name);
+    if (n <= 0 || (size_t)n >= sizeof(path)) return;
+    FILE *f = fopen(path, "wb");
+    if (!f) return;
+    (void)fwrite(data, sizeof(float), (size_t)count, f);
+    fclose(f);
+}}
 
 static int do_init(const char *weights_path) {{
     if (g_model) return 0;

--- a/version/v8/scripts/compare_first_token_logits_v8.py
+++ b/version/v8/scripts/compare_first_token_logits_v8.py
@@ -25,7 +25,12 @@ import numpy as np
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT_DIR = Path(__file__).resolve().parent
-LLAMA_CPP = ROOT / "llama.cpp"
+_LLAMA_CPP_ENV = os.environ.get("CK_LLAMA_CPP_DIR")
+LLAMA_CPP = Path(_LLAMA_CPP_ENV).expanduser().resolve() if _LLAMA_CPP_ENV else ROOT / "llama.cpp"
+if not (LLAMA_CPP / "include").exists():
+    _software_llama = Path("/opt/app-root/src/Software/llama.cpp")
+    if (_software_llama / "include").exists():
+        LLAMA_CPP = _software_llama
 HELPER_SRC = SCRIPT_DIR / "llama_token_replay_v8.cpp"
 HELPER_BIN = Path("/tmp/ckv8_llama_token_replay")
 
@@ -175,10 +180,21 @@ def ensure_llama_helper() -> Path:
     return HELPER_BIN
 
 
-def run_llama_logits(gguf_path: Path, tokens: list[int], ctx_len: int, top_k: int, threads: int) -> dict[str, Any]:
+def run_llama_logits(
+    gguf_path: Path,
+    tokens: list[int],
+    ctx_len: int,
+    top_k: int,
+    threads: int,
+    decode_mode: str = "batched",
+    no_repack: bool = False,
+) -> dict[str, Any]:
     helper = ensure_llama_helper()
     with tempfile.TemporaryDirectory(prefix="llama_token_replay_") as td:
         logits_path = Path(td) / "llama_logits.f32"
+        mode = str(decode_mode or "batched").strip().lower()
+        if mode not in {"batched", "sequential"}:
+            raise ValueError(f"unsupported llama decode mode: {decode_mode}")
         cmd = [
             str(helper),
             "--model",
@@ -191,7 +207,11 @@ def run_llama_logits(gguf_path: Path, tokens: list[int], ctx_len: int, top_k: in
             str(int(top_k)),
             "--logits-out",
             str(logits_path),
+            "--decode-mode",
+            mode,
         ]
+        if no_repack:
+            cmd.append("--no-repack")
         if threads > 0:
             cmd.extend(["--threads", str(int(threads))])
         proc = _run(cmd, cwd=ROOT)
@@ -217,7 +237,89 @@ def run_llama_logits(gguf_path: Path, tokens: list[int], ctx_len: int, top_k: in
         }
 
 
-def load_ck_logits(model_dir: Path, tokens: list[int]) -> dict[str, Any]:
+def run_llama_logits_segmented(
+    gguf_path: Path,
+    tokens_before: list[int],
+    tokens_after: list[int],
+    ctx_len: int,
+    top_k: int,
+    threads: int,
+    prefix_decode_mode: str = "batched",
+    decode_mode: str = "sequential",
+    no_repack: bool = False,
+) -> dict[str, Any]:
+    helper = ensure_llama_helper()
+    if not tokens_before and not tokens_after:
+        raise ValueError("segmented llama replay needs at least one token")
+    with tempfile.TemporaryDirectory(prefix="llama_token_replay_") as td:
+        logits_path = Path(td) / "llama_logits.f32"
+        before_mode = str(prefix_decode_mode or "batched").strip().lower()
+        after_mode = str(decode_mode or "sequential").strip().lower()
+        if before_mode not in {"batched", "sequential"}:
+            raise ValueError(f"unsupported llama prefix decode mode: {prefix_decode_mode}")
+        if after_mode not in {"batched", "sequential"}:
+            raise ValueError(f"unsupported llama decode mode: {decode_mode}")
+        cmd = [
+            str(helper),
+            "--model",
+            str(gguf_path),
+            "--ctx",
+            str(int(ctx_len)),
+            "--top-k",
+            str(int(top_k)),
+            "--logits-out",
+            str(logits_path),
+            "--prefix-decode-mode",
+            before_mode,
+            "--decode-mode",
+            after_mode,
+        ]
+        if tokens_before:
+            cmd.extend(["--tokens-before", ",".join(str(t) for t in tokens_before)])
+        if tokens_after:
+            cmd.extend(["--tokens-after", ",".join(str(t) for t in tokens_after)])
+        if no_repack:
+            cmd.append("--no-repack")
+        if threads > 0:
+            cmd.extend(["--threads", str(int(threads))])
+        proc = _run(cmd, cwd=ROOT)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "llama_token_replay segmented replay failed\n"
+                f"cmd: {' '.join(cmd)}\n"
+                f"rc: {proc.returncode}\n"
+                f"stdout:\n{proc.stdout}\n"
+                f"stderr:\n{proc.stderr}\n"
+            )
+        meta = json.loads(proc.stdout.strip())
+        if not isinstance(meta, dict) or not meta.get("ok"):
+            raise RuntimeError(f"llama_token_replay returned invalid payload: {proc.stdout.strip()}")
+
+        n_vocab = int(meta.get("n_vocab", 0))
+        logits = np.fromfile(logits_path, dtype=np.float32)
+        if logits.size != n_vocab:
+            raise RuntimeError(f"llama logits size mismatch: got={logits.size} expected={n_vocab}")
+        return {
+            "meta": meta,
+            "logits": logits,
+        }
+
+
+def load_ck_logits(model_dir: Path, tokens: list[int], ck_prefill_mode: str = "auto") -> dict[str, Any]:
+    return load_ck_logits_segmented(
+        model_dir=model_dir,
+        prompt_tokens=tokens,
+        decode_tokens=[],
+        ck_prefill_mode=ck_prefill_mode,
+    )
+
+
+def load_ck_logits_segmented(
+    model_dir: Path,
+    prompt_tokens: list[int],
+    decode_tokens: list[int],
+    ck_prefill_mode: str = "auto",
+) -> dict[str, Any]:
     lib_path = model_dir / "libmodel.so"
     lib = ctypes.CDLL(str(lib_path), mode=ctypes.RTLD_GLOBAL)
 
@@ -286,10 +388,27 @@ def load_ck_logits(model_dir: Path, tokens: list[int]) -> dict[str, Any]:
             strict_env = os.environ.get("CK_STRICT_PARITY")
             lib.ck_set_strict_parity(1 if strict_env and int(strict_env) != 0 else 0)
         runtime_contract = load_runtime_contract(model_dir)
-        prefill_policy = str(runtime_contract.get("prefill_policy") or "batched").strip().lower()
+        contract_prefill_policy = str(runtime_contract.get("prefill_policy") or "batched").strip().lower()
+        requested_mode = str(ck_prefill_mode or "auto").strip().lower()
+        if requested_mode == "auto":
+            prefill_policy = contract_prefill_policy
+        elif requested_mode == "sequential":
+            prefill_policy = "sequential_decode"
+        elif requested_mode == "batched":
+            prefill_policy = "batched"
+        elif requested_mode == "hybrid":
+            prefill_policy = "hybrid"
+        else:
+            raise ValueError(f"unsupported CK prefill mode: {ck_prefill_mode}")
         vocab = int(lib.ck_model_get_vocab_size())
         if vocab <= 0:
             raise RuntimeError(f"invalid CK vocab size: {vocab}")
+        prompt = [int(x) for x in prompt_tokens]
+        generated = [int(x) for x in decode_tokens]
+        tokens = prompt + generated
+        if not tokens:
+            raise RuntimeError("CK logit replay requires at least one token")
+
         if prefill_policy == "sequential_decode":
             if not has_decode:
                 raise RuntimeError("runtime contract requires sequential prefill but ck_model_decode is unavailable")
@@ -299,8 +418,24 @@ def load_ck_logits(model_dir: Path, tokens: list[int]) -> dict[str, Any]:
                 rc = lib.ck_model_decode(ctypes.c_int32(int(tok)), None)
                 if rc != 0:
                     raise RuntimeError(f"ck_model_decode failed rc={rc}")
+        elif prefill_policy == "hybrid":
+            if not has_decode:
+                raise RuntimeError("hybrid CK replay requires ck_model_decode")
+            if not prompt:
+                raise RuntimeError("hybrid CK replay requires at least one prompt token")
+            arr = (ctypes.c_int32 * len(prompt))(*prompt)
+            rc = lib.ck_model_embed_tokens(arr, len(prompt))
+            if rc != 0:
+                raise RuntimeError(f"ck_model_embed_tokens failed rc={rc}")
+            rc = lib.ck_model_forward(None)
+            if rc != 0:
+                raise RuntimeError(f"ck_model_forward failed rc={rc}")
+            for tok in generated:
+                rc = lib.ck_model_decode(ctypes.c_int32(int(tok)), None)
+                if rc != 0:
+                    raise RuntimeError(f"ck_model_decode failed rc={rc}")
         else:
-            arr = (ctypes.c_int32 * len(tokens))(*[int(x) for x in tokens])
+            arr = (ctypes.c_int32 * len(tokens))(*tokens)
             rc = lib.ck_model_embed_tokens(arr, len(tokens))
             if rc != 0:
                 raise RuntimeError(f"ck_model_embed_tokens failed rc={rc}")
@@ -326,6 +461,8 @@ def load_ck_logits(model_dir: Path, tokens: list[int]) -> dict[str, Any]:
             "stride": stride,
             "init_dir": str(init_dir_used) if init_dir_used is not None else str(model_dir),
             "prefill_policy": prefill_policy,
+            "contract_prefill_policy": contract_prefill_policy,
+            "ck_prefill_mode": requested_mode,
             "logits": logits,
         }
     finally:
@@ -360,6 +497,14 @@ def compare_logits(
 
     ck_top_list = [int(x) for x in ck_top.tolist()]
     ll_top_list = [int(x) for x in ll_top.tolist()]
+    ck_top1 = ck_top_list[0]
+    ll_top1 = ll_top_list[0]
+    ck_top2 = ck_top_list[1] if len(ck_top_list) > 1 else ck_top1
+    ll_top2 = ll_top_list[1] if len(ll_top_list) > 1 else ll_top1
+    ck_top1_margin = float(a[ck_top1] - a[ck_top2]) if ck_top2 != ck_top1 else 0.0
+    llama_top1_margin = float(b[ll_top1] - b[ll_top2]) if ll_top2 != ll_top1 else 0.0
+    ck_llama_winner_delta_in_ck = float(a[ck_top1] - a[ll_top1])
+    llama_winner_delta_in_llama = float(b[ll_top1] - b[ck_top1])
     overlap = set(ck_top_list) & set(ll_top_list)
     inspected_ids = sorted(set(ck_top_list) | set(ll_top_list))
     inspected_logits = [
@@ -378,9 +523,13 @@ def compare_logits(
         "mean_abs_diff": mean_abs,
         "rmse": rmse,
         "cosine": cosine,
-        "top1_ck": ck_top_list[0],
-        "top1_llama": ll_top_list[0],
-        "top1_match": bool(ck_top_list[0] == ll_top_list[0]),
+        "top1_ck": ck_top1,
+        "top1_llama": ll_top1,
+        "top1_match": bool(ck_top1 == ll_top1),
+        "ck_top1_margin": ck_top1_margin,
+        "llama_top1_margin": llama_top1_margin,
+        "ck_llama_winner_delta_in_ck": ck_llama_winner_delta_in_ck,
+        "llama_winner_delta_in_llama": llama_winner_delta_in_llama,
         "topk_overlap_count": len(overlap),
         "topk_overlap_ratio": float(len(overlap) / float(k)),
         "topk": k,
@@ -398,6 +547,17 @@ def main() -> int:
     ap.add_argument("--ctx-len", type=int, default=256)
     ap.add_argument("--top-k", type=int, default=16)
     ap.add_argument("--threads", type=int, default=0)
+    ap.add_argument(
+        "--llama-decode-mode",
+        choices=["auto", "batched", "sequential"],
+        default="auto",
+        help="llama.cpp replay mode; auto mirrors CK sequential_decode contracts.",
+    )
+    ap.add_argument(
+        "--llama-no-repack",
+        action="store_true",
+        help="Disable llama.cpp CPU tensor repacking in the replay helper for accumulation-order attribution.",
+    )
     ap.add_argument("--require-top1-match", action=argparse.BooleanOptionalAction, default=True)
     ap.add_argument("--min-topk-overlap", type=float, default=0.50)
     ap.add_argument("--max-abs-threshold", type=float, default=1.0e9)
@@ -407,10 +567,22 @@ def main() -> int:
     model_dir = discover_ck_model_dir(args.model_dir)
     gguf_path = discover_gguf(args.gguf, model_dir)
     tokens = parse_tokens_csv(args.tokens)
+    runtime_contract = load_runtime_contract(model_dir)
+    llama_decode_mode = str(args.llama_decode_mode)
+    if llama_decode_mode == "auto":
+        llama_decode_mode = "batched"
 
     # Run llama helper first. CK runtime initializes OpenMP/threadpool state;
     # forking a subprocess after that can crash on some systems.
-    ll = run_llama_logits(gguf_path, tokens, int(args.ctx_len), int(args.top_k), int(args.threads))
+    ll = run_llama_logits(
+        gguf_path,
+        tokens,
+        int(args.ctx_len),
+        int(args.top_k),
+        int(args.threads),
+        decode_mode=llama_decode_mode,
+        no_repack=bool(args.llama_no_repack),
+    )
     ck = load_ck_logits(model_dir, tokens)
     cmp = compare_logits(ck["logits"], ll["logits"], int(args.top_k))
 
@@ -441,6 +613,8 @@ def main() -> int:
         "llama": {
             "n_vocab": int(ll["meta"]["n_vocab"]),
             "token_count": int(ll["meta"]["token_count"]),
+            "decode_mode": llama_decode_mode,
+            "no_repack": bool(args.llama_no_repack),
             "topk_count": int(len(ll["meta"].get("topk", []) or [])),
             "topk_sample": ll["meta"].get("topk", [])[: min(8, int(args.top_k))],
         },

--- a/version/v8/scripts/compare_hidden_dirs_v8.py
+++ b/version/v8/scripts/compare_hidden_dirs_v8.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Compare CK hidden dumps against llama.cpp tensor dumps for a token."""
+
+import argparse
+import csv
+from pathlib import Path
+
+import numpy as np
+
+
+def _compare(a_path: Path, b_path: Path, token: int | None = None) -> dict:
+    a = np.fromfile(a_path, dtype=np.float32)
+    b = np.fromfile(b_path, dtype=np.float32)
+    if token is not None and a.size > 0 and b.size > a.size and b.size % a.size == 0:
+        rows = int(b.size // a.size)
+        if 0 <= int(token) < rows:
+            start = int(token) * int(a.size)
+            b = b[start : start + int(a.size)]
+    n = min(int(a.size), int(b.size))
+    if n <= 0:
+        raise ValueError(f"empty vector input: {a_path} {b_path}")
+    af = a[:n].astype(np.float64)
+    bf = b[:n].astype(np.float64)
+    diff = af - bf
+    denom = float(np.linalg.norm(af) * np.linalg.norm(bf))
+    cosine = float(np.dot(af, bf) / denom) if denom else float("nan")
+    return {
+        "a_size": int(a.size),
+        "b_size": int(b.size),
+        "compared": n,
+        "cosine": cosine,
+        "rmse": float(np.sqrt(np.mean(diff * diff))),
+        "mean_abs": float(np.mean(np.abs(diff))),
+        "max_abs": float(np.max(np.abs(diff))),
+        "max_idx": int(np.argmax(np.abs(diff))),
+    }
+
+
+def _ck_name(token: int, layer: int, name: str) -> str:
+    if layer < 0:
+        return f"tok_{token:04d}_layer_-01_{name}.f32"
+    return f"tok_{token:04d}_layer_{layer:03d}_{name}.f32"
+
+
+def _llama_name(token: int, layer: int, name: str) -> str:
+    if layer < 0:
+        return f"{name}-token-{token:06d}-occ-000.bin"
+    return f"{name}-{layer}-token-{token:06d}-occ-000.bin"
+
+
+def _default_pairs(layer: int) -> list[tuple[str, str]]:
+    return [
+        ("after_attn", "attn_residual"),
+        ("post_attn_norm", "attn_post_norm"),
+        ("mlp_gate", "ffn_gate"),
+        ("mlp_up", "ffn_up"),
+        ("mlp_swiglu", "ffn_swiglu"),
+        ("mlp_down", "ffn_out"),
+        ("layer_out", "l_out"),
+    ]
+
+
+def _recurrent_pairs(layer: int) -> list[tuple[str, str]]:
+    del layer
+    return [
+        ("linear_attn_qkv_mixed", "linear_attn_qkv_mixed"),
+        ("q_conv", "q_conv"),
+        ("k_conv", "k_conv"),
+        ("q_conv_predelta", "q_conv_predelta"),
+        ("k_conv_predelta", "k_conv_predelta"),
+        ("v_conv_predelta", "v_conv_predelta"),
+        ("attn_output", "attn_output"),
+        ("final_output", "final_output"),
+        ("linear_attn_out", "linear_attn_out"),
+    ]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ck-dir", required=True, type=Path)
+    ap.add_argument("--llama-dir", required=True, type=Path)
+    ap.add_argument("--token", required=True, type=int)
+    ap.add_argument("--layers", default="0-23", help="comma/range list, e.g. 0-23 or 19,23")
+    ap.add_argument(
+        "--include-recurrent",
+        action="store_true",
+        help="Also compare recurrent/Qwen3.5 linear-attention intermediate labels when present.",
+    )
+    ap.add_argument("--csv-out", type=Path)
+    args = ap.parse_args()
+
+    layers: list[int] = []
+    for part in args.layers.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo_s, hi_s = part.split("-", 1)
+            layers.extend(range(int(lo_s), int(hi_s) + 1))
+        else:
+            layers.append(int(part))
+
+    rows: list[dict] = []
+    for layer in layers:
+        pairs = _default_pairs(layer)
+        if args.include_recurrent:
+            pairs = _recurrent_pairs(layer) + pairs
+        for ck_label, ll_label in pairs:
+            ck_path = args.ck_dir / _ck_name(args.token, layer, ck_label)
+            ll_path = args.llama_dir / _llama_name(args.token, layer, ll_label)
+            if not ck_path.exists() or not ll_path.exists():
+                continue
+            result = _compare(ck_path, ll_path, token=args.token)
+            rows.append({"layer": layer, "ck": ck_label, "llama": ll_label, **result})
+
+    final_ck = args.ck_dir / _ck_name(args.token, -1, "final_hidden")
+    final_ll = args.llama_dir / _llama_name(args.token, -1, "result_norm")
+    if final_ck.exists() and final_ll.exists():
+        rows.append({"layer": -1, "ck": "final_hidden", "llama": "result_norm", **_compare(final_ck, final_ll, token=args.token)})
+
+    fieldnames = [
+        "layer",
+        "ck",
+        "llama",
+        "a_size",
+        "b_size",
+        "compared",
+        "cosine",
+        "rmse",
+        "mean_abs",
+        "max_abs",
+        "max_idx",
+    ]
+    if args.csv_out:
+        args.csv_out.parent.mkdir(parents=True, exist_ok=True)
+        with args.csv_out.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    print(",".join(fieldnames))
+    for row in rows:
+        print(",".join(str(row[k]) for k in fieldnames))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/compare_hidden_vectors_v8.py
+++ b/version/v8/scripts/compare_hidden_vectors_v8.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Compare two raw float32 hidden/vector dumps."""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def compare_vectors(a_path: Path, b_path: Path) -> dict:
+    a = np.fromfile(a_path, dtype=np.float32)
+    b = np.fromfile(b_path, dtype=np.float32)
+    n = min(int(a.size), int(b.size))
+    if n <= 0:
+        raise ValueError("empty vector input")
+    af = a[:n].astype(np.float64)
+    bf = b[:n].astype(np.float64)
+    diff = af - bf
+    denom = float(np.linalg.norm(af) * np.linalg.norm(bf))
+    cosine = float(np.dot(af, bf) / denom) if denom else float("nan")
+    max_idx = int(np.argmax(np.abs(diff)))
+    return {
+        "a": str(a_path),
+        "b": str(b_path),
+        "a_size": int(a.size),
+        "b_size": int(b.size),
+        "compared": n,
+        "cosine": cosine,
+        "rmse": float(np.sqrt(np.mean(diff * diff))),
+        "mean_abs": float(np.mean(np.abs(diff))),
+        "max_abs": float(np.max(np.abs(diff))),
+        "max_idx": max_idx,
+        "a_at_max": float(af[max_idx]),
+        "b_at_max": float(bf[max_idx]),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Compare raw float32 hidden/vector dumps")
+    ap.add_argument("a", type=Path)
+    ap.add_argument("b", type=Path)
+    ap.add_argument("--json", action="store_true", help="print JSON instead of text")
+    args = ap.parse_args()
+
+    result = compare_vectors(args.a, args.b)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"sizes={result['a_size']}/{result['b_size']} "
+            f"cosine={result['cosine']:.9f} "
+            f"rmse={result['rmse']:.9f} "
+            f"mean_abs={result['mean_abs']:.9f} "
+            f"max_abs={result['max_abs']:.9f} "
+            f"max_idx={result['max_idx']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/compare_multitoken_logits_v8.py
+++ b/version/v8/scripts/compare_multitoken_logits_v8.py
@@ -20,8 +20,11 @@ from compare_first_token_logits_v8 import (  # type: ignore
     discover_ck_model_dir,
     discover_gguf,
     load_ck_logits,
+    load_ck_logits_segmented,
+    load_runtime_contract,
     parse_tokens_csv,
     run_llama_logits,
+    run_llama_logits_segmented,
 )
 
 
@@ -35,14 +38,47 @@ def run_multitoken_parity(
     top_k: int,
     threads: int,
     append_on_divergence: str,
+    ck_prefill_mode: str,
+    llama_decode_mode: str,
+    llama_no_repack: bool,
 ) -> dict[str, Any]:
     tokens = [int(t) for t in prompt_tokens]
     steps: list[dict[str, Any]] = []
     first_divergence: dict[str, Any] | None = None
 
     for step in range(max(1, int(max_new_tokens))):
-        ll = run_llama_logits(gguf_path, tokens, int(ctx_len), int(top_k), int(threads))
-        ck = load_ck_logits(model_dir, tokens)
+        if llama_decode_mode == "hybrid":
+            ll = run_llama_logits_segmented(
+                gguf_path,
+                [int(t) for t in prompt_tokens],
+                [int(t) for t in tokens[len(prompt_tokens) :]],
+                int(ctx_len),
+                int(top_k),
+                int(threads),
+                prefix_decode_mode="batched",
+                decode_mode="sequential",
+                no_repack=llama_no_repack,
+            )
+        else:
+            ll = run_llama_logits(
+                gguf_path,
+                tokens,
+                int(ctx_len),
+                int(top_k),
+                int(threads),
+                decode_mode=llama_decode_mode,
+                no_repack=llama_no_repack,
+            )
+        generated_tokens = [int(t) for t in tokens[len(prompt_tokens) :]]
+        if ck_prefill_mode == "hybrid":
+            ck = load_ck_logits_segmented(
+                model_dir=model_dir,
+                prompt_tokens=[int(t) for t in prompt_tokens],
+                decode_tokens=generated_tokens,
+                ck_prefill_mode="hybrid",
+            )
+        else:
+            ck = load_ck_logits(model_dir, tokens, ck_prefill_mode=ck_prefill_mode)
         cmp = compare_logits(ck["logits"], ll["logits"], int(top_k))
         ck_next = int(cmp["top1_ck"])
         llama_next = int(cmp["top1_llama"])
@@ -58,6 +94,10 @@ def run_multitoken_parity(
             "rmse": float(cmp["rmse"]),
             "mean_abs_diff": float(cmp["mean_abs_diff"]),
             "max_abs_diff": float(cmp["max_abs_diff"]),
+            "ck_top1_margin": float(cmp.get("ck_top1_margin", 0.0)),
+            "llama_top1_margin": float(cmp.get("llama_top1_margin", 0.0)),
+            "ck_llama_winner_delta_in_ck": float(cmp.get("ck_llama_winner_delta_in_ck", 0.0)),
+            "llama_winner_delta_in_llama": float(cmp.get("llama_winner_delta_in_llama", 0.0)),
             "topk_overlap_count": int(cmp["topk_overlap_count"]),
             "topk_overlap_ratio": float(cmp["topk_overlap_ratio"]),
             "ck_topk_ids": list(cmp["ck_topk_ids"]),
@@ -90,6 +130,9 @@ def run_multitoken_parity(
         "top_k": int(top_k),
         "threads": int(threads),
         "append_on_divergence": str(append_on_divergence),
+        "ck_prefill_mode": str(ck_prefill_mode),
+        "llama_decode_mode": str(llama_decode_mode),
+        "llama_no_repack": bool(llama_no_repack),
         "first_divergence": first_divergence,
         "steps": steps,
     }
@@ -105,6 +148,27 @@ def main() -> int:
     ap.add_argument("--top-k", type=int, default=20)
     ap.add_argument("--threads", type=int, default=0)
     ap.add_argument(
+        "--llama-decode-mode",
+        choices=["auto", "batched", "sequential", "hybrid"],
+        default="auto",
+        help="llama.cpp replay mode; hybrid batches the initial prompt then decodes generated tokens sequentially.",
+    )
+    ap.add_argument(
+        "--ck-prefill-mode",
+        choices=["auto", "sequential", "batched", "hybrid"],
+        default="auto",
+        help=(
+            "CK replay mode. auto follows runtime_contract; sequential feeds every token through decode; "
+            "batched runs the whole prefix through ck_model_forward; hybrid batches the initial prompt "
+            "then decodes generated tokens one by one."
+        ),
+    )
+    ap.add_argument(
+        "--llama-no-repack",
+        action="store_true",
+        help="Disable llama.cpp CPU tensor repacking in the replay helper for accumulation-order attribution.",
+    )
+    ap.add_argument(
         "--append-on-divergence",
         choices=["stop", "llama", "ck"],
         default="stop",
@@ -117,6 +181,11 @@ def main() -> int:
     model_dir = discover_ck_model_dir(args.model_dir)
     gguf_path = discover_gguf(args.gguf, model_dir)
     prompt_tokens = parse_tokens_csv(args.tokens)
+    runtime_contract = load_runtime_contract(model_dir)
+    llama_decode_mode = str(args.llama_decode_mode)
+    if llama_decode_mode == "auto":
+        prefill_policy = str(runtime_contract.get("prefill_policy") or "batched").strip().lower()
+        llama_decode_mode = "hybrid" if prefill_policy == "sequential_decode" else "batched"
     report = run_multitoken_parity(
         model_dir=model_dir,
         gguf_path=gguf_path,
@@ -126,6 +195,9 @@ def main() -> int:
         top_k=int(args.top_k),
         threads=int(args.threads),
         append_on_divergence=str(args.append_on_divergence),
+        ck_prefill_mode=str(args.ck_prefill_mode),
+        llama_decode_mode=llama_decode_mode,
+        llama_no_repack=bool(args.llama_no_repack),
     )
 
     if args.json_out:
@@ -138,12 +210,19 @@ def main() -> int:
                 "status=fail "
                 f"step={first['step']} prefix_len={first['prefix_len']} "
                 f"ck_next={first['ck_next']} llama_next={first['llama_next']} "
+                f"llama_mode={llama_decode_mode} "
+                f"ck_mode={args.ck_prefill_mode} "
+                f"llama_no_repack={bool(args.llama_no_repack)} "
                 f"cosine={first['cosine']:.6f} rmse={first['rmse']:.6f} "
+                f"ck_margin={first['ck_top1_margin']:.6f} llama_margin={first['llama_top1_margin']:.6f} "
                 f"topk_overlap={first['topk_overlap_count']}/{args.top_k}"
             )
         else:
             print(
                 "status=pass "
+                f"llama_mode={llama_decode_mode} "
+                f"ck_mode={args.ck_prefill_mode} "
+                f"llama_no_repack={bool(args.llama_no_repack)} "
                 f"steps={len(report.get('steps', []))} "
                 f"final_prefix_len={len(report.get('final_prefix', []))}"
             )

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -298,7 +298,10 @@ def _inject_runtime_config_defaults(config: dict, arch: str) -> dict:
         config.setdefault("prefer_fp32_logits", True)
     elif arch_lc == "gemma4":
         config.setdefault("prefer_q8_0_contract", True)
-        config.setdefault("prefer_fp32_logits", True)
+        # Gemma4's 262k-token vocab makes the FP32-activation logits GEMV the
+        # dominant decode cost. Use the Q8 activation contract for tied logits;
+        # this keeps the same quantized weight path as the rest of inference.
+        config.setdefault("prefer_fp32_logits", False)
     return config
 
 
@@ -992,6 +995,214 @@ def describe_layer_contract(tensors: Dict[str, "TensorInfo"], layer: int, arch: 
     return None
 
 
+def build_gemma4_attention_plan(meta: Dict[str, object], num_layers: int) -> Dict[str, object]:
+    """Resolve Gemma4 attention/cache policy from GGUF metadata.
+
+    Keep this as architecture config instead of kernel behavior. The lowered IR
+    should receive already-resolved layer kinds and cache ownership; kernels
+    should only see concrete pointers plus mask/window parameters.
+    """
+    sliding_window_pattern = meta.get("gemma4.attention.sliding_window_pattern")
+    if not isinstance(sliding_window_pattern, list) or len(sliding_window_pattern) != num_layers:
+        raise GGUFError(
+            "Gemma4 requires gemma4.attention.sliding_window_pattern metadata "
+            f"with one entry per layer (expected {num_layers})."
+        )
+
+    try:
+        shared_kv_layers = int(meta.get("gemma4.attention.shared_kv_layers", 0) or 0)
+    except Exception as exc:
+        raise GGUFError("Gemma4 gemma4.attention.shared_kv_layers must be an integer") from exc
+    if shared_kv_layers < 0 or shared_kv_layers > num_layers:
+        raise GGUFError(
+            "Gemma4 gemma4.attention.shared_kv_layers must be between 0 and num_layers "
+            f"(got {shared_kv_layers}, num_layers={num_layers})."
+        )
+
+    sliding_window = meta.get("gemma4.attention.sliding_window", 0)
+    try:
+        sliding_window_i = int(sliding_window or 0)
+    except Exception:
+        sliding_window_i = 0
+
+    def _meta_int_any(*keys: str) -> Optional[int]:
+        for key in keys:
+            value = meta.get(key)
+            if value is None:
+                continue
+            try:
+                return int(value)
+            except Exception:
+                continue
+        return None
+
+    num_heads = _meta_int_any("gemma4.attention.head_count", "attention.head_count")
+    num_kv_heads = _meta_int_any("gemma4.attention.head_count_kv", "attention.head_count_kv")
+    key_length = _meta_int_any("gemma4.attention.key_length", "attention.key_length")
+    value_length = _meta_int_any("gemma4.attention.value_length", "attention.value_length")
+    key_length_swa = _meta_int_any("gemma4.attention.key_length_swa")
+    value_length_swa = _meta_int_any("gemma4.attention.value_length_swa")
+    rotary_dim = _meta_int_any("gemma4.rope.dimension_count", "rope.dimension_count")
+    rotary_dim_swa = _meta_int_any("gemma4.rope.dimension_count_swa")
+
+    first_shared_kv_layer = num_layers - shared_kv_layers
+    full_kv_producer = first_shared_kv_layer - 1
+    sliding_kv_producer = first_shared_kv_layer - 2
+    layer_kinds: list[str] = []
+    layer_kv_policy: list[str] = []
+    layer_kv_source: list[int] = []
+    layer_sliding_window: list[int] = []
+    layer_rope_kind: list[str] = []
+    layer_q_head_dim: list[int] = []
+    layer_k_head_dim: list[int] = []
+    layer_v_head_dim: list[int] = []
+    layer_rotary_dim: list[int] = []
+    layer_q_dim: list[int] = []
+    layer_kv_dim: list[int] = []
+    layer_attention_plan: list[Dict[str, object]] = []
+
+    for layer, sliding_flag in enumerate(sliding_window_pattern):
+        attention_kind = "sliding" if bool(sliding_flag) else "full"
+        owns_kv = layer < first_shared_kv_layer
+        kv_policy = "produce" if owns_kv else "reuse"
+        if owns_kv:
+            kv_source = layer
+        elif attention_kind == "sliding":
+            kv_source = sliding_kv_producer
+        else:
+            kv_source = full_kv_producer
+        if kv_source < 0:
+            raise GGUFError("Gemma4 shared-KV plan has no producer layer to reuse")
+
+        kind = f"{attention_kind}_attention_kv" if owns_kv else f"{attention_kind}_attention_shared_kv"
+        rope_kind = "swa" if attention_kind == "sliding" else "full"
+        window = sliding_window_i if attention_kind == "sliding" else 0
+        q_head_dim = (key_length_swa if attention_kind == "sliding" and key_length_swa else key_length) or 0
+        k_head_dim = q_head_dim
+        v_head_dim = (value_length_swa if attention_kind == "sliding" and value_length_swa else value_length) or q_head_dim
+        rope_dim = (rotary_dim_swa if attention_kind == "sliding" and rotary_dim_swa else rotary_dim) or q_head_dim
+        q_dim = int(num_heads or 0) * int(q_head_dim)
+        kv_dim = int(num_kv_heads or 0) * int(k_head_dim)
+
+        layer_kinds.append(kind)
+        layer_kv_policy.append(kv_policy)
+        layer_kv_source.append(kv_source)
+        layer_sliding_window.append(window)
+        layer_rope_kind.append(rope_kind)
+        layer_q_head_dim.append(int(q_head_dim))
+        layer_k_head_dim.append(int(k_head_dim))
+        layer_v_head_dim.append(int(v_head_dim))
+        layer_rotary_dim.append(int(rope_dim))
+        layer_q_dim.append(int(q_dim))
+        layer_kv_dim.append(int(kv_dim))
+        layer_attention_plan.append({
+            "layer": layer,
+            "kind": kind,
+            "attention_kind": attention_kind,
+            "kv_policy": kv_policy,
+            "kv_source_layer": kv_source,
+            "sliding_window": window,
+            "rope_kind": rope_kind,
+            "q_head_dim": int(q_head_dim),
+            "k_head_dim": int(k_head_dim),
+            "v_head_dim": int(v_head_dim),
+            "rotary_dim": int(rope_dim),
+            "q_dim": int(q_dim),
+            "kv_dim": int(kv_dim),
+        })
+
+    layer_k_cache_offset: list[int] = []
+    layer_v_cache_offset: list[int] = []
+    kv_cache_token_stride_total = 0
+    kv_heads_i = int(num_kv_heads or 0)
+    for k_dim_i, v_dim_i in zip(layer_k_head_dim, layer_v_head_dim):
+        k_elems = kv_heads_i * int(k_dim_i)
+        v_elems = kv_heads_i * int(v_dim_i)
+        layer_k_cache_offset.append(kv_cache_token_stride_total)
+        kv_cache_token_stride_total += k_elems
+        layer_v_cache_offset.append(kv_cache_token_stride_total)
+        kv_cache_token_stride_total += v_elems
+
+    return {
+        "layer_kinds": layer_kinds,
+        "layer_attention_plan": layer_attention_plan,
+        "layer_kv_policy": layer_kv_policy,
+        "layer_kv_source": layer_kv_source,
+        "layer_sliding_window": layer_sliding_window,
+        "layer_rope_kind": layer_rope_kind,
+        "layer_q_head_dim": layer_q_head_dim,
+        "layer_k_head_dim": layer_k_head_dim,
+        "layer_v_head_dim": layer_v_head_dim,
+        "layer_rotary_dim": layer_rotary_dim,
+        "layer_q_dim": layer_q_dim,
+        "layer_kv_dim": layer_kv_dim,
+        "layer_k_cache_offset": layer_k_cache_offset,
+        "layer_v_cache_offset": layer_v_cache_offset,
+        "kv_cache_layer_stride_variable": True,
+        "kv_cache_token_stride_total": kv_cache_token_stride_total,
+        "max_q_head_dim": max(layer_q_head_dim) if layer_q_head_dim else 0,
+        "max_k_head_dim": max(layer_k_head_dim) if layer_k_head_dim else 0,
+        "max_v_head_dim": max(layer_v_head_dim) if layer_v_head_dim else 0,
+        "kv_cache_head_dim": max(
+            max(layer_k_head_dim) if layer_k_head_dim else 0,
+            max(layer_v_head_dim) if layer_v_head_dim else 0,
+        ),
+        "max_rotary_dim": max(layer_rotary_dim) if layer_rotary_dim else 0,
+        "shared_kv_layers": shared_kv_layers,
+        "first_shared_kv_layer": first_shared_kv_layer,
+    }
+
+
+def build_qwen35_execution_plan(layer_kinds: list[str]) -> Dict[str, object]:
+    """Resolve Qwen3.5 layer state/cache ownership from layer kinds.
+
+    The converter has already classified layers from tensor contracts. This
+    helper makes the runtime policy explicit so later IR/codegen/debug paths do
+    not rediscover architecture semantics from tensor names.
+    """
+    layer_state_policy: list[str] = []
+    layer_attention_policy: list[str] = []
+    layer_recurrent_policy: list[str] = []
+    layer_kv_policy: list[str] = []
+    layer_execution_plan: list[Dict[str, object]] = []
+
+    for layer, raw_kind in enumerate(layer_kinds):
+        kind = str(raw_kind or "").strip().lower()
+        if kind == "recurrent":
+            state_policy = "recurrent_state"
+            attention_policy = "none"
+            recurrent_policy = "deltanet"
+            kv_policy = "none"
+        elif kind == "full_attention":
+            state_policy = "kv_cache"
+            attention_policy = "full"
+            recurrent_policy = "none"
+            kv_policy = "produce"
+        else:
+            raise GGUFError(f"Qwen3.5 unsupported layer kind in execution plan: {raw_kind!r}")
+
+        layer_state_policy.append(state_policy)
+        layer_attention_policy.append(attention_policy)
+        layer_recurrent_policy.append(recurrent_policy)
+        layer_kv_policy.append(kv_policy)
+        layer_execution_plan.append({
+            "layer": layer,
+            "kind": kind,
+            "state_policy": state_policy,
+            "attention_policy": attention_policy,
+            "recurrent_policy": recurrent_policy,
+            "kv_policy": kv_policy,
+        })
+
+    return {
+        "layer_execution_plan": layer_execution_plan,
+        "layer_state_policy": layer_state_policy,
+        "layer_attention_policy": layer_attention_policy,
+        "layer_recurrent_policy": layer_recurrent_policy,
+        "layer_kv_policy": layer_kv_policy,
+    }
+
+
 def extract_mrope_sections_for_arch(meta: Dict[str, object], arch: str) -> Optional[list]:
     """Return GGUF RoPE dimension sections for architectures that use text MRoPE."""
     arch_lc = str(arch or "").strip().lower()
@@ -1192,6 +1403,12 @@ def write_f32_zeros(w: HashingWriter, count: int) -> None:
     if count <= 0:
         return
     w.write(np.zeros((count,), dtype=np.float32).tobytes())
+
+
+def write_f32_constant(w: HashingWriter, count: int, value: float) -> None:
+    if count <= 0:
+        return
+    w.write(np.full((count,), float(value), dtype=np.float32).tobytes())
 
 
 def copy_bytes_stream(f_in: BinaryIO, src_pos: int, nbytes: int, w_out: HashingWriter, chunk: int = 1 << 20) -> None:
@@ -2006,6 +2223,7 @@ def main() -> None:
         "gemma4.attention.sliding_window",
         "gemma4.attention.sliding_window_pattern",
         "gemma4.attention.shared_kv_layers",
+        "gemma4.final_logit_softcapping",
         "gemma4.rope.freq_base",
         "gemma4.rope.freq_base_swa",
         "gemma4.rope.dimension_count",
@@ -3371,6 +3589,7 @@ def main() -> None:
                 "unconsumed_source_tensors": unconsumed_sources,
                 "pass": not unconsumed_sources,
             }
+            qwen35_execution_plan = build_qwen35_execution_plan(layer_kinds)
 
             qwen35_config = {
                 "model": arch,
@@ -3403,6 +3622,11 @@ def main() -> None:
                 "dtype": "fp32",
                 "layer_kinds": layer_kinds,
                 "hybrid_block_pattern": layer_kinds[:],
+                "layer_execution_plan": qwen35_execution_plan["layer_execution_plan"],
+                "layer_state_policy": qwen35_execution_plan["layer_state_policy"],
+                "layer_attention_policy": qwen35_execution_plan["layer_attention_policy"],
+                "layer_recurrent_policy": qwen35_execution_plan["layer_recurrent_policy"],
+                "layer_kv_policy": qwen35_execution_plan["layer_kv_policy"],
                 # Qwen3.5 contains recurrent stateful layers. Batched prefill
                 # for those layers is not equivalent to autoregressive decode
                 # until the recurrent prefill state update has dedicated parity.
@@ -3703,7 +3927,6 @@ def main() -> None:
             return
 
         if arch == "gemma4":
-            layer_kinds: list[str] = []
             q_dims: set[int] = set()
             kv_dims: set[int] = set()
             rotary_dims: set[int] = set()
@@ -3725,31 +3948,119 @@ def main() -> None:
                 if q_norm is not None and q_norm.dims:
                     rotary_dims.add(int(q_norm.ne0))
 
-            sliding_window_pattern = meta.get("gemma4.attention.sliding_window_pattern")
-            if isinstance(sliding_window_pattern, list) and len(sliding_window_pattern) == num_layers:
-                layer_kinds = [
-                    "sliding_attention" if bool(flag) else "full_attention"
-                    for flag in sliding_window_pattern
-                ]
+            attention_plan = build_gemma4_attention_plan(meta, num_layers)
+            layer_kinds = attention_plan["layer_kinds"]
 
+            gemma4_materialized_shared_kv = False
+            shared_layers = [
+                layer
+                for layer, policy in enumerate(attention_plan.get("layer_kv_policy", []))
+                if str(policy) == "reuse"
+            ]
+            if shared_layers:
+                materializable = all(
+                    tensors.get(f"blk.{layer}.attn_k.weight") is not None
+                    and tensors.get(f"blk.{layer}.attn_v.weight") is not None
+                    and tensors.get(f"blk.{layer}.attn_k_norm.weight") is not None
+                    for layer in shared_layers
+                )
+                if materializable:
+                    # llama.cpp treats these as shared-KV/Q-only layers. CK does not yet
+                    # lower that form, but this GGUF carries optional per-layer K/V tensors,
+                    # so materialize them for the first compile/run bring-up. This is not
+                    # final parity; it is an explicit temporary fallback.
+                    gemma4_materialized_shared_kv = True
+                    for layer in shared_layers:
+                        kind = str(attention_plan["layer_kinds"][layer])
+                        if kind == "sliding_attention_shared_kv":
+                            attention_plan["layer_kinds"][layer] = "sliding_attention_kv"
+                        elif kind == "full_attention_shared_kv":
+                            attention_plan["layer_kinds"][layer] = "full_attention_kv"
+                        # Keep the original llama.cpp source layer for attention reads.
+                        # We still materialize optional per-layer K/V tensors as a compile/run
+                        # fallback, but shared-KV layers must attend to the producer cache.
+                        attention_plan["layer_kv_policy"][layer] = "produce"
+                    layer_kinds = attention_plan["layer_kinds"]
+
+            gemma4_per_layer_dim = int(meta.get("gemma4.embedding_length_per_layer_input", 0) or 0)
+            per_layer_token_emb = tensors.get("per_layer_token_embd.weight")
+            per_layer_model_proj = tensors.get("per_layer_model_proj.weight")
+            per_layer_proj_norm = tensors.get("per_layer_proj_norm.weight")
+            missing_per_layer = [
+                name
+                for name, info in (
+                    ("per_layer_token_embd.weight", per_layer_token_emb),
+                    ("per_layer_model_proj.weight", per_layer_model_proj),
+                    ("per_layer_proj_norm.weight", per_layer_proj_norm),
+                )
+                if info is None
+            ]
+            if missing_per_layer:
+                raise GGUFError(f"Gemma4 per-layer embedding tensors are required: missing {missing_per_layer}")
+            if gemma4_per_layer_dim <= 0:
+                gemma4_per_layer_dim = int(per_layer_proj_norm.ne0)
+            expected_per_layer_total = int(num_layers) * int(gemma4_per_layer_dim)
+            if int(per_layer_proj_norm.ne0) != int(gemma4_per_layer_dim):
+                raise GGUFError(
+                    f"{per_layer_proj_norm.name}: expected {gemma4_per_layer_dim} elements, got {per_layer_proj_norm.dims}"
+                )
+            if int(per_layer_model_proj.ne0) != int(embed_dim) or int(per_layer_model_proj.ne1) != expected_per_layer_total:
+                raise GGUFError(
+                    f"{per_layer_model_proj.name}: expected dims [ne0={embed_dim}, ne1={expected_per_layer_total}], "
+                    f"got {per_layer_model_proj.dims}"
+                )
+            if int(per_layer_token_emb.ne0) != expected_per_layer_total or int(per_layer_token_emb.ne1) != int(vocab_size):
+                raise GGUFError(
+                    f"{per_layer_token_emb.name}: expected dims [ne0={expected_per_layer_total}, ne1={vocab_size}], "
+                    f"got {per_layer_token_emb.dims}"
+                )
+            if per_layer_token_emb.ggml_type != GGML_TYPE_Q5_K:
+                raise GGUFError(
+                    f"{per_layer_token_emb.name}: only Q5_K is supported in the first Gemma4 per-layer embedding kernel, "
+                    f"got {ggml_type_name(per_layer_token_emb.ggml_type)}"
+                )
+            if per_layer_model_proj.ggml_type != GGML_TYPE_BF16:
+                raise GGUFError(
+                    f"{per_layer_model_proj.name}: expected BF16, got {ggml_type_name(per_layer_model_proj.ggml_type)}"
+                )
+            if per_layer_proj_norm.ggml_type != GGML_TYPE_F32:
+                raise GGUFError(
+                    f"{per_layer_proj_norm.name}: expected F32, got {ggml_type_name(per_layer_proj_norm.ggml_type)}"
+                )
+            gemma4_rope_freqs = tensors.get("rope_freqs.weight")
+            if gemma4_rope_freqs is None:
+                raise GGUFError("Gemma4 full-attention proportional RoPE tensor is required: missing rope_freqs.weight")
+            if gemma4_rope_freqs.ggml_type != GGML_TYPE_F32:
+                raise GGUFError(
+                    f"{gemma4_rope_freqs.name}: expected F32, got {ggml_type_name(gemma4_rope_freqs.ggml_type)}"
+                )
             extra_tensors = [
                 name
                 for name in (
                     "per_layer_model_proj.weight",
                     "per_layer_proj_norm.weight",
                     "per_layer_token_embd.weight",
+                    "rope_freqs.weight",
                     "blk.0.inp_gate.weight",
                     "blk.0.proj.weight",
+                    "blk.0.post_norm.weight",
                 )
                 if name in tensors
             ]
-            raise GGUFError(
-                "Gemma4 bring-up reached family recognition, but v8 cannot lower it yet. "
-                f"Detected layer_kinds={layer_kinds[:8]}{'...' if len(layer_kinds) > 8 else ''}, "
-                f"attention_q_dims={sorted(q_dims)}, kv_dims={sorted(kv_dims)}, rotary_dims={sorted(rotary_dims)}, "
-                f"extra_projection_tensors={extra_tensors}. "
-                "Gemma4 needs layer-kind-aware attention dimensions plus inp_gate/proj/per-layer projection lowering "
-                "before it can run as a promoted v8 family."
+            if any(str(policy) == "reuse" for policy in attention_plan.get("layer_kv_policy", [])):
+                raise GGUFError(
+                    "Gemma4 shared-KV/Q-only layers are detected, but v8 does not lower shared-KV attention yet. "
+                    f"Detected layer_kinds={layer_kinds[:8]}{'...' if len(layer_kinds) > 8 else ''}, "
+                    f"kv_policy={attention_plan['layer_kv_policy'][:8]}{'...' if len(attention_plan['layer_kv_policy']) > 8 else ''}, "
+                    f"kv_source={attention_plan['layer_kv_source'][:8]}{'...' if len(attention_plan['layer_kv_source']) > 8 else ''}."
+                )
+            print(
+                "[gemma4] Experimental bring-up: lowering KV-producing Gemma4 layers with per-layer "
+                f"attention dims. layer_kinds={layer_kinds[:8]}{'...' if len(layer_kinds) > 8 else ''}, "
+                f"q_head_dim={attention_plan['layer_q_head_dim'][:8]}{'...' if len(attention_plan['layer_q_head_dim']) > 8 else ''}, "
+                f"rotary_dim={attention_plan['layer_rotary_dim'][:8]}{'...' if len(attention_plan['layer_rotary_dim']) > 8 else ''}, "
+                f"materialized_shared_kv={gemma4_materialized_shared_kv}, "
+                f"extra_projection_tensors={extra_tensors}."
             )
 
         layer_infos = []
@@ -3757,7 +4068,27 @@ def main() -> None:
         if out_weight is not None:
             dtype_table.append(output_dtype)
         dtype_table.append(CK_DT_FP32)
+        if arch == "gemma4":
+            dtype_table.extend([
+                weight_dtype(per_layer_token_emb, "per_layer_token_embd"),
+                CK_DT_BF16,
+                CK_DT_FP32,
+            ])
         for layer in range(num_layers):
+            if arch == "gemma4":
+                layer_q_head_dim = int(attention_plan["layer_q_head_dim"][layer])
+                layer_k_head_dim = int(attention_plan["layer_k_head_dim"][layer])
+                layer_v_head_dim = int(attention_plan["layer_v_head_dim"][layer])
+                layer_q_dim = int(attention_plan["layer_q_dim"][layer])
+                layer_k_dim = int(num_kv_heads) * layer_k_head_dim
+                layer_v_dim = int(num_kv_heads) * layer_v_head_dim
+            else:
+                layer_q_head_dim = int(head_dim)
+                layer_k_head_dim = int(head_dim)
+                layer_v_head_dim = int(head_dim)
+                layer_q_dim = int(num_heads) * int(head_dim)
+                layer_k_dim = int(embed_kv)
+                layer_v_dim = int(embed_kv)
             attn_norm = tensors.get(f"blk.{layer}.attn_norm.weight")
             ffn_norm = tensors.get(f"blk.{layer}.ffn_norm.weight")
             post_attention_norm = tensors.get(f"blk.{layer}.post_attention_norm.weight")
@@ -3782,6 +4113,45 @@ def main() -> None:
             # QK norm weights (optional - Qwen3 has them, Qwen2/LLaMA don't)
             q_norm = tensors.get(f"blk.{layer}.attn_q_norm.weight")
             k_norm = tensors.get(f"blk.{layer}.attn_k_norm.weight")
+            per_layer_inp_gate = None
+            per_layer_proj = None
+            per_layer_post_norm = None
+            layer_output_scale = None
+            if arch == "gemma4":
+                per_layer_inp_gate = tensors.get(f"blk.{layer}.inp_gate.weight")
+                per_layer_proj = tensors.get(f"blk.{layer}.proj.weight")
+                per_layer_post_norm = tensors.get(f"blk.{layer}.post_norm.weight")
+                layer_output_scale = tensors.get(f"blk.{layer}.layer_output_scale.weight")
+                if not per_layer_inp_gate or not per_layer_proj or not per_layer_post_norm:
+                    raise GGUFError(
+                        f"Layer {layer}: missing Gemma4 per-layer embedding tensors "
+                        "(inp_gate/proj/post_norm)"
+                    )
+                if per_layer_inp_gate.ne0 != embed_dim or per_layer_inp_gate.ne1 != gemma4_per_layer_dim:
+                    raise GGUFError(
+                        f"{per_layer_inp_gate.name}: expected dims [ne0={embed_dim}, ne1={gemma4_per_layer_dim}], "
+                        f"got {per_layer_inp_gate.dims}"
+                    )
+                if per_layer_proj.ne0 != gemma4_per_layer_dim or per_layer_proj.ne1 != embed_dim:
+                    raise GGUFError(
+                        f"{per_layer_proj.name}: expected dims [ne0={gemma4_per_layer_dim}, ne1={embed_dim}], "
+                        f"got {per_layer_proj.dims}"
+                    )
+                if per_layer_post_norm.ne0 != embed_dim:
+                    raise GGUFError(
+                        f"{per_layer_post_norm.name}: expected {embed_dim} elements, got {per_layer_post_norm.dims}"
+                    )
+                if layer_output_scale is not None and layer_output_scale.ne0 != 1:
+                    raise GGUFError(
+                        f"{layer_output_scale.name}: expected scalar layer output scale, got {layer_output_scale.dims}"
+                    )
+                for per_info in (per_layer_inp_gate, per_layer_proj, per_layer_post_norm):
+                    if per_info.ggml_type != GGML_TYPE_F32:
+                        raise GGUFError(f"{per_info.name}: expected F32, got {ggml_type_name(per_info.ggml_type)}")
+                if layer_output_scale is not None and layer_output_scale.ggml_type != GGML_TYPE_F32:
+                    raise GGUFError(
+                        f"{layer_output_scale.name}: expected F32, got {ggml_type_name(layer_output_scale.ggml_type)}"
+                    )
             if not wq or not wk or not wv or not wo:
                 detail = describe_layer_contract(tensors, layer, arch=arch)
                 if detail:
@@ -3802,12 +4172,12 @@ def main() -> None:
                 raise GGUFError(f"{wo.name}: ne1 mismatch: expected {embed_dim}, got {wo.ne1}")
 
             # For ne1 dimensions, check against inferred values
-            if wq.ne1 != embed_dim and wq.ne1 != head_dim * num_heads:
-                raise GGUFError(f"{wq.name}: ne1 invalid: expected {embed_dim} or {head_dim * num_heads}, got {wq.ne1}")
-            if wk.ne1 != embed_kv:
-                raise GGUFError(f"{wk.name}: ne1 invalid: expected {embed_kv}, got {wk.ne1}")
-            if wv.ne1 != embed_kv:
-                raise GGUFError(f"{wv.name}: ne1 invalid: expected {embed_kv}, got {wv.ne1}")
+            if wq.ne1 != embed_dim and wq.ne1 != layer_q_dim:
+                raise GGUFError(f"{wq.name}: ne1 invalid: expected {embed_dim} or {layer_q_dim}, got {wq.ne1}")
+            if wk.ne1 != layer_k_dim:
+                raise GGUFError(f"{wk.name}: ne1 invalid: expected {layer_k_dim}, got {wk.ne1}")
+            if wv.ne1 != layer_v_dim:
+                raise GGUFError(f"{wv.name}: ne1 invalid: expected {layer_v_dim}, got {wv.ne1}")
             if wo.ne0 != wq.ne1:
                 raise GGUFError(f"{wo.name}: ne0 mismatch with Q ne1: expected {wq.ne1}, got {wo.ne0}")
 
@@ -3868,6 +4238,13 @@ def main() -> None:
                 down_dt,
                 CK_DT_FP32,  # b2
             ])
+            if arch == "gemma4":
+                layer_dtypes.extend([
+                    CK_DT_FP32,  # per_layer_inp_gate
+                    CK_DT_FP32,  # per_layer_proj
+                    CK_DT_FP32,  # per_layer_post_norm
+                    CK_DT_FP32,  # layer_output_scale
+                ])
             dtype_table.extend(layer_dtypes)
 
             layer_infos.append({
@@ -3887,6 +4264,10 @@ def main() -> None:
                 "bv": bv,
                 "q_norm": q_norm,  # Optional QK norm (None if not present)
                 "k_norm": k_norm,
+                "per_layer_inp_gate": per_layer_inp_gate,
+                "per_layer_proj": per_layer_proj,
+                "per_layer_post_norm": per_layer_post_norm,
+                "layer_output_scale": layer_output_scale,
                 "wq_dt": wq_dt,
                 "wk_dt": wk_dt,
                 "wv_dt": wv_dt,
@@ -3894,6 +4275,12 @@ def main() -> None:
                 "gate_dt": gate_dt,
                 "up_dt": up_dt,
                 "down_dt": down_dt,
+                "q_head_dim": layer_q_head_dim,
+                "k_head_dim": layer_k_head_dim,
+                "v_head_dim": layer_v_head_dim,
+                "q_dim": layer_q_dim,
+                "k_dim": layer_k_dim,
+                "v_dim": layer_v_dim,
             })
 
         layers_with_bias = sum(1 for info in layer_infos if info["bq"] is not None)
@@ -3999,6 +4386,23 @@ def main() -> None:
                 if merges_bytes:
                     w.write(merges_bytes)
 
+            if arch == "gemma4":
+                per_token_size = ggml_tensor_bytes(per_layer_token_emb)
+                record_entry("per_layer_token_emb", get_quant_type_name(per_layer_token_emb.ggml_type), per_token_size)
+                copy_bytes_stream(f, data_start + per_layer_token_emb.offset, per_token_size, w)
+
+                per_model_proj_size = ggml_tensor_bytes(per_layer_model_proj)
+                record_entry("per_layer_model_proj", get_quant_type_name(per_layer_model_proj.ggml_type), per_model_proj_size)
+                copy_bytes_stream(f, data_start + per_layer_model_proj.offset, per_model_proj_size, w)
+
+                per_proj_norm = read_vector_f32(f, data_start, per_layer_proj_norm)
+                record_entry("per_layer_proj_norm", "fp32", gemma4_per_layer_dim * 4)
+                write_f32_padded(w, per_proj_norm, gemma4_per_layer_dim)
+
+                rope_freqs_size = ggml_tensor_bytes(gemma4_rope_freqs)
+                record_entry("rope_freqs", get_quant_type_name(gemma4_rope_freqs.ggml_type), rope_freqs_size)
+                copy_bytes_stream(f, data_start + gemma4_rope_freqs.offset, rope_freqs_size, w)
+
             # 2) pos_emb: only for non-RoPE models (absolute position embeddings)
             if not uses_rope:
                 pos_emb_size = context_len * aligned_embed_dim * 4
@@ -4032,78 +4436,91 @@ def main() -> None:
                     write_f32_padded(w, post_ffn, aligned_embed_dim)
 
                 # WQ
-                wq_size = ggml_row_bytes(info["wq"].ggml_type, aligned_embed_dim) * (num_heads * aligned_head_dim)
+                layer_q_head_dim = int(info.get("q_head_dim", head_dim))
+                layer_k_head_dim = int(info.get("k_head_dim", head_dim))
+                layer_v_head_dim = int(info.get("v_head_dim", head_dim))
+                layer_q_dim = int(info.get("q_dim", num_heads * head_dim))
+                layer_k_dim = int(info.get("k_dim", num_kv_heads * head_dim))
+                layer_v_dim = int(info.get("v_dim", num_kv_heads * head_dim))
+
+                wq_size = ggml_row_bytes(info["wq"].ggml_type, aligned_embed_dim) * layer_q_dim
                 record_entry(f"layer.{layer}.wq", get_quant_type_name(info["wq"].ggml_type), wq_size)
                 copy_qk_head_packed(
                     f, data_start, info["wq"], w,
                     group_count=num_heads,
-                    head_dim=head_dim,
-                    aligned_head_dim=aligned_head_dim,
+                    head_dim=layer_q_head_dim,
+                    aligned_head_dim=layer_q_head_dim,
                     aligned_embed_dim=aligned_embed_dim,
                 )
 
                 # bq - write actual bias if present, else zeros
-                bq_size = num_heads * aligned_head_dim * 4
+                bq_size = layer_q_dim * 4
                 record_entry(f"layer.{layer}.bq", "fp32", bq_size)
                 if info["bq"] is not None:
                     bq_vec = read_vector_f32(f, data_start, info["bq"])
-                    write_f32_padded(w, bq_vec, num_heads * aligned_head_dim)
+                    write_f32_padded(w, bq_vec, layer_q_dim)
                 else:
-                    write_f32_zeros(w, num_heads * aligned_head_dim)
+                    write_f32_zeros(w, layer_q_dim)
 
                 # q_norm - per-head RMSNorm on Q (Qwen3-style)
                 if info["q_norm"] is not None:
                     q_norm_vec = read_vector_f32(f, data_start, info["q_norm"])
-                    q_norm_size = aligned_head_dim * 4
+                    q_norm_size = layer_q_head_dim * 4
                     record_entry(f"layer.{layer}.q_norm", "fp32", q_norm_size)
-                    write_f32_padded(w, q_norm_vec, aligned_head_dim)
+                    write_f32_padded(w, q_norm_vec, layer_q_head_dim)
 
                 # WK
-                wk_size = ggml_row_bytes(info["wk"].ggml_type, aligned_embed_dim) * (num_kv_heads * aligned_head_dim)
+                wk_size = ggml_row_bytes(info["wk"].ggml_type, aligned_embed_dim) * layer_k_dim
                 record_entry(f"layer.{layer}.wk", get_quant_type_name(info["wk"].ggml_type), wk_size)
                 copy_qk_head_packed(
                     f, data_start, info["wk"], w,
                     group_count=num_kv_heads,
-                    head_dim=head_dim,
-                    aligned_head_dim=aligned_head_dim,
+                    head_dim=layer_k_head_dim,
+                    aligned_head_dim=layer_k_head_dim,
                     aligned_embed_dim=aligned_embed_dim,
                 )
 
                 # bk
-                bk_size = num_kv_heads * aligned_head_dim * 4
+                bk_size = layer_k_dim * 4
                 record_entry(f"layer.{layer}.bk", "fp32", bk_size)
                 if info["bk"] is not None:
                     bk_vec = read_vector_f32(f, data_start, info["bk"])
-                    write_f32_padded(w, bk_vec, num_kv_heads * aligned_head_dim)
+                    write_f32_padded(w, bk_vec, layer_k_dim)
                 else:
-                    write_f32_zeros(w, num_kv_heads * aligned_head_dim)
+                    write_f32_zeros(w, layer_k_dim)
 
                 # k_norm - per-head RMSNorm on K (Qwen3-style)
                 if info["k_norm"] is not None:
                     k_norm_vec = read_vector_f32(f, data_start, info["k_norm"])
-                    k_norm_size = aligned_head_dim * 4
+                    k_norm_size = layer_k_head_dim * 4
                     record_entry(f"layer.{layer}.k_norm", "fp32", k_norm_size)
-                    write_f32_padded(w, k_norm_vec, aligned_head_dim)
+                    write_f32_padded(w, k_norm_vec, layer_k_head_dim)
 
                 # WV
-                wv_size = ggml_row_bytes(info["wv"].ggml_type, aligned_embed_dim) * (num_kv_heads * aligned_head_dim)
+                wv_size = ggml_row_bytes(info["wv"].ggml_type, aligned_embed_dim) * layer_v_dim
                 record_entry(f"layer.{layer}.wv", get_quant_type_name(info["wv"].ggml_type), wv_size)
                 copy_qk_head_packed(
                     f, data_start, info["wv"], w,
                     group_count=num_kv_heads,
-                    head_dim=head_dim,
-                    aligned_head_dim=aligned_head_dim,
+                    head_dim=layer_v_head_dim,
+                    aligned_head_dim=layer_v_head_dim,
                     aligned_embed_dim=aligned_embed_dim,
                 )
 
                 # bv
-                bv_size = num_kv_heads * aligned_head_dim * 4
+                bv_size = layer_v_dim * 4
                 record_entry(f"layer.{layer}.bv", "fp32", bv_size)
                 if info["bv"] is not None:
                     bv_vec = read_vector_f32(f, data_start, info["bv"])
-                    write_f32_padded(w, bv_vec, num_kv_heads * aligned_head_dim)
+                    write_f32_padded(w, bv_vec, layer_v_dim)
                 else:
-                    write_f32_zeros(w, num_kv_heads * aligned_head_dim)
+                    write_f32_zeros(w, layer_v_dim)
+
+                if arch == "gemma4":
+                    # llama.cpp applies RMSNorm to V without a learned scale.
+                    # v_norm is now lowered to a no-weight RMSNorm kernel, so no
+                    # synthetic gamma tensor is written here.
+                    pass
 
                 # Wo
                 wo_size = ggml_tensor_bytes(info["wo"])
@@ -4130,6 +4547,26 @@ def main() -> None:
                 b2_size = aligned_embed_dim * 4
                 record_entry(f"layer.{layer}.b2", "fp32", b2_size)
                 write_f32_zeros(w, aligned_embed_dim)  # b2
+
+                if arch == "gemma4":
+                    pli_size = ggml_tensor_bytes(info["per_layer_inp_gate"])
+                    record_entry(f"layer.{layer}.per_layer_inp_gate", "fp32", pli_size)
+                    copy_bytes_stream(f, data_start + info["per_layer_inp_gate"].offset, pli_size, w)
+
+                    plp_size = ggml_tensor_bytes(info["per_layer_proj"])
+                    record_entry(f"layer.{layer}.per_layer_proj", "fp32", plp_size)
+                    copy_bytes_stream(f, data_start + info["per_layer_proj"].offset, plp_size, w)
+
+                    pln = read_vector_f32(f, data_start, info["per_layer_post_norm"])
+                    record_entry(f"layer.{layer}.per_layer_post_norm", "fp32", aligned_embed_dim * 4)
+                    write_f32_padded(w, pln, aligned_embed_dim)
+
+                    record_entry(f"layer.{layer}.layer_output_scale", "fp32", 4)
+                    if info["layer_output_scale"] is not None:
+                        scale = read_vector_f32(f, data_start, info["layer_output_scale"])
+                        write_f32_padded(w, scale, 1)
+                    else:
+                        write_f32_constant(w, 1, 1.0)
 
             # 4) final RMSNorm weight and bias placeholder
             final_norm = read_vector_f32(f, data_start, tensors["output_norm.weight"])
@@ -4178,6 +4615,36 @@ def main() -> None:
                     if mrope_sections:
                         config["mrope_sections"] = [int(v) for v in mrope_sections]
                         config["mrope_n_dims"] = int(sum(int(v) for v in mrope_sections))
+                if arch == "gemma4":
+                    config.update({
+                        "layer_kinds": attention_plan["layer_kinds"],
+                        "layer_attention_plan": attention_plan["layer_attention_plan"],
+                        "layer_kv_policy": attention_plan["layer_kv_policy"],
+                        "layer_kv_source": attention_plan["layer_kv_source"],
+                        "layer_sliding_window": attention_plan["layer_sliding_window"],
+                        "layer_rope_kind": attention_plan["layer_rope_kind"],
+                        "layer_q_head_dim": attention_plan["layer_q_head_dim"],
+                        "layer_k_head_dim": attention_plan["layer_k_head_dim"],
+                        "layer_v_head_dim": attention_plan["layer_v_head_dim"],
+                        "layer_rotary_dim": attention_plan["layer_rotary_dim"],
+                        "layer_q_dim": attention_plan["layer_q_dim"],
+                        "layer_kv_dim": attention_plan["layer_kv_dim"],
+                        "layer_k_cache_offset": attention_plan["layer_k_cache_offset"],
+                        "layer_v_cache_offset": attention_plan["layer_v_cache_offset"],
+                        "kv_cache_layer_stride_variable": attention_plan["kv_cache_layer_stride_variable"],
+                        "kv_cache_token_stride_total": attention_plan["kv_cache_token_stride_total"],
+                        "max_q_head_dim": attention_plan["max_q_head_dim"],
+                        "max_k_head_dim": attention_plan["max_k_head_dim"],
+                        "max_v_head_dim": attention_plan["max_v_head_dim"],
+                        "kv_cache_head_dim": attention_plan["kv_cache_head_dim"],
+                        "max_rotary_dim": attention_plan["max_rotary_dim"],
+                        "shared_kv_layers": attention_plan["shared_kv_layers"],
+                        "first_shared_kv_layer": attention_plan["first_shared_kv_layer"],
+                        "gemma4_materialized_shared_kv": bool(gemma4_materialized_shared_kv),
+                        "gemma4_per_layer_embedding": True,
+                        "per_layer_dim": int(gemma4_per_layer_dim),
+                        "final_logit_softcapping": float(meta.get("gemma4.final_logit_softcapping", 0.0) or 0.0),
+                    })
                 chat_template = meta.get("tokenizer.chat_template")
                 if isinstance(chat_template, str) and chat_template.strip():
                     config["chat_template"] = chat_template
@@ -4202,6 +4669,12 @@ def main() -> None:
                 quant_summary = {
                     "token_emb": get_quant_type_name(tok.ggml_type),
                 }
+                if arch == "gemma4":
+                    quant_summary.update({
+                        "per_layer_token_emb": get_quant_type_name(per_layer_token_emb.ggml_type),
+                        "per_layer_model_proj": get_quant_type_name(per_layer_model_proj.ggml_type),
+                        "per_layer_proj_norm": "fp32",
+                    })
                 if out_weight is not None:
                     quant_summary["lm_head"] = get_quant_type_name(out_weight.ggml_type)
                 else:
@@ -4215,6 +4688,12 @@ def main() -> None:
                         "w1": get_quant_type_name(info["gate"].ggml_type),
                         "w2": get_quant_type_name(info["down"].ggml_type),
                     }
+                    if arch == "gemma4":
+                        quant_summary[f"layer.{i}"].update({
+                            "per_layer_inp_gate": "fp32",
+                            "per_layer_proj": "fp32",
+                            "per_layer_post_norm": "fp32",
+                        })
 
                 # Template already loaded earlier (for RoPE check)
                 if template_data is None:

--- a/version/v8/scripts/export_ck_hidden_v8.py
+++ b/version/v8/scripts/export_ck_hidden_v8.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""
+Export CK hidden-vector snapshots for an explicit token prefix.
+
+The generated model writes snapshots only when CK_DEBUG_EXPORT_HIDDEN points to
+an output directory. This script sets that environment variable, replays tokens
+through sequential decode, and leaves raw float32 files in the output directory.
+It is tokenizer-free so it can be paired with the deterministic logit parity
+runner.
+"""
+
+import argparse
+import ctypes
+import os
+from pathlib import Path
+
+from compare_first_token_logits_v8 import discover_ck_model_dir, parse_tokens_csv  # type: ignore
+
+
+def export_ck_hidden(model_dir: Path, tokens: list[int], out_dir: Path) -> None:
+    model_dir = discover_ck_model_dir(model_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["CK_DEBUG_EXPORT_HIDDEN"] = str(out_dir)
+
+    lib_path = model_dir / "libmodel.so"
+    lib = ctypes.CDLL(str(lib_path), mode=ctypes.RTLD_GLOBAL)
+
+    lib.ck_model_init.argtypes = [ctypes.c_char_p]
+    lib.ck_model_init.restype = ctypes.c_int
+    lib.ck_model_decode.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_float)]
+    lib.ck_model_decode.restype = ctypes.c_int
+    if hasattr(lib, "ck_model_kv_cache_reset"):
+        lib.ck_model_kv_cache_reset.argtypes = []
+        lib.ck_model_kv_cache_reset.restype = None
+    if hasattr(lib, "ck_model_free"):
+        lib.ck_model_free.argtypes = []
+        lib.ck_model_free.restype = None
+
+    init_candidates = [model_dir / "weights.bump", model_dir]
+    init_ok = False
+    init_errors: list[str] = []
+    for init_dir in init_candidates:
+        rc = lib.ck_model_init(str(init_dir.resolve()).encode("utf-8"))
+        if rc == 0:
+            init_ok = True
+            break
+        init_errors.append(f"{init_dir}:rc={rc}")
+    if not init_ok:
+        raise RuntimeError(f"ck_model_init failed ({', '.join(init_errors)})")
+
+    try:
+        if hasattr(lib, "ck_model_kv_cache_reset"):
+            lib.ck_model_kv_cache_reset()
+        for tok in tokens:
+            rc = lib.ck_model_decode(ctypes.c_int32(int(tok)), None)
+            if rc != 0:
+                raise RuntimeError(f"ck_model_decode failed rc={rc} token={tok}")
+    finally:
+        if hasattr(lib, "ck_model_free"):
+            lib.ck_model_free()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Export CK hidden snapshots for explicit token IDs")
+    ap.add_argument("--model-dir", required=True, type=Path)
+    ap.add_argument("--tokens", required=True, help="comma-separated token IDs")
+    ap.add_argument("--out-dir", required=True, type=Path)
+    args = ap.parse_args()
+
+    export_ck_hidden(
+        model_dir=args.model_dir,
+        tokens=parse_tokens_csv(args.tokens),
+        out_dir=args.out_dir,
+    )
+    files = sorted(args.out_dir.glob("*.f32"))
+    print(f"exported={len(files)} out_dir={args.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/export_llama_hidden_v8.py
+++ b/version/v8/scripts/export_llama_hidden_v8.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""
+Export llama.cpp final hidden embedding for an explicit token prefix.
+
+This uses the same token-replay helper as the logits parity runner and writes
+the final output embedding from llama.cpp embeddings mode. It does not rely on
+tokenizer text reconstruction.
+"""
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from compare_first_token_logits_v8 import (  # type: ignore
+    ROOT,
+    discover_gguf,
+    ensure_llama_helper,
+    parse_tokens_csv,
+)
+
+
+def export_llama_hidden(
+    *,
+    gguf_path: Path,
+    tokens: list[int],
+    tokens_before: list[int] | None = None,
+    tokens_after: list[int] | None = None,
+    ctx_len: int,
+    threads: int,
+    decode_mode: str,
+    prefix_decode_mode: str,
+    out_path: Path,
+) -> dict:
+    helper = ensure_llama_helper()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="llama_hidden_probe_") as td:
+        logits_path = Path(td) / "llama_logits.f32"
+        cmd = [
+            str(helper),
+            "--model",
+            str(gguf_path),
+            "--ctx",
+            str(int(ctx_len)),
+            "--top-k",
+            "16",
+            "--logits-out",
+            str(logits_path),
+            "--embeddings-out",
+            str(out_path),
+            "--decode-mode",
+            decode_mode,
+        ]
+        before = list(tokens_before or [])
+        after = list(tokens_after or [])
+        if before or after:
+            cmd.extend(["--prefix-decode-mode", prefix_decode_mode])
+            if before:
+                cmd.extend(["--tokens-before", ",".join(str(t) for t in before)])
+            if after:
+                cmd.extend(["--tokens-after", ",".join(str(t) for t in after)])
+        else:
+            cmd.extend(["--tokens", ",".join(str(t) for t in tokens)])
+        if threads > 0:
+            cmd.extend(["--threads", str(int(threads))])
+        proc = subprocess.run(cmd, cwd=str(ROOT), text=True, capture_output=True, check=False)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "llama hidden export failed\n"
+                f"cmd: {' '.join(cmd)}\n"
+                f"rc: {proc.returncode}\n"
+                f"stdout:\n{proc.stdout}\n"
+                f"stderr:\n{proc.stderr}\n"
+            )
+        meta = json.loads(proc.stdout.strip())
+        if not isinstance(meta, dict) or not meta.get("ok"):
+            raise RuntimeError(f"invalid llama helper output: {proc.stdout.strip()}")
+        return meta
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Export llama.cpp final hidden embedding for explicit token IDs")
+    ap.add_argument("--gguf", required=True, type=Path)
+    ap.add_argument("--tokens", required=True, help="comma-separated token IDs")
+    ap.add_argument("--tokens-before", default=None, help="comma-separated prompt/prefix token IDs")
+    ap.add_argument("--tokens-after", default=None, help="comma-separated continuation token IDs")
+    ap.add_argument("--ctx-len", type=int, default=1034)
+    ap.add_argument("--threads", type=int, default=0)
+    ap.add_argument("--decode-mode", choices=("batched", "sequential"), default="batched")
+    ap.add_argument("--prefix-decode-mode", choices=("batched", "sequential"), default="batched")
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    gguf_path = discover_gguf(args.gguf, args.gguf.parent)
+    tokens_before = parse_tokens_csv(args.tokens_before) if args.tokens_before else None
+    tokens_after = parse_tokens_csv(args.tokens_after) if args.tokens_after else None
+    meta = export_llama_hidden(
+        gguf_path=gguf_path,
+        tokens=parse_tokens_csv(args.tokens),
+        tokens_before=tokens_before,
+        tokens_after=tokens_after,
+        ctx_len=int(args.ctx_len),
+        threads=int(args.threads),
+        decode_mode=args.decode_mode,
+        prefix_decode_mode=args.prefix_decode_mode,
+        out_path=args.out,
+    )
+    print(f"exported={args.out} n_embd_out={meta.get('n_embd_out')} token_count={meta.get('token_count')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/llama_token_replay_v8.cpp
+++ b/version/v8/scripts/llama_token_replay_v8.cpp
@@ -23,6 +23,7 @@ struct Args {
     std::string prompt;
     std::string prefix_f32_path;
     std::string logits_out_path;
+    std::string embeddings_out_path;
     std::string dump_dir;
     std::vector<std::string> dump_names;
     std::string decode_mode = "batched";
@@ -34,6 +35,7 @@ struct Args {
     int prefix_grid_y = 0;
     int prefix_row_dim = 0;
     int prefix_text_pos = -1;
+    bool no_repack = false;
 };
 
 struct DumpState {
@@ -183,6 +185,12 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
             args.logits_out_path = v;
             continue;
         }
+        if (a == "--embeddings-out") {
+            const char * v = need_value("--embeddings-out");
+            if (!v) return false;
+            args.embeddings_out_path = v;
+            continue;
+        }
         if (a == "--dump-dir") {
             const char * v = need_value("--dump-dir");
             if (!v) return false;
@@ -215,14 +223,18 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
             }
             continue;
         }
+        if (a == "--no-repack") {
+            args.no_repack = true;
+            continue;
+        }
         if (a == "-h" || a == "--help") {
             std::cout
                 << "Usage: llama_token_replay --model <path.gguf> "
                 << "(--tokens <id,id,...> | --prompt <text> | [--tokens-before <id,id,...>] [--tokens-after <id,id,...>]) "
-                << "--logits-out <path.bin> [--prefix-f32 <path.f32>] "
+                << "--logits-out <path.bin> [--embeddings-out <path.f32>] [--prefix-f32 <path.f32>] "
                 << "[--prefix-grid-x N --prefix-grid-y N] [--prefix-row-dim N] [--prefix-text-pos N] [--ctx N] [--top-k K] [--threads N] "
                 << "[--decode-mode batched|sequential] [--prefix-decode-mode batched|sequential] "
-                << "[--dump-dir dir --dump-names a,b,c]\n";
+                << "[--dump-dir dir --dump-names a,b,c] [--no-repack]\n";
             std::exit(0);
         }
         err = "unknown arg: " + a;
@@ -707,6 +719,7 @@ int main(int argc, char ** argv) {
     mparams.n_gpu_layers = 0;
     mparams.use_mmap = true;
     mparams.use_mlock = false;
+    mparams.use_extra_bufts = !args.no_repack;
 
     llama_model * model = llama_model_load_from_file(args.model_path.c_str(), mparams);
     if (!model) {
@@ -753,6 +766,7 @@ int main(int argc, char ** argv) {
     int n_threads = args.threads > 0 ? args.threads : std::max(1, hw_threads);
     cparams.n_threads = n_threads;
     cparams.n_threads_batch = n_threads;
+    cparams.embeddings = !args.embeddings_out_path.empty();
     DumpState dump_state;
     if (!args.dump_dir.empty()) {
         dump_state.dump_dir = args.dump_dir;
@@ -789,13 +803,13 @@ int main(int argc, char ** argv) {
         int32_t rc = decode_tokens(
             ctx,
             tokens_before,
-            args.decode_mode,
+            args.prefix_decode_mode,
             0,
             dump_state.dump_dir.empty() ? nullptr : &dump_state
         );
         if (rc != 0) {
             std::ostringstream oss;
-            oss << "llama_decode failed rc=" << rc << " mode=" << args.decode_mode << " while replaying tokens-before";
+            oss << "llama_decode failed rc=" << rc << " mode=" << args.prefix_decode_mode << " while replaying tokens-before";
             print_json_error(oss.str());
             llama_free(ctx);
             llama_model_free(model);
@@ -875,6 +889,38 @@ int main(int argc, char ** argv) {
         return 8;
     }
 
+    int32_t n_embd_out = 0;
+    if (!args.embeddings_out_path.empty()) {
+        n_embd_out = llama_model_n_embd_out(model);
+        const float * emb = llama_get_embeddings_ith(ctx, -1);
+        if (!emb) {
+            emb = llama_get_embeddings(ctx);
+        }
+        if (!emb || n_embd_out <= 0) {
+            print_json_error("llama embeddings pointer is null");
+            llama_free(ctx);
+            llama_model_free(model);
+            llama_backend_free();
+            return 15;
+        }
+        std::ofstream f(args.embeddings_out_path, std::ios::binary | std::ios::trunc);
+        if (!f) {
+            print_json_error("failed opening embeddings-out file");
+            llama_free(ctx);
+            llama_model_free(model);
+            llama_backend_free();
+            return 16;
+        }
+        f.write(reinterpret_cast<const char *>(emb), static_cast<std::streamsize>(n_embd_out) * sizeof(float));
+        if (!f.good()) {
+            print_json_error("failed writing embeddings-out file");
+            llama_free(ctx);
+            llama_model_free(model);
+            llama_backend_free();
+            return 17;
+        }
+    }
+
     {
         std::ofstream f(args.logits_out_path, std::ios::binary | std::ios::trunc);
         if (!f) {
@@ -914,6 +960,7 @@ int main(int argc, char ** argv) {
     std::cout << "\"prefix_position_count\":" << std::max<int32_t>(0, prefix_text_pos - static_cast<int32_t>(tokens_before.size())) << ",";
     std::cout << "\"prefix_start_pos\":" << tokens_before.size() << ",";
     std::cout << "\"prefix_text_pos\":" << prefix_text_pos << ",";
+    std::cout << "\"n_embd_out\":" << n_embd_out << ",";
     std::cout << "\"tokens\":[";
     for (size_t i = 0; i < tokens_before.size(); ++i) {
         if (i) std::cout << ",";

--- a/version/v8/scripts/probe_ck_deltanet_v8.py
+++ b/version/v8/scripts/probe_ck_deltanet_v8.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+from pathlib import Path
+
+import numpy as np
+
+
+def _load_f32(path: Path) -> np.ndarray:
+    data = np.fromfile(path, dtype=np.float32)
+    if data.size == 0:
+        raise ValueError(f"empty float32 file: {path}")
+    return np.ascontiguousarray(data, dtype=np.float32)
+
+
+def _stats(actual: np.ndarray, expected: np.ndarray) -> str:
+    a = actual.astype(np.float64, copy=False).ravel()
+    b = expected.astype(np.float64, copy=False).ravel()
+    n = min(a.size, b.size)
+    if n == 0:
+        raise ValueError("cannot compare empty arrays")
+    a = a[:n]
+    b = b[:n]
+    diff = a - b
+    na = float(np.linalg.norm(a))
+    nb = float(np.linalg.norm(b))
+    cosine = float(np.dot(a, b) / (na * nb)) if na and nb else 0.0
+    return (
+        f"sizes={actual.size}/{expected.size} cosine={cosine:.9f} "
+        f"rmse={float(np.sqrt(np.mean(diff * diff))):.9f} "
+        f"mean_abs={float(np.mean(np.abs(diff))):.9f} "
+        f"max_abs={float(np.max(np.abs(diff))):.9f} "
+        f"max_idx={int(np.argmax(np.abs(diff)))}"
+    )
+
+
+def _ptr(arr: np.ndarray) -> ctypes.POINTER(ctypes.c_float):
+    return arr.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Probe CK DeltaNet with external float32 tensors")
+    ap.add_argument("--lib", type=Path, default=Path("build/libckernel_engine.so"))
+    ap.add_argument("--q", required=True, type=Path)
+    ap.add_argument("--k", required=True, type=Path)
+    ap.add_argument("--v", required=True, type=Path)
+    ap.add_argument("--g", required=True, type=Path)
+    ap.add_argument("--beta", required=True, type=Path)
+    ap.add_argument("--state-in", required=True, type=Path)
+    ap.add_argument("--expected-out", required=True, type=Path)
+    ap.add_argument("--expected-state", required=True, type=Path)
+    ap.add_argument("--num-heads", type=int, default=16)
+    ap.add_argument("--state-dim", type=int, default=128)
+    ap.add_argument("--eps", type=float, default=1e-6)
+    ap.add_argument(
+        "--llama-state-layout",
+        action="store_true",
+        help="treat state files as llama [head,col,row] dumps and transpose to CK layout",
+    )
+    args = ap.parse_args()
+
+    lib = ctypes.CDLL(str(args.lib.resolve()))
+    fn = lib.gated_deltanet_autoregressive_forward
+    fn.argtypes = [
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_float,
+    ]
+    fn.restype = None
+
+    h = int(args.num_heads)
+    d = int(args.state_dim)
+    vec_size = h * d
+    state_size = h * d * d
+
+    q = _load_f32(args.q)
+    k = _load_f32(args.k)
+    v = _load_f32(args.v)
+    g = _load_f32(args.g)
+    beta = _load_f32(args.beta)
+    state_in = _load_f32(args.state_in)
+    expected_out = _load_f32(args.expected_out)
+    expected_state = _load_f32(args.expected_state)
+
+    if q.size != vec_size or k.size != vec_size or v.size != vec_size:
+        raise ValueError(f"q/k/v must have {vec_size} floats")
+    if g.size != h or beta.size != h:
+        raise ValueError(f"g/beta must have {h} floats")
+    if state_in.size != state_size or expected_state.size != state_size:
+        raise ValueError(f"state tensors must have {state_size} floats")
+    if expected_out.size != vec_size:
+        raise ValueError(f"expected output must have {vec_size} floats")
+
+    if args.llama_state_layout:
+        state_in = np.ascontiguousarray(state_in.reshape(h, d, d).transpose(0, 2, 1).ravel(), dtype=np.float32)
+        expected_state_ck = np.ascontiguousarray(
+            expected_state.reshape(h, d, d).transpose(0, 2, 1).ravel(),
+            dtype=np.float32,
+        )
+    else:
+        expected_state_ck = expected_state
+
+    state_out = np.empty(state_size, dtype=np.float32)
+    out = np.empty(vec_size, dtype=np.float32)
+    fn(
+        _ptr(q),
+        _ptr(k),
+        _ptr(v),
+        _ptr(g),
+        _ptr(beta),
+        _ptr(state_in),
+        _ptr(state_out),
+        _ptr(out),
+        h,
+        d,
+        ctypes.c_float(float(args.eps)),
+    )
+
+    print("out", _stats(out, expected_out))
+    print("state_ck_layout", _stats(state_out, expected_state_ck))
+    if args.llama_state_layout:
+        state_out_llama = np.ascontiguousarray(state_out.reshape(h, d, d).transpose(0, 2, 1).ravel(), dtype=np.float32)
+        print("state_llama_layout", _stats(state_out_llama, expected_state))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/probe_ck_q6_projection_v8.py
+++ b/version/v8/scripts/probe_ck_q6_projection_v8.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Probe a generated CK quantized projection with an external FP32 input vector."""
+
+import argparse
+import ctypes
+import re
+from pathlib import Path
+
+import numpy as np
+
+from compare_first_token_logits_v8 import discover_ck_model_dir  # type: ignore
+
+
+QK_K = 256
+BLOCK_Q8_K_SIZE = 292
+
+
+def _parse_define(c_path: Path, name: str) -> int:
+    pattern = re.compile(rf"^\s*#define\s+{re.escape(name)}\s+([0-9]+)\s*$")
+    for line in c_path.read_text(errors="replace").splitlines():
+        m = pattern.match(line)
+        if m:
+            return int(m.group(1))
+    raise KeyError(f"missing define {name} in {c_path}")
+
+
+def _compare(a: np.ndarray, b: np.ndarray) -> dict:
+    n = min(int(a.size), int(b.size))
+    af = a[:n].astype(np.float64)
+    bf = b[:n].astype(np.float64)
+    diff = af - bf
+    denom = float(np.linalg.norm(af) * np.linalg.norm(bf))
+    cosine = float(np.dot(af, bf) / denom) if denom else float("nan")
+    max_idx = int(np.argmax(np.abs(diff)))
+    return {
+        "compared": n,
+        "cosine": cosine,
+        "rmse": float(np.sqrt(np.mean(diff * diff))),
+        "mean_abs": float(np.mean(np.abs(diff))),
+        "max_abs": float(np.max(np.abs(diff))),
+        "max_idx": max_idx,
+        "actual_at_max": float(af[max_idx]),
+        "expected_at_max": float(bf[max_idx]),
+    }
+
+
+def _init_model(lib: ctypes.CDLL, model_dir: Path) -> None:
+    lib.ck_model_init.argtypes = [ctypes.c_char_p]
+    lib.ck_model_init.restype = ctypes.c_int
+    tried: list[str] = []
+    for init_path in (model_dir / "weights.bump", model_dir):
+        rc = lib.ck_model_init(str(init_path.resolve()).encode("utf-8"))
+        tried.append(f"{init_path}:rc={rc}")
+        if rc == 0:
+            return
+    raise RuntimeError(f"ck_model_init failed: {', '.join(tried)}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model-dir", required=True, type=Path)
+    ap.add_argument("--weight-symbol", required=True, help="generated C define, e.g. W_LAYER_23_FFN_DOWN")
+    ap.add_argument("--input", required=True, type=Path, help="float32 input vector")
+    ap.add_argument("--expected", type=Path, help="optional float32 expected output vector")
+    ap.add_argument("--output", type=Path, help="optional float32 output path")
+    ap.add_argument("--rows", type=int, required=True, help="projection output rows")
+    ap.add_argument("--cols", type=int, required=True, help="projection input cols")
+    ap.add_argument(
+        "--kernel",
+        choices=("q6_k_q8_k", "q4_k_q8_k", "q5_k", "q5_k_q8_k"),
+        default="q6_k_q8_k",
+        help="CK quantized projection kernel to call",
+    )
+    args = ap.parse_args()
+
+    model_dir = discover_ck_model_dir(args.model_dir)
+    c_path = model_dir / "model_v8.c"
+    weight_offset = _parse_define(c_path, args.weight_symbol)
+
+    engine_path = Path("build/libckernel_engine.so").resolve()
+    ctypes.CDLL(str(engine_path), mode=ctypes.RTLD_GLOBAL)
+    lib = ctypes.CDLL(str((model_dir / "libmodel.so").resolve()), mode=ctypes.RTLD_GLOBAL)
+    _init_model(lib, model_dir)
+
+    try:
+        lib.ck_model_get_base_ptr.restype = ctypes.c_uint64
+        base = int(lib.ck_model_get_base_ptr())
+        if base == 0:
+            raise RuntimeError("ck_model_get_base_ptr returned null")
+
+        lib.quantize_row_q8_k.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.c_void_p, ctypes.c_int]
+        lib.quantize_row_q8_k.restype = None
+        kernel_name_by_id = {
+            "q6_k_q8_k": "gemv_q6_k_q8_k",
+            "q4_k_q8_k": "gemv_q4_k_q8_k",
+            "q5_k": "gemv_q5_k",
+            "q5_k_q8_k": "gemv_q5_k_q8_k",
+        }
+        kernel_name = kernel_name_by_id[args.kernel]
+        kernel = getattr(lib, kernel_name)
+        input_is_q8 = args.kernel in ("q6_k_q8_k", "q4_k_q8_k", "q5_k_q8_k")
+        input_arg_type = ctypes.c_void_p if input_is_q8 else ctypes.POINTER(ctypes.c_float)
+        kernel.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.c_void_p, input_arg_type, ctypes.c_int, ctypes.c_int]
+        kernel.restype = None
+
+        x = np.fromfile(args.input, dtype=np.float32)
+        if int(x.size) != int(args.cols):
+            raise ValueError(f"input has {x.size} floats, expected {args.cols}")
+        x = np.ascontiguousarray(x, dtype=np.float32)
+        y = np.zeros(int(args.rows), dtype=np.float32)
+        if input_is_q8:
+            if int(args.cols) % QK_K != 0:
+                raise ValueError(f"Q8_K probe input cols must be divisible by {QK_K}, got {args.cols}")
+            q8_bytes = (int(args.cols) // QK_K) * BLOCK_Q8_K_SIZE
+            q8 = (ctypes.c_uint8 * q8_bytes)()
+            lib.quantize_row_q8_k(
+                x.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                ctypes.cast(q8, ctypes.c_void_p),
+                int(args.cols),
+            )
+            kernel(
+                y.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                ctypes.c_void_p(base + weight_offset),
+                ctypes.cast(q8, ctypes.c_void_p),
+                int(args.rows),
+                int(args.cols),
+            )
+        else:
+            kernel(
+                y.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                ctypes.c_void_p(base + weight_offset),
+                x.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                int(args.rows),
+                int(args.cols),
+            )
+
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            y.tofile(args.output)
+
+        print(
+            f"kernel={args.kernel} weight_symbol={args.weight_symbol} weight_offset={weight_offset} "
+            f"rows={args.rows} cols={args.cols} output_norm={float(np.linalg.norm(y)):.9f}"
+        )
+        if args.expected:
+            expected = np.fromfile(args.expected, dtype=np.float32)
+            result = _compare(y, expected)
+            print(
+                f"sizes={y.size}/{expected.size} cosine={result['cosine']:.9f} "
+                f"rmse={result['rmse']:.9f} mean_abs={result['mean_abs']:.9f} "
+                f"max_abs={result['max_abs']:.9f} max_idx={result['max_idx']} "
+                f"actual_at_max={result['actual_at_max']:.9f} "
+                f"expected_at_max={result['expected_at_max']:.9f}"
+            )
+    finally:
+        if hasattr(lib, "ck_model_free"):
+            lib.ck_model_free()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/probe_ck_recurrent_norm_gate_v8.py
+++ b/version/v8/scripts/probe_ck_recurrent_norm_gate_v8.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Probe CK recurrent_norm_gate_forward with external FP32 tensors."""
+
+import argparse
+import ctypes
+import re
+from pathlib import Path
+
+import numpy as np
+
+from compare_first_token_logits_v8 import discover_ck_model_dir  # type: ignore
+
+
+def _parse_define(c_path: Path, name: str) -> int:
+    pattern = re.compile(rf"^\s*#define\s+{re.escape(name)}\s+([0-9]+)\s*$")
+    for line in c_path.read_text(errors="replace").splitlines():
+        m = pattern.match(line)
+        if m:
+            return int(m.group(1))
+    raise KeyError(f"missing define {name} in {c_path}")
+
+
+def _compare(a: np.ndarray, b: np.ndarray) -> dict:
+    n = min(int(a.size), int(b.size))
+    af = a[:n].astype(np.float64)
+    bf = b[:n].astype(np.float64)
+    diff = af - bf
+    denom = float(np.linalg.norm(af) * np.linalg.norm(bf))
+    cosine = float(np.dot(af, bf) / denom) if denom else float("nan")
+    max_idx = int(np.argmax(np.abs(diff)))
+    return {
+        "compared": n,
+        "cosine": cosine,
+        "rmse": float(np.sqrt(np.mean(diff * diff))),
+        "mean_abs": float(np.mean(np.abs(diff))),
+        "max_abs": float(np.max(np.abs(diff))),
+        "max_idx": max_idx,
+        "actual_at_max": float(af[max_idx]),
+        "expected_at_max": float(bf[max_idx]),
+    }
+
+
+def _init_model(lib: ctypes.CDLL, model_dir: Path) -> None:
+    lib.ck_model_init.argtypes = [ctypes.c_char_p]
+    lib.ck_model_init.restype = ctypes.c_int
+    tried: list[str] = []
+    for init_path in (model_dir / "weights.bump", model_dir):
+        rc = lib.ck_model_init(str(init_path.resolve()).encode("utf-8"))
+        tried.append(f"{init_path}:rc={rc}")
+        if rc == 0:
+            return
+    raise RuntimeError(f"ck_model_init failed: {', '.join(tried)}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model-dir", required=True, type=Path)
+    ap.add_argument("--weight-symbol", required=True, help="generated C define, e.g. W_LAYER_0_SSM_NORM")
+    ap.add_argument("--x", required=True, type=Path, help="float32 recurrent attention output")
+    ap.add_argument("--gate", required=True, type=Path, help="float32 z/gate vector")
+    ap.add_argument("--expected", type=Path, help="optional float32 expected final_output vector")
+    ap.add_argument("--output", type=Path, help="optional float32 output path")
+    ap.add_argument("--rows", type=int, default=1)
+    ap.add_argument("--num-heads", type=int, required=True)
+    ap.add_argument("--head-dim", type=int, required=True)
+    ap.add_argument("--eps", type=float, default=1.0e-6)
+    args = ap.parse_args()
+
+    model_dir = discover_ck_model_dir(args.model_dir)
+    c_path = model_dir / "model_v8.c"
+    weight_offset = _parse_define(c_path, args.weight_symbol)
+
+    engine_path = Path("build/libckernel_engine.so").resolve()
+    ctypes.CDLL(str(engine_path), mode=ctypes.RTLD_GLOBAL)
+    lib = ctypes.CDLL(str((model_dir / "libmodel.so").resolve()), mode=ctypes.RTLD_GLOBAL)
+    _init_model(lib, model_dir)
+
+    try:
+        lib.ck_model_get_base_ptr.restype = ctypes.c_uint64
+        base = int(lib.ck_model_get_base_ptr())
+        if base == 0:
+            raise RuntimeError("ck_model_get_base_ptr returned null")
+
+        kernel = lib.recurrent_norm_gate_forward
+        kernel.argtypes = [
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_float,
+        ]
+        kernel.restype = None
+
+        x = np.ascontiguousarray(np.fromfile(args.x, dtype=np.float32), dtype=np.float32)
+        gate = np.ascontiguousarray(np.fromfile(args.gate, dtype=np.float32), dtype=np.float32)
+        expected_size = int(args.rows) * int(args.num_heads) * int(args.head_dim)
+        if int(x.size) != expected_size:
+            raise ValueError(f"x has {x.size} floats, expected {expected_size}")
+        if int(gate.size) != expected_size:
+            raise ValueError(f"gate has {gate.size} floats, expected {expected_size}")
+
+        y = np.zeros(expected_size, dtype=np.float32)
+        kernel(
+            x.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            gate.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            ctypes.cast(ctypes.c_void_p(base + weight_offset), ctypes.POINTER(ctypes.c_float)),
+            y.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            int(args.rows),
+            int(args.num_heads),
+            int(args.head_dim),
+            ctypes.c_float(float(args.eps)),
+        )
+
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            y.tofile(args.output)
+
+        print(
+            f"kernel=recurrent_norm_gate_forward weight_symbol={args.weight_symbol} "
+            f"weight_offset={weight_offset} rows={args.rows} num_heads={args.num_heads} "
+            f"head_dim={args.head_dim} eps={args.eps:g} output_norm={float(np.linalg.norm(y)):.9f}"
+        )
+        if args.expected:
+            expected = np.fromfile(args.expected, dtype=np.float32)
+            result = _compare(y, expected)
+            print(
+                f"sizes={y.size}/{expected.size} cosine={result['cosine']:.9f} "
+                f"rmse={result['rmse']:.9f} mean_abs={result['mean_abs']:.9f} "
+                f"max_abs={result['max_abs']:.9f} max_idx={result['max_idx']} "
+                f"actual_at_max={result['actual_at_max']:.9f} "
+                f"expected_at_max={result['expected_at_max']:.9f}"
+            )
+    finally:
+        if hasattr(lib, "ck_model_free"):
+            lib.ck_model_free()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/templates/gemma4.json
+++ b/version/v8/templates/gemma4.json
@@ -37,12 +37,19 @@
       "system_prompt_separator": "\n\n",
       "default_system_prompt": "",
       "inject_default_system_prompt": false,
-      "force_bos_text_if_tokenizer_add_bos_false": "",
+      "force_bos_text_if_tokenizer_add_bos_false": "<bos>",
       "last_user_prefix": "",
       "last_user_prefix_suppression_markers": [],
-      "stop_text_markers": ["<turn|>"],
-      "token_stop_markers": ["<turn|>"],
-      "template_markers": ["<|turn>", "<turn|>"],
+      "stop_text_markers": [
+        "<turn|>"
+      ],
+      "token_stop_markers": [
+        "<turn|>"
+      ],
+      "template_markers": [
+        "<|turn>",
+        "<turn|>"
+      ],
       "min_response_tokens": 8
     },
     "attention_contract": {
@@ -50,7 +57,13 @@
       "rope_type": "rope",
       "qk_norm": true,
       "kv_layout": "layer_major_kv_cache",
-      "attn_variant": "hybrid_sliding_attention"
+      "attn_variant": "hybrid_sliding_attention",
+      "layer_policy_config_key": "layer_attention_plan",
+      "layer_kind_config_key": "layer_kinds",
+      "kv_policy_config_key": "layer_kv_policy",
+      "kv_source_config_key": "layer_kv_source",
+      "sliding_window_config_key": "layer_sliding_window",
+      "rope_kind_config_key": "layer_rope_kind"
     },
     "block_contract": {
       "norm_type": "rmsnorm",
@@ -82,16 +95,27 @@
     }
   },
   "kernels": {
-    "rope_qk": "rope_forward_qk",
-    "rope_init": "rope_precompute_cache_split"
+    "rope_qk": "rope_forward_qk_gemma4",
+    "rope_init": "rope_precompute_cache_split",
+    "attn": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+    "attn_sliding": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+    "attn_decode": "attention_forward_decode_head_major_gqa_flash_gemma4",
+    "attn_sliding_decode": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4"
   },
-  "sequence": ["decoder"],
+  "sequence": [
+    "decoder"
+  ],
   "block_types": {
     "decoder": {
-      "sequence": ["header", "body", "footer"],
+      "sequence": [
+        "header",
+        "body",
+        "footer"
+      ],
       "header": [
         "bpe_tokenizer",
-        "dense_embedding_lookup"
+        "dense_embedding_lookup",
+        "gemma4_per_layer_prepare"
       ],
       "body": {
         "type": "hybrid_sliding_attention",
@@ -99,13 +123,15 @@
         "default_kind": "sliding_attention",
         "quant_aliases_common": {
           "ln1_gamma": "attn_norm",
-          "ln2_gamma": "post_attention_norm",
+          "ln2_gamma": "ffn_norm",
+          "post_attention_norm": "attn_post_norm",
+          "post_ffn_norm": "ffn_post_norm",
           "w1": "ffn_gate",
           "w3": "ffn_up",
           "w2": "ffn_down"
         },
         "quant_aliases_by_kind": {
-          "sliding_attention": {
+          "sliding_attention_kv": {
             "wq": "attn_q",
             "wk": "attn_k",
             "wv": "attn_v",
@@ -113,54 +139,107 @@
             "q_norm": "attn_q_norm",
             "k_norm": "attn_k_norm"
           },
-          "full_attention": {
+          "full_attention_kv": {
             "wq": "attn_q",
             "wk": "attn_k",
             "wv": "attn_v",
             "wo": "attn_output",
             "q_norm": "attn_q_norm",
             "k_norm": "attn_k_norm"
+          },
+          "sliding_attention_shared_kv": {
+            "wq": "attn_q",
+            "wo": "attn_output",
+            "q_norm": "attn_q_norm"
+          },
+          "full_attention_shared_kv": {
+            "wq": "attn_q",
+            "wo": "attn_output",
+            "q_norm": "attn_q_norm"
           }
         },
         "ops_by_kind": {
-          "sliding_attention": [
+          "sliding_attention_kv": [
             "attn_norm",
             "q_proj",
             "k_proj",
             "v_proj",
+            "v_norm",
             "qk_norm",
             "rope_qk",
             "attn_sliding",
             "out_proj",
-            "residual_add",
             "post_attention_norm",
+            "residual_add",
+            "ffn_norm",
             "mlp_gate_up",
             "geglu",
             "mlp_down",
-            "residual_add"
+            "post_ffn_norm",
+            "residual_add",
+            "gemma4_per_layer_embed"
           ],
-          "full_attention": [
+          "full_attention_kv": [
             "attn_norm",
             "q_proj",
             "k_proj",
             "v_proj",
+            "v_norm",
             "qk_norm",
             "rope_qk",
             "attn",
             "out_proj",
-            "residual_add",
             "post_attention_norm",
+            "residual_add",
+            "ffn_norm",
             "mlp_gate_up",
             "geglu",
             "mlp_down",
-            "residual_add"
+            "post_ffn_norm",
+            "residual_add",
+            "gemma4_per_layer_embed"
+          ],
+          "sliding_attention_shared_kv": [
+            "attn_norm",
+            "q_proj",
+            "q_norm",
+            "rope_q",
+            "attn_sliding_shared_kv",
+            "out_proj",
+            "post_attention_norm",
+            "residual_add",
+            "ffn_norm",
+            "mlp_gate_up",
+            "geglu",
+            "mlp_down",
+            "post_ffn_norm",
+            "residual_add",
+            "gemma4_per_layer_embed"
+          ],
+          "full_attention_shared_kv": [
+            "attn_norm",
+            "q_proj",
+            "q_norm",
+            "rope_q",
+            "attn_shared_kv",
+            "out_proj",
+            "post_attention_norm",
+            "residual_add",
+            "ffn_norm",
+            "mlp_gate_up",
+            "geglu",
+            "mlp_down",
+            "post_ffn_norm",
+            "residual_add",
+            "gemma4_per_layer_embed"
           ]
         }
       },
       "footer": [
         "final_rmsnorm",
         "weight_tying",
-        "logits"
+        "logits",
+        "final_logit_softcap"
       ]
     }
   }

--- a/version/v8/templates/qwen35.json
+++ b/version/v8/templates/qwen35.json
@@ -58,7 +58,13 @@
       "rope_type": "rope",
       "qk_norm": "hybrid_full_attention_only",
       "kv_layout": "layer_major_kv_cache",
-      "attn_variant": "hybrid_recurrent_attention"
+      "attn_variant": "hybrid_recurrent_attention",
+      "layer_policy_config_key": "layer_execution_plan",
+      "layer_kind_config_key": "layer_kinds",
+      "state_policy_config_key": "layer_state_policy",
+      "attention_policy_config_key": "layer_attention_policy",
+      "recurrent_policy_config_key": "layer_recurrent_policy",
+      "kv_policy_config_key": "layer_kv_policy"
     },
     "block_contract": {
       "norm_type": "rmsnorm",


### PR DESCRIPTION
## Summary
- add Gemma4 v8 template, kernels, kernel maps, and registry entries
- extend Qwen3.5 v8 policy/codegen support and parity probe tooling
- add compatibility fixes for v8 runner tests and scaffold normalization

## Validation
- .venv/bin/python -m py_compile changed v8 scripts
- .venv/bin/python -m unittest -b tests.test_v8_gemma4_scaffold tests.test_v8_qwen35_policy tests.test_build_ir_v8_scaffold tests.test_v8_codegen_bridge tests.test_v8_native_bridge_host tests.test_qwen35_contract_detection tests.test_qwen35_template_guard tests.test_qwen35_rope_metadata_v8 tests.test_ck_chat_runtime_contract
- make -B build/libckernel_engine.so
- .venv/bin/python unittest/test_q8_k_quantize_parity.py
- .venv/bin/python unittest/test_q6k_q8k_parity.py
- .venv/bin/python unittest/test_q4_k_q8_k_matvec.py
- .venv/bin/python unittest/test_rmsnorm.py
- .venv/bin/python unittest/test_rope.py
- .venv/bin/python unittest/test_attention.py
- .venv/bin/python unittest/test_attention_sliding_contract.py
- .venv/bin/python version/v8/scripts/run_regression_v8.py --mode fast --family qwen35 --force-rebuild
- .venv/bin/python version/v8/scripts/run_regression_v8.py --mode fast --family qwen2 --family qwen3 --force-rebuild