### PR TITLE
fix(v8/gemma4): add prefill parity fallback

### DIFF
--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -437,6 +437,10 @@ OP_DATAFLOW = {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "main_stream_q8", "dtype": "q8_0"}},
     },
+    "quantize_input_2": {
+        "inputs": {"input": "main_stream"},
+        "outputs": {"output": {"slot": "main_stream_q8", "dtype": "q8_0"}},
+    },
     "residual_save": {
         "inputs": {"src": "main_stream"},
         "outputs": {"dst": {"slot": "residual", "dtype": "fp32"}},
@@ -2761,6 +2765,8 @@ def apply_layer_attention_dims(op_name: str, params: Dict, layer: int, config: D
         if sliding_window > 0:
             params["sliding_window"] = sliding_window
     elif op_name == "v_norm":
+        params["head_dim"] = v_head_dim
+        params["v_head_dim"] = v_head_dim
         params["embed_dim"] = v_dim
         params["d_model"] = v_dim
         params["aligned_embed_dim"] = v_dim

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -824,7 +824,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name in {"q_gate_proj", "k_proj", "v_proj"} and function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}:
+    if op_name in {"q_proj", "q_gate_proj", "k_proj", "v_proj"} and function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}:
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -907,6 +907,10 @@ def emit_op(
                 f"(debug_outproj_fp32_layer == {layer}) || {1 if force_outproj_fp32 else 0};"
             )
             lines.append(f"    ck_debug_outproj_fp32_input = {x_expr};")
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "attn_out", '
+                f'(const float*)({x_expr}), (int)({k_expr}));'
+            )
             lines.append(f"    if (!{active_name}) {{")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
@@ -1310,7 +1314,7 @@ def emit_op(
 
         if x_expr and y_expr and k_expr and rows_expr:
             active_name = None
-            if op_name == "quantize_input_1":
+            if op_name in {"quantize_input_1", "quantize_input_2"}:
                 active_name = f"ck_debug_mlp_gate_up_fp32_active_{seq_idx if seq_idx is not None else idx}"
                 lines.append(
                     f"    const int {active_name} = debug_mlp_gate_up_fp32 || "
@@ -1389,6 +1393,13 @@ def emit_op(
                 return ex
         return default
 
+    def _hidden_token_count() -> str | None:
+        for nm in ("num_tokens", "tokens", "token_count", "rows", "n_tokens"):
+            ex = arg_expr_by_name_for_hidden.get(nm)
+            if ex:
+                return ex
+        return None
+
     def _emit_hidden_export(expr: str | None, label: str, count_expr: str | None) -> None:
         raw_expr = _hidden_raw(expr)
         if raw_expr and count_expr:
@@ -1397,26 +1408,102 @@ def emit_op(
                 f'(const float*){raw_expr}, {count_expr});'
             )
 
+    def _emit_hidden_export_last_row(
+        expr: str | None,
+        label: str,
+        row_count_expr: str | None,
+        row_stride_expr: str | None = None,
+    ) -> None:
+        raw_expr = _hidden_raw(expr)
+        token_count_expr = _hidden_token_count()
+        if raw_expr and row_count_expr and token_count_expr:
+            stride_expr = row_stride_expr or row_count_expr
+            lines.append(
+                f'    if (({token_count_expr}) > 1) ck_debug_export_hidden(model, {layer}, "{label}_last", '
+                f'(const float*)(((const float*){raw_expr}) + (((size_t)({token_count_expr}) - 1u) * (size_t)({stride_expr}))), '
+                f'{row_count_expr});'
+            )
+
     if op_name == "residual_add":
         out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
+        residual_expr = _hidden_raw(_hidden_arg("b"))
+        if op_instance_idx == 0 and residual_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "after_attn_residual", (const float*){residual_expr}, EMBED_DIM);')
+            _emit_hidden_export_last_row(residual_expr, "after_attn_residual", "EMBED_DIM")
+        elif op_instance_idx == 1 and residual_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "ffn_residual", (const float*){residual_expr}, EMBED_DIM);')
+            _emit_hidden_export_last_row(residual_expr, "ffn_residual", "EMBED_DIM")
         if out_expr:
             if op_instance_idx == 0:
                 lines.append(f'    ck_debug_export_hidden(model, {layer}, "after_attn", (const float*){out_expr}, EMBED_DIM);')
+                _emit_hidden_export_last_row(out_expr, "after_attn", "EMBED_DIM")
             elif op_instance_idx == 1:
                 lines.append(f'    ck_debug_export_hidden(model, {layer}, "layer_out", (const float*){out_expr}, EMBED_DIM);')
+                _emit_hidden_export_last_row(out_expr, "layer_out", "EMBED_DIM")
     elif op_name == "post_attention_norm":
         out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y"))
         if out_expr:
             lines.append(f'    ck_debug_export_hidden(model, {layer}, "post_attn_norm", (const float*){out_expr}, EMBED_DIM);')
+            _emit_hidden_export_last_row(out_expr, "post_attn_norm", "EMBED_DIM")
+    elif op_name == "ffn_norm":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y"))
+        if out_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "ffn_norm", (const float*){out_expr}, EMBED_DIM);')
+            _emit_hidden_export_last_row(out_expr, "ffn_norm", "EMBED_DIM")
+    elif op_name == "post_ffn_norm":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y"))
+        if out_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "post_ffn_norm", (const float*){out_expr}, EMBED_DIM);')
+            _emit_hidden_export_last_row(out_expr, "post_ffn_norm", "EMBED_DIM")
+    elif op_name == "qk_norm":
+        q_expr = _hidden_raw(_hidden_arg("q"))
+        k_expr = _hidden_raw(_hidden_arg("k"))
+        q_count = _mul_expr(_hidden_arg("num_heads") or "NUM_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+        k_count = _mul_expr(_hidden_arg("num_kv_heads") or "NUM_KV_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+        if q_expr and q_count:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "qk_norm_q", (const float*){q_expr}, {q_count});')
+        if k_expr and k_count:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "qk_norm_k", (const float*){k_expr}, {k_count});')
+    elif op_name == "rope_qk":
+        q_expr = _hidden_raw(_hidden_arg("q"))
+        k_expr = _hidden_raw(_hidden_arg("k"))
+        q_count = _mul_expr(_hidden_arg("num_heads") or "NUM_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+        k_count = _mul_expr(_hidden_arg("num_kv_heads") or "NUM_KV_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+        if q_expr and q_count:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "rope_q", (const float*){q_expr}, {q_count});')
+        if k_expr and k_count:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "rope_k", (const float*){k_expr}, {k_count});')
     elif op_name in ("silu_mul", "swiglu"):
         out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y", "data"))
         if out_expr:
             count_expr = _hidden_count("dim", "n", "intermediate_dim", default="INTERMEDIATE_DIM")
             lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_swiglu", (const float*){out_expr}, {count_expr});')
+            _emit_hidden_export_last_row(out_expr, "mlp_swiglu", count_expr)
+    elif op_name == "geglu":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y", "data"))
+        if out_expr:
+            count_expr = _hidden_count("dim", "n", "intermediate_dim", default="INTERMEDIATE_DIM")
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_geglu", (const float*){out_expr}, {count_expr});')
+            _emit_hidden_export_last_row(out_expr, "mlp_geglu", count_expr)
     elif op_name == "mlp_down":
         out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
         if out_expr:
             lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_down", (const float*){out_expr}, EMBED_DIM);')
+            _emit_hidden_export_last_row(out_expr, "mlp_down", "EMBED_DIM")
+    elif op_name == "gemma4_per_layer_prepare":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "per_layer_input", "y"))
+        if out_expr:
+            count_expr = _hidden_count("tokens", "rows", "n", default="1")
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "gemma4_per_layer_prepare", '
+                f'(const float*){out_expr}, ({count_expr}) * NUM_LAYERS * 256);'
+            )
+            _emit_hidden_export_last_row(out_expr, "gemma4_per_layer_prepare", "NUM_LAYERS * 256", "NUM_LAYERS * 256")
+    elif op_name == "gemma4_per_layer_embed":
+        out_expr = _hidden_raw(_hidden_arg("hidden", "output", "out", "x", "y"))
+        if out_expr:
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "gemma4_per_layer_embed", (const float*){out_expr}, EMBED_DIM);')
+            _emit_hidden_export_last_row(out_expr, "gemma4_per_layer_embed", "EMBED_DIM")
     elif op_name == "recurrent_qkv_proj":
         _emit_hidden_export(
             _hidden_arg("output", "out", "c", "y"),
@@ -2277,7 +2364,7 @@ CK_EXPORT void ck_model_profile_dump(void) {
     recurrent_reset_lines: list[str] = []
     prefill_policy = str(config.get("prefill_policy") or "").strip().lower()
     force_sequential_prefill = prefill_policy in {"sequential_decode", "decode"}
-    prefill_guard = " && 0" if force_sequential_prefill else ""
+    prefill_guard = " && 0" if force_sequential_prefill else " && !(getenv(\"CK_V8_FORCE_DECODE_PREFILL\") && atoi(getenv(\"CK_V8_FORCE_DECODE_PREFILL\")) != 0)"
     for buf_name, macro_name in (
         ("recurrent_conv_state", "A_RECURRENT_CONV_STATE"),
         ("recurrent_ssm_state", "A_RECURRENT_SSM_STATE"),

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -50,15 +50,51 @@ from typing import Dict, List, Optional
 
 
 def _annotate_kv_transpose_roles(ops: List[Dict]) -> None:
-    """Mark each transpose_kv_to_head_major op as K or V within its layer."""
-    layer_kv_count: Dict[int, int] = {}
+    """Mark synthetic transpose ops with K/V role and per-layer head geometry."""
+
+    def _arg_expr(op: Dict, name: str) -> Optional[str]:
+        target = name.lower()
+        for arg in op.get("args", []) or []:
+            if str(arg.get("name", "")).lower() == target:
+                expr = str(arg.get("expr", "")).strip()
+                return expr or None
+        return None
+
+    layer_dims: Dict[int, Dict[str, str]] = {}
     for op in ops:
-        if op.get("op") != "transpose_kv_to_head_major":
+        if op.get("op") != "qk_norm":
             continue
         layer = int(op.get("layer", 0))
-        count = layer_kv_count.get(layer, 0)
-        op["_is_k"] = (count == 0)
-        layer_kv_count[layer] = count + 1
+        num_heads = _arg_expr(op, "num_heads")
+        num_kv_heads = _arg_expr(op, "num_kv_heads")
+        head_dim = _arg_expr(op, "head_dim")
+        if num_heads and num_kv_heads and head_dim:
+            layer_dims[layer] = {
+                "num_heads": num_heads,
+                "num_kv_heads": num_kv_heads,
+                "head_dim": head_dim,
+            }
+
+    layer_kv_count: Dict[int, int] = {}
+    for op in ops:
+        op_name = op.get("op")
+        if op_name not in {
+            "transpose_qkv_to_head_major",
+            "transpose_kv_to_head_major",
+            "transpose_attn_out_to_token_major",
+            "kv_cache_batch_copy",
+        }:
+            continue
+        layer = int(op.get("layer", 0))
+        dims = layer_dims.get(layer)
+        if dims:
+            op["_num_heads"] = dims["num_heads"]
+            op["_num_kv_heads"] = dims["num_kv_heads"]
+            op["_head_dim"] = dims["head_dim"]
+        if op_name == "transpose_kv_to_head_major":
+            count = layer_kv_count.get(layer, 0)
+            op["_is_k"] = (count == 0)
+            layer_kv_count[layer] = count + 1
 
 
 def get_parallel_pragma(op: Dict) -> str:
@@ -195,8 +231,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         # Scratch layout: [num_kv_heads, num_tokens, head_dim] (compact, head-major)
         # KV cache layout: [num_kv_heads, max_seq_len, head_dim] (with stride, head-major)
         layer = op.get("layer", 0)
-        num_kv_heads = config.get("num_kv_heads", 2)
-        head_dim = config.get("head_dim", 64)
+        num_kv_heads = op.get("_num_kv_heads", config.get("num_kv_heads", 2))
+        head_dim = op.get("_head_dim", config.get("head_dim", 64))
         context_len = config.get("context_len", config.get("context_length", 1024))
         return f"""    /* Op {seq_idx}: kv_cache_batch_copy layer={layer} */
     /* Copy K/V from head-major scratch to KV cache for subsequent decode */
@@ -226,8 +262,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
 
     # Handle transpose_kv_to_head_major: convert from [T, Hkv*D] to [Hkv, T, D]
     if op_type == "transpose_kv_to_head_major":
-        num_kv_heads = config.get("num_kv_heads", 2)
-        head_dim = config.get("head_dim", 64)
+        num_kv_heads = op.get("_num_kv_heads", config.get("num_kv_heads", 2))
+        head_dim = op.get("_head_dim", config.get("head_dim", 64))
         # _is_k is set by emit_prefill_function preprocessing
         is_k = op.get("_is_k", True)
         scratch_name = "A_K_SCRATCH" if is_k else "A_V_SCRATCH"
@@ -259,8 +295,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     if op_type == "transpose_qkv_to_head_major":
         qkv_type = op.get("_qkv_type", "q")
         if qkv_type == "q":
-            num_heads = config.get("num_heads", 14)
-            head_dim = config.get("head_dim", 64)
+            num_heads = op.get("_num_heads", config.get("num_heads", 14))
+            head_dim = op.get("_head_dim", config.get("head_dim", 64))
             scratch_name = "A_Q_SCRATCH"
             max_tokens = config.get("context_len", config.get("context_length", 1024))
             omp_pragma = get_parallel_pragma(op)
@@ -289,8 +325,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     # Handle transpose_attn_out_to_token_major: convert from [H, T, D] to [T, H*D]
     # This is the reverse of the Q transpose - needed after attention before out_proj
     if op_type == "transpose_attn_out_to_token_major":
-        num_heads = config.get("num_heads", 14)
-        head_dim = config.get("head_dim", 64)
+        num_heads = op.get("_num_heads", config.get("num_heads", 14))
+        head_dim = op.get("_head_dim", config.get("head_dim", 64))
         max_tokens = config.get("context_len", config.get("context_length", 1024))
         # Parallelize over heads (outer loop)
         omp_pragma = get_parallel_pragma(op)
@@ -409,12 +445,103 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             if profile:
                 lines.append(f'    CK_PROFILE_END("prefill", "{func}", "{op_type}", {layer});')
 
+            raw_expr = c_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append(
+                f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "out_proj_last", '
+                f'(const float*)(((const float*){raw_expr}) + (((size_t)num_tokens - 1u) * (size_t)(EMBED_DIM))), '
+                f'EMBED_DIM);'
+            )
+
             if dump:
                 raw_expr = c_expr.replace("(float*)", "").replace("(void*)", "").strip()
                 size_expr = f"({m_expr}) * ({n_expr})"
                 lines.append("    #ifdef CK_PARITY_DUMP")
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "attn_output", {size_expr});')
                 lines.append("    #endif")
+            return "\n".join(lines)
+
+    if op_type == "mlp_gate_up" and func in ("gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"):
+        a_expr = arg_expr_by_name.get("a")
+        b_expr = arg_expr_by_name.get("b")
+        bias_expr = arg_expr_by_name.get("bias", "NULL")
+        c_expr = arg_expr_by_name.get("c")
+        m_expr = arg_expr_by_name.get("m", "num_tokens")
+        n_expr = arg_expr_by_name.get("n")
+        k_expr = arg_expr_by_name.get("k")
+        row_gemv_func = "gemv_q4_k_q8_k" if func == "gemm_nt_q4_k_q8_k" else "gemv_q6_k_q8_k"
+        weight_row_bytes_expr = f"(((size_t)({k_expr}) / 256u) * 144u)" if func == "gemm_nt_q4_k_q8_k" else f"(((size_t)({k_expr}) / 256u) * 210u)"
+        if a_expr and b_expr and c_expr and n_expr and k_expr:
+            lines.append(f"    if (debug_prefill_mlp_gate_up_row_gemv || debug_prefill_mlp_gate_up_row_gemv_layer == {layer}) {{")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.extend([
+                f"        const int _ck_m = (int)({m_expr});",
+                f"        const int _ck_n = (int)({n_expr});",
+                f"        const int _ck_k = (int)({k_expr});",
+                "        const int _ck_half = _ck_n / 2;",
+                "        const size_t _ck_a_row_bytes = (size_t)(_ck_k / QK_K) * sizeof(block_q8_K);",
+                f"        const size_t _ck_w_row_bytes = {weight_row_bytes_expr};",
+                f"        const uint8_t *_ck_a_base = (const uint8_t*)({a_expr});",
+                f"        const uint8_t *_ck_w_base = (const uint8_t*)({b_expr});",
+                f"        const float *_ck_bias = (const float*)({bias_expr});",
+                f"        float *_ck_c_base = (float*)({c_expr});",
+                "        for (int _ck_t = 0; _ck_t < _ck_m; ++_ck_t) {",
+                "            const void *_ck_xq8 = (const void*)(_ck_a_base + (size_t)_ck_t * _ck_a_row_bytes);",
+                "            float *_ck_y = _ck_c_base + (size_t)_ck_t * (size_t)_ck_n;",
+                f"            {row_gemv_func}(_ck_y, (const void*)_ck_w_base, _ck_xq8, _ck_half, _ck_k);",
+                f"            {row_gemv_func}(_ck_y + _ck_half, (const void*)(_ck_w_base + (size_t)_ck_half * _ck_w_row_bytes), _ck_xq8, _ck_half, _ck_k);",
+                "            if (_ck_bias != NULL) {",
+                "                for (int _ck_i = 0; _ck_i < _ck_n; ++_ck_i) _ck_y[_ck_i] += _ck_bias[_ck_i];",
+                "            }",
+                "        }",
+            ])
+            if profile:
+                lines.append(f'        CK_PROFILE_END("prefill", "{row_gemv_func}", "{op_type}_row_gemv", {layer});')
+            fp32_func = "gemm_nt_q4_k" if func == "gemm_nt_q4_k_q8_k" else "gemm_nt_q6_k"
+            lines.append(f"    }} else if ((debug_mlp_gate_up_fp32 || debug_mlp_gate_up_fp32_layer == {layer}) && ck_debug_mlp_gate_up_fp32_input != NULL) {{")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.extend([
+                f"        {fp32_func}(",
+                "            ck_debug_mlp_gate_up_fp32_input,",
+                f"            {b_expr},",
+                f"            {bias_expr},",
+                f"            {c_expr},",
+                f"            {m_expr},",
+                f"            {n_expr},",
+                f"            {k_expr}",
+                "        );",
+            ])
+            if profile:
+                lines.append(f'        CK_PROFILE_END("prefill", "{fp32_func}", "{op_type}", {layer});')
+            lines.append("    } else {")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.extend([
+                f"        {func}(",
+                f"            {a_expr},",
+                f"            {b_expr},",
+                f"            {bias_expr},",
+                f"            {c_expr},",
+                f"            {m_expr},",
+                f"            {n_expr},",
+                f"            {k_expr}",
+                "        );",
+            ])
+            if profile:
+                lines.append(f'        CK_PROFILE_END("prefill", "{func}", "{op_type}", {layer});')
+            lines.append("    }")
+            raw_expr = c_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append(
+                f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "mlp_gate_last", '
+                f'(const float*)(((const float*){raw_expr}) + (((size_t)num_tokens - 1u) * (size_t)({n_expr}))), '
+                f'(({n_expr}) / 2));'
+            )
+            lines.append(
+                f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "mlp_up_last", '
+                f'(const float*)(((const float*){raw_expr}) + (((size_t)num_tokens - 1u) * (size_t)({n_expr})) + (size_t)((({n_expr}) / 2))), '
+                f'(({n_expr}) / 2));'
+            )
             return "\n".join(lines)
 
     # Format the function call / quantization loop
@@ -426,8 +553,15 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)"
         else:
             row_bytes_expr = "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+        if op_type == "quantize_input_2":
+            lines.append(f"    ck_debug_mlp_gate_up_fp32_input = (const float*)({x_expr});")
         if op_type == "quantize_out_proj_input":
             lines.append(f"    ck_debug_outproj_fp32_input = (const float*)({x_expr});")
+            lines.append(
+                f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "attn_out_last", '
+                f'(const float*)(((const float*)({x_expr})) + (((size_t)num_tokens - 1u) * (size_t)({k_expr}))), '
+                f'(int)({k_expr}));'
+            )
             lines.append("    if (!debug_outproj_fp32) {")
             lines.append(f"        const float *_x_base = (const float*)({x_expr});")
             lines.append(f"        uint8_t *_y_base = (uint8_t*)({y_expr});")
@@ -470,6 +604,101 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             lines.append("    );")
     if profile:
         lines.append(f'    CK_PROFILE_END("prefill", "{func}", "{op_type}", {layer});')
+
+    def _hidden_arg(*names: str) -> Optional[str]:
+        for nm in names:
+            ex = arg_expr_by_name.get(nm.lower())
+            if ex:
+                return ex
+        return None
+
+    def _hidden_raw(expr: Optional[str]) -> Optional[str]:
+        if not expr:
+            return None
+        return expr.replace("(float*)", "").replace("(void*)", "").strip()
+
+    def _emit_hidden_last(
+        expr: Optional[str],
+        label: str,
+        width_expr: Optional[str],
+        stride_expr: Optional[str] = None,
+    ) -> None:
+        raw = _hidden_raw(expr)
+        if not raw or not width_expr:
+            return
+        row_stride = stride_expr or width_expr
+        lines.append(
+            f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "{label}_last", '
+            f'(const float*)(((const float*){raw}) + (((size_t)num_tokens - 1u) * (size_t)({row_stride}))), '
+            f'{width_expr});'
+        )
+
+    def _emit_head_major_last(expr: Optional[str], label: str, heads_expr: Optional[str], dim_expr: Optional[str]) -> None:
+        raw = _hidden_raw(expr)
+        if not raw or not heads_expr or not dim_expr:
+            return
+        safe_label = label.replace("-", "_").replace(".", "_")
+        lines.append("    if (num_tokens > 1) {")
+        lines.append(f"        const int _ck_{safe_label}_heads = (int)({heads_expr});")
+        lines.append(f"        const int _ck_{safe_label}_dim = (int)({dim_expr});")
+        lines.append(f"        const float *_ck_{safe_label}_src = (const float*){raw};")
+        lines.append(f"        float _ck_{safe_label}_last[(size_t)_ck_{safe_label}_heads * (size_t)_ck_{safe_label}_dim];")
+        lines.append(f"        for (int _ck_h = 0; _ck_h < _ck_{safe_label}_heads; ++_ck_h) {{")
+        lines.append(f"            const float *_ck_s = _ck_{safe_label}_src + ((size_t)_ck_h * (size_t)num_tokens + ((size_t)num_tokens - 1u)) * (size_t)_ck_{safe_label}_dim;")
+        lines.append(f"            memcpy(_ck_{safe_label}_last + (size_t)_ck_h * (size_t)_ck_{safe_label}_dim, _ck_s, (size_t)_ck_{safe_label}_dim * sizeof(float));")
+        lines.append("        }")
+        lines.append(f'        ck_debug_export_hidden(model, {layer}, "{label}_last", _ck_{safe_label}_last, _ck_{safe_label}_heads * _ck_{safe_label}_dim);')
+        lines.append("    }")
+
+    if op_type == "gemma4_per_layer_prepare":
+        _emit_hidden_last(_hidden_arg("output", "out", "per_layer_input", "y"), "gemma4_per_layer_prepare", "NUM_LAYERS * 256")
+    elif op_type == "q_proj":
+        _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "q_proj", _hidden_arg("n") or "NUM_HEADS * HEAD_DIM")
+    elif op_type == "k_proj":
+        _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "k_proj", _hidden_arg("n") or "NUM_KV_HEADS * HEAD_DIM")
+    elif op_type == "v_proj":
+        _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "v_proj", _hidden_arg("n") or "NUM_KV_HEADS * HEAD_DIM")
+    elif op_type == "qk_norm":
+        _emit_head_major_last(_hidden_arg("q"), "qk_norm_q", _hidden_arg("num_heads") or "NUM_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+        _emit_head_major_last(_hidden_arg("k"), "qk_norm_k", _hidden_arg("num_kv_heads") or "NUM_KV_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+    elif op_type == "rope_qk":
+        _emit_head_major_last(_hidden_arg("q"), "rope_q", _hidden_arg("num_heads") or "NUM_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+        _emit_head_major_last(_hidden_arg("k"), "rope_k", _hidden_arg("num_kv_heads") or "NUM_KV_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
+    elif op_type == "out_proj":
+        _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "out_proj", "EMBED_DIM")
+    elif op_type == "post_attention_norm":
+        _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "post_attn_norm", "EMBED_DIM")
+    elif op_type == "ffn_norm":
+        _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "ffn_norm", "EMBED_DIM")
+    elif op_type == "post_ffn_norm":
+        _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "post_ffn_norm", "EMBED_DIM")
+    elif op_type == "residual_add":
+        if op_instance_idx == 0:
+            _emit_hidden_last(_hidden_arg("b"), "after_attn_residual", "EMBED_DIM")
+            _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "after_attn", "EMBED_DIM")
+        elif op_instance_idx == 1:
+            _emit_hidden_last(_hidden_arg("b"), "ffn_residual", "EMBED_DIM")
+            _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "layer_out", "EMBED_DIM")
+    elif op_type == "mlp_gate_up":
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        total_expr = _hidden_arg("n") or "(2 * INTERMEDIATE_DIM)"
+        half_expr = f"(({total_expr}) / 2)"
+        _emit_hidden_last(out_expr, "mlp_gate", half_expr, total_expr)
+        raw = _hidden_raw(out_expr)
+        if raw:
+            lines.append(
+                f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "mlp_up_last", '
+                f'(const float*)(((const float*){raw}) + (((size_t)num_tokens - 1u) * (size_t)({total_expr})) + (size_t)({half_expr})), '
+                f'{half_expr});'
+            )
+    elif op_type == "geglu":
+        _emit_hidden_last(_hidden_arg("output", "out", "x", "y", "data"), "mlp_geglu", _hidden_arg("dim") or "INTERMEDIATE_DIM")
+    elif op_type == "mlp_down":
+        _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "mlp_down", "EMBED_DIM")
+    elif op_type == "gemma4_per_layer_embed":
+        _emit_hidden_last(_hidden_arg("hidden", "output", "out", "x", "y"), "gemma4_per_layer_embed", "EMBED_DIM")
+    elif op_type == "final_rmsnorm":
+        _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "final_hidden", "EMBED_DIM")
 
     if dump:
         dump_op_map = {
@@ -586,6 +815,15 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     const char *debug_outproj_env = getenv("CK_V7_DEBUG_OUTPROJ_FP32");
     int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;
     const float *ck_debug_outproj_fp32_input = NULL;
+    const char *debug_mlp_gate_up_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_FP32");
+    int debug_mlp_gate_up_fp32 = debug_mlp_gate_up_env ? (atoi(debug_mlp_gate_up_env) != 0) : 0;
+    const char *debug_mlp_gate_up_layer_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_FP32_LAYER");
+    int debug_mlp_gate_up_fp32_layer = debug_mlp_gate_up_layer_env ? atoi(debug_mlp_gate_up_layer_env) : -1;
+    const float *ck_debug_mlp_gate_up_fp32_input = NULL;
+    const char *debug_prefill_mlp_gate_up_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MLP_GATE_UP_ROW_GEMV");
+    int debug_prefill_mlp_gate_up_row_gemv = debug_prefill_mlp_gate_up_row_gemv_env ? (atoi(debug_prefill_mlp_gate_up_row_gemv_env) != 0) : 0;
+    const char *debug_prefill_mlp_gate_up_row_gemv_layer_env = getenv("CK_V8_DEBUG_PREFILL_MLP_GATE_UP_ROW_GEMV_LAYER");
+    int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
 
     /* Copy input tokens to activation buffer (follow same pattern as decode) */
     memcpy((void*)(model->bump + A_TOKEN_IDS), tokens, (size_t)num_tokens * sizeof(int32_t));
@@ -602,8 +840,16 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
 
     _annotate_kv_transpose_roles(ops)
     residual_add_count_total = 0
+    residual_add_counts_by_layer: Dict[int, int] = {}
 
     for seq_idx, op in enumerate(ops):
+        op_type_for_instance = str(op.get("op", ""))
+        if op_type_for_instance == "residual_add" and "op_instance_idx" not in op and "instance" not in op:
+            layer_for_instance = int(op.get("layer", -1))
+            inst = residual_add_counts_by_layer.get(layer_for_instance, 0)
+            op = dict(op)
+            op["op_instance_idx"] = inst
+            residual_add_counts_by_layer[layer_for_instance] = inst + 1
         lines.append(emit_prefill_op(op, seq_idx, config, profile=profile, dump=dump))
         lines.append(f"    if (stop_seq == {seq_idx}) return;")
         if (scale_embeddings_sqrt_dim
@@ -624,7 +870,10 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     }
     #ifdef CK_PARITY_DUMP
     ck_dump_tensor((float*)(model->bump + A_EMBEDDED_INPUT), -1, "inp_scaled", num_tokens * EMBED_DIM);
-    #endif""")
+    #endif
+    if (num_tokens > 1) ck_debug_export_hidden(model, -1, "embedding_scaled_last",
+        (const float*)(((const float*)(model->bump + A_EMBEDDED_INPUT)) + (((size_t)num_tokens - 1u) * (size_t)EMBED_DIM)),
+        EMBED_DIM);""")
             embed_scale_emitted = True
         lines.append("")
 
@@ -871,10 +1120,42 @@ def _emit_prefill_gemm_fp32_override(op: Dict, seq_idx: int, *, debug_flag_name:
     fp32_func = "gemm_nt_q4_k" if func == "gemm_nt_q4_k_q8_k" else "gemm_nt_q6_k"
     layer_value = op.get("layer", -1)
     layer = int(layer_value) if layer_value is not None else -1
+    row_gemv_func = "gemv_q4_k_q8_k" if func == "gemm_nt_q4_k_q8_k" else "gemv_q6_k_q8_k"
+    weight_row_bytes_expr = f"(((size_t)({k_expr}) / 256u) * 144u)" if func == "gemm_nt_q4_k_q8_k" else f"(((size_t)({k_expr}) / 256u) * 210u)"
+
+    row_gemv_allowed = 1 if str(op.get("op", "")) == "mlp_gate_up" else 0
     lines = [
         f"    /* Op {seq_idx}: {func} ({op.get('op', 'unknown')}) layer={layer} */",
-        f"    if ({debug_flag_name} && {debug_input_name} != NULL) {{",
+        f"    if ({row_gemv_allowed} && (debug_prefill_mlp_gate_up_row_gemv || debug_prefill_mlp_gate_up_row_gemv_layer == {layer})) {{",
     ]
+    if profile:
+        lines.append("        CK_PROFILE_BEGIN();")
+    lines.extend(
+        [
+            f"        const int _ck_m = (int)({m_expr});",
+            f"        const int _ck_n = (int)({n_expr});",
+            f"        const int _ck_k = (int)({k_expr});",
+            "        const int _ck_half = _ck_n / 2;",
+            f"        const size_t _ck_a_row_bytes = (size_t)(_ck_k / QK_K) * sizeof(block_q8_K);",
+            f"        const size_t _ck_w_row_bytes = {weight_row_bytes_expr};",
+            f"        const uint8_t *_ck_a_base = (const uint8_t*)({a_expr});",
+            f"        const uint8_t *_ck_w_base = (const uint8_t*)({b_expr});",
+            f"        const float *_ck_bias = (const float*)({bias_expr});",
+            f"        float *_ck_c_base = (float*)({c_expr});",
+            "        for (int _ck_t = 0; _ck_t < _ck_m; ++_ck_t) {",
+            "            const void *_ck_xq8 = (const void*)(_ck_a_base + (size_t)_ck_t * _ck_a_row_bytes);",
+            "            float *_ck_y = _ck_c_base + (size_t)_ck_t * (size_t)_ck_n;",
+            f"            {row_gemv_func}(_ck_y, (const void*)_ck_w_base, _ck_xq8, _ck_half, _ck_k);",
+            f"            {row_gemv_func}(_ck_y + _ck_half, (const void*)(_ck_w_base + (size_t)_ck_half * _ck_w_row_bytes), _ck_xq8, _ck_half, _ck_k);",
+            "            if (_ck_bias != NULL) {",
+            "                for (int _ck_i = 0; _ck_i < _ck_n; ++_ck_i) _ck_y[_ck_i] += _ck_bias[_ck_i];",
+            "            }",
+            "        }",
+        ]
+    )
+    if profile:
+        lines.append(f'        CK_PROFILE_END("prefill", "{row_gemv_func}", "{op.get("op", "unknown")}_row_gemv", {layer});')
+    lines.append(f"    }} else if ({debug_flag_name} && {debug_input_name} != NULL) {{")
     if profile:
         lines.append("        CK_PROFILE_BEGIN();")
     lines.extend(
@@ -960,6 +1241,13 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     const char *debug_mlp_down_env = getenv("CK_V7_DEBUG_MLP_DOWN_FP32");
     int debug_mlp_down_fp32 = debug_mlp_down_env ? (atoi(debug_mlp_down_env) != 0) : 0;
     const float *ck_debug_mlp_down_fp32_input = NULL;
+    const char *debug_mlp_gate_up_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_FP32");
+    int debug_mlp_gate_up_fp32 = debug_mlp_gate_up_env ? (atoi(debug_mlp_gate_up_env) != 0) : 0;
+    const char *debug_prefill_mlp_gate_up_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MLP_GATE_UP_ROW_GEMV");
+    int debug_prefill_mlp_gate_up_row_gemv = debug_prefill_mlp_gate_up_row_gemv_env ? (atoi(debug_prefill_mlp_gate_up_row_gemv_env) != 0) : 0;
+    const char *debug_prefill_mlp_gate_up_row_gemv_layer_env = getenv("CK_V8_DEBUG_PREFILL_MLP_GATE_UP_ROW_GEMV_LAYER");
+    int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
+    const float *ck_debug_mlp_gate_up_fp32_input = NULL;
 """
     prologue = prologue.replace(
         "int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;",
@@ -983,9 +1271,16 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
 
     _annotate_kv_transpose_roles(ops)
     residual_add_count_total = 0
+    residual_add_counts_by_layer: Dict[int, int] = {}
 
     for seq_idx, op in enumerate(ops):
         op_type = str(op.get("op", ""))
+        if op_type == "residual_add" and "op_instance_idx" not in op and "instance" not in op:
+            layer_for_instance = int(op.get("layer", -1))
+            inst = residual_add_counts_by_layer.get(layer_for_instance, 0)
+            op = dict(op)
+            op["op_instance_idx"] = inst
+            residual_add_counts_by_layer[layer_for_instance] = inst + 1
         if op_type == "dense_embedding_lookup":
             lines.append(f"    if (stop_seq == {seq_idx}) return;")
             if (
@@ -998,7 +1293,25 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                 lines.append("")
             continue
 
-        if is_qwen3vl and op_type == "quantize_mlp_down_input" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+        if op_type == "quantize_input_2" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+            op_code = _emit_prefill_quant_debug_override(
+                op,
+                seq_idx,
+                config,
+                debug_flag_name="debug_mlp_gate_up_fp32",
+                debug_input_name="ck_debug_mlp_gate_up_fp32_input",
+                profile=profile,
+            )
+        elif op_type == "mlp_gate_up" and str(op.get("function", "")) in {"gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"}:
+            op_code = _emit_prefill_gemm_fp32_override(
+                op,
+                seq_idx,
+                debug_flag_name="debug_mlp_gate_up_fp32",
+                debug_input_name="ck_debug_mlp_gate_up_fp32_input",
+                profile=profile,
+                dump=dump,
+            )
+        elif is_qwen3vl and op_type == "quantize_mlp_down_input" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
             op_code = _emit_prefill_quant_debug_override(
                 op,
                 seq_idx,

--- a/version/v8/scripts/export_ck_hidden_v8.py
+++ b/version/v8/scripts/export_ck_hidden_v8.py
@@ -6,9 +6,9 @@ Export CK hidden-vector snapshots for an explicit token prefix.
 
 The generated model writes snapshots only when CK_DEBUG_EXPORT_HIDDEN points to
 an output directory. This script sets that environment variable, replays tokens
-through sequential decode, and leaves raw float32 files in the output directory.
-It is tokenizer-free so it can be paired with the deterministic logit parity
-runner.
+through either sequential decode or batched prefill, and leaves raw float32
+files in the output directory. It is tokenizer-free so it can be paired with
+the deterministic logit parity runner.
 """
 
 import argparse
@@ -16,21 +16,28 @@ import ctypes
 import os
 from pathlib import Path
 
+from compare_ck_prefill_decode_logits_v8 import _init_model  # type: ignore
 from compare_first_token_logits_v8 import discover_ck_model_dir, parse_tokens_csv  # type: ignore
 
 
-def export_ck_hidden(model_dir: Path, tokens: list[int], out_dir: Path) -> None:
+def export_ck_hidden(model_dir: Path, tokens: list[int], out_dir: Path, mode: str = "decode") -> None:
     model_dir = discover_ck_model_dir(model_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+    for old in out_dir.glob("*.f32"):
+        old.unlink()
     os.environ["CK_DEBUG_EXPORT_HIDDEN"] = str(out_dir)
 
     lib_path = model_dir / "libmodel.so"
     lib = ctypes.CDLL(str(lib_path), mode=ctypes.RTLD_GLOBAL)
 
-    lib.ck_model_init.argtypes = [ctypes.c_char_p]
-    lib.ck_model_init.restype = ctypes.c_int
     lib.ck_model_decode.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_float)]
     lib.ck_model_decode.restype = ctypes.c_int
+    if hasattr(lib, "ck_model_embed_tokens"):
+        lib.ck_model_embed_tokens.argtypes = [ctypes.POINTER(ctypes.c_int32), ctypes.c_int]
+        lib.ck_model_embed_tokens.restype = ctypes.c_int
+    if hasattr(lib, "ck_model_forward"):
+        lib.ck_model_forward.argtypes = [ctypes.POINTER(ctypes.c_float)]
+        lib.ck_model_forward.restype = ctypes.c_int
     if hasattr(lib, "ck_model_kv_cache_reset"):
         lib.ck_model_kv_cache_reset.argtypes = []
         lib.ck_model_kv_cache_reset.restype = None
@@ -38,25 +45,28 @@ def export_ck_hidden(model_dir: Path, tokens: list[int], out_dir: Path) -> None:
         lib.ck_model_free.argtypes = []
         lib.ck_model_free.restype = None
 
-    init_candidates = [model_dir / "weights.bump", model_dir]
-    init_ok = False
-    init_errors: list[str] = []
-    for init_dir in init_candidates:
-        rc = lib.ck_model_init(str(init_dir.resolve()).encode("utf-8"))
-        if rc == 0:
-            init_ok = True
-            break
-        init_errors.append(f"{init_dir}:rc={rc}")
-    if not init_ok:
-        raise RuntimeError(f"ck_model_init failed ({', '.join(init_errors)})")
+    _init_model(lib, model_dir)
 
     try:
         if hasattr(lib, "ck_model_kv_cache_reset"):
             lib.ck_model_kv_cache_reset()
-        for tok in tokens:
-            rc = lib.ck_model_decode(ctypes.c_int32(int(tok)), None)
+        if mode == "decode":
+            for tok in tokens:
+                rc = lib.ck_model_decode(ctypes.c_int32(int(tok)), None)
+                if rc != 0:
+                    raise RuntimeError(f"ck_model_decode failed rc={rc} token={tok}")
+        elif mode == "prefill":
+            if not hasattr(lib, "ck_model_embed_tokens") or not hasattr(lib, "ck_model_forward"):
+                raise RuntimeError("ck_model_embed_tokens/ck_model_forward unavailable")
+            arr = (ctypes.c_int32 * len(tokens))(*[int(t) for t in tokens])
+            rc = lib.ck_model_embed_tokens(arr, len(tokens))
             if rc != 0:
-                raise RuntimeError(f"ck_model_decode failed rc={rc} token={tok}")
+                raise RuntimeError(f"ck_model_embed_tokens failed rc={rc}")
+            rc = lib.ck_model_forward(None)
+            if rc != 0:
+                raise RuntimeError(f"ck_model_forward failed rc={rc}")
+        else:
+            raise ValueError(f"unknown mode: {mode}")
     finally:
         if hasattr(lib, "ck_model_free"):
             lib.ck_model_free()
@@ -67,12 +77,14 @@ def main() -> int:
     ap.add_argument("--model-dir", required=True, type=Path)
     ap.add_argument("--tokens", required=True, help="comma-separated token IDs")
     ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument("--mode", choices=("decode", "prefill"), default="decode")
     args = ap.parse_args()
 
     export_ck_hidden(
         model_dir=args.model_dir,
         tokens=parse_tokens_csv(args.tokens),
         out_dir=args.out_dir,
+        mode=args.mode,
     )
     files = sorted(args.out_dir.glob("*.f32"))
     print(f"exported={len(files)} out_dir={args.out_dir}")

--- a/version/v8/scripts/memory_planner_v8.py
+++ b/version/v8/scripts/memory_planner_v8.py
@@ -449,7 +449,7 @@ class MemoryPlanner:
             # rmsnorm reads main stream
             return self.state.main_stream_buffer, "fp32"
 
-        elif op_type in ("quantize_input_0", "quantize_input_1"):
+        elif op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2"):
             # quantize reads from main stream (FP32)
             return self.state.main_stream_buffer, "fp32"
 
@@ -512,7 +512,7 @@ class MemoryPlanner:
             self.state.record_write(buffer, op_id, "fp32")
             return buffer, "fp32"
 
-        elif op_type in ("quantize_input_0", "quantize_input_1"):
+        elif op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2"):
             # Quantize writes Q8 to the "other" buffer (ping-pong)
             buffer = self.state.main_stream_q8_buffer
             self.state.record_write(buffer, op_id, dtype)
@@ -622,7 +622,7 @@ class MemoryPlanner:
 
         # Swap after quantize ops that feed into projections
         # This ensures the FP32 output buffer is ready for the next op
-        if op_type in ("quantize_input_0", "quantize_input_1",
+        if op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2",
                        "quantize_out_proj_input", "quantize_mlp_down_input"):
             # After quantize, the Q8 is in main_stream_q8_buffer
             # The projection will read from there and write FP32 to main_stream_buffer

--- a/version/v8/src/ck_cli_v8.c
+++ b/version/v8/src/ck_cli_v8.c
@@ -159,6 +159,7 @@ typedef enum {
     CHAT_TEMPLATE_CHATML,
     CHAT_TEMPLATE_MISTRAL,
     CHAT_TEMPLATE_GEMMA,
+    CHAT_TEMPLATE_GEMMA4,
 } ChatTemplateType;
 
 typedef struct {
@@ -222,6 +223,15 @@ static const ChatTemplate g_templates[] = {
         .user_suffix = "<end_of_turn>\n",
         .assistant_prefix = "<start_of_turn>model\n",
         .assistant_suffix = "<end_of_turn>\n",
+    },
+    [CHAT_TEMPLATE_GEMMA4] = {
+        .type = CHAT_TEMPLATE_GEMMA4,
+        .system_prefix = "<|turn>system\n",
+        .system_suffix = "<turn|>\n",
+        .user_prefix = "<|turn>user\n",
+        .user_suffix = "<turn|>\n",
+        .assistant_prefix = "<|turn>model\n",
+        .assistant_suffix = "<turn|>\n",
     },
 };
 
@@ -1674,6 +1684,7 @@ static ChatTemplateType detect_chat_template(const char *model_name) {
     if (strstr(lower, "qwen")) return CHAT_TEMPLATE_QWEN;
     if (strstr(lower, "llama")) return CHAT_TEMPLATE_LLAMA;
     if (strstr(lower, "mistral")) return CHAT_TEMPLATE_MISTRAL;
+    if (strstr(lower, "gemma4") || strstr(lower, "gemma-4") || strstr(lower, "gemma_4")) return CHAT_TEMPLATE_GEMMA4;
     if (strstr(lower, "gemma")) return CHAT_TEMPLATE_GEMMA;
 
     return CHAT_TEMPLATE_CHATML;  /* Default */
@@ -1779,6 +1790,10 @@ static void eos_pattern_init(ChatTemplateType tmpl) {
         case CHAT_TEMPLATE_GEMMA:
             g_eos_state.target_pattern = "end_of_turn";
             g_eos_state.partial_prefix = "end";
+            break;
+        case CHAT_TEMPLATE_GEMMA4:
+            g_eos_state.target_pattern = "turn|";
+            g_eos_state.partial_prefix = "turn";
             break;
         default:
             break;
@@ -4801,6 +4816,7 @@ int main(int argc, char **argv) {
            opt.chat_template == CHAT_TEMPLATE_QWEN ? "qwen" :
            opt.chat_template == CHAT_TEMPLATE_LLAMA ? "llama" :
            opt.chat_template == CHAT_TEMPLATE_MISTRAL ? "mistral" :
+           opt.chat_template == CHAT_TEMPLATE_GEMMA4 ? "gemma4" :
            opt.chat_template == CHAT_TEMPLATE_GEMMA ? "gemma" : "chatml");
 
     /* Print CPU capability info */


### PR DESCRIPTION
## Summary
- add v8 hidden-state export coverage for Gemma4 prefill/decode parity debugging
- add CK_V8_FORCE_DECODE_PREFILL fallback so Gemma4 can use decode-prefill when batched prefill diverges
- add Gemma4 chat-template detection and EOS pattern support
- wire quantize_input_2 through v8 IR/dataflow/memory planning for debug MLP gate/up paths

## Notes
This does not claim to fix fast Gemma4 batched prefill yet. The default Gemma4 prefill/decode logit comparison still fails, which is the current known bug. The new fallback gives an exact correctness path while preserving diagnostics for the fast path.

## Test
- python compile for touched v8 scripts
- Gemma4 v8 smoke run
- compare_ck_prefill_decode_logits_v8 default: fails as expected for current fast batched prefill
- CK_V8_FORCE_DECODE_PREFILL=1 compare_ck_prefill_decode_logits_v8: pass, cosine=1.000000, rmse=0.000000, topk_overlap=20/20
- make test-threadpool-parity-quick
- make test
- make llamacpp-parity-full
- make v8-regression-fast
- pre-commit v8-regression-fast passed
- pre-push: build, kernel parity, v8 E2E, v7 inference, v8 fast regression, training-kernel parity all passed