### PR TITLE
perf(v8): cap active threads for large ops

### DIFF
--- a/benchmarks/sweep_q4_q5_prefill_dispatch.py
+++ b/benchmarks/sweep_q4_q5_prefill_dispatch.py
@@ -37,6 +37,7 @@ SHAPES: dict[str, dict[str, Any]] = {
     "qwen35_gate_up_q4_k_smoke": {"kind": "q4_k", "N": 512, "K": 1024},
     "qwen35_gate_up_q4_k": {"kind": "q4_k", "N": 3584, "K": 1024},
     "nanbeige_gate_up_q4_k": {"kind": "q4_k", "N": 10496, "K": 2560},
+    "gemma4_gate_up_q4_k": {"kind": "q4_k", "N": 10240, "K": 2560},
 }
 
 
@@ -201,14 +202,23 @@ def _run_one(engine: ctypes.CDLL, model: ctypes.CDLL, *, shape: str, kind: str, 
     c_pool = (ctypes.c_float * (m * n))()
     serial, dispatch = _bind(engine, model, kind)
 
+    os.environ["CK_NUM_THREADS"] = str(threads)
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+    if hasattr(engine, "ck_threadpool_global_destroy"):
+        engine.ck_threadpool_global_destroy.argtypes = []
+        engine.ck_threadpool_global_destroy.restype = None
+        engine.ck_threadpool_global_destroy()
+    elif hasattr(engine, "ck_threadpool_shutdown"):
+        engine.ck_threadpool_shutdown.argtypes = []
+        engine.ck_threadpool_shutdown.restype = None
+        engine.ck_threadpool_shutdown()
+
     if hasattr(engine, "ck_set_num_threads"):
         engine.ck_set_num_threads.argtypes = [ctypes.c_int]
         engine.ck_set_num_threads(threads)
     if hasattr(model, "ck_parallel_prefill_init"):
         model.ck_parallel_prefill_init()
-
-    os.environ["CK_NUM_THREADS"] = str(threads)
-    os.environ.setdefault("OMP_NUM_THREADS", "1")
     if kind == "q4_k":
         os.environ["CK_ENABLE_Q4K_Q8K_PREFILL_POOL"] = "1"
 

--- a/version/v8/src/ck_parallel_decode_v8.c
+++ b/version/v8/src/ck_parallel_decode_v8.c
@@ -126,7 +126,7 @@ static int ck_select_gemv_active_threads(const ck_threadpool_t *pool, int M, int
     const int pool_threads = ck_threadpool_n_threads(pool);
     if (pool_threads <= 1 || M <= 1 || K <= 0) return 1;
     if (!ck_shape_aware_enabled(pool)) return pool_threads;
-    if (M >= 4096) return pool_threads;
+    if (M >= 4096) return ck_min_int(pool_threads, ck_env_int_or("CK_GEMV_THREAD_CAP", 32));
     if (M >= 512) return ck_min_int(pool_threads, ck_env_int_or("CK_GEMV_THREAD_CAP", 12));
     return 1;
 }

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -289,7 +289,7 @@ static int ck_select_gemm_active_threads(const ck_threadpool_t *pool, int M, int
                           ck_env_int_or2("CK_GEMM_THREAD_CAP", "CK_GEMV_THREAD_CAP", pool_threads));
     }
 
-    if (N >= 4096 || K >= 4096) return pool_threads;
+    if (N >= 4096 || K >= 4096) return ck_min_int(pool_threads, ck_env_int_or2("CK_GEMM_THREAD_CAP", "CK_GEMV_THREAD_CAP", 24));
     if (M >= 512) return ck_min_int(pool_threads, 24);
     return pool_threads;
 }


### PR DESCRIPTION
## Summary
- cap active v8 GEMM worker threads for large prefill ops, default 24
- cap active v8 GEMV worker threads for very large decode rows, default 32
- preserve overrides through CK_GEMM_THREAD_CAP and CK_GEMV_THREAD_CAP
- fix Q4/Q5 sweep measurements by rebuilding the global threadpool when CK_NUM_THREADS changes
- add Gemma4 Q4_K gate/up shape to the sweep harness

## Why
High-core hosts can regress when every logical thread participates in memory-bound large GEMM/GEMV work. The Xeon sweep showed Gemma4 and Qwen3.5 prefer a lower active-thread cap than the full 48 logical-thread pool. The old sweep was also misleading because it changed CK_NUM_THREADS after the global pool was already created.

## Test
- make test-threadpool-parity-quick
- make test-q4-q5-prefill-dispatch-sweep-quick
- CK_Q4_Q5_SWEEP_SHAPE=gemma4_gate_up_q4_k make test-q4-q5-prefill-thread-sweep-quick
- make test-q4-q5-prefill-thread-sweep-quick
- make v8-regression-fast
- pre-commit v8-regression-fast
- pre-push build, kernel parity, v8 E2E, v7 inference, v8 fast regression, training-kernel parity