### PR TITLE
Fix v8 Qwen3.5 batched prefill length

### DIFF
--- a/tests/test_v8_prefill_codegen.py
+++ b/tests/test_v8_prefill_codegen.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CODEGEN_PREFILL_PATH = ROOT / "version" / "v8" / "scripts" / "codegen_prefill_v8.py"
+
+
+def _load_module(name: str, path: Path):
+    if str(path.parent) not in sys.path:
+        sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+codegen_prefill_v8 = _load_module("codegen_prefill_v8_tests", CODEGEN_PREFILL_PATH)
+
+
+class TestV8PrefillCodegen(unittest.TestCase):
+    def test_recurrent_prefill_seq_len_args_use_runtime_num_tokens(self) -> None:
+        op = {
+            "function": "recurrent_split_qkv_forward",
+            "op": "recurrent_split_qkv",
+            "layer": 0,
+            "section": "body",
+            "args": [
+                {"name": "packed_qkv", "expr": "(const float*)(model->bump + A_RECURRENT_PACKED)"},
+                {"name": "q", "expr": "(float*)(model->bump + A_RECURRENT_Q)"},
+                {"name": "k", "expr": "(float*)(model->bump + A_RECURRENT_K)"},
+                {"name": "v", "expr": "(float*)(model->bump + A_RECURRENT_V)"},
+                {"name": "seq_len", "expr": "1034"},
+                {"name": "q_dim", "expr": "2048"},
+                {"name": "k_dim", "expr": "2048"},
+                {"name": "v_dim", "expr": "2048"},
+            ],
+        }
+
+        emitted = codegen_prefill_v8.emit_prefill_op(op, 7, {"embed_dim": 1024})
+
+        self.assertIn("num_tokens", emitted)
+        self.assertNotIn("\n        1034,", emitted)
+        self.assertIn("\n        2048,", emitted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -5731,7 +5731,10 @@ def generate_ir_lower_1(
         # Special handling for residual_save/memcpy: compute _memcpy_bytes
         if op_name == "residual_save":
             embed_dim = manifest.get("config", {}).get("embed_dim", 896)
-            seq_len = 1 if mode == "decode" else manifest.get("config", {}).get("context_length", 2048)
+            seq_len = int(lowered_op["params"].get(
+                "seq_len",
+                1 if mode == "decode" else manifest.get("config", {}).get("context_length", 2048),
+            ))
             lowered_op["params"]["_memcpy_bytes"] = embed_dim * seq_len * 4  # FP32 = 4 bytes
         elif op_name == "kv_cache_batch_copy":
             # NOTE: "batch" here means a token block in prefill, not multi-request batching.

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -326,15 +326,30 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     # Build argument list with substitutions
     args = []
     arg_expr_by_name: Dict[str, str] = {}
+    dynamic_token_arg_names = {
+        "seq_len",
+        "num_tokens",
+        "token_count",
+        "tokens",
+        "rows",
+        "m",
+    }
     for arg in args_list:
         expr = arg.get("expr", "0")
         source = arg.get("source", "")
         name = arg.get("name", "")
+        name_lc = str(name).lower()
 
         # Substitute num_tokens for token count parameters
         if source == "const:1":
             expr = "num_tokens"
         elif source == "dim:seq_len":
+            expr = "num_tokens"
+        elif source in ("param:seq_len", "runtime:seq_len"):
+            expr = "num_tokens"
+        elif name_lc in dynamic_token_arg_names and source in {"dim:_m", "param:_m", "runtime:kv_tokens", "runtime:cache_len"}:
+            expr = "num_tokens"
+        elif name_lc in {"seq_len", "num_tokens", "token_count", "tokens", "rows"} and str(expr).isdigit():
             expr = "num_tokens"
         # For memcpy size, compute dynamically
         elif source == "dim:_memcpy_bytes" and op_type == "residual_save":

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -3627,10 +3627,12 @@ def main() -> None:
                 "layer_attention_policy": qwen35_execution_plan["layer_attention_policy"],
                 "layer_recurrent_policy": qwen35_execution_plan["layer_recurrent_policy"],
                 "layer_kv_policy": qwen35_execution_plan["layer_kv_policy"],
-                # Qwen3.5 contains recurrent stateful layers. Batched prefill
-                # for those layers is not equivalent to autoregressive decode
-                # until the recurrent prefill state update has dedicated parity.
-                "prefill_policy": "sequential_decode",
+                # Qwen3.5 contains recurrent stateful layers. Prefill must run
+                # recurrent kernels over the runtime prompt length, not the
+                # static IR context length. The v8 prefill generator now emits
+                # dynamic num_tokens for those calls, and CK-vs-decode plus
+                # llama.cpp replay parity cover this contract.
+                "prefill_policy": "batched",
                 "sampler_defaults": {
                     "repeat_penalty": 1.12,
                     "repeat_last_n": 96,


### PR DESCRIPTION
## Summary
- fix v8 prefill codegen to emit runtime num_tokens for recurrent sequence/count arguments
- enable Qwen3.5 batched prefill now that CK decode, CK prefill, and llama.cpp replay parity pass
- keep residual memcpy metadata aligned with lowered seq_len
- include earlier branch commits for q6 prefill dispatch sweep tuning and v6.6 pre-push gate opt-in

## Validation
- python3 -m py_compile version/v8/scripts/codegen_prefill_v8.py version/v8/scripts/convert_gguf_to_bump_v8.py version/v8/scripts/build_ir_v8.py tests/test_v8_prefill_codegen.py
- .venv/bin/python -m unittest tests.test_v8_prefill_codegen tests.test_ck_chat_runtime_contract tests.test_qwen35_template_guard tests.test_v8_qwen35_policy
- make v8-regression-fast
- pre-commit hook: v7-regression-fast PASS, v8-regression-fast PASS
- pre-push hook: build PASS, kernel parity PASS, v8 E2E smoke PASS, v7 gate PASS, v7/v8 fast regression PASS, training-kernel parity PASS

## Notes
- DeepSeek reference kernels were restored and are not deleted in this PR.
- Qwen3.5 512-token prefill improved from about 25.6 tok/s to roughly 65-66 tok/s on the local i7 run.