### PR TITLE
Optimize quantized v8 decode dispatch

### DIFF
--- a/docs/site/_pages/spec-training-results.html
+++ b/docs/site/_pages/spec-training-results.html
@@ -156,7 +156,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-04-13 12:46 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-05 05:12 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-04-13 05:46</span>
+        <span class="folder-updated">Updated: 2026-06-04 22:12</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -12970,7 +12970,7 @@ rmsnorm_backward(d_norm_out, input, gamma, rstd_cache, d_input, d_gamma, tokens,
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1217,7 +1217,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-04-13 05:46</span>
+        <span class="folder-updated">Updated: 2026-06-04 22:12</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1587,7 +1587,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/codegen.html
+++ b/docs/site/codegen.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1760,7 +1760,7 @@ static size_t bump(size_t *off, size_t bytes) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/contributing.html
+++ b/docs/site/contributing.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1270,7 +1270,7 @@ make test</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions-dynamic.html
+++ b/docs/site/decisions-dynamic.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1456,7 +1456,7 @@ details.adr pre {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions.html
+++ b/docs/site/decisions.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1930,7 +1930,7 @@ weight_mapping:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deltanet-deep-dive.html
+++ b/docs/site/deltanet-deep-dive.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1692,7 +1692,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deterministic-memory.html
+++ b/docs/site/deterministic-memory.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1611,7 +1611,7 @@ class TrainingObserver:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/developer-guide.html
+++ b/docs/site/developer-guide.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1730,7 +1730,7 @@ make emit CONFIG=x.json OUT=out.c  # Generate runtime</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/flash_attention.html
+++ b/docs/site/flash_attention.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="active">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1717,7 +1717,7 @@ pthread_setaffinity_np(pthread_self(),
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout-temp.html
+++ b/docs/site/gemm-memory-layout-temp.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1395,7 +1395,7 @@ for (m_tile = 0; m_tile < M; m_tile += MB) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout.html
+++ b/docs/site/gemm-memory-layout.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1651,7 +1651,7 @@ Token 2: offset 1972    ✗ Kernel expects 1904!</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-optimization.html
+++ b/docs/site/gemm-optimization.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2407,7 +2407,7 @@ gemm_microkernel_packed(A, B, C, M, N, K);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-bump.html
+++ b/docs/site/gguf-bump.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1831,7 +1831,7 @@ make gguf-to-bump GGUF=models/qwen2.5-3b-instruct-q4_k_m.gguf
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-conversion.html
+++ b/docs/site/gguf-conversion.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2179,7 +2179,7 @@ with open(output_path, "w+b") as f:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1540,7 +1540,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-04-13 05:46</span>
+        <span class="folder-updated">Updated: 2026-06-04 22:12</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1910,7 +1910,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-pipeline.html
+++ b/docs/site/ir-pipeline.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2260,7 +2260,7 @@ python version/v6.6/tools/open_ir_visualizer.py Qwen--Qwen3-0.6B-GGUF</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-v2.html
+++ b/docs/site/ir-v2.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1656,7 +1656,7 @@ Page 2 (2-3GB)   → DRAM Bank 2 (Layer 12-17)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/iteration-philosophy.html
+++ b/docs/site/iteration-philosophy.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2574,7 +2574,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernels.html
+++ b/docs/site/kernels.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1400,7 +1400,7 @@ out     = S_new^T * q_hat</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/mega_fusion.html
+++ b/docs/site/mega_fusion.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1940,7 +1940,7 @@ mega_fused_attention_decode():
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-reality.html
+++ b/docs/site/memory-reality.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1712,7 +1712,7 @@ CPU (2TB server): FITS with 1.8TB headroom
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-safety.html
+++ b/docs/site/memory-safety.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1919,7 +1919,7 @@ echo "=== All memory safety checks passed ==="</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1844,7 +1844,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/profiling.html
+++ b/docs/site/profiling.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1572,7 +1572,7 @@ make flamegraph       # Generate SVG flamegraph</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/pytorch-parity.html
+++ b/docs/site/pytorch-parity.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1333,7 +1333,7 @@ make litmus</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quant-formats.html
+++ b/docs/site/quant-formats.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1613,7 +1613,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-math-temp.html
+++ b/docs/site/quantization-math-temp.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1377,7 +1377,7 @@ for (int ib = 0; ib < nb; ib++) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-visuals.html
+++ b/docs/site/quantization-visuals.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1509,7 +1509,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization.html
+++ b/docs/site/quantization.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2387,7 +2387,7 @@ void matmul_q4(float* out, const float* x, const tensor* W) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1677,7 +1677,7 @@ firefox build/flamegraph.svg</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/research.html
+++ b/docs/site/research.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1625,7 +1625,7 @@ K = [K_rope (with position), K_nope (from latent)]</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -3380,7 +3380,7 @@ That's it. For any model size.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sentencepiece.html
+++ b/docs/site/sentencepiece.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1869,7 +1869,7 @@ ck_tokenizer_free(tok);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/simd-architecture.html
+++ b/docs/site/simd-architecture.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2362,7 +2362,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,246 +2,246 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/architecture.html</loc>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/googlece55eb69a9ccdaae.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/quantization.html</loc>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-04-13</lastmod>
-  </url>
-  <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-06-04</lastmod>
   </url>
   <url>
     <loc>https://antshiv.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-04-25</lastmod>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-runbook.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/v8-runbook.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/version-history.html</loc>
+    <lastmod>2026-06-04</lastmod>
+  </url>
+  <url>
+    <loc>https://antshiv.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
+    <lastmod>2026-06-04</lastmod>
   </url>
 </urlset>

--- a/docs/site/spec-training-method.html
+++ b/docs/site/spec-training-method.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -3771,7 +3771,7 @@ Next run:</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1095,7 +1095,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-04-13 12:46 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-05 05:12 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>
@@ -1413,7 +1413,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec17-curriculum-blueprint.html
+++ b/docs/site/spec17-curriculum-blueprint.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1469,7 +1469,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec19-textbook-routing-mixture.html
+++ b/docs/site/spec19-textbook-routing-mixture.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1582,7 +1582,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spectrum.html
+++ b/docs/site/spectrum.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1760,7 +1760,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2337,7 +2337,7 @@ document.addEventListener('DOMContentLoaded', loadResults);
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-viewer.html
+++ b/docs/site/test-viewer.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1383,7 +1383,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1796,7 +1796,7 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/threadpool.html
+++ b/docs/site/threadpool.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2824,7 +2824,7 @@ make test-threadpool-parity-verbose
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/tokenizer.html
+++ b/docs/site/tokenizer.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2311,7 +2311,7 @@ True BPE (merge rules applied in order):
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-curriculum.html
+++ b/docs/site/training-curriculum.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1844,7 +1844,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-intuition.html
+++ b/docs/site/training-intuition.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2251,7 +2251,7 @@ report:    version/v7/tools/ir_visualizer.html (or generated ir_report*.html)</c
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-lessons-learned.html
+++ b/docs/site/training-lessons-learned.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1837,7 +1837,7 @@ AFTER TRAINING:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-backprop-ir.html
+++ b/docs/site/v7-backprop-ir.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2006,7 +2006,7 @@ version/v7/scripts/cks-v7-run init \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-cross-entropy-parity.html
+++ b/docs/site/v7-cross-entropy-parity.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1393,7 +1393,7 @@ CK_NUM_THREADS=8 python version/v7/scripts/train_parity_epochs_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-grad-accum-windows.html
+++ b/docs/site/v7-grad-accum-windows.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1323,7 +1323,7 @@ at accumulation boundary:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-parity-checklist.html
+++ b/docs/site/v7-parity-checklist.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1522,7 +1522,7 @@ PY</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-profiling.html
+++ b/docs/site/v7-profiling.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1441,7 +1441,7 @@ python3 version/v7/tools/open_ir_visualizer.py --generate --run /tmp/v7_ht_threa
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-python-authoring.html
+++ b/docs/site/v7-python-authoring.html
@@ -860,7 +860,7 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="active">Getting Started</a>
+            <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
             <div class="nav-dropdown">
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -1594,7 +1594,7 @@ python3 version/v7/examples/python_module_api_tiny_lm_v7.py --run-name py-module
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-25</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-runbook.html
+++ b/docs/site/v7-runbook.html
@@ -860,7 +860,7 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="active">Getting Started</a>
+            <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
             <div class="nav-dropdown">
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -2178,7 +2178,6 @@ python3 version/v7/tools/open_ir_hub.py --open</pre>
     </div>
 </section>
 
-<!-- Pipeline Graph Popup Overlay -->
 <div id="pg-popup-overlay" class="pg-popup-overlay" onclick="if(event.target===this)pgPopupClose()" style="display:none;">
     <div class="pg-popup" id="pg-popup">
         <button class="pg-popup-close" onclick="pgPopupClose()" title="Close">✕</button>
@@ -5605,7 +5604,7 @@ python3 scripts/ck_chat.py --help</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-25</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-svg-dataset-runbook.html
+++ b/docs/site/v7-svg-dataset-runbook.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1652,7 +1652,7 @@ tail -n 20 "$RUN/autopilot/summary.jsonl"</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-training-progression-playbook.html
+++ b/docs/site/v7-training-progression-playbook.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1572,7 +1572,7 @@ jq -r '.status, (.stages // [])' "$RUN/training_parity_regimen_latest.json" 2>/d
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-visualizer-test-runbook.html
+++ b/docs/site/v7-visualizer-test-runbook.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1923,7 +1923,7 @@ document.querySelectorAll('.copy-btn').forEach(btn => {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1528,7 +1528,7 @@ python -m pip install -r requirements-v8.txt</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1575,7 +1575,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/version-history.html
+++ b/docs/site/version-history.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -2677,7 +2677,7 @@ console.log('Roadmap: ' + versionData.roadmap.map(v => 'v' + v.major).join(' →
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -899,7 +899,7 @@
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,7 +916,7 @@
             </div>
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
+            <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
@@ -1324,7 +1324,7 @@ permalink: /vision-encoder-parity/
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-04-13</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
             </div>
         </div>
     </footer>

--- a/src/kernels/gemm_kernels_q4k_q8k_avx2.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_avx2.c
@@ -16,7 +16,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "ckernel_quant.h"
 
@@ -39,50 +38,70 @@ static inline int32_t hsum256_epi32(__m256i v) {
     return _mm_cvtsi128_si32(sum);
 }
 
-static inline void load_q8_even_odd_16(const int8_t *q8,
-                                       __m256i *even16,
-                                       __m256i *odd16) {
-    const __m128i q8_lo = _mm_loadu_si128((const __m128i *)q8);
-    const __m128i q8_hi = _mm_loadu_si128((const __m128i *)(q8 + 16));
-    const __m128i even_mask = _mm_setr_epi8(
-        0, 2, 4, 6, 8, 10, 12, 14,
-        (char)0x80, (char)0x80, (char)0x80, (char)0x80,
-        (char)0x80, (char)0x80, (char)0x80, (char)0x80);
-    const __m128i odd_mask = _mm_setr_epi8(
-        1, 3, 5, 7, 9, 11, 13, 15,
-        (char)0x80, (char)0x80, (char)0x80, (char)0x80,
-        (char)0x80, (char)0x80, (char)0x80, (char)0x80);
+static inline int32_t dot_q4_q8_16_avx2(const uint8_t *q4,
+                                        const int8_t *q8,
+                                        int high_nibble) {
+    const __m128i q4_packed = _mm_loadu_si128((const __m128i *)q4);
+    const __m128i mask4 = _mm_set1_epi8(0x0F);
+    const __m128i q4_nibbles = high_nibble
+        ? _mm_and_si128(_mm_srli_epi16(q4_packed, 4), mask4)
+        : _mm_and_si128(q4_packed, mask4);
+    const __m128i q8_bytes = _mm_loadu_si128((const __m128i *)q8);
 
-    const __m128i q8_lo_even = _mm_shuffle_epi8(q8_lo, even_mask);
-    const __m128i q8_hi_even = _mm_shuffle_epi8(q8_hi, even_mask);
-    const __m128i q8_even = _mm_unpacklo_epi64(q8_lo_even, q8_hi_even);
+    const __m256i q4_16 = _mm256_cvtepu8_epi16(q4_nibbles);
+    const __m256i q8_16 = _mm256_cvtepi8_epi16(q8_bytes);
+    const __m256i prod = _mm256_madd_epi16(q4_16, q8_16);
 
-    const __m128i q8_lo_odd = _mm_shuffle_epi8(q8_lo, odd_mask);
-    const __m128i q8_hi_odd = _mm_shuffle_epi8(q8_hi, odd_mask);
-    const __m128i q8_odd = _mm_unpacklo_epi64(q8_lo_odd, q8_hi_odd);
-
-    *even16 = _mm256_cvtepi8_epi16(q8_even);
-    *odd16 = _mm256_cvtepi8_epi16(q8_odd);
+    return hsum256_epi32(prod);
 }
 
 static inline int32_t dot_q4_q8_32_avx2(const uint8_t *q4,
-                                        const int8_t *q8) {
-    const __m128i q4_packed = _mm_loadu_si128((const __m128i *)q4);
-    const __m128i mask4 = _mm_set1_epi8(0x0F);
-    const __m128i q4_lo = _mm_and_si128(q4_packed, mask4);
-    const __m128i q4_hi = _mm_and_si128(_mm_srli_epi16(q4_packed, 4), mask4);
+                                        const int8_t *q8,
+                                        int high_nibble) {
+    return dot_q4_q8_16_avx2(q4, q8, high_nibble)
+         + dot_q4_q8_16_avx2(q4 + 16, q8 + 16, high_nibble);
+}
 
-    const __m256i q4_lo16 = _mm256_cvtepu8_epi16(q4_lo);
-    const __m256i q4_hi16 = _mm256_cvtepu8_epi16(q4_hi);
+static float dot_q4_k_q8_k_avx2(const block_q4_K *w,
+                                const block_q8_K *x,
+                                int k)
+{
+    const int nb = k / QK_K;
+    float sumf = 0.0f;
 
-    __m256i q8_even16;
-    __m256i q8_odd16;
-    load_q8_even_odd_16(q8, &q8_even16, &q8_odd16);
+    for (int i = 0; i < nb; ++i) {
+        uint8_t sc[8], m_val[8];
+        unpack_q4_k_scales(w[i].scales, sc, m_val);
 
-    const __m256i prod_lo = _mm256_madd_epi16(q4_lo16, q8_even16);
-    const __m256i prod_hi = _mm256_madd_epi16(q4_hi16, q8_odd16);
+        const float d = CK_FP16_TO_FP32(w[i].d) * x[i].d;
+        const float dmin = CK_FP16_TO_FP32(w[i].dmin) * x[i].d;
 
-    return hsum256_epi32(prod_lo) + hsum256_epi32(prod_hi);
+        int sumi = 0;
+        for (int j = 0; j < QK_K / 16; ++j) {
+            sumi += (int)x[i].bsums[j] * (int)m_val[j / 2];
+        }
+
+        int32_t sumi_block = 0;
+        int is = 0;
+        int q_offset = 0;
+
+        for (int j = 0; j < QK_K; j += 64) {
+            const uint8_t *qs = &w[i].qs[q_offset];
+            const int8_t *q8_lo = &x[i].qs[j];
+            const int8_t *q8_hi = &x[i].qs[j + 32];
+
+            const int32_t lo = dot_q4_q8_32_avx2(qs, q8_lo, 0);
+            const int32_t hi = dot_q4_q8_32_avx2(qs, q8_hi, 1);
+            sumi_block += (int32_t)sc[is] * lo + (int32_t)sc[is + 1] * hi;
+
+            q_offset += 32;
+            is += 2;
+        }
+
+        sumf += d * (float)sumi_block - dmin * (float)sumi;
+    }
+
+    return sumf;
 }
 #endif
 
@@ -91,9 +110,20 @@ void gemv_q4_k_q8_k_avx2(float *y,
                          const void *x_q8,
                          int M, int K)
 {
-    /* TODO: Implement AVX2 version with correct Q4_K memory layout.
-     * For now, fall back to reference implementation which has been
-     * fixed to use the correct layout.
-     */
+#if defined(__AVX2__)
+    if (!y || !W || !x_q8 || M <= 0 || K <= 0) {
+        return;
+    }
+
+    const block_q4_K *blocks = (const block_q4_K *)W;
+    const block_q8_K *x = (const block_q8_K *)x_q8;
+    const int blocks_per_row = K / QK_K;
+
+    for (int row = 0; row < M; ++row) {
+        const block_q4_K *w_row = blocks + (size_t)row * (size_t)blocks_per_row;
+        y[row] = dot_q4_k_q8_k_avx2(w_row, x, K);
+    }
+#else
     gemv_q4_k_q8_k_ref(y, W, x_q8, M, K);
+#endif
 }

--- a/src/kernels/gemm_kernels_q5_0.c
+++ b/src/kernels/gemm_kernels_q5_0.c
@@ -1081,7 +1081,7 @@ void vec_dot_q5_0_q8_0_avx512(int n, float *s, const void *vx, const void *vy)
 }
 #endif
 
-#if defined(__AVX2__) && !defined(__AVX512F__)
+#if defined(__AVX2__)
 static inline __m256i bytes_from_bits_32_avx(const uint8_t *qh);
 static inline __m256i bytes_from_nibbles_32_avx(const uint8_t *qs);
 static inline __m256 mul_sum_i8_pairs_float_avx(const __m256i x, const __m256i y);
@@ -1247,7 +1247,7 @@ void vec_dot_q5_0_q8_0_sse(int n, float *s, const void *vx, const void *vy)
 }
 #endif
 
-#if defined(__AVX__) && !defined(__AVX512F__)
+#if defined(__AVX__)
 
 /* Combine two __m128i into __m256i (AVX without AVX2) */
 #define MM256_SET_M128I(hi, lo) _mm256_insertf128_si256(_mm256_castsi128_si256(lo), (hi), 1)
@@ -1601,10 +1601,13 @@ void gemm_nt_q5_0_q8_0_unroll_avx(
  */
 void vec_dot_q5_0_q8_0(int n, float *s, const void *vx, const void *vy)
 {
-#if defined(__AVX512F__)
-    vec_dot_q5_0_q8_0_avx512(n, s, vx, vy);
-#elif defined(__AVX2__)
+#if defined(__AVX2__)
+    /* llama.cpp uses the packed AVX2 dot on AVX-512 hosts as well. It keeps
+     * Q5/Q8 data in byte lanes and avoids the per-block 32-bit lane expansion
+     * overhead of the baseline AVX-512 path. */
     vec_dot_q5_0_q8_0_avx2(n, s, vx, vy);
+#elif defined(__AVX512F__)
+    vec_dot_q5_0_q8_0_avx512(n, s, vx, vy);
 #elif defined(__ARM_NEON) || defined(__aarch64__)
     vec_dot_q5_0_q8_0_neon(n, s, vx, vy);
 #elif defined(__AVX__)

--- a/src/kernels/gemm_kernels_q6k_q8k.c
+++ b/src/kernels/gemm_kernels_q6k_q8k.c
@@ -34,6 +34,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 
+#include "ckernel_engine.h"
 #include "ckernel_quant.h"
 
 /* Include SIMD headers based on available extensions */
@@ -50,6 +51,16 @@ void gemv_q6_k_q8_k_avx512_vbmi(float *y, const void *W, const void *x_q8, int M
 void gemv_q6_k_q8_k_avx2(float *y, const void *W, const void *x_q8, int M, int K);
 void gemv_q6_k_q8_k_avx(float *y, const void *W, const void *x_q8, int M, int K);
 void gemv_q6_k_q8_k_sse(float *y, const void *W, const void *x_q8, int M, int K);
+
+static int ck_q6k_q8k_force_ref(void)
+{
+    static int cached = -1;
+    if (cached < 0) {
+        const char *env = getenv("CK_DEBUG_Q6K_Q8K_REF");
+        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+    }
+    return cached;
+}
 
 /* ============================================================================
  * Reference Implementation
@@ -1062,12 +1073,26 @@ void gemv_q6_k_q8_k(float *y,
                      const void *x_q8,
                      int M, int K)
 {
+    if (ck_strict_parity_enabled() || ck_q6k_q8k_force_ref()) {
+        gemv_q6_k_q8_k_ref(y, W, x_q8, M, K);
+        return;
+    }
+
     const char *simd_env = getenv("CK_DEBUG_Q6K_Q8K_SIMD");
-    if (simd_env && simd_env[0] && simd_env[0] != '0') {
-#if defined(__AVX512VBMI__)
+    if (!(simd_env && simd_env[0] && simd_env[0] != '0')) {
+        /* Keep the public Q6_K dispatcher on the llama-compatible scalar
+         * reduction for now. The AVX/AVX2 path is faster, but it changes the
+         * reduction order enough to fail tight GEMM parity in some cases.
+         * Promote SIMD/packed Q6 only after the faster path is numerically
+         * reliable across model-family parity and long-decode tests. */
+        gemv_q6_k_q8_k_ref(y, W, x_q8, M, K);
+        return;
+    }
+
+#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512VBMI__)
         gemv_q6_k_q8_k_avx512_vbmi(y, W, x_q8, M, K);
         return;
-#elif defined(__AVX512F__)
+#elif defined(__AVX512F__) && defined(__AVX512BW__)
         gemv_q6_k_q8_k_avx512(y, W, x_q8, M, K);
         return;
 #elif defined(__AVX2__)
@@ -1080,7 +1105,6 @@ void gemv_q6_k_q8_k(float *y,
         gemv_q6_k_q8_k_sse(y, W, x_q8, M, K);
         return;
 #endif
-    }
     gemv_q6_k_q8_k_ref(y, W, x_q8, M, K);
 }
 
@@ -1149,10 +1173,28 @@ void gemv_q6_k_q8_k_parallel_simd(float *y,
     const block_q6_K *blocks = (const block_q6_K *)W;
     const block_q8_K *x = (const block_q8_K *)x_q8;
     const int blocks_per_row = K / QK_K;
+    const int strict = ck_strict_parity_enabled() || ck_q6k_q8k_force_ref();
 
     for (int row = r0; row < r1; ++row) {
         const block_q6_K *w_row = blocks + (size_t)row * (size_t)blocks_per_row;
+#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512VBMI__)
+        y[row] = strict ? dot_q6_k_q8_k_ref(w_row, x, K)
+                        : dot_q6_k_q8_k_avx512_vbmi(w_row, x, K);
+#elif defined(__AVX512F__) && defined(__AVX512BW__)
+        y[row] = strict ? dot_q6_k_q8_k_ref(w_row, x, K)
+                        : dot_q6_k_q8_k_avx512(w_row, x, K);
+#elif defined(__AVX2__)
+        y[row] = strict ? dot_q6_k_q8_k_ref(w_row, x, K)
+                        : dot_q6_k_q8_k_avx2(w_row, x, K);
+#elif defined(__AVX__)
+        y[row] = strict ? dot_q6_k_q8_k_ref(w_row, x, K)
+                        : dot_q6_k_q8_k_avx(w_row, x, K);
+#elif defined(__SSSE3__)
+        y[row] = strict ? dot_q6_k_q8_k_ref(w_row, x, K)
+                        : dot_q6_k_q8_k_sse(w_row, x, K);
+#else
         y[row] = dot_q6_k_q8_k_ref(w_row, x, K);
+#endif
     }
 }
 

--- a/src/kernels/gemm_kernels_q8_0.c
+++ b/src/kernels/gemm_kernels_q8_0.c
@@ -52,6 +52,16 @@ static int ck_q8_0_debug_ref(void)
     return cached;
 }
 
+static int ck_q8_0_q8_0_debug_ref(void)
+{
+    static int cached = -1;
+    if (cached < 0) {
+        const char *env = getenv("CK_DEBUG_Q8_0_Q8_0_REF");
+        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+    }
+    return cached;
+}
+
 static inline int ck_nearest_int_q8_0(float fval) {
     /* Match llama.cpp's deterministic nearest-even helper. */
     float val = fval + 12582912.f;
@@ -1219,8 +1229,7 @@ void vec_dot_q8_0_q8_0_sse(int n, float *s, const void *vx, const void *vy)
  */
 void vec_dot_q8_0_q8_0(int n, float *s, const void *vx, const void *vy)
 {
-    const char *ref_env = getenv("CK_DEBUG_Q8_0_Q8_0_REF");
-    if (ref_env && ref_env[0] && ref_env[0] != '0') {
+    if (ck_q8_0_q8_0_debug_ref()) {
         vec_dot_q8_0_q8_0_ref(n, s, vx, vy);
         return;
     }

--- a/unittest/test_gemv_kernels_comprehensive.py
+++ b/unittest/test_gemv_kernels_comprehensive.py
@@ -326,6 +326,10 @@ def get_test_cases(quick: bool = False, large: bool = False) -> dict:
                 TestCase("tiny", M=1, K=256, description="Minimal Q4_K"),
                 TestCase("small", M=256, K=256, description="Small square"),
             ],
+            "Q6_K": [
+                TestCase("tiny", M=1, K=256, description="Minimal Q6_K decode"),
+                TestCase("small", M=1, K=512, description="Small Q6_K decode"),
+            ],
             "Q5_0": [
                 TestCase("tiny", M=1, K=32, tol=1e-2, description="Minimal Q5_0"),
                 TestCase("small", M=32, K=256, tol=1e-2, description="Small"),
@@ -360,6 +364,16 @@ def get_test_cases(quick: bool = False, large: bool = False) -> dict:
             TestCase("medium_sq", M=1024, K=1024, description="Medium square"),
             TestCase("medium_wide", M=1024, K=2048, description="Medium wide"),
             TestCase("medium_tall", M=2048, K=1024, description="Medium tall"),
+        ],
+        "Q6_K": [
+            # Q6_K parity harness currently exposes a decode-style single-row
+            # entry point. Keep M=1 so reported GFLOPS match actual work.
+            TestCase("tiny", M=1, K=256, description="Minimal Q6_K decode"),
+            TestCase("small", M=1, K=512, description="Small Q6_K decode"),
+            TestCase("qwen", M=1, K=768, description="Qwen 0.5B Q6_K decode"),
+            TestCase("medium", M=1, K=1024, description="Medium Q6_K decode"),
+            TestCase("wide", M=1, K=2048, description="Wide Q6_K decode"),
+            TestCase("mlp_down", M=1, K=4864, description="Qwen 0.5B MLP down decode"),
         ],
         "Q5_0": [
             # Q5_0 tolerance set to 2e-2 because CK and llama.cpp use different
@@ -412,6 +426,10 @@ def get_test_cases(quick: bool = False, large: bool = False) -> dict:
                 TestCase("llama_mlp_up", M=11264, K=4096, description="LLaMA 7B MLP up"),
                 TestCase("llama_mlp_down", M=4096, K=11264, description="LLaMA 7B MLP down"),
                 TestCase("llama_embed", M=32000, K=4096, description="LLaMA 7B embedding"),
+            ],
+            "Q6_K": [
+                TestCase("llama_qkv", M=1, K=4096, description="LLaMA 7B Q6_K decode"),
+                TestCase("llama_mlp_down", M=1, K=11264, description="LLaMA 7B Q6_K MLP down decode"),
             ],
             "Q5_0": [
                 TestCase("llama_qkv", M=4096, K=4096, tol=2e-2, description="LLaMA 7B QKV"),
@@ -531,6 +549,15 @@ class KernelTester:
             ctypes.c_int
         ]
         lib.ck_test_gemv_q4_k.restype = None
+
+        # GEMV Q6_K (FP32 input quantized to Q8_K, decode path)
+        lib.ck_test_gemv_q6_k.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.c_int   # cols
+        ]
+        lib.ck_test_gemv_q6_k.restype = None
 
         # GEMV Q5_0 (FP32 input - dequant path)
         lib.ck_test_gemv_q5_0.argtypes = [
@@ -658,6 +685,20 @@ class KernelTester:
                     if has_llama_ref:
                         # llama.cpp test only does single dot product (M=1)
                         self.libggml.test_gemv_q5_0(w, x, y, K)
+
+        elif qtype == "Q6_K":
+            if K % QK_K != 0:
+                return TestResult(name, False, 0, 0, error=f"K={K} not multiple of {QK_K}")
+            if M != 1:
+                return TestResult(name, False, 0, 0, error="Q6_K harness currently supports decode M=1 only")
+            weight_gen = random_q6k_weights
+            has_llama_ref = False
+
+            def call_ck(w, x, y):
+                self.libck.ck_test_gemv_q6_k(w, x, y, K)
+
+            def call_llama(w, x, y):
+                return None
 
         elif qtype == "Q8_0":
             if K % QK8_0 != 0:
@@ -929,6 +970,7 @@ def print_header():
             Testing: output[M] = weights[M,K] x input[K]
 
   {CYAN}KERNELS:{RESET} Q4_K     - 4-bit K-quant (llama.cpp reference)
+            Q6_K     - 6-bit K-quant decode (CK timing + sanity check)
             Q5_0     - 5-bit legacy quant (llama.cpp reference)
             Q8_0     - 8-bit legacy quant (llama.cpp reference)
             Q5_0_Q8_0 - Direct Q5_0 x Q8_0 vec_dot (llama.cpp reference)

--- a/version/v7/reports/spec_training_manifest.json
+++ b/version/v7/reports/spec_training_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "ck.spec_training_manifest.v1",
-  "generated_at": "2026-04-13T12:46:50.196182+00:00",
+  "generated_at": "2026-06-05T05:12:15.166899+00:00",
   "generator": "build_spec_training_story_v7.py",
   "source_roots": [
     {

--- a/version/v7/reports/spec_training_story.html
+++ b/version/v7/reports/spec_training_story.html
@@ -146,7 +146,7 @@ li{margin:.3rem 0}
 </section>
 
 <footer class="muted" style="margin-top:2.5rem;padding-top:1rem;border-top:1px solid var(--border)">
-  Generated from local artifacts at 2026-04-13T12:46:50.196182+00:00. Visible source links are included next to each major metric block.
+  Generated from local artifacts at 2026-06-05T05:12:15.166899+00:00. Visible source links are included next to each major metric block.
 </footer>
 </main>
 </body>

--- a/version/v7/src/ck_parallel_decode.c
+++ b/version/v7/src/ck_parallel_decode.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 /* External parallel GEMV kernels (defined in src/kernels/) */
 extern void gemv_q5_0_parallel_simd(float *y, const void *W, const float *x,
@@ -90,6 +91,58 @@ typedef struct {
     int          K;
     size_t       W_row_bytes;
 } gemv_fp32_args_t;
+
+static int ck_min_int(int a, int b) { return a < b ? a : b; }
+
+static int ck_env_enabled(const char *name)
+{
+    const char *v = getenv(name);
+    return v && v[0] && strcmp(v, "0") != 0;
+}
+
+static int ck_env_int_or(const char *name, int fallback)
+{
+    const char *v = getenv(name);
+    if (!v || !v[0]) return fallback;
+    int parsed = atoi(v);
+    return parsed > 0 ? parsed : fallback;
+}
+
+static int ck_shape_aware_enabled(const ck_threadpool_t *pool)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (ck_env_enabled("CK_DISABLE_SHAPE_AWARE_THREADPOOL")) return 0;
+    if (getenv("CK_GEMV_THREAD_CAP") || getenv("CK_GEMV_SMALL_SERIAL_THRESHOLD")) return 1;
+    return pool_threads > 16;
+}
+
+static int ck_select_gemv_active_threads(const ck_threadpool_t *pool, int M, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (pool_threads <= 1 || M <= 1 || K <= 0) return 1;
+    if (!ck_shape_aware_enabled(pool)) return pool_threads;
+    if (M >= 4096) return pool_threads;
+    if (M >= 512) return ck_min_int(pool_threads, ck_env_int_or("CK_GEMV_THREAD_CAP", 12));
+    return 1;
+}
+
+static int ck_select_fused_q5_active_threads(const ck_threadpool_t *pool, int M, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (pool_threads <= 1 || M <= 1 || K <= 0) return 1;
+    if (!ck_shape_aware_enabled(pool)) return pool_threads;
+    if (M < 512) return 1;
+    if (M < 1024 && K < 2048) return 1;
+    return ck_min_int(pool_threads, ck_env_int_or("CK_GEMV_THREAD_CAP", 24));
+}
+
+static int ck_should_run_gemv_serial(const ck_threadpool_t *pool, int M, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (!ck_shape_aware_enabled(pool)) return 0;
+    if (M < ck_env_int_or("CK_GEMV_SMALL_SERIAL_THRESHOLD", 512)) return 1;
+    return pool_threads > 16 && M < 1024 && K < 2048;
+}
 
 /* Q5_K weights are row-major packed super-blocks.
  * Keep a local layout copy to compute byte offsets without pulling in
@@ -175,60 +228,60 @@ void gemv_q5_0_q8_0_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         /* Fall back to serial — avoids overhead for single-thread */
         gemv_q5_0_q8_0(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q5_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q5_0_q8_0, &args);
 }
 
 void gemv_q6_k_q8_k_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q6_k_q8_k(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q6_k_q8_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q6_k_q8_k, &args);
 }
 
 void gemv_q4_k_q8_k_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q4_k_q8_k(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q4_k_q8_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q4_k_q8_k, &args);
 }
 
 void gemv_q8_0_q8_0_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q8_0_q8_0(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q8_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q8_0_q8_0, &args);
 }
 
 void gemv_q5_1_q8_1_parallel_dispatch(
     float *y, const void *W, const float *x, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || (K % QK5_1) != 0) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K) || M <= 1 || (K % QK5_1) != 0) {
         gemv_q5_1_q8_1(y, W, x, M, K);
         return;
     }
@@ -237,14 +290,14 @@ void gemv_q5_1_q8_1_parallel_dispatch(
     gemv_fp32_args_t args = {
         .y = y, .W = W, .x = x, .M = M, .K = K, .W_row_bytes = W_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemv_q5_1_q8_1, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q5_1_q8_1, &args);
 }
 
 void gemv_q5_k_parallel_dispatch(
     float *y, const void *W, const float *x, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || (K % QK_K) != 0) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K) || M <= 1 || (K % QK_K) != 0) {
         gemv_q5_k(y, W, x, M, K);
         return;
     }
@@ -253,7 +306,7 @@ void gemv_q5_k_parallel_dispatch(
     gemv_fp32_args_t args = {
         .y = y, .W = W, .x = x, .M = M, .K = K, .W_row_bytes = W_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemv_q5_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q5_k, &args);
 }
 
 /* Keep stack footprint aligned with the contract kernel implementation. */
@@ -263,7 +316,7 @@ void gemv_q8_0_q8_0_contract_parallel_dispatch(
     float *y, const void *W, const float *x, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q8_0_q8_0_contract(y, W, x, M, K);
         return;
     }
@@ -303,7 +356,7 @@ void gemv_fused_q5_0_bias_parallel_dispatch(
     float *y, const void *W, const float *x, const float *bias, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         /* Fall back to original fused kernel (serial) */
         gemv_fused_q5_0_bias_dispatch(y, W, x, bias, M, K);
         return;
@@ -317,7 +370,7 @@ void gemv_fused_q5_0_bias_parallel_dispatch(
 
     /* Step 2: Parallel GEMV — reuse existing parallel dispatch */
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8_buf, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q5_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_fused_q5_active_threads(pool, M, K), work_gemv_q5_0_q8_0, &args);
 
     /* Step 3: Add bias (serial, fast) */
     if (bias) {

--- a/version/v7/src/ck_parallel_prefill.c
+++ b/version/v7/src/ck_parallel_prefill.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 /* Serial GEMM kernels (defined in src/kernels/) */
 extern void gemm_nt_q5_0_q8_0(const void *A, const void *B, const float *bias,
@@ -70,6 +71,48 @@ typedef struct {
     int          K;           /* Input dimension */
     size_t       A_row_bytes; /* Bytes per row of A (for pointer arithmetic) */
 } gemm_args_t;
+
+static int ck_min_int(int a, int b) { return a < b ? a : b; }
+
+static int ck_env_enabled(const char *name)
+{
+    const char *v = getenv(name);
+    return v && v[0] && strcmp(v, "0") != 0;
+}
+
+static int ck_env_int_or2(const char *primary, const char *secondary, int fallback)
+{
+    const char *v = getenv(primary);
+    if ((!v || !v[0]) && secondary) v = getenv(secondary);
+    if (!v || !v[0]) return fallback;
+    int parsed = atoi(v);
+    return parsed > 0 ? parsed : fallback;
+}
+
+static int ck_shape_aware_enabled(const ck_threadpool_t *pool)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (ck_env_enabled("CK_DISABLE_SHAPE_AWARE_THREADPOOL")) return 0;
+    if (getenv("CK_GEMM_THREAD_CAP") || getenv("CK_GEMV_THREAD_CAP")) return 1;
+    return pool_threads > 16;
+}
+
+static int ck_select_gemm_active_threads(const ck_threadpool_t *pool, int M, int N, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (pool_threads <= 1 || M <= 1 || N <= 0 || K <= 0) return 1;
+    if (!ck_shape_aware_enabled(pool)) return pool_threads;
+    if (N >= 4096 || K >= 4096) return pool_threads;
+    if (M >= 512) return ck_min_int(pool_threads, ck_env_int_or2("CK_GEMM_THREAD_CAP", "CK_GEMV_THREAD_CAP", 24));
+    return pool_threads;
+}
+
+static int ck_should_run_gemm_serial(const ck_threadpool_t *pool, int M, int N, int K)
+{
+    if (!ck_shape_aware_enabled(pool)) return 0;
+    const int threshold = ck_env_int_or2("CK_GEMM_SMALL_SERIAL_THRESHOLD", NULL, 16);
+    return M < threshold && N < 512 && K < 512;
+}
 
 /* ============================================================================
  * Work Functions (called on each thread)
@@ -175,7 +218,7 @@ void gemm_nt_q5_0_q8_0_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q5_0_q8_0(A, B, bias, C, M, N, K);
         return;
     }
@@ -188,7 +231,7 @@ void gemm_nt_q5_0_q8_0_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q5_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q5_0_q8_0, &args);
 }
 
 void gemm_nt_q8_0_q8_0_parallel_dispatch(
@@ -196,7 +239,7 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q8_0_q8_0(A, B, bias, C, M, N, K);
         return;
     }
@@ -209,7 +252,7 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q8_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q8_0_q8_0, &args);
 }
 
 void gemm_nt_q6_k_q8_k_parallel_dispatch(
@@ -217,7 +260,7 @@ void gemm_nt_q6_k_q8_k_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q6_k_q8_k(A, B, bias, C, M, N, K);
         return;
     }
@@ -230,7 +273,7 @@ void gemm_nt_q6_k_q8_k_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q6_k_q8_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q6_k_q8_k, &args);
 }
 
 void gemm_nt_q5_1_q8_1_parallel_dispatch(
@@ -238,7 +281,7 @@ void gemm_nt_q5_1_q8_1_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q5_1_q8_1(A, B, bias, C, M, N, K);
         return;
     }
@@ -251,7 +294,7 @@ void gemm_nt_q5_1_q8_1_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q5_1_q8_1, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q5_1_q8_1, &args);
 }
 
 void gemm_nt_q5_k_parallel_dispatch(
@@ -259,7 +302,7 @@ void gemm_nt_q5_k_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q5_k(A, B, bias, C, M, N, K);
         return;
     }
@@ -272,5 +315,5 @@ void gemm_nt_q5_k_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q5_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q5_k, &args);
 }

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -936,7 +936,7 @@ def emit_op(
         rows_expr = arg_expr_by_name.get("rows")
         if x_expr and y_expr and k_expr and rows_expr:
             lines.append(f"    ck_debug_lm_head_fp32_input = {x_expr};")
-            lines.append("    if (!debug_lm_head_fp32) {")
+            lines.append("    if (!g_ck_skip_decode_logits && !debug_lm_head_fp32) {")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
             lines.extend([
@@ -973,7 +973,8 @@ def emit_op(
         k_expr = arg_expr_by_name.get("k")
         fp32_function = "gemv_q4_k" if function == "gemv_q4_k_q8_k" else "gemv_q6_k"
         if y_expr and w_expr and x_expr and m_expr and k_expr:
-            lines.append("    if (debug_lm_head_fp32 && ck_debug_lm_head_fp32_input != NULL) {")
+            lines.append("    if (!g_ck_skip_decode_logits) {")
+            lines.append("        if (debug_lm_head_fp32 && ck_debug_lm_head_fp32_input != NULL) {")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
             lines.append(f"        {fp32_function}(")
@@ -985,7 +986,7 @@ def emit_op(
             lines.append("        );")
             if profile:
                 lines.append(f'        CK_PROFILE_END("decode", "{fp32_function}", "{op_name}", {layer});')
-            lines.append("    } else {")
+            lines.append("        } else {")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
             lines.append(f"        {function}(")
@@ -997,12 +998,13 @@ def emit_op(
             lines.append("        );")
             if profile:
                 lines.append(f'        CK_PROFILE_END("decode", "{function}", "{op_name}", {layer});')
-            lines.append("    }")
+            lines.append("        }")
             if dump:
                 raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
-                lines.append("    #ifdef CK_PARITY_DUMP")
+                lines.append("        #ifdef CK_PARITY_DUMP")
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "logits", {m_expr});')
-                lines.append("    #endif")
+                lines.append("        #endif")
+            lines.append("    }")
             if seq_idx is not None:
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
@@ -2315,6 +2317,7 @@ typedef struct {{
 
 static CKModel *g_model = NULL;
 static ck_manifest_map_t *g_manifest = NULL;
+static int g_ck_skip_decode_logits = 0;
 
 /* Weight pointer macros */
 #define W_PTR(off) ((void*)(g_model->bump_weights + (off)))
@@ -2551,8 +2554,10 @@ CK_EXPORT int ck_model_embed_tokens(const int32_t *tokens, int count) {{
 
     /* Single token or no prefill: process one by one via decode */
     for (int i = 0; i < count; i++) {{
+        g_ck_skip_decode_logits = (i + 1 < count);
         ck_decode(g_model, tokens[i]);
-    }}{profile_dump_after_decode}
+    }}
+    g_ck_skip_decode_logits = 0;{profile_dump_after_decode}
     ck_trace_pos("embed_decode_end", tokens[count - 1], count, before_pos, g_model->pos);
     return 0;
 }}
@@ -2571,6 +2576,7 @@ CK_EXPORT int ck_model_decode(int32_t token, float *output) {{
     /* Capture position before decode (ck_decode increments pos at end) */
     int token_pos = g_model->pos;
     ck_trace_pos("decode_begin", token, 1, token_pos, g_model->pos);
+    g_ck_skip_decode_logits = 0;
     ck_decode(g_model, token);{profile_dump_after_decode}{decode_logits_copy}
     ck_trace_pos("decode_end", token, 1, token_pos, g_model->pos);
     return 0;

--- a/version/v8/src/ck_parallel_decode_v8.c
+++ b/version/v8/src/ck_parallel_decode_v8.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 /* External parallel GEMV kernels (defined in src/kernels/) */
 extern void gemv_q5_0_parallel_simd(float *y, const void *W, const float *x,
@@ -92,6 +93,58 @@ typedef struct {
     int          K;
     size_t       W_row_bytes;
 } gemv_fp32_args_t;
+
+static int ck_min_int(int a, int b) { return a < b ? a : b; }
+
+static int ck_env_enabled(const char *name)
+{
+    const char *v = getenv(name);
+    return v && v[0] && strcmp(v, "0") != 0;
+}
+
+static int ck_env_int_or(const char *name, int fallback)
+{
+    const char *v = getenv(name);
+    if (!v || !v[0]) return fallback;
+    int parsed = atoi(v);
+    return parsed > 0 ? parsed : fallback;
+}
+
+static int ck_shape_aware_enabled(const ck_threadpool_t *pool)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (ck_env_enabled("CK_DISABLE_SHAPE_AWARE_THREADPOOL")) return 0;
+    if (getenv("CK_GEMV_THREAD_CAP") || getenv("CK_GEMV_SMALL_SERIAL_THRESHOLD")) return 1;
+    return pool_threads > 16;
+}
+
+static int ck_select_gemv_active_threads(const ck_threadpool_t *pool, int M, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (pool_threads <= 1 || M <= 1 || K <= 0) return 1;
+    if (!ck_shape_aware_enabled(pool)) return pool_threads;
+    if (M >= 4096) return pool_threads;
+    if (M >= 512) return ck_min_int(pool_threads, ck_env_int_or("CK_GEMV_THREAD_CAP", 12));
+    return 1;
+}
+
+static int ck_select_fused_q5_active_threads(const ck_threadpool_t *pool, int M, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (pool_threads <= 1 || M <= 1 || K <= 0) return 1;
+    if (!ck_shape_aware_enabled(pool)) return pool_threads;
+    if (M < 512) return 1;
+    if (M < 1024 && K < 2048) return 1;
+    return ck_min_int(pool_threads, ck_env_int_or("CK_GEMV_THREAD_CAP", 24));
+}
+
+static int ck_should_run_gemv_serial(const ck_threadpool_t *pool, int M, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (!ck_shape_aware_enabled(pool)) return 0;
+    if (M < ck_env_int_or("CK_GEMV_SMALL_SERIAL_THRESHOLD", 512)) return 1;
+    return pool_threads > 16 && M < 1024 && K < 2048;
+}
 
 /* Q5_K weights are row-major packed super-blocks.
  * Keep a local layout copy to compute byte offsets without pulling in
@@ -181,60 +234,60 @@ void gemv_q5_0_q8_0_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         /* Fall back to serial — avoids overhead for single-thread */
         gemv_q5_0_q8_0(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q5_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q5_0_q8_0, &args);
 }
 
 void gemv_q6_k_q8_k_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q6_k_q8_k(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q6_k_q8_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q6_k_q8_k, &args);
 }
 
 void gemv_q4_k_q8_k_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q4_k_q8_k(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q4_k_q8_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q4_k_q8_k, &args);
 }
 
 void gemv_q8_0_q8_0_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q8_0_q8_0(y, W, x_q8, M, K);
         return;
     }
 
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q8_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q8_0_q8_0, &args);
 }
 
 void gemv_q5_1_q8_1_parallel_dispatch(
     float *y, const void *W, const float *x, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || (K % QK5_1) != 0) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K) || M <= 1 || (K % QK5_1) != 0) {
         gemv_q5_1_q8_1(y, W, x, M, K);
         return;
     }
@@ -243,14 +296,14 @@ void gemv_q5_1_q8_1_parallel_dispatch(
     gemv_fp32_args_t args = {
         .y = y, .W = W, .x = x, .M = M, .K = K, .W_row_bytes = W_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemv_q5_1_q8_1, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q5_1_q8_1, &args);
 }
 
 void gemv_q5_k_parallel_dispatch(
     float *y, const void *W, const float *x, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || (K % QK_K) != 0) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K) || M <= 1 || (K % QK_K) != 0) {
         gemv_q5_k(y, W, x, M, K);
         return;
     }
@@ -259,7 +312,7 @@ void gemv_q5_k_parallel_dispatch(
     gemv_fp32_args_t args = {
         .y = y, .W = W, .x = x, .M = M, .K = K, .W_row_bytes = W_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemv_q5_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemv_active_threads(pool, M, K), work_gemv_q5_k, &args);
 }
 
 /* Keep stack footprint aligned with the contract kernel implementation. */
@@ -269,7 +322,7 @@ void gemv_q8_0_q8_0_contract_parallel_dispatch(
     float *y, const void *W, const float *x, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         gemv_q8_0_q8_0_contract(y, W, x, M, K);
         return;
     }
@@ -309,7 +362,7 @@ void gemv_fused_q5_0_bias_parallel_dispatch(
     float *y, const void *W, const float *x, const float *bias, int M, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || ck_should_run_gemv_serial(pool, M, K)) {
         /* Fall back to original fused kernel (serial) */
         gemv_fused_q5_0_bias_dispatch(y, W, x, bias, M, K);
         return;
@@ -323,7 +376,7 @@ void gemv_fused_q5_0_bias_parallel_dispatch(
 
     /* Step 2: Parallel GEMV — reuse existing parallel dispatch */
     gemv_args_t args = { .y = y, .W = W, .x_q8 = x_q8_buf, .M = M, .K = K };
-    ck_threadpool_dispatch(pool, work_gemv_q5_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_fused_q5_active_threads(pool, M, K), work_gemv_q5_0_q8_0, &args);
 
     /* Step 3: Add bias (serial, fast) */
     if (bias) {

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 /* Serial GEMM kernels (defined in src/kernels/) */
 extern void gemm_nt_q5_0_q8_0(const void *A, const void *B, const float *bias,
@@ -70,6 +71,48 @@ typedef struct {
     int          K;           /* Input dimension */
     size_t       A_row_bytes; /* Bytes per row of A (for pointer arithmetic) */
 } gemm_args_t;
+
+static int ck_min_int(int a, int b) { return a < b ? a : b; }
+
+static int ck_env_enabled(const char *name)
+{
+    const char *v = getenv(name);
+    return v && v[0] && strcmp(v, "0") != 0;
+}
+
+static int ck_env_int_or2(const char *primary, const char *secondary, int fallback)
+{
+    const char *v = getenv(primary);
+    if ((!v || !v[0]) && secondary) v = getenv(secondary);
+    if (!v || !v[0]) return fallback;
+    int parsed = atoi(v);
+    return parsed > 0 ? parsed : fallback;
+}
+
+static int ck_shape_aware_enabled(const ck_threadpool_t *pool)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (ck_env_enabled("CK_DISABLE_SHAPE_AWARE_THREADPOOL")) return 0;
+    if (getenv("CK_GEMM_THREAD_CAP") || getenv("CK_GEMV_THREAD_CAP")) return 1;
+    return pool_threads > 16;
+}
+
+static int ck_select_gemm_active_threads(const ck_threadpool_t *pool, int M, int N, int K)
+{
+    const int pool_threads = ck_threadpool_n_threads(pool);
+    if (pool_threads <= 1 || M <= 1 || N <= 0 || K <= 0) return 1;
+    if (!ck_shape_aware_enabled(pool)) return pool_threads;
+    if (N >= 4096 || K >= 4096) return pool_threads;
+    if (M >= 512) return ck_min_int(pool_threads, ck_env_int_or2("CK_GEMM_THREAD_CAP", "CK_GEMV_THREAD_CAP", 24));
+    return pool_threads;
+}
+
+static int ck_should_run_gemm_serial(const ck_threadpool_t *pool, int M, int N, int K)
+{
+    if (!ck_shape_aware_enabled(pool)) return 0;
+    const int threshold = ck_env_int_or2("CK_GEMM_SMALL_SERIAL_THRESHOLD", NULL, 16);
+    return M < threshold && N < 512 && K < 512;
+}
 
 /* ============================================================================
  * Work Functions (called on each thread)
@@ -175,7 +218,7 @@ void gemm_nt_q5_0_q8_0_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q5_0_q8_0(A, B, bias, C, M, N, K);
         return;
     }
@@ -188,7 +231,7 @@ void gemm_nt_q5_0_q8_0_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q5_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q5_0_q8_0, &args);
 }
 
 void gemm_nt_q8_0_q8_0_parallel_dispatch(
@@ -196,7 +239,7 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q8_0_q8_0(A, B, bias, C, M, N, K);
         return;
     }
@@ -209,7 +252,7 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q8_0_q8_0, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q8_0_q8_0, &args);
 }
 
 void gemm_nt_q6_k_q8_k_parallel_dispatch(
@@ -217,7 +260,7 @@ void gemm_nt_q6_k_q8_k_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q6_k_q8_k(A, B, bias, C, M, N, K);
         return;
     }
@@ -230,7 +273,7 @@ void gemm_nt_q6_k_q8_k_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q6_k_q8_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q6_k_q8_k, &args);
 }
 
 void gemm_nt_q5_1_q8_1_parallel_dispatch(
@@ -238,7 +281,7 @@ void gemm_nt_q5_1_q8_1_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q5_1_q8_1(A, B, bias, C, M, N, K);
         return;
     }
@@ -251,7 +294,7 @@ void gemm_nt_q5_1_q8_1_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q5_1_q8_1, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q5_1_q8_1, &args);
 }
 
 void gemm_nt_q5_k_parallel_dispatch(
@@ -259,7 +302,7 @@ void gemm_nt_q5_k_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
-    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1) {
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
         gemm_nt_q5_k(A, B, bias, C, M, N, K);
         return;
     }
@@ -272,5 +315,5 @@ void gemm_nt_q5_k_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
-    ck_threadpool_dispatch(pool, work_gemm_nt_q5_k, &args);
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q5_k, &args);
 }


### PR DESCRIPTION
## Summary
- skip redundant intermediate logits during v8 sequential prompt replay while preserving final logits and public decode behavior
- add Q4_K AVX2 GEMV and Q6_K parity controls/coverage
- add shape-aware v7/v8 quantized dispatch defaults for high-core hosts with env overrides

## Validation
- git diff --check on staged files
- make regression-family FAMILY=qwen35
- make v8-validate-contracts
- make v8-kernel-map-gate
- make v8-regression-fast
- pre-commit staged v7-kernel-map-contracts, v7-regression-fast, v8-regression-fast
- pre-push build, kernel parity, v8 E2E, v6.6 compatibility, v7/v8 fast regressions, v7 training-kernel parity