### PR TITLE
perf(v8): add Q4/Q6 prefill sweep coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2286,13 +2286,14 @@ test-gemv-omp-verbose: $(GEMV_OMP_BIN)
 
 THREADPOOL_BIN := $(BUILD_DIR)/test_threadpool_parity
 V66_SRC_DIR    := version/v6.6/src
+V8_SRC_DIR     := version/v8/src
 
-$(THREADPOOL_BIN): $(LIB) tests/test_threadpool_parity.c $(V66_SRC_DIR)/ck_parallel_decode.c $(V66_SRC_DIR)/ck_parallel_prefill.c
+$(THREADPOOL_BIN): $(LIB) tests/test_threadpool_parity.c $(V66_SRC_DIR)/ck_parallel_decode.c $(V8_SRC_DIR)/ck_parallel_prefill_v8.c
 	@mkdir -p $(BUILD_DIR)
-	$(CC) -O3 -march=native -Iinclude -I$(V66_SRC_DIR) \
+	$(CC) -O3 -march=native -Iinclude -I$(V66_SRC_DIR) -I$(V8_SRC_DIR) \
 		tests/test_threadpool_parity.c \
 		$(V66_SRC_DIR)/ck_parallel_decode.c \
-		$(V66_SRC_DIR)/ck_parallel_prefill.c \
+		$(V8_SRC_DIR)/ck_parallel_prefill_v8.c \
 		-L$(BUILD_DIR) -lckernel_engine -lm -lpthread \
 		-Wl,-rpath,$(BUILD_DIR) \
 		-o $(THREADPOOL_BIN)
@@ -2348,7 +2349,41 @@ test-q6k-prefill-dispatch-sweep-avx2:
 		--threads $${CK_NUM_THREADS:-12} --engine-lib build_avx2/libckernel_engine.so \
 		--json-out build/q6k_prefill_dispatch_sweep_avx2.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2
+test-q6k-prefill-thread-sweep-quick: $(LIB)
+	@echo "Running Q6_K x Q8_K prefill thread sweep (quick)..."
+	CK_Q6K_Q8K_SIMD=1 OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+		$(PYTHON) $(PYTHONFLAGS) benchmarks/sweep_q6k_prefill_dispatch.py \
+		--shape $${CK_Q6K_SWEEP_SHAPE:-qwen2_mlp_down} \
+		--m-values $${CK_Q6K_SWEEP_M:-128} \
+		--thread-values $${CK_Q6K_SWEEP_THREADS:-1,2,4,8,12,24,48} \
+		--warmup $${CK_Q6K_SWEEP_WARMUP:-1} \
+		--iters $${CK_Q6K_SWEEP_ITERS:-2} \
+		--engine-lib build/libckernel_engine.so \
+		--json-out build/q6k_prefill_$${CK_Q6K_SWEEP_SHAPE:-qwen2_mlp_down}_thread_sweep.json
+
+test-v8-decoder-matrix: ck-cli-v8
+	@echo "Running v8 decoder matrix benchmark (CKE vs llama.cpp)..."
+	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+		$(PYTHON) $(PYTHONFLAGS) benchmarks/bench_v8_decoder_matrix.py \
+		--models $${CK_V8_DECODER_MODELS:-all} \
+		--threads $${CK_NUM_THREADS:-12} \
+		--prompt $${CK_V8_DECODER_PROMPT:-512} \
+		--decode $${CK_V8_DECODER_DECODE:-128} \
+		--repeats $${CK_V8_DECODER_REPEATS:-1} \
+		--json-out build/v8_decoder_matrix_t$${CK_NUM_THREADS:-12}_p$${CK_V8_DECODER_PROMPT:-512}_n$${CK_V8_DECODER_DECODE:-128}.json
+
+test-v8-decoder-matrix-quick: ck-cli-v8
+	@echo "Running v8 decoder matrix benchmark (quick, CKE vs llama.cpp)..."
+	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+		$(PYTHON) $(PYTHONFLAGS) benchmarks/bench_v8_decoder_matrix.py \
+		--models $${CK_V8_DECODER_MODELS:-qwen35-0.8b-q4_k_m,qwen2-0.5b-q4_k_m} \
+		--threads $${CK_NUM_THREADS:-12} \
+		--prompt $${CK_V8_DECODER_PROMPT:-128} \
+		--decode $${CK_V8_DECODER_DECODE:-32} \
+		--repeats $${CK_V8_DECODER_REPEATS:-1} \
+		--json-out build/v8_decoder_matrix_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_DECODER_PROMPT:-128}_n$${CK_V8_DECODER_DECODE:-32}.json
+
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/benchmarks/bench_v8_decoder_matrix.py
+++ b/benchmarks/bench_v8_decoder_matrix.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Compare CKE v8 decoder throughput against llama.cpp for cached GGUFs.
+
+The benchmark intentionally avoids chat templates and tokenizer differences:
+llama.cpp uses llama-bench with synthetic prompt/generation sizes, while CKE
+uses ck-cli-v8 with repeated prompt token ids.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CACHE = Path(os.getenv("CK_V8_MODEL_CACHE", str(Path.home() / ".cache" / "ck-engine-v8" / "models")))
+LLAMA_BIN = Path(os.getenv("LLAMA_BENCH", str(ROOT / "llama.cpp" / "build" / "bin" / "llama-bench")))
+LLAMA_LIB = Path(os.getenv("LLAMA_LIB_DIR", str(LLAMA_BIN.parent)))
+CK_CLI = ROOT / "build" / "ck-cli-v8"
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+CK_RE = re.compile(
+    r"prefill\s+(\d+)\s+tok.*?([0-9.]+)\s+ms\s+([0-9.]+)\s+tok/s"
+    r".*?decode\s+(\d+)\s+tok\s+([0-9.]+)\s+ms\s+([0-9.]+)\s+tok/s",
+    re.S,
+)
+
+MODELS: dict[str, dict[str, str]] = {
+    "gemma3-270m-q5_k_m": {
+        "label": "Gemma3 270M",
+        "quant": "Q5_K_M",
+        "run": "unsloth--gemma-3-270m-it-GGUF",
+        "gguf": "unsloth--gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf",
+    },
+    "qwen2-0.5b-q4_k_m": {
+        "label": "Qwen2 0.5B",
+        "quant": "Q4_K_M",
+        "run": "qwen2-0_5b-instruct-q4_k_m",
+        "gguf": "Qwen--Qwen2-0.5B-Instruct-GGUF/qwen2-0_5b-instruct-q4_k_m.gguf",
+    },
+    "qwen3-0.6b-q8_0": {
+        "label": "Qwen3 0.6B",
+        "quant": "Q8_0",
+        "run": "Qwen--Qwen3-0.6B-GGUF",
+        "gguf": "Qwen--Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf",
+    },
+    "qwen35-0.8b-q4_k_m": {
+        "label": "Qwen3.5 0.8B",
+        "quant": "Q4_K_M",
+        "run": "Qwen3.5-0.8B-Q4_K_M",
+        "gguf": "unsloth--Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf",
+    },
+    "gemma4-e4b-q4_k_m": {
+        "label": "Gemma4 E4B",
+        "quant": "Q4_K_M",
+        "run": "unsloth--gemma-4-E4B-it-GGUF",
+        "gguf": "unsloth--gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf",
+    },
+}
+
+
+def _run(cmd: list[str], *, env: dict[str, str], timeout: int) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    return proc.returncode, proc.stdout
+
+
+def _run_llama(gguf: Path, *, prompt: int, decode: int, threads: int, repeats: int, timeout: int) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["LD_LIBRARY_PATH"] = f"{LLAMA_LIB}:{env.get('LD_LIBRARY_PATH', '')}"
+    cmd = [
+        str(LLAMA_BIN),
+        "-m",
+        str(gguf),
+        "-p",
+        str(prompt),
+        "-n",
+        str(decode),
+        "-t",
+        str(threads),
+        "-ngl",
+        "0",
+        "-r",
+        str(repeats),
+        "-o",
+        "json",
+    ]
+    rc, out = _run(cmd, env=env, timeout=timeout)
+    row: dict[str, Any] = {"command": cmd, "returncode": rc, "stdout_tail": "\n".join(out.splitlines()[-40:])}
+    if rc != 0:
+        row["status"] = "fail"
+        return row
+    try:
+        doc = json.loads(out)
+    except json.JSONDecodeError as exc:
+        row.update({"status": "fail", "error": f"json parse failed: {exc}"})
+        return row
+    pp = next((x for x in doc if int(x.get("n_prompt", 0)) > 0), None)
+    tg = next((x for x in doc if int(x.get("n_gen", 0)) > 0), None)
+    row.update(
+        {
+            "status": "pass",
+            "prompt_tok_s": float(pp["avg_ts"]) if pp else None,
+            "decode_tok_s": float(tg["avg_ts"]) if tg else None,
+            "raw": doc,
+        }
+    )
+    return row
+
+
+def _run_cke(run_dir: Path, *, prompt: int, decode: int, threads: int, timeout: int) -> dict[str, Any]:
+    lib = run_dir / "libmodel.so"
+    weights = run_dir / "weights.bump"
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(threads)
+    env["OMP_NUM_THREADS"] = "1"
+    env["LD_LIBRARY_PATH"] = f"{ROOT / 'build'}:{run_dir}:{env.get('LD_LIBRARY_PATH', '')}"
+    prompt_tokens = ",".join(["100"] * prompt)
+    cmd = [
+        str(CK_CLI),
+        str(lib),
+        str(weights),
+        "--prompt-tokens",
+        prompt_tokens,
+        "--max-tokens",
+        str(decode),
+        "--ignore-eos",
+        "--quiet-output",
+        "--timing",
+    ]
+    rc, out = _run(cmd, env=env, timeout=timeout)
+    clean = ANSI_RE.sub("", out)
+    row: dict[str, Any] = {"command": cmd[:3] + ["--prompt-tokens", f"<{prompt} ids>", *cmd[5:]], "returncode": rc, "stdout_tail": "\n".join(clean.splitlines()[-40:])}
+    match = CK_RE.search(clean)
+    if rc != 0 or not match:
+        row["status"] = "fail"
+        return row
+    row.update(
+        {
+            "status": "pass",
+            "prompt_tokens": int(match.group(1)),
+            "prompt_ms": float(match.group(2)),
+            "prompt_tok_s": float(match.group(3)),
+            "decode_tokens": int(match.group(4)),
+            "decode_ms": float(match.group(5)),
+            "decode_tok_s": float(match.group(6)),
+        }
+    )
+    return row
+
+
+def _fmt(v: float | None) -> str:
+    if v is None:
+        return "fail"
+    return f"{v:.1f}"
+
+
+def _ratio(a: float | None, b: float | None) -> str:
+    if a is None or b in (None, 0):
+        return "fail"
+    return f"{a / b:.2f}x"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models", default=",".join(MODELS), help="Comma-separated model ids, or 'all'")
+    parser.add_argument("--prompt", type=int, default=512)
+    parser.add_argument("--decode", type=int, default=128)
+    parser.add_argument("--threads", type=int, default=12)
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--json-out", type=Path, default=ROOT / "build" / "v8_decoder_matrix.json")
+    args = parser.parse_args()
+
+    selected = list(MODELS) if args.models == "all" else [x.strip() for x in args.models.split(",") if x.strip()]
+    results: list[dict[str, Any]] = []
+    for model_id in selected:
+        spec = MODELS[model_id]
+        run_dir = CACHE / spec["run"]
+        gguf = Path(spec["gguf"])
+        if not gguf.is_absolute():
+            gguf = CACHE / gguf
+        row: dict[str, Any] = {"id": model_id, "label": spec["label"], "quant": spec["quant"], "run_dir": str(run_dir), "gguf": str(gguf)}
+        missing = [str(p) for p in [CK_CLI, LLAMA_BIN, run_dir / "libmodel.so", run_dir / "weights.bump", gguf] if not p.exists()]
+        if missing:
+            row.update({"status": "skip", "missing": missing})
+            results.append(row)
+            continue
+        print(f"== {spec['label']} {spec['quant']} ==", flush=True)
+        row["llama"] = _run_llama(gguf, prompt=args.prompt, decode=args.decode, threads=args.threads, repeats=args.repeats, timeout=args.timeout)
+        row["cke"] = _run_cke(run_dir, prompt=args.prompt, decode=args.decode, threads=args.threads, timeout=args.timeout)
+        results.append(row)
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    arg_doc = dict(vars(args))
+    arg_doc["json_out"] = str(args.json_out)
+    args.json_out.write_text(json.dumps({"args": arg_doc, "results": results}, indent=2), encoding="utf-8")
+
+    print("\n| Model | Quant | llama prompt | CKE prompt | CKE/llama | llama decode | CKE decode | CKE/llama |")
+    print("|---|---:|---:|---:|---:|---:|---:|---:|")
+    for row in results:
+        llama = row.get("llama") or {}
+        cke = row.get("cke") or {}
+        lp = llama.get("prompt_tok_s")
+        cp = cke.get("prompt_tok_s")
+        ld = llama.get("decode_tok_s")
+        cd = cke.get("decode_tok_s")
+        print(
+            f"| {row['label']} | {row['quant']} | {_fmt(lp)} tok/s | {_fmt(cp)} tok/s | {_ratio(cp, lp)} | "
+            f"{_fmt(ld)} tok/s | {_fmt(cd)} tok/s | {_ratio(cd, ld)} |"
+        )
+    print(f"\nWrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/sweep_q6k_prefill_dispatch.py
+++ b/benchmarks/sweep_q6k_prefill_dispatch.py
@@ -173,6 +173,7 @@ def main() -> int:
     parser.add_argument("--max-n", type=int, default=32768, help="Skip extracted shapes with very large N, such as full-vocab logits")
     parser.add_argument("--max-shapes", type=int, default=8, help="Maximum unique lowered shapes to sweep")
     parser.add_argument("--threads", type=int, default=int(os.getenv("CK_NUM_THREADS", "12")))
+    parser.add_argument("--thread-values", default=None, help="Comma-separated thread counts to sweep; overrides --threads")
     parser.add_argument("--engine-lib", type=Path, default=ROOT / "build" / "libckernel_engine.so")
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument("--iters", type=int, default=2)
@@ -188,60 +189,63 @@ def main() -> int:
         selected = args.shape or ["qwen2_mlp_down", "nanbeige_mlp_down"]
         shapes_map = {name: SHAPES[name] for name in selected}
     m_values = [16, 128, 512] if args.quick else _parse_csv_ints(args.m_values)
+    thread_values = _parse_csv_ints(args.thread_values) if args.thread_values else [args.threads]
 
     results: list[dict[str, Any]] = []
-    print(f"Q6_K x Q8_K prefill dispatch sweep threads={args.threads}")
-    for shape_name, (n, k) in shapes_map.items():
-        print(f"\nshape={shape_name} N={n} K={k}")
-        for m in m_values:
-            row = _run_one(
-                shape_name=shape_name,
-                m=m,
-                n=n,
-                k=k,
-                mode="row",
-                threads=args.threads,
-                warmup=args.warmup,
-                iters=args.iters,
-                force_2d=False,
-                engine_lib=args.engine_lib,
-            )
-            tiled = _run_one(
-                shape_name=shape_name,
-                m=m,
-                n=n,
-                k=k,
-                mode="2d",
-                threads=args.threads,
-                warmup=args.warmup,
-                iters=args.iters,
-                force_2d=True,
-                engine_lib=args.engine_lib,
-            )
-            results.extend([row, tiled])
-            if row.get("status") == "pass" and tiled.get("status") == "pass":
-                speedup = float(row["best_ms"]) / float(tiled["best_ms"])
-                delta = (float(row["best_ms"]) - float(tiled["best_ms"])) / float(row["best_ms"]) * 100.0
-                checksum_abs_diff = abs(float(row["checksum"]) - float(tiled["checksum"]))
-                checksum_ok = checksum_abs_diff <= CHECKSUM_ABS_TOL
-                row["paired_with"] = "2d"
-                tiled["paired_with"] = "row"
-                row["checksum_abs_diff"] = checksum_abs_diff
-                tiled["checksum_abs_diff"] = checksum_abs_diff
-                row["checksum_match"] = checksum_ok
-                tiled["checksum_match"] = checksum_ok
-                print(
-                    f"M={m:4d} row={row['best_ms']:8.2f}ms "
-                    f"2d={tiled['best_ms']:8.2f}ms speed={speedup:5.3f} "
-                    f"delta={delta:+6.2f}% checksum={'ok' if checksum_ok else 'DIFF'} "
-                    f"diff={checksum_abs_diff:.3e}"
+    print(f"Q6_K x Q8_K prefill dispatch sweep threads={','.join(str(t) for t in thread_values)}")
+    for threads in thread_values:
+        print(f"\nthreads={threads}")
+        for shape_name, (n, k) in shapes_map.items():
+            print(f"\nshape={shape_name} N={n} K={k}")
+            for m in m_values:
+                row = _run_one(
+                    shape_name=shape_name,
+                    m=m,
+                    n=n,
+                    k=k,
+                    mode="row",
+                    threads=threads,
+                    warmup=args.warmup,
+                    iters=args.iters,
+                    force_2d=False,
+                    engine_lib=args.engine_lib,
                 )
-            else:
-                print(f"M={m:4d} FAIL row={row.get('status')} 2d={tiled.get('status')}")
+                tiled = _run_one(
+                    shape_name=shape_name,
+                    m=m,
+                    n=n,
+                    k=k,
+                    mode="2d",
+                    threads=threads,
+                    warmup=args.warmup,
+                    iters=args.iters,
+                    force_2d=True,
+                    engine_lib=args.engine_lib,
+                )
+                results.extend([row, tiled])
+                if row.get("status") == "pass" and tiled.get("status") == "pass":
+                    speedup = float(row["best_ms"]) / float(tiled["best_ms"])
+                    delta = (float(row["best_ms"]) - float(tiled["best_ms"])) / float(row["best_ms"]) * 100.0
+                    checksum_abs_diff = abs(float(row["checksum"]) - float(tiled["checksum"]))
+                    checksum_ok = checksum_abs_diff <= CHECKSUM_ABS_TOL
+                    row["paired_with"] = "2d"
+                    tiled["paired_with"] = "row"
+                    row["checksum_abs_diff"] = checksum_abs_diff
+                    tiled["checksum_abs_diff"] = checksum_abs_diff
+                    row["checksum_match"] = checksum_ok
+                    tiled["checksum_match"] = checksum_ok
+                    print(
+                        f"T={threads:2d} M={m:4d} row={row['best_ms']:8.2f}ms "
+                        f"2d={tiled['best_ms']:8.2f}ms speed={speedup:5.3f} "
+                        f"delta={delta:+6.2f}% checksum={'ok' if checksum_ok else 'DIFF'} "
+                        f"diff={checksum_abs_diff:.3e}"
+                    )
+                else:
+                    print(f"T={threads:2d} M={m:4d} FAIL row={row.get('status')} 2d={tiled.get('status')}")
 
     report = {
         "kind": "q6k_q8k_prefill_dispatch_sweep",
-        "threads": args.threads,
+        "threads": thread_values,
         "engine_lib": str(args.engine_lib),
         "warmup": args.warmup,
         "iters": args.iters,

--- a/tests/test_threadpool_parity.c
+++ b/tests/test_threadpool_parity.c
@@ -15,6 +15,7 @@
  *   6. gemm_nt_q5_0_q8_0    vs  gemm_nt_q5_0_q8_0_parallel_dispatch    (Q/K proj, out proj, MLP gate+up)
  *   7. gemm_nt_q8_0_q8_0    vs  gemm_nt_q8_0_q8_0_parallel_dispatch    (V proj)
  *   8. gemm_nt_q6_k_q8_k    vs  gemm_nt_q6_k_q8_k_parallel_dispatch    (MLP down proj)
+ *   9. gemm_nt_q4_k_q8_k    vs  gemm_nt_q4_k_q8_k_parallel_dispatch    (Q4_K proj)
  *
  * ADR: Thread pool vs OpenMP
  *   - OpenMP fork/join creates threads per #pragma region (~15-50us overhead)
@@ -170,6 +171,8 @@ extern void gemm_nt_q8_0_q8_0(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemm_nt_q6_k_q8_k(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
+extern void gemm_nt_q4_k_q8_k(const void *A, const void *B, const float *bias,
+                                float *C, int M, int N, int K);
 
 /* GEMM kernel declarations (thread pool dispatch from ck_parallel_prefill.c) */
 extern void gemm_nt_q5_0_q8_0_parallel_dispatch(const void *A, const void *B,
@@ -179,6 +182,9 @@ extern void gemm_nt_q8_0_q8_0_parallel_dispatch(const void *A, const void *B,
                                                    const float *bias, float *C,
                                                    int M, int N, int K);
 extern void gemm_nt_q6_k_q8_k_parallel_dispatch(const void *A, const void *B,
+                                                   const float *bias, float *C,
+                                                   int M, int N, int K);
+extern void gemm_nt_q4_k_q8_k_parallel_dispatch(const void *A, const void *B,
                                                    const float *bias, float *C,
                                                    int M, int N, int K);
 
@@ -311,6 +317,50 @@ static double bench_gemm(gemm_fn_t fn, const void *A, const void *B,
     return (t1 - t0) / iters;
 }
 
+/* Simple Q4_K quantization for test data (lossy but deterministic).
+ * This is only for serial-vs-dispatch parity: both paths consume the same
+ * synthetic Q4_K blocks, so exact reconstruction quality is not the target.
+ */
+static void quantize_to_q4_K(const float *src, void *dst, int M, int K) {
+    block_q4_K *blocks = (block_q4_K *)dst;
+    const int blocks_per_row = K / QK_K;  /* QK_K = 256 */
+
+    for (int row = 0; row < M; row++) {
+        for (int b = 0; b < blocks_per_row; b++) {
+            const float *wp = &src[row * K + b * QK_K];
+            block_q4_K *blk = &blocks[row * blocks_per_row + b];
+
+            float amax = 0.0f;
+            for (int i = 0; i < QK_K; i++) {
+                float a = fabsf(wp[i]);
+                if (a > amax) amax = a;
+            }
+
+            float d = amax / 15.0f;
+            float id = (d != 0.0f) ? 1.0f / d : 0.0f;
+            blk->d = fp32_to_fp16(d);
+            blk->dmin = fp32_to_fp16(0.0f);
+
+            memset(blk->scales, 0, sizeof(blk->scales));
+            for (int i = 0; i < 4; i++) blk->scales[i] = 1;      /* sc[0..3] */
+            for (int i = 8; i < 12; i++) blk->scales[i] = 1;     /* sc[4..7] low nibble */
+            memset(blk->qs, 0, sizeof(blk->qs));
+
+            for (int iter = 0; iter < 4; iter++) {
+                uint8_t *qs = &blk->qs[iter * 32];
+                const int base = iter * 64;
+                for (int l = 0; l < 32; l++) {
+                    int q0 = (int)(fabsf(wp[base + l]) * id + 0.5f);
+                    int q1 = (int)(fabsf(wp[base + 32 + l]) * id + 0.5f);
+                    if (q0 < 0) q0 = 0; if (q0 > 15) q0 = 15;
+                    if (q1 < 0) q1 = 0; if (q1 > 15) q1 = 15;
+                    qs[l] = (uint8_t)((q0 & 0x0F) | ((q1 & 0x0F) << 4));
+                }
+            }
+        }
+    }
+}
+
 /* Simple Q6_K quantization for test data (lossy but deterministic) */
 static void quantize_to_q6_K(const float *src, void *dst, int M, int K) {
     block_q6_K *blocks = (block_q6_K *)dst;
@@ -412,6 +462,7 @@ static int run_gemm_test(const char *test_name,
                           int B_is_q5,  /* 1 = Q5_0 weights, 0 = Q8_0 weights */
                           int A_is_q8_K,  /* 1 = Q8_K activations, 0 = Q8_0 activations */
                           int B_is_q6_K,  /* 1 = Q6_K weights */
+                          int B_is_q4_K,  /* 1 = Q4_K weights */
                           gemm_test_config_t *configs,
                           int warmup, int iters, float abs_tol, int verbose) {
     int pass_count = 0, fail_count = 0;
@@ -454,6 +505,8 @@ static int run_gemm_test(const char *test_name,
         /* Quantize B (weights) */
         if (B_is_q6_K) {
             quantize_to_q6_K(B_fp32, B_q, N, K);
+        } else if (B_is_q4_K) {
+            quantize_to_q4_K(B_fp32, B_q, N, K);
         } else if (B_is_q5) {
             quantize_to_q5_0(B_fp32, B_q, N, K);
         } else {
@@ -805,6 +858,7 @@ int main(int argc, char **argv) {
         1,  /* B_is_q5 */
         0,  /* A_is_q8_K */
         0,  /* B_is_q6_K */
+        0,  /* B_is_q4_K */
         gemm_cfgs, warmup, iters, abs_tol, verbose
     );
 
@@ -826,6 +880,7 @@ int main(int argc, char **argv) {
         0,  /* B_is_q5 */
         0,  /* A_is_q8_K */
         0,  /* B_is_q6_K */
+        0,  /* B_is_q4_K */
         gemm_cfgs, warmup, iters, abs_tol, verbose
     );
 
@@ -860,7 +915,45 @@ int main(int argc, char **argv) {
                 0,  /* B_is_q5 */
                 1,  /* A_is_q8_K */
                 1,  /* B_is_q6_K */
+                0,  /* B_is_q4_K */
                 q6k_configs, warmup, iters, abs_tol, verbose
+            );
+        } else {
+            printf("\n  (Skipped: no configs with K %% 256 == 0)\n");
+        }
+    }
+
+    /* =========================================================================
+     * Test 9: gemm_nt_q4_k_q8_k serial vs thread pool dispatch
+     *         (Q8_K activations x Q4_K weights — Q/K/out/MLP proj)
+     * ========================================================================= */
+    printf("\n");
+    printf("================================================================================\n");
+    printf("  TEST 9: gemm_nt_q4_k_q8_k (serial) vs\n");
+    printf("          gemm_nt_q4_k_q8_k_parallel_dispatch (pool) [prefill]\n");
+    printf("================================================================================\n");
+
+    {
+        gemm_test_config_t q4k_configs[16];
+        int q4k_count = 0;
+        for (int c = 0; gemm_cfgs[c].name && q4k_count < 15; c++) {
+            if (gemm_cfgs[c].K % QK_K == 0) {
+                q4k_configs[q4k_count++] = gemm_cfgs[c];
+            }
+        }
+        q4k_configs[q4k_count] = (gemm_test_config_t){NULL, 0, 0, 0};
+
+        if (q4k_count > 0) {
+            total_fail += run_gemm_test(
+                "q4_k_q8_k",
+                gemm_nt_q4_k_q8_k, gemm_nt_q4_k_q8_k_parallel_dispatch,
+                QK_K, sizeof(block_q8_K),   /* A = Q8_K */
+                QK_K, sizeof(block_q4_K),   /* B = Q4_K */
+                0,  /* B_is_q5 */
+                1,  /* A_is_q8_K */
+                0,  /* B_is_q6_K */
+                1,  /* B_is_q4_K */
+                q4k_configs, warmup, iters, abs_tol, verbose
             );
         } else {
             printf("\n  (Skipped: no configs with K %% 256 == 0)\n");
@@ -874,7 +967,7 @@ int main(int argc, char **argv) {
     printf("  SUMMARY\n");
     printf("================================================================================\n");
     printf("  Thread pool:   %d threads\n", n_threads);
-    printf("  Tests:         GEMV decode (1-5) + GEMM prefill (6-8)\n");
+    printf("  Tests:         GEMV decode (1-5) + GEMM prefill (6-9)\n");
     printf("  Failed:        %d\n", total_fail);
     printf("================================================================================\n");
 

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -47,6 +47,8 @@ extern void gemm_nt_q5_0_q8_0(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemm_nt_q8_0_q8_0(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
+extern void gemm_nt_q4_k_q8_k(const void *A, const void *B, const float *bias,
+                                float *C, int M, int N, int K);
 extern void gemm_nt_q6_k_q8_k(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemm_nt_q6_k_q8_k_tile(const void *A, const void *B, const float *bias,
@@ -224,6 +226,23 @@ static void work_gemm_nt_q8_0_q8_0(int ith, int nth, void *args)
     );
 }
 
+static void work_gemm_nt_q4_k_q8_k(int ith, int nth, void *args)
+{
+    const gemm_args_t *a = (const gemm_args_t *)args;
+    int dr = (a->M + nth - 1) / nth;
+    int r0 = dr * ith;
+    int r1 = (r0 + dr < a->M) ? (r0 + dr) : a->M;
+    if (r0 >= a->M) return;
+
+    gemm_nt_q4_k_q8_k(
+        (const char *)a->A + (size_t)r0 * a->A_row_bytes,
+        a->B,
+        a->bias,
+        a->C + (size_t)r0 * a->N,
+        r1 - r0, a->N, a->K
+    );
+}
+
 static void work_gemm_nt_q6_k_q8_k(int ith, int nth, void *args)
 {
     const gemm_args_t *a = (const gemm_args_t *)args;
@@ -355,6 +374,38 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
         .A_row_bytes = A_row_bytes
     };
     ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q8_0_q8_0, &args);
+}
+
+void gemm_nt_q4_k_q8_k_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K)
+{
+    /* Q4_K prefill row-splitting is currently a benchmark path, not a default
+     * production path. On local i7 AVX2 testing it was parity-clean but slower
+     * for the Qwen/Qwen3.5 shapes measured by test_threadpool_parity and the
+     * v8 decoder matrix. Keep it opt-in until hardware sweeps show a stable win.
+     */
+    const char *enable_q4_pool = getenv("CK_ENABLE_Q4K_Q8K_PREFILL_POOL");
+    if (!enable_q4_pool || enable_q4_pool[0] == '\0' || enable_q4_pool[0] == '0') {
+        gemm_nt_q4_k_q8_k(A, B, bias, C, M, N, K);
+        return;
+    }
+
+    ck_threadpool_t *pool = ck_threadpool_global();
+    if (!pool || ck_threadpool_n_threads(pool) <= 1 || M <= 1 || ck_should_run_gemm_serial(pool, M, N, K)) {
+        gemm_nt_q4_k_q8_k(A, B, bias, C, M, N, K);
+        return;
+    }
+
+    /* A is Q8_K: row_bytes = (K / QK_K) * sizeof(block_q8_K) */
+    size_t A_row_bytes = (size_t)(K / QK_K) * sizeof(block_q8_K);
+
+    gemm_args_t args = {
+        .A = A, .B = B, .bias = bias, .C = C,
+        .M = M, .N = N, .K = K,
+        .A_row_bytes = A_row_bytes
+    };
+    ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q4_k_q8_k, &args);
 }
 
 void gemm_nt_q6_k_q8_k_parallel_dispatch(

--- a/version/v8/src/ck_parallel_prefill_v8.h
+++ b/version/v8/src/ck_parallel_prefill_v8.h
@@ -18,6 +18,7 @@
  * Kernel types:
  *   - gemm_nt_q5_0_q8_0: Q8_0 activations x Q5_0 weights (Q/K proj, out proj, MLP gate+up)
  *   - gemm_nt_q8_0_q8_0: Q8_0 activations x Q8_0 weights (V proj)
+ *   - gemm_nt_q4_k_q8_k: Q8_K activations x Q4_K weights (Q/K/out/MLP proj)
  *   - gemm_nt_q6_k_q8_k: Q8_K activations x Q6_K weights (MLP down proj)
  *   - gemm_nt_q5_1_q8_1: FP32 activations x Q5_1 weights
  *   - gemm_nt_q5_k:      FP32 activations x Q5_K weights
@@ -45,6 +46,10 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K);
 
+void gemm_nt_q4_k_q8_k_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K);
+
 void gemm_nt_q6_k_q8_k_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K);
@@ -66,6 +71,9 @@ void gemm_nt_q5_k_parallel_dispatch(
 
 #define gemm_nt_q8_0_q8_0(A, B, bias, C, M, N, K) \
     gemm_nt_q8_0_q8_0_parallel_dispatch(A, B, bias, C, M, N, K)
+
+#define gemm_nt_q4_k_q8_k(A, B, bias, C, M, N, K) \
+    gemm_nt_q4_k_q8_k_parallel_dispatch(A, B, bias, C, M, N, K)
 
 #define gemm_nt_q6_k_q8_k(A, B, bias, C, M, N, K) \
     gemm_nt_q6_k_q8_k_parallel_dispatch(A, B, bias, C, M, N, K)


### PR DESCRIPTION
## Summary
- Add a repeatable v8 decoder matrix benchmark for CKE vs llama.cpp.
- Extend Q6_K prefill sweep tooling with thread-count sweeps.
- Add Q4_K x Q8_K prefill threadpool parity coverage.
- Keep Q4_K prefill pool dispatch opt-in with CK_ENABLE_Q4K_Q8K_PREFILL_POOL=1 because local AVX2 results were parity-clean but not a default speed win.

## Local results
- make test-threadpool-parity-quick: PASS
- make test-q6k-prefill-dispatch-sweep-quick: PASS
- make test-q6k-prefill-thread-sweep-quick: PASS
- make test-v8-decoder-matrix-quick: PASS
  - Qwen3.5 Q4_K_M: CKE prompt 64.6 tok/s vs llama 291.1 tok/s; CKE decode 49.5 tok/s vs llama 34.3 tok/s
  - Qwen2 Q4_K_M: CKE prompt 68.3 tok/s vs llama 284.5 tok/s; CKE decode 75.3 tok/s vs llama 49.0 tok/s
- make v8-regression-fast: PASS overall

## Pre-push
- Build: PASS
- Kernel parity: PASS
- v8 E2E smoke: PASS
- v7 inference gate: PASS
- v7 fast regression: PASS
- v8 fast regression: PASS
- v7 training-kernel parity: PASS