### PR TITLE
fix(ci): keep nightly report dependencies available

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -138,11 +138,13 @@ jobs:
           export LD_LIBRARY_PATH="$PWD/llama.cpp/build/bin:$LD_LIBRARY_PATH"
           ./scripts/run_parity_smoketest.sh --quick 2>&1 | tee build/parity_test.log
 
-      - name: Clean llama.cpp build artifacts
+      - name: Check disk after llama.cpp parity setup
         if: always()
         run: |
-          rm -rf llama.cpp
-          echo "=== Disk after llama.cpp cleanup ==="
+          # Keep llama.cpp available through the full nightly runner. The
+          # report includes litmus and llama.cpp parity rows that compile
+          # against ggml headers/libraries after this point.
+          echo "=== Disk after llama.cpp parity setup ==="
           df -h
 
       - name: Determine v7 Fast Regression Scope
@@ -557,6 +559,7 @@ jobs:
       - name: Final disk cleanup before artifact upload
         if: always()
         run: |
+          rm -rf llama.cpp
           rm -rf "${RUNNER_TEMP}/ck-engine-v8"
           rm -rf "${RUNNER_TEMP}/ck-engine"
           rm -rf "${HOME}/.cache/ck-engine"

--- a/unittest/test_lm_head_litmus.py
+++ b/unittest/test_lm_head_litmus.py
@@ -4,6 +4,7 @@ import math
 import os
 import shutil
 import subprocess
+import tempfile
 
 import numpy as np
 import torch
@@ -462,7 +463,10 @@ def main():
     args = parse_args()
     here = os.path.dirname(os.path.abspath(__file__))
     root = os.path.dirname(here)
-    build_dir = args.build_dir or os.path.join(root, "build")
+    build_dir = args.build_dir or tempfile.mkdtemp(
+        prefix=f"litmus-{os.getpid()}-",
+        dir=os.path.join(root, "build"),
+    )
     os.makedirs(build_dir, exist_ok=True)
 
     cfg = build_config(args)


### PR DESCRIPTION
## Summary
- isolate LM head litmus generated build artifacts per process
- keep llama.cpp checkout/build available until after nightly report tests finish
- move llama.cpp cleanup to final CI cleanup before artifact upload

## Why
The latest GitHub job was green, but the generated nightly report contained three failed rows: LM Head Litmus, Litmus Test, and llama.cpp Parity (Nightly). The artifact logs showed missing llama.cpp/ggml headers/libraries because the workflow removed llama.cpp before scripts/nightly_runner.py.

## Test
- make litmus and .venv/bin/python -B unittest/test_lm_head_litmus.py in parallel
- make llamacpp-parity-nightly
- pre-commit v7/v8 fast regression
- pre-push build, kernel parity, v8 E2E, v7 gate, v7/v8 fast regression, training-kernel parity