### PR TITLE
fix(v8): add Gemma4 BF16 safetensors path and split-half direct RoPE

### DIFF
--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -188,6 +188,17 @@ void gemm_nt_f16(const float *A,
                  float *C,
                  int M, int N, int K);
 
+void gemv_bf16(float *y,
+               const void *W,
+               const float *x,
+               int M, int K);
+
+void gemm_nt_bf16(const float *A,
+                  const void *B,
+                  const float *bias,
+                  float *C,
+                  int M, int N, int K);
+
 // =============================================================================
 // Quantized (GGML-style) GEMM/GEMV helpers
 // =============================================================================
@@ -900,6 +911,19 @@ void gemma4_per_layer_prepare_forward(float *per_layer_input,
                                       int per_layer_dim,
                                       int vocab_size,
                                       float eps);
+
+void gemma4_per_layer_prepare_bf16_forward(float *per_layer_input,
+                                           const float *hidden,
+                                           const int32_t *token_ids,
+                                           const uint16_t *per_layer_token_emb,
+                                           const uint16_t *per_layer_model_proj,
+                                           const float *per_layer_proj_norm,
+                                           int tokens,
+                                           int num_layers,
+                                           int embed_dim,
+                                           int per_layer_dim,
+                                           int vocab_size,
+                                           float eps);
 
 void gemma4_per_layer_embed_forward(float *hidden,
                                     const float *per_layer_input,
@@ -2394,6 +2418,19 @@ void rope_forward_qk_with_rotary_dim(float *q,
                                      int pos_offset,
                                      int rotary_dim);
 
+void rope_forward_qk_split_direct_f32(float *q,
+                                      float *k,
+                                      const float *freq_factors,
+                                      int use_freq_factors,
+                                      int num_heads,
+                                      int num_kv_heads,
+                                      int num_tokens,
+                                      int head_dim,
+                                      int aligned_head_dim,
+                                      int pos_offset,
+                                      int rotary_dim,
+                                      float freq_base);
+
 void rope_forward_qk_gemma4_direct(float *q,
                                    float *k,
                                    const float *freq_factors,
@@ -2663,6 +2700,17 @@ void embedding_forward_q8_0(const int32_t *token_ids,
 	                            int aligned_embed_dim,
 	                            int context_window,
 	                            int add_pos);
+
+void embedding_forward_bf16_fp32(const int32_t *token_ids,
+                                 int token_count,
+                                 int vocab_size,
+                                 const uint16_t *token_embeddings,
+                                 const float *pos_embeddings,
+                                 float *output,
+                                 int embed_dim,
+                                 int aligned_embed_dim,
+                                 int context_window,
+                                 int add_pos);
 
 // Embedding backward: accumulates into d_token_embeddings and d_pos_embeddings.
 // d_output: [context_window x aligned_embed_dim]

--- a/src/kernels/embedding_kernels_bf16.c
+++ b/src/kernels/embedding_kernels_bf16.c
@@ -69,6 +69,57 @@ void embedding_forward_bf16(const int32_t *token_ids,
     }
 }
 
+
+void embedding_forward_bf16_fp32(const int32_t *token_ids,
+                                 int token_count,
+                                 int vocab_size,
+                                 const uint16_t *token_embeddings,
+                                 const float *pos_embeddings,
+                                 float *output,
+                                 int embed_dim,
+                                 int aligned_embed_dim,
+                                 int context_window,
+                                 int add_pos)
+{
+    if (!token_ids || !token_embeddings || !output) {
+        return;
+    }
+
+    int tokens = token_count;
+    if (tokens < 0) tokens = 0;
+    if (tokens > context_window) tokens = context_window;
+
+    for (int t = 0; t < tokens; ++t) {
+        int id = token_ids[t];
+        if (id < 0 || id >= vocab_size) {
+            id = 0;
+        }
+
+        const uint16_t *tok = token_embeddings + (size_t)id * (size_t)aligned_embed_dim;
+        const float *pos = pos_embeddings ? (pos_embeddings + (size_t)t * (size_t)aligned_embed_dim) : NULL;
+        float *out = output + (size_t)t * (size_t)aligned_embed_dim;
+
+        if (add_pos && pos) {
+            for (int d = 0; d < embed_dim; ++d) {
+                out[d] = bf16_to_float(tok[d]) + pos[d];
+            }
+        } else {
+            for (int d = 0; d < embed_dim; ++d) {
+                out[d] = bf16_to_float(tok[d]);
+            }
+        }
+
+        for (int d = embed_dim; d < aligned_embed_dim; ++d) {
+            out[d] = 0.0f;
+        }
+    }
+
+    for (int t = tokens; t < context_window; ++t) {
+        float *out = output + (size_t)t * (size_t)aligned_embed_dim;
+        memset(out, 0, (size_t)aligned_embed_dim * sizeof(float));
+    }
+}
+
 void embedding_backward_bf16(const int32_t *token_ids,
                              int token_count,
                              const uint16_t *d_output,

--- a/src/kernels/gemm_kernels_bf16.c
+++ b/src/kernels/gemm_kernels_bf16.c
@@ -544,6 +544,69 @@ void gemm_bf16_fp32out(const uint16_t *A,
 #endif
 }
 
+
+/* ============================================================================
+ * Inference kernels for exact safetensors/BUMP BF16 weights.
+ *
+ * The v8 inference graph currently keeps activation streams as FP32.  These
+ * wrappers preserve the established quantized/FP16 inference ABI while consuming
+ * BF16 row-major weights from safetensors BUMP artifacts:
+ *   GEMV: y[M]      = W[M,K] @ bf16_round(x[K])
+ *   GEMM: C[M,N]    = bf16_round(A[M,K]) @ W[N,K].T + bias[N]
+ *
+ * Rounding the FP32 activation to BF16 before multiply gives a closer contract
+ * to a BF16 PyTorch model than multiplying full FP32 activations by BF16
+ * weights, while still avoiding a separate activation-conversion buffer.
+ * ========================================================================== */
+void gemv_bf16(float *y,
+               const void *W,
+               const float *x,
+               int M, int K)
+{
+    const uint16_t *w = (const uint16_t *)W;
+    if (!y || !w || !x || M <= 0 || K <= 0) {
+        return;
+    }
+
+#pragma omp parallel for schedule(static) if(M > 16)
+    for (int i = 0; i < M; ++i) {
+        const uint16_t *w_row = w + (size_t)i * (size_t)K;
+        float sum = 0.0f;
+        for (int k = 0; k < K; ++k) {
+            const float xb = bf16_to_float(float_to_bf16(x[k]));
+            sum += xb * bf16_to_float(w_row[k]);
+        }
+        y[i] = sum;
+    }
+}
+
+void gemm_nt_bf16(const float *A,
+                  const void *B,
+                  const float *bias,
+                  float *C,
+                  int M, int N, int K)
+{
+    const uint16_t *w = (const uint16_t *)B;
+    if (!A || !w || !C || M <= 0 || N <= 0 || K <= 0) {
+        return;
+    }
+
+#pragma omp parallel for schedule(dynamic) if(M * N > 4096)
+    for (int i = 0; i < M; ++i) {
+        const float *a_row = A + (size_t)i * (size_t)K;
+        float *c_row = C + (size_t)i * (size_t)N;
+        for (int j = 0; j < N; ++j) {
+            const uint16_t *w_row = w + (size_t)j * (size_t)K;
+            float sum = bias ? bias[j] : 0.0f;
+            for (int k = 0; k < K; ++k) {
+                const float ab = bf16_to_float(float_to_bf16(a_row[k]));
+                sum += ab * bf16_to_float(w_row[k]);
+            }
+            c_row[j] = sum;
+        }
+    }
+}
+
 /* ==========================================================================
  * Backward kernels for training
  * ========================================================================== */

--- a/src/kernels/gemma4_per_layer_embed.c
+++ b/src/kernels/gemma4_per_layer_embed.c
@@ -147,6 +147,68 @@ void gemma4_per_layer_prepare_forward(float *per_layer_input,
     }
 }
 
+
+void gemma4_per_layer_prepare_bf16_forward(float *per_layer_input,
+                                           const float *hidden,
+                                           const int32_t *token_ids,
+                                           const uint16_t *per_layer_token_emb,
+                                           const uint16_t *per_layer_model_proj,
+                                           const float *per_layer_proj_norm,
+                                           int tokens,
+                                           int num_layers,
+                                           int embed_dim,
+                                           int per_layer_dim,
+                                           int vocab_size,
+                                           float eps)
+{
+    if (!per_layer_input || !hidden || !token_ids || !per_layer_token_emb ||
+        !per_layer_model_proj || !per_layer_proj_norm || tokens <= 0 ||
+        num_layers <= 0 || embed_dim <= 0 || per_layer_dim <= 0 || vocab_size <= 0) {
+        return;
+    }
+
+    const float token_scale = sqrtf((float)per_layer_dim);
+    const float model_scale = 1.0f / sqrtf((float)embed_dim);
+    const float mix_scale = 0.7071067811865475f;
+
+    float token_vec[QK_K];
+    float proj_vec[QK_K];
+    float proj_normed[QK_K];
+    if (per_layer_dim > QK_K) {
+        return;
+    }
+
+    for (int t = 0; t < tokens; ++t) {
+        const int token = token_ids[t];
+        if (token < 0 || token >= vocab_size) {
+            continue;
+        }
+        const float *h = hidden + (size_t)t * (size_t)embed_dim;
+        for (int layer = 0; layer < num_layers; ++layer) {
+            float *dst = per_layer_input + ((size_t)t * (size_t)num_layers + (size_t)layer) * (size_t)per_layer_dim;
+            const uint16_t *tok_row = per_layer_token_emb +
+                ((size_t)token * (size_t)num_layers + (size_t)layer) * (size_t)per_layer_dim;
+            for (int i = 0; i < per_layer_dim; ++i) {
+                token_vec[i] = ck_bf16_to_f32(tok_row[i]) * token_scale;
+            }
+
+            const uint16_t *model_proj_base = per_layer_model_proj + (size_t)layer * (size_t)per_layer_dim * (size_t)embed_dim;
+            for (int i = 0; i < per_layer_dim; ++i) {
+                const uint16_t *row = model_proj_base + (size_t)i * (size_t)embed_dim;
+                float acc = 0.0f;
+                for (int j = 0; j < embed_dim; ++j) {
+                    acc += ck_bf16_to_f32(row[j]) * h[j];
+                }
+                proj_vec[i] = acc * model_scale;
+            }
+            ck_gemma4_rmsnorm_tmp(proj_vec, per_layer_proj_norm, proj_normed, per_layer_dim, eps);
+            for (int i = 0; i < per_layer_dim; ++i) {
+                dst[i] = (token_vec[i] + proj_normed[i]) * mix_scale;
+            }
+        }
+    }
+}
+
 void gemma4_per_layer_embed_forward(float *hidden,
                                     const float *per_layer_input,
                                     const float *inp_gate,

--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -837,6 +837,79 @@ void rope_forward_qk_with_rotary_dim(float *q,
 }
 
 
+static void rope_forward_split_direct_one(float *x,
+                                          const float *freq_factors,
+                                          int use_freq_factors,
+                                          int num_heads,
+                                          int num_tokens,
+                                          int head_dim,
+                                          int aligned_head_dim,
+                                          int pos_offset,
+                                          int rotary_dim,
+                                          float freq_base)
+{
+    if (!x || num_heads <= 0 || num_tokens <= 0 || head_dim <= 0 || aligned_head_dim <= 0) {
+        return;
+    }
+    if (rotary_dim <= 0 || rotary_dim > head_dim) {
+        rotary_dim = head_dim;
+    }
+    if (freq_base <= 0.0f) {
+        freq_base = 10000.0f;
+    }
+
+    /* Split-half rotate_half layout, matching HF/Llama-style RoPE:
+     *   [x0...xH, y0...yH] -> [-y0...-yH, x0...xH]
+     * Gemma4 is currently the first v8 model that needs direct per-layer
+     * theta/rotary_dim control; keep this model-neutral and select it from
+     * the IR via rope_layout=split_half + rope_param_mode=per_layer/direct.
+     */
+    const int rotary_half = rotary_dim / 2;
+    const size_t head_stride = (size_t)num_tokens * (size_t)aligned_head_dim;
+    const float theta_scale = powf(freq_base, -2.0f / (float)rotary_dim);
+
+    for (int h = 0; h < num_heads; ++h) {
+        float *head = x + (size_t)h * head_stride;
+        for (int t = 0; t < num_tokens; ++t) {
+            const float pos = (float)(pos_offset + t);
+            float *x_row = head + (size_t)t * (size_t)aligned_head_dim;
+            for (int i = 0; i < rotary_half; ++i) {
+                const int idx0 = i;
+                const int idx1 = i + rotary_half;
+                const float ff = (use_freq_factors && freq_factors) ? freq_factors[i] : 1.0f;
+                const float theta = pos * powf(theta_scale, (float)i) / ff;
+                const float c = cosf(theta);
+                const float sv = sinf(theta);
+                const float x0 = x_row[idx0];
+                const float x1 = x_row[idx1];
+                x_row[idx0] = x0 * c - x1 * sv;
+                x_row[idx1] = x1 * c + x0 * sv;
+            }
+        }
+    }
+}
+
+void rope_forward_qk_split_direct_f32(float *q,
+                                      float *k,
+                                      const float *freq_factors,
+                                      int use_freq_factors,
+                                      int num_heads,
+                                      int num_kv_heads,
+                                      int num_tokens,
+                                      int head_dim,
+                                      int aligned_head_dim,
+                                      int pos_offset,
+                                      int rotary_dim,
+                                      float freq_base)
+{
+    rope_forward_split_direct_one(q, freq_factors, use_freq_factors,
+                                  num_heads, num_tokens, head_dim, aligned_head_dim,
+                                  pos_offset, rotary_dim, freq_base);
+    rope_forward_split_direct_one(k, freq_factors, use_freq_factors,
+                                  num_kv_heads, num_tokens, head_dim, aligned_head_dim,
+                                  pos_offset, rotary_dim, freq_base);
+}
+
 void rope_forward_qk_gemma4_direct(float *q,
                                    float *k,
                                    const float *freq_factors,
@@ -850,55 +923,10 @@ void rope_forward_qk_gemma4_direct(float *q,
                                    int rotary_dim,
                                    float freq_base)
 {
-    if (rotary_dim <= 0 || rotary_dim > head_dim) {
-        rotary_dim = head_dim;
-    }
-    if (freq_base <= 0.0f) {
-        freq_base = 10000.0f;
-    }
-    const int rotary_half = rotary_dim / 2;
-    const size_t head_stride = (size_t)num_tokens * (size_t)aligned_head_dim;
-    const float theta_scale = powf(freq_base, -2.0f / (float)rotary_dim);
-
-    for (int h = 0; h < num_heads; ++h) {
-        float *head = q + (size_t)h * head_stride;
-        for (int t = 0; t < num_tokens; ++t) {
-            const float pos = (float)(pos_offset + t);
-            float *x_row = head + (size_t)t * (size_t)aligned_head_dim;
-            for (int i = 0; i < rotary_half; ++i) {
-                const int idx0 = 2 * i;
-                const int idx1 = idx0 + 1;
-                const float ff = (use_freq_factors && freq_factors) ? freq_factors[i] : 1.0f;
-                const float theta = pos * powf(theta_scale, (float)i) / ff;
-                const float c = cosf(theta);
-                const float sv = sinf(theta);
-                const float x0 = x_row[idx0];
-                const float x1 = x_row[idx1];
-                x_row[idx0] = x0 * c - x1 * sv;
-                x_row[idx1] = x0 * sv + x1 * c;
-            }
-        }
-    }
-
-    for (int h = 0; h < num_kv_heads; ++h) {
-        float *head = k + (size_t)h * head_stride;
-        for (int t = 0; t < num_tokens; ++t) {
-            const float pos = (float)(pos_offset + t);
-            float *x_row = head + (size_t)t * (size_t)aligned_head_dim;
-            for (int i = 0; i < rotary_half; ++i) {
-                const int idx0 = 2 * i;
-                const int idx1 = idx0 + 1;
-                const float ff = (use_freq_factors && freq_factors) ? freq_factors[i] : 1.0f;
-                const float theta = pos * powf(theta_scale, (float)i) / ff;
-                const float c = cosf(theta);
-                const float sv = sinf(theta);
-                const float x0 = x_row[idx0];
-                const float x1 = x_row[idx1];
-                x_row[idx0] = x0 * c - x1 * sv;
-                x_row[idx1] = x0 * sv + x1 * c;
-            }
-        }
-    }
+    rope_forward_qk_split_direct_f32(q, k, freq_factors, use_freq_factors,
+                                    num_heads, num_kv_heads, num_tokens,
+                                    head_dim, aligned_head_dim, pos_offset,
+                                    rotary_dim, freq_base);
 }
 
 void rope_forward_qk_with_rotary_dim_cache_stride(float *q,

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -3,9 +3,9 @@
     "description": "Kernel registry generated from v8 kernel maps",
     "version": "v8",
     "generated_by": "ck_run_v8.py",
-    "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
+    "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 142,
+      "total": 147,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -15,7 +15,7 @@
         "attn_gate_sigmoid_mul": 1,
         "attn_gate_sigmoid_mul_backward": 1,
         "bias_add": 1,
-        "embedding": 5,
+        "embedding": 6,
         "embedding_backward": 1,
         "feature_concat": 1,
         "feature_slice_copy": 1,
@@ -27,11 +27,11 @@
         "gated_deltanet": 2,
         "geglu": 4,
         "gelu": 3,
-        "gemm": 14,
+        "gemm": 15,
         "gemm_backward": 1,
         "gemma4_per_layer_embed": 1,
-        "gemma4_per_layer_prepare": 1,
-        "gemv": 13,
+        "gemma4_per_layer_prepare": 2,
+        "gemv": 14,
         "kv_cache_store": 2,
         "layernorm": 2,
         "logits_store_indexed": 1,
@@ -55,7 +55,7 @@
         "residual_add": 1,
         "residual_save": 1,
         "rmsnorm": 2,
-        "rope": 6,
+        "rope": 7,
         "rope_backward": 2,
         "rope_init": 2,
         "rowwise_bias_add": 1,
@@ -3625,6 +3625,107 @@
       "_source_file": "embedding_backward_f32.json"
     },
     {
+      "id": "embedding_forward_bf16_fp32",
+      "op": "embedding",
+      "variant": "bf16_weight_fp32_output",
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "tokens",
+          "dtype": "int32",
+          "shape": [
+            "T"
+          ],
+          "desc": "Input token IDs [tokens]"
+        }
+      ],
+      "weights": [
+        {
+          "name": "weight",
+          "dtype": "bf16",
+          "shape": [
+            "V",
+            "E"
+          ],
+          "desc": "Embedding weights [vocab_size, embed_dim] (FP32)"
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Embeddings [tokens, embed_dim]"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "T",
+        "E",
+        "V"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "token"
+        ],
+        "preferred": {
+          "prefill": "token",
+          "decode": "token"
+        },
+        "strategies": [
+          {
+            "name": "token",
+            "partition_dim": "T",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            },
+            "notes": "Process tokens in parallel; each thread handles a slice of tokens."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "E": 64
+        },
+        "notes": "Simple table lookup; E should be multiple of 64 for SIMD."
+      },
+      "impl": {
+        "function": "embedding_forward_bf16_fp32",
+        "c_declaration": "void embedding_forward_bf16_fp32(const int32_t *token_ids, int token_count, int vocab_size, const uint16_t *token_embeddings, const float *pos_embeddings, float *output, int embed_dim, int aligned_embed_dim, int context_window, int add_pos);",
+        "sources": [
+          "src/kernels/embedding_kernels_bf16.c"
+        ],
+        "variants": [
+          {
+            "name": "default",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_embedding.py"
+        ],
+        "bench": [
+          "scripts/bench_embedding.py"
+        ]
+      },
+      "notes": "Token embedding lookup with BF16 weights and FP32 output for v8 inference streams.",
+      "name": "embedding_forward_bf16_fp32",
+      "_source_file": "embedding_forward_bf16_fp32.json"
+    },
+    {
       "id": "embedding_forward_fp32",
       "op": "embedding",
       "variant": "fp32",
@@ -5535,6 +5636,78 @@
       "_source_file": "gemm_blocked_serial.json"
     },
     {
+      "id": "gemm_nt_bf16",
+      "op": "gemm",
+      "variant": "bf16_w_fp32_a_fp32_out",
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "A",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "K"
+          ],
+          "desc": "Activation matrix [rows, cols] (FP32, rounded to BF16 inside kernel)"
+        },
+        {
+          "name": "B",
+          "dtype": "bf16",
+          "shape": [
+            "N",
+            "K"
+          ],
+          "desc": "Weight matrix [output rows, input cols] BF16"
+        },
+        {
+          "name": "bias",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ],
+          "optional": true,
+          "desc": "Bias [N] (optional)"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "C",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "N"
+          ],
+          "desc": "Result [M, N]"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "M",
+        "N",
+        "K"
+      ],
+      "constraints": {},
+      "impl": {
+        "function": "gemm_nt_bf16",
+        "c_declaration": "void gemm_nt_bf16(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);",
+        "sources": [
+          "src/kernels/gemm_kernels_bf16.c"
+        ]
+      },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "notes": "Exact safetensors/BUMP BF16 weight inference path for prefill. Activation rows are rounded to BF16 before multiply.",
+      "name": "gemm_nt_bf16",
+      "_source_file": "gemm_nt_bf16.json"
+    },
+    {
       "id": "gemm_nt_f16",
       "op": "gemm",
       "variant": "f16_w_fp32_a_fp32_out",
@@ -6940,6 +7113,100 @@
       "_source_file": "gemma4_per_layer_embed_forward.json"
     },
     {
+      "id": "gemma4_per_layer_prepare_bf16_forward",
+      "op": "gemma4_per_layer_prepare",
+      "variant": "gemma4_bf16_scalar_correctness",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ]
+        },
+        {
+          "name": "tokens",
+          "dtype": "i32",
+          "shape": [
+            "T"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "per_layer_token_emb",
+          "dtype": "bf16",
+          "shape": [
+            "V",
+            "L",
+            "P"
+          ]
+        },
+        {
+          "name": "per_layer_model_proj",
+          "dtype": "bf16",
+          "shape": [
+            "L",
+            "P",
+            "E"
+          ]
+        },
+        {
+          "name": "per_layer_proj_norm",
+          "dtype": "fp32",
+          "shape": [
+            "P"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "per_layer_input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "L",
+            "P"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "seq_len",
+        "num_layers",
+        "embed_dim",
+        "per_layer_dim",
+        "vocab_size"
+      ],
+      "params": [
+        {
+          "name": "eps",
+          "dtype": "float32"
+        }
+      ],
+      "impl": {
+        "function": "gemma4_per_layer_prepare_bf16_forward",
+        "c_declaration": "void gemma4_per_layer_prepare_bf16_forward(float *per_layer_input, const float *hidden, const int32_t *token_ids, const uint16_t *per_layer_token_emb, const uint16_t *per_layer_model_proj, const float *per_layer_proj_norm, int tokens, int num_layers, int embed_dim, int per_layer_dim, int vocab_size, float eps);",
+        "sources": [
+          "src/kernels/gemma4_per_layer_embed.c"
+        ]
+      },
+      "notes": "Prepare Gemma4 per-layer input stream from BF16 safetensors token embeddings and BF16 projection weights.",
+      "name": "gemma4_per_layer_prepare_bf16_forward",
+      "_source_file": "gemma4_per_layer_prepare_bf16_forward.json"
+    },
+    {
       "id": "gemma4_per_layer_prepare_forward",
       "op": "gemma4_per_layer_prepare",
       "variant": "gemma4_scalar_correctness",
@@ -7032,6 +7299,68 @@
       "notes": "Prepare Gemma4 per-layer input stream once from original token embedding stream.",
       "name": "gemma4_per_layer_prepare_forward",
       "_source_file": "gemma4_per_layer_prepare_forward.json"
+    },
+    {
+      "id": "gemv_bf16",
+      "op": "gemv",
+      "variant": "bf16_w_fp32_a_fp32_out",
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "K"
+          ],
+          "desc": "Input vector [K] (FP32, rounded to BF16 inside kernel)"
+        }
+      ],
+      "weights": [
+        {
+          "name": "W",
+          "dtype": "bf16",
+          "shape": [
+            "M",
+            "K"
+          ],
+          "desc": "Weight matrix [rows, cols] BF16"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "y",
+          "dtype": "fp32",
+          "shape": [
+            "M"
+          ],
+          "desc": "Output vector [M] = W @ x"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "M",
+        "K"
+      ],
+      "constraints": {},
+      "impl": {
+        "function": "gemv_bf16",
+        "c_declaration": "void gemv_bf16(float *y, const void *W, const float *x, int M, int K);",
+        "sources": [
+          "src/kernels/gemm_kernels_bf16.c"
+        ]
+      },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "notes": "Exact safetensors/BUMP BF16 weight inference path for decode. Activation is rounded to BF16 before multiply.",
+      "name": "gemv_bf16",
+      "_source_file": "gemv_bf16.json"
     },
     {
       "id": "gemv_fused_q5_0_bias",
@@ -14256,8 +14585,8 @@
         "notes": "D should be multiple of 64 for optimal SIMD. D is the unpadded dimension; AD is used for alignment."
       },
       "impl": {
-        "function": "rope_forward_qk_gemma4_direct",
-        "c_declaration": "void rope_forward_qk_gemma4_direct(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+        "function": "rope_forward_qk_split_direct_f32",
+        "c_declaration": "void rope_forward_qk_split_direct_f32(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
         "sources": [
           "src/kernels/rope_kernels.c"
         ],
@@ -14305,7 +14634,7 @@
           }
         ]
       },
-      "notes": "Rotary Position Embedding (RoPE) for queries and keys. Applies rotation in complex plane: x_rot = x * cos(theta) + rotate_half(x) * sin(theta). Only rotates first rotary_dim channels; remaining channels pass through unchanged. Gemma4 variant uses max_rotary_dim as cache row stride so sliding/full layers can share one RoPE cache.",
+      "notes": "Compatibility map for Gemma4 templates. The implementation is the generic split-half direct RoPE path, selected by rope_layout=split and rope_param_mode=per_layer_direct in new templates.",
       "name": "rope_forward_qk_gemma4",
       "_source_file": "rope_forward_qk_gemma4.json"
     },
@@ -14653,6 +14982,130 @@
       "notes": "Split-cache RoPE for queries and keys (head_dim/2 cache layout). Matches legacy precompute layout.",
       "name": "rope_forward_qk_split",
       "_source_file": "rope_forward_qk_split.json"
+    },
+    {
+      "id": "rope_forward_qk_split_direct",
+      "op": "rope",
+      "variant": "fp32_head_major_split_half_direct",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [heads, tokens, head_dim] to be rotated in-place"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ],
+          "desc": "Key tensor [kv_heads, tokens, head_dim] to be rotated in-place"
+        }
+      ],
+      "weights": [
+        {
+          "name": "rope_freqs",
+          "dtype": "fp32",
+          "shape": [
+            "rotary_dim/2"
+          ],
+          "desc": "Optional proportional RoPE frequency factors; ignored when use_rope_freq_factors=0"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor after split-half RoPE application"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ],
+          "desc": "Key tensor after split-half RoPE application"
+        }
+      ],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "D",
+        "rotary_dim"
+      ],
+      "params": [
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Aligned head dimension for SIMD"
+        },
+        {
+          "name": "pos_offset",
+          "dtype": "int32",
+          "desc": "Absolute position offset"
+        },
+        {
+          "name": "rotary_dim",
+          "dtype": "int32",
+          "desc": "RoPE rotary dimensions"
+        },
+        {
+          "name": "freq_base",
+          "dtype": "float32",
+          "source": "dim:rope_freq_base",
+          "desc": "Per-layer RoPE theta/base"
+        }
+      ],
+      "impl": {
+        "function": "rope_forward_qk_split_direct_f32",
+        "c_declaration": "void rope_forward_qk_split_direct_f32(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+        "sources": [
+          "src/kernels/rope_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_rope.py"
+        ],
+        "parity": [
+          {
+            "kind": "torch",
+            "command": "python version/v8/scripts/gemma4_answer_parity_debug_v8.py --debug-hidden",
+            "tolerance": "1e-5",
+            "notes": "Validated against HF split-half rotate_half semantics for direct per-layer theta RoPE."
+          }
+        ]
+      },
+      "notes": "Generic split-half direct RoPE for models that need per-layer theta/rotary_dim and optional frequency factors instead of one precomputed cache. Gemma4 is the first v8 user, but the contract is model-neutral.",
+      "name": "rope_forward_qk_split_direct",
+      "_source_file": "rope_forward_qk_split_direct.json"
     },
     {
       "id": "rope_precompute_cache",

--- a/version/v8/kernel_maps/embedding_forward_bf16_fp32.json
+++ b/version/v8/kernel_maps/embedding_forward_bf16_fp32.json
@@ -1,0 +1,99 @@
+{
+  "id": "embedding_forward_bf16_fp32",
+  "op": "embedding",
+  "variant": "bf16_weight_fp32_output",
+  "quant": {
+    "weight": "bf16",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "tokens",
+      "dtype": "int32",
+      "shape": [
+        "T"
+      ],
+      "desc": "Input token IDs [tokens]"
+    }
+  ],
+  "weights": [
+    {
+      "name": "weight",
+      "dtype": "bf16",
+      "shape": [
+        "V",
+        "E"
+      ],
+      "desc": "Embedding weights [vocab_size, embed_dim] (FP32)"
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Embeddings [tokens, embed_dim]"
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "T",
+    "E",
+    "V"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "token"
+    ],
+    "preferred": {
+      "prefill": "token",
+      "decode": "token"
+    },
+    "strategies": [
+      {
+        "name": "token",
+        "partition_dim": "T",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        },
+        "notes": "Process tokens in parallel; each thread handles a slice of tokens."
+      }
+    ]
+  },
+  "constraints": {
+    "alignment": {
+      "E": 64
+    },
+    "notes": "Simple table lookup; E should be multiple of 64 for SIMD."
+  },
+  "impl": {
+    "function": "embedding_forward_bf16_fp32",
+    "c_declaration": "void embedding_forward_bf16_fp32(const int32_t *token_ids, int token_count, int vocab_size, const uint16_t *token_embeddings, const float *pos_embeddings, float *output, int embed_dim, int aligned_embed_dim, int context_window, int add_pos);",
+    "sources": [
+      "src/kernels/embedding_kernels_bf16.c"
+    ],
+    "variants": [
+      {
+        "name": "default",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_embedding.py"
+    ],
+    "bench": [
+      "scripts/bench_embedding.py"
+    ]
+  },
+  "notes": "Token embedding lookup with BF16 weights and FP32 output for v8 inference streams."
+}

--- a/version/v8/kernel_maps/gemm_nt_bf16.json
+++ b/version/v8/kernel_maps/gemm_nt_bf16.json
@@ -1,0 +1,28 @@
+{
+  "id": "gemm_nt_bf16",
+  "op": "gemm",
+  "variant": "bf16_w_fp32_a_fp32_out",
+  "quant": {
+    "weight": "bf16",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {"name": "A", "dtype": "fp32", "shape": ["M", "K"], "desc": "Activation matrix [rows, cols] (FP32, rounded to BF16 inside kernel)"},
+    {"name": "B", "dtype": "bf16", "shape": ["N", "K"], "desc": "Weight matrix [output rows, input cols] BF16"},
+    {"name": "bias", "dtype": "fp32", "shape": ["N"], "optional": true, "desc": "Bias [N] (optional)"}
+  ],
+  "outputs": [
+    {"name": "C", "dtype": "fp32", "shape": ["M", "N"], "desc": "Result [M, N]"}
+  ],
+  "scratch": [],
+  "dims": ["M", "N", "K"],
+  "constraints": {},
+  "impl": {
+    "function": "gemm_nt_bf16",
+    "c_declaration": "void gemm_nt_bf16(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);",
+    "sources": ["src/kernels/gemm_kernels_bf16.c"]
+  },
+  "modes": {"inference": true, "training": false, "backward": false},
+  "notes": "Exact safetensors/BUMP BF16 weight inference path for prefill. Activation rows are rounded to BF16 before multiply."
+}

--- a/version/v8/kernel_maps/gemma4_per_layer_prepare_bf16_forward.json
+++ b/version/v8/kernel_maps/gemma4_per_layer_prepare_bf16_forward.json
@@ -1,0 +1,92 @@
+{
+  "id": "gemma4_per_layer_prepare_bf16_forward",
+  "op": "gemma4_per_layer_prepare",
+  "variant": "gemma4_bf16_scalar_correctness",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "bf16",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ]
+    },
+    {
+      "name": "tokens",
+      "dtype": "i32",
+      "shape": [
+        "T"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "per_layer_token_emb",
+      "dtype": "bf16",
+      "shape": [
+        "V",
+        "L",
+        "P"
+      ]
+    },
+    {
+      "name": "per_layer_model_proj",
+      "dtype": "bf16",
+      "shape": [
+        "L",
+        "P",
+        "E"
+      ]
+    },
+    {
+      "name": "per_layer_proj_norm",
+      "dtype": "fp32",
+      "shape": [
+        "P"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "per_layer_input",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "L",
+        "P"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "seq_len",
+    "num_layers",
+    "embed_dim",
+    "per_layer_dim",
+    "vocab_size"
+  ],
+  "params": [
+    {
+      "name": "eps",
+      "dtype": "float32"
+    }
+  ],
+  "impl": {
+    "function": "gemma4_per_layer_prepare_bf16_forward",
+    "c_declaration": "void gemma4_per_layer_prepare_bf16_forward(float *per_layer_input, const float *hidden, const int32_t *token_ids, const uint16_t *per_layer_token_emb, const uint16_t *per_layer_model_proj, const float *per_layer_proj_norm, int tokens, int num_layers, int embed_dim, int per_layer_dim, int vocab_size, float eps);",
+    "sources": [
+      "src/kernels/gemma4_per_layer_embed.c"
+    ]
+  },
+  "notes": "Prepare Gemma4 per-layer input stream from BF16 safetensors token embeddings and BF16 projection weights."
+}

--- a/version/v8/kernel_maps/gemv_bf16.json
+++ b/version/v8/kernel_maps/gemv_bf16.json
@@ -1,0 +1,29 @@
+{
+  "id": "gemv_bf16",
+  "op": "gemv",
+  "variant": "bf16_w_fp32_a_fp32_out",
+  "quant": {
+    "weight": "bf16",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {"name": "x", "dtype": "fp32", "shape": ["K"], "desc": "Input vector [K] (FP32, rounded to BF16 inside kernel)"}
+  ],
+  "weights": [
+    {"name": "W", "dtype": "bf16", "shape": ["M", "K"], "desc": "Weight matrix [rows, cols] BF16"}
+  ],
+  "outputs": [
+    {"name": "y", "dtype": "fp32", "shape": ["M"], "desc": "Output vector [M] = W @ x"}
+  ],
+  "scratch": [],
+  "dims": ["M", "K"],
+  "constraints": {},
+  "impl": {
+    "function": "gemv_bf16",
+    "c_declaration": "void gemv_bf16(float *y, const void *W, const float *x, int M, int K);",
+    "sources": ["src/kernels/gemm_kernels_bf16.c"]
+  },
+  "modes": {"inference": true, "training": false, "backward": false},
+  "notes": "Exact safetensors/BUMP BF16 weight inference path for decode. Activation is rounded to BF16 before multiply."
+}

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -1,333 +1,17 @@
 {
   "bindings": {
-    "im2patch": {
-      "note": "Allow rectangular vision inputs by binding explicit image_height/image_width.",
-      "params": [
-        {
-          "name": "image",
-          "source": "activation:image",
-          "cast": "const float*"
-        },
-        {
-          "name": "patches",
-          "source": "output:patches",
-          "cast": "float*"
-        },
-        {
-          "name": "C",
-          "source": "dim:vision_channels"
-        },
-        {
-          "name": "H",
-          "source": "dim:image_height"
-        },
-        {
-          "name": "W",
-          "source": "dim:image_width"
-        },
-        {
-          "name": "P",
-          "source": "dim:patch_size"
-        }
-      ]
-    },
-    "gemm_nt_fp32_exact": {
-      "note": "Exact FP32 NT GEMM binding for parity-sensitive matmuls.",
-      "params": [
-        {
-          "name": "A",
-          "source": "activation:a",
-          "cast": "const float*"
-        },
-        {
-          "name": "B",
-          "source": "weight:_first_weight"
-        },
-        {
-          "name": "bias",
-          "source": "weight_f:_bias"
-        },
-        {
-          "name": "C",
-          "source": "output:c",
-          "cast": "float*"
-        },
-        {
-          "name": "M",
-          "source": "dim:_m"
-        },
-        {
-          "name": "N",
-          "source": "dim:_output_dim"
-        },
-        {
-          "name": "K",
-          "source": "dim:_input_dim"
-        }
-      ]
-    },
-    "gemm_naive_parallel": {
-      "note": "Exact FP32 NT GEMM binding for parity-sensitive matmuls.",
-      "params": [
-        {
-          "name": "A",
-          "source": "activation:a",
-          "cast": "const float*"
-        },
-        {
-          "name": "B",
-          "source": "weight:_first_weight"
-        },
-        {
-          "name": "bias",
-          "source": "weight_f:_bias"
-        },
-        {
-          "name": "C",
-          "source": "output:c",
-          "cast": "float*"
-        },
-        {
-          "name": "M",
-          "source": "dim:_m"
-        },
-        {
-          "name": "N",
-          "source": "dim:_output_dim"
-        },
-        {
-          "name": "K",
-          "source": "dim:_input_dim"
-        }
-      ]
-    },
-    "rmsnorm_forward": {
-      "note": "RMSNorm does not require an rstd cache in v8 runtimes.",
-      "params": [
-        {
-          "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
-        },
-        {
-          "name": "gamma",
-          "source": "weight_f:_gamma",
-          "alt": [
-            "ln1_gamma",
-            "ln2_gamma",
-            "post_attention_norm",
-            "post_ffn_norm",
-            "v_norm_gamma",
-            "final_ln_weight"
-          ]
-        },
-        {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
-        },
-        {
-          "name": "rstd_cache",
-          "source": "null"
-        },
-        {
-          "name": "tokens",
-          "source": "dim:seq_len"
-        },
-        {
-          "name": "d_model",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "aligned_embed_dim",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "eps",
-          "source": "dim:rms_eps"
-        }
-      ]
-    },
-    "layernorm_fp32_exact": {
-      "note": "Exact LayerNorm binding for parity-sensitive templates.",
-      "params": [
-        {
-          "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
-        },
-        {
-          "name": "gamma",
-          "source": "weight_f:gamma",
-          "alt": [
-            "ln1_gamma",
-            "ln2_gamma",
-            "final_ln_weight",
-            "branch_norm_gamma"
-          ]
-        },
-        {
-          "name": "beta",
-          "source": "weight_f:beta",
-          "alt": [
-            "ln1_beta",
-            "ln2_beta",
-            "final_ln_bias",
-            "branch_norm_beta"
-          ]
-        },
-        {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
-        },
-        {
-          "name": "mean_cache",
-          "source": "null"
-        },
-        {
-          "name": "rstd_cache",
-          "source": "null"
-        },
-        {
-          "name": "tokens",
-          "source": "dim:seq_len"
-        },
-        {
-          "name": "d_model",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "eps",
-          "source": "dim:rms_eps"
-        }
-      ]
-    },
-    "layernorm_naive_serial_matched_precision": {
-      "note": "Direct function-name alias for the exact LayerNorm binding.",
-      "params": [
-        {
-          "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
-        },
-        {
-          "name": "gamma",
-          "source": "weight_f:gamma",
-          "alt": [
-            "ln1_gamma",
-            "ln2_gamma",
-            "final_ln_weight",
-            "branch_norm_gamma"
-          ]
-        },
-        {
-          "name": "beta",
-          "source": "weight_f:beta",
-          "alt": [
-            "ln1_beta",
-            "ln2_beta",
-            "final_ln_bias",
-            "branch_norm_beta"
-          ]
-        },
-        {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
-        },
-        {
-          "name": "mean_cache",
-          "source": "null"
-        },
-        {
-          "name": "rstd_cache",
-          "source": "null"
-        },
-        {
-          "name": "tokens",
-          "source": "dim:seq_len"
-        },
-        {
-          "name": "d_model",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "eps",
-          "source": "dim:rms_eps"
-        }
-      ]
-    },
-    "gemm_nt_f16": {
-      "note": "FP16-weight dense GEMM wrapper with the standard matmul ABI.",
-      "params": [
-        {
-          "name": "A",
-          "source": "activation:a",
-          "cast": "const float*"
-        },
-        {
-          "name": "B",
-          "source": "weight:_first_weight"
-        },
-        {
-          "name": "bias",
-          "source": "weight_f:_bias"
-        },
-        {
-          "name": "C",
-          "source": "output:c",
-          "cast": "float*"
-        },
-        {
-          "name": "M",
-          "source": "dim:_m"
-        },
-        {
-          "name": "N",
-          "source": "dim:_output_dim"
-        },
-        {
-          "name": "K",
-          "source": "dim:_input_dim"
-        }
-      ]
-    },
-    "rowwise_bias_add": {
-      "note": "Explicit in-place rowwise bias binding for vision/header bring-up.",
-      "params": [
-        {
-          "name": "x",
-          "source": "output:x",
-          "cast": "float*"
-        },
-        {
-          "name": "bias",
-          "source": "weight:bias",
-          "cast": "const float*"
-        },
-        {
-          "name": "rows",
-          "source": "dim:rows"
-        },
-        {
-          "name": "dim",
-          "source": "dim:dim"
-        }
-      ]
-    },
     "add_stream_reorder_2d": {
       "note": "Sum two token-major streams and reorder the result into merged-tile traversal.",
       "params": [
         {
+          "cast": "float*",
           "name": "main_inout",
-          "source": "output:out",
-          "cast": "float*"
+          "source": "output:out"
         },
         {
+          "cast": "float*",
           "name": "aux_scratch",
-          "source": "activation:b",
-          "cast": "float*"
+          "source": "activation:b"
         },
         {
           "name": "grid_h",
@@ -347,315 +31,28 @@
         }
       ]
     },
-    "position_embeddings_add_tiled_2d": {
-      "note": "Add position embeddings to an activation stream already laid out in merged-tile order.",
+    "attention_forward_causal_head_major_gqa_flash_strided_gemma4": {
+      "note": "Prefill: all tokens process together with causal mask Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
       "params": [
         {
-          "name": "x",
-          "source": "output:x",
-          "cast": "float*"
-        },
-        {
-          "name": "position_embd",
-          "source": "weight:pos_emb",
-          "cast": "const float*"
-        },
-        {
-          "name": "grid_h",
-          "source": "dim:vision_grid_h"
-        },
-        {
-          "name": "grid_w",
-          "source": "dim:vision_grid_w"
-        },
-        {
-          "name": "embed_dim",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "merge_size",
-          "source": "dim:merge_size"
-        },
-        {
-          "name": "source_grid_size",
-          "source": "dim:source_grid_size"
-        }
-      ]
-    },
-    "spatial_merge_contiguous_tiled": {
-      "note": "Merge contiguous groups of merge_size^2 tokens from a merged-tile-ordered stream.",
-      "params": [
-        {
-          "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
-        },
-        {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
-        },
-        {
-          "name": "grid_h",
-          "source": "dim:vision_grid_h"
-        },
-        {
-          "name": "grid_w",
-          "source": "dim:vision_grid_w"
-        },
-        {
-          "name": "embed_dim",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "merge_size",
-          "source": "dim:merge_size"
-        }
-      ]
-    },
-    "layernorm_forward": {
-      "note": "Generic LayerNorm binding with explicit gamma and beta.",
-      "params": [
-        {
-          "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
-        },
-        {
-          "name": "gamma",
-          "source": "weight_f:gamma",
-          "alt": [
-            "ln1_gamma",
-            "ln2_gamma",
-            "final_ln_weight",
-            "branch_norm_gamma"
-          ]
-        },
-        {
-          "name": "beta",
-          "source": "weight_f:beta",
-          "alt": [
-            "ln1_beta",
-            "ln2_beta",
-            "final_ln_bias",
-            "branch_norm_beta"
-          ]
-        },
-        {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
-        },
-        {
-          "name": "mean_cache_slice",
-          "source": "null"
-        },
-        {
-          "name": "rstd_cache_slice",
-          "source": "null"
-        },
-        {
-          "name": "num_tokens_in_slice",
-          "source": "dim:seq_len"
-        },
-        {
-          "name": "d_model",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "eps",
-          "source": "dim:rms_eps"
-        }
-      ]
-    },
-    "layernorm_forward_unrolled_slice": {
-      "note": "Generic LayerNorm binding with explicit gamma and beta.",
-      "params": [
-        {
-          "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
-        },
-        {
-          "name": "gamma",
-          "source": "weight_f:gamma",
-          "alt": [
-            "ln1_gamma",
-            "ln2_gamma",
-            "final_ln_weight",
-            "branch_norm_gamma"
-          ]
-        },
-        {
-          "name": "beta",
-          "source": "weight_f:beta",
-          "alt": [
-            "ln1_beta",
-            "ln2_beta",
-            "final_ln_bias",
-            "branch_norm_beta"
-          ]
-        },
-        {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
-        },
-        {
-          "name": "mean_cache_slice",
-          "source": "null"
-        },
-        {
-          "name": "rstd_cache_slice",
-          "source": "null"
-        },
-        {
-          "name": "num_tokens_in_slice",
-          "source": "dim:seq_len"
-        },
-        {
-          "name": "d_model",
-          "source": "dim:embed_dim"
-        },
-        {
-          "name": "eps",
-          "source": "dim:rms_eps"
-        }
-      ]
-    },
-    "gelu_exact_inplace": {
-      "note": "Exact in-place GELU binding for parity-sensitive v8 paths.",
-      "params": [
-        {
-          "name": "data",
-          "source": "output:out",
-          "cast": "float*"
-        },
-        {
-          "name": "n",
-          "source": "dim:gelu_elems"
-        }
-      ]
-    },
-    "gelu_ggml_inplace": {
-      "note": "GGML-compatible in-place GELU binding for llama.cpp parity-sensitive v8 paths.",
-      "params": [
-        {
-          "name": "data",
-          "source": "output:out",
-          "cast": "float*"
-        },
-        {
-          "name": "n",
-          "source": "dim:gelu_elems"
-        }
-      ]
-    },
-    "feature_slice_copy": {
-      "note": "Generic row-wise copy into a feature-axis slice of a wider destination tensor.",
-      "params": [
-        {
-          "name": "src",
-          "source": "activation:src",
-          "cast": "const float*"
-        },
-        {
-          "name": "dst",
-          "source": "output:dst",
-          "cast": "float*"
-        },
-        {
-          "name": "rows",
-          "source": "dim:rows"
-        },
-        {
-          "name": "src_dim",
-          "source": "dim:src_dim"
-        },
-        {
-          "name": "dst_dim",
-          "source": "dim:dst_dim"
-        },
-        {
-          "name": "dst_feature_offset",
-          "source": "dim:dst_feature_offset"
-        }
-      ]
-    },
-    "feature_concat": {
-      "note": "Concatenate a main output with fixed-width collected branch slices.",
-      "params": [
-        {
-          "name": "main_input",
-          "source": "activation:main_input",
-          "cast": "const float*"
-        },
-        {
-          "name": "branch_input",
-          "source": "activation:branch_input",
-          "cast": "const float*"
-        },
-        {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
-        },
-        {
-          "name": "rows",
-          "source": "dim:rows"
-        },
-        {
-          "name": "main_dim",
-          "source": "dim:main_dim"
-        },
-        {
-          "name": "branch_slice_dim",
-          "source": "dim:branch_slice_dim"
-        },
-        {
-          "name": "num_branch_slices",
-          "source": "dim:num_branch_slices"
-        }
-      ]
-    },
-    "split_qkv_packed_head_major_forward": {
-      "note": "Split packed token-major QKV rows into head-major Q/K/V buffers for transformer attention.",
-      "params": [
-        {
-          "name": "packed_qkv",
-          "source": "activation:packed_qkv",
-          "cast": "const float*"
-        },
-        {
+          "cast": "float*",
           "name": "q",
-          "source": "output:q",
-          "cast": "float*"
+          "source": "scratch:q_scratch"
         },
         {
+          "cast": "float*",
           "name": "k",
-          "source": "output:k",
-          "cast": "float*"
+          "source": "scratch:k_scratch"
         },
         {
+          "cast": "float*",
           "name": "v",
-          "source": "output:v",
-          "cast": "float*"
+          "source": "scratch:v_scratch"
         },
         {
-          "name": "rows",
-          "source": "runtime:seq_len"
-        },
-        {
-          "name": "q_dim",
-          "source": "dim:q_dim"
-        },
-        {
-          "name": "k_dim",
-          "source": "dim:k_dim"
-        },
-        {
-          "name": "v_dim",
-          "source": "dim:v_dim"
+          "cast": "float*",
+          "name": "output",
+          "source": "output:out"
         },
         {
           "name": "num_heads",
@@ -664,6 +61,226 @@
         {
           "name": "num_kv_heads",
           "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        }
+      ]
+    },
+    "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4": {
+      "note": "Prefill: sliding window attention with causal mask Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "k",
+          "source": "scratch:k_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "v",
+          "source": "scratch:v_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "sliding_window",
+          "source": "dim:sliding_window"
+        }
+      ]
+    },
+    "attention_forward_decode_head_major_gqa_flash_f16cache": {
+      "note": "Decode flash attention over packed FP16 KV-cache storage.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "q_token",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "const uint16_t*",
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer_f16"
+        },
+        {
+          "cast": "const uint16_t*",
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer_f16"
+        },
+        {
+          "cast": "float*",
+          "name": "out_token",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "kv_tokens",
+          "source": "runtime:kv_tokens"
+        },
+        {
+          "name": "cache_capacity",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        }
+      ]
+    },
+    "attention_forward_decode_head_major_gqa_flash_gemma4": {
+      "note": "Decode: single query token attends to KV cache (positions 0..pos) Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "q_token",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer"
+        },
+        {
+          "cast": "const float*",
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer"
+        },
+        {
+          "cast": "float*",
+          "name": "out_token",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "kv_tokens",
+          "source": "runtime:kv_tokens"
+        },
+        {
+          "name": "cache_capacity",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        }
+      ]
+    },
+    "attention_forward_decode_head_major_gqa_flash_sliding_gemma4": {
+      "note": "Decode: sliding window attention - single query token attends to last W KV cache entries Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "q_token",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer"
+        },
+        {
+          "cast": "const float*",
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer"
+        },
+        {
+          "cast": "float*",
+          "name": "out_token",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "kv_tokens",
+          "source": "runtime:kv_tokens"
+        },
+        {
+          "name": "cache_capacity",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "sliding_window",
+          "source": "dim:sliding_window"
         }
       ]
     },
@@ -671,24 +288,73 @@
       "note": "Prefill: exact full / bidirectional grouped-query attention across the entire sequence",
       "params": [
         {
+          "cast": "float*",
           "name": "q",
-          "source": "scratch:q_scratch",
-          "cast": "float*"
+          "source": "scratch:q_scratch"
         },
         {
+          "cast": "float*",
           "name": "k",
-          "source": "scratch:k_scratch",
-          "cast": "float*"
+          "source": "scratch:k_scratch"
         },
         {
+          "cast": "float*",
           "name": "v",
-          "source": "scratch:v_scratch",
-          "cast": "float*"
+          "source": "scratch:v_scratch"
         },
         {
+          "cast": "float*",
           "name": "output",
-          "source": "output:out",
-          "cast": "float*"
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        }
+      ]
+    },
+    "attention_forward_full_head_major_gqa_flash_strided_gemma4": {
+      "note": "Prefill: full / bidirectional attention across the entire sequence Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "k",
+          "source": "scratch:k_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "v",
+          "source": "scratch:v_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:out"
         },
         {
           "name": "num_heads",
@@ -720,24 +386,24 @@
       "note": "Prefill: GGML-compatible non-flash full / bidirectional grouped-query attention across the entire sequence",
       "params": [
         {
+          "cast": "float*",
           "name": "q",
-          "source": "scratch:q_scratch",
-          "cast": "float*"
+          "source": "scratch:q_scratch"
         },
         {
+          "cast": "float*",
           "name": "k",
-          "source": "scratch:k_scratch",
-          "cast": "float*"
+          "source": "scratch:k_scratch"
         },
         {
+          "cast": "float*",
           "name": "v",
-          "source": "scratch:v_scratch",
-          "cast": "float*"
+          "source": "scratch:v_scratch"
         },
         {
+          "cast": "float*",
           "name": "output",
-          "source": "output:out",
-          "cast": "float*"
+          "source": "output:out"
         },
         {
           "name": "num_heads",
@@ -765,340 +431,308 @@
         }
       ]
     },
-    "vision_position_ids_2d_merge": {
-      "note": "Materialize merged-tile vision position IDs for position-driven M-RoPE.",
+    "embedding_forward_bf16_fp32": {
+      "note": "BF16 token embedding lookup with FP32 output for v8 inference streams.",
       "params": [
         {
-          "name": "positions",
-          "source": "output:positions",
-          "cast": "int32_t*"
+          "cast": "int32_t*",
+          "name": "token_ids",
+          "source": "activation:tokens"
         },
         {
-          "name": "grid_h",
-          "source": "dim:vision_grid_h"
-        },
-        {
-          "name": "grid_w",
-          "source": "dim:vision_grid_w"
-        },
-        {
-          "name": "merge_size",
-          "source": "dim:merge_size"
-        }
-      ]
-    },
-    "mrope_qk_vision": {
-      "note": "Vision multi-section RoPE driven by explicit per-token position IDs.",
-      "params": [
-        {
-          "name": "q",
-          "source": "output:q",
-          "cast": "float*"
-        },
-        {
-          "name": "k",
-          "source": "output:k",
-          "cast": "float*"
-        },
-        {
-          "name": "positions",
-          "source": "activation:positions",
-          "cast": "const int32_t*"
-        },
-        {
-          "name": "num_heads",
-          "source": "dim:num_heads"
-        },
-        {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
-        },
-        {
-          "name": "num_tokens",
+          "name": "token_count",
           "source": "dim:seq_len"
         },
         {
-          "name": "head_dim",
-          "source": "dim:head_dim"
+          "name": "vocab_size",
+          "source": "dim:vocab_size"
         },
         {
-          "name": "aligned_head_dim",
-          "source": "dim:head_dim"
+          "cast": "const uint16_t*",
+          "name": "token_embeddings",
+          "source": "weight:token_emb"
         },
         {
-          "name": "n_dims",
-          "source": "dim:n_dims"
+          "name": "pos_embeddings",
+          "source": "null"
         },
         {
-          "name": "section_0",
-          "source": "dim:section_0"
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
         },
         {
-          "name": "section_1",
-          "source": "dim:section_1"
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
         },
         {
-          "name": "section_2",
-          "source": "dim:section_2"
+          "name": "aligned_embed_dim",
+          "source": "dim:embed_dim"
         },
         {
-          "name": "section_3",
-          "source": "dim:section_3"
-        },
-        {
-          "name": "n_ctx_orig",
-          "source": "dim:n_ctx_orig"
-        },
-        {
-          "name": "freq_base",
-          "source": "dim:freq_base"
-        },
-        {
-          "name": "freq_scale",
-          "source": "dim:freq_scale"
-        },
-        {
-          "name": "ext_factor",
-          "source": "dim:ext_factor"
-        },
-        {
-          "name": "attn_factor",
-          "source": "dim:attn_factor"
-        },
-        {
-          "name": "beta_fast",
-          "source": "dim:beta_fast"
-        },
-        {
-          "name": "beta_slow",
-          "source": "dim:beta_slow"
-        }
-      ]
-    },
-    "mrope_qk_text": {
-      "note": "Text multi-section RoPE driven by runtime token position offset.",
-      "params": [
-        {
-          "name": "q",
-          "source": "output:q",
-          "cast": "float*"
-        },
-        {
-          "name": "k",
-          "source": "output:k",
-          "cast": "float*"
-        },
-        {
-          "name": "num_heads",
-          "source": "dim:num_heads"
-        },
-        {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
-        },
-        {
-          "name": "num_tokens",
+          "name": "context_window",
           "source": "dim:seq_len"
         },
         {
-          "name": "head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "aligned_head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "pos_offset",
-          "source": "runtime:pos"
-        },
-        {
-          "name": "n_dims",
-          "source": "dim:n_dims"
-        },
-        {
-          "name": "section_0",
-          "source": "dim:section_0"
-        },
-        {
-          "name": "section_1",
-          "source": "dim:section_1"
-        },
-        {
-          "name": "section_2",
-          "source": "dim:section_2"
-        },
-        {
-          "name": "section_3",
-          "source": "dim:section_3"
-        },
-        {
-          "name": "n_ctx_orig",
-          "source": "dim:n_ctx_orig"
-        },
-        {
-          "name": "freq_base",
-          "source": "dim:freq_base"
-        },
-        {
-          "name": "freq_scale",
-          "source": "dim:freq_scale"
-        },
-        {
-          "name": "ext_factor",
-          "source": "dim:ext_factor"
-        },
-        {
-          "name": "attn_factor",
-          "source": "dim:attn_factor"
-        },
-        {
-          "name": "beta_fast",
-          "source": "dim:beta_fast"
-        },
-        {
-          "name": "beta_slow",
-          "source": "dim:beta_slow"
+          "name": "add_pos",
+          "source": "const:0"
         }
       ]
     },
-    "quantize_row_q8_0": {
-      "note": "Allow vision/footer quantize ops to request batched row emission when rows is present.",
+    "feature_concat": {
+      "note": "Concatenate a main output with fixed-width collected branch slices.",
       "params": [
         {
-          "name": "x",
-          "source": "activation:input",
-          "cast": "const float*"
+          "cast": "const float*",
+          "name": "main_input",
+          "source": "activation:main_input"
         },
         {
-          "name": "y",
-          "source": "output:output",
-          "cast": "void*"
+          "cast": "const float*",
+          "name": "branch_input",
+          "source": "activation:branch_input"
         },
         {
-          "name": "k",
-          "source": "dim:_input_dim"
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
         },
         {
           "name": "rows",
           "source": "dim:rows"
+        },
+        {
+          "name": "main_dim",
+          "source": "dim:main_dim"
+        },
+        {
+          "name": "branch_slice_dim",
+          "source": "dim:branch_slice_dim"
+        },
+        {
+          "name": "num_branch_slices",
+          "source": "dim:num_branch_slices"
         }
       ]
     },
-    "quantize_row_q8_k": {
-      "note": "Allow vision/footer quantize ops to request batched row emission when rows is present.",
+    "feature_slice_copy": {
+      "note": "Generic row-wise copy into a feature-axis slice of a wider destination tensor.",
       "params": [
         {
-          "name": "x",
-          "source": "activation:input",
-          "cast": "const float*"
+          "cast": "const float*",
+          "name": "src",
+          "source": "activation:src"
         },
         {
-          "name": "y",
-          "source": "output:output",
-          "cast": "void*"
-        },
-        {
-          "name": "k",
-          "source": "dim:_input_dim"
+          "cast": "float*",
+          "name": "dst",
+          "source": "output:dst"
         },
         {
           "name": "rows",
           "source": "dim:rows"
+        },
+        {
+          "name": "src_dim",
+          "source": "dim:src_dim"
+        },
+        {
+          "name": "dst_dim",
+          "source": "dim:dst_dim"
+        },
+        {
+          "name": "dst_feature_offset",
+          "source": "dim:dst_feature_offset"
         }
       ]
     },
-    "kv_cache_store_f16": {
-      "note": "Store K,V into the packed FP16 decode KV cache.",
+    "gelu_exact_inplace": {
+      "note": "Exact in-place GELU binding for parity-sensitive v8 paths.",
       "params": [
         {
-          "name": "kv_cache_k",
-          "source": "runtime:kv_cache_k_layer_f16",
-          "cast": "uint16_t*"
+          "cast": "float*",
+          "name": "data",
+          "source": "output:out"
         },
         {
-          "name": "kv_cache_v",
-          "source": "runtime:kv_cache_v_layer_f16",
-          "cast": "uint16_t*"
-        },
-        {
-          "name": "k",
-          "source": "scratch:k_scratch",
-          "cast": "const float*"
-        },
-        {
-          "name": "v",
-          "source": "scratch:v_scratch",
-          "cast": "const float*"
-        },
-        {
-          "name": "layer",
-          "source": "runtime:layer"
-        },
-        {
-          "name": "pos",
-          "source": "runtime:pos"
-        },
-        {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
-        },
-        {
-          "name": "head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "max_seq_len",
-          "source": "dim:max_seq_len"
+          "name": "n",
+          "source": "dim:gelu_elems"
         }
       ]
     },
-    "attention_forward_decode_head_major_gqa_flash_f16cache": {
-      "note": "Decode flash attention over packed FP16 KV-cache storage.",
+    "gelu_ggml_inplace": {
+      "note": "GGML-compatible in-place GELU binding for llama.cpp parity-sensitive v8 paths.",
       "params": [
         {
-          "name": "q_token",
-          "source": "scratch:q_scratch",
-          "cast": "const float*"
+          "cast": "float*",
+          "name": "data",
+          "source": "output:out"
         },
         {
-          "name": "k_cache",
-          "source": "runtime:kv_cache_k_layer_f16",
-          "cast": "const uint16_t*"
+          "name": "n",
+          "source": "dim:gelu_elems"
+        }
+      ]
+    },
+    "gemm_naive_parallel": {
+      "note": "Exact FP32 NT GEMM binding for parity-sensitive matmuls.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "A",
+          "source": "activation:a"
         },
         {
-          "name": "v_cache",
-          "source": "runtime:kv_cache_v_layer_f16",
-          "cast": "const uint16_t*"
+          "name": "B",
+          "source": "weight:_first_weight"
         },
         {
-          "name": "out_token",
-          "source": "output:out",
-          "cast": "float*"
+          "name": "bias",
+          "source": "weight_f:_bias"
         },
         {
-          "name": "num_heads",
-          "source": "dim:num_heads"
+          "cast": "float*",
+          "name": "C",
+          "source": "output:c"
         },
         {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
+          "name": "M",
+          "source": "dim:_m"
         },
         {
-          "name": "kv_tokens",
-          "source": "runtime:kv_tokens"
+          "name": "N",
+          "source": "dim:_output_dim"
         },
         {
-          "name": "cache_capacity",
-          "source": "dim:max_seq_len"
+          "name": "K",
+          "source": "dim:_input_dim"
+        }
+      ]
+    },
+    "gemm_nt_bf16": {
+      "note": "BF16-weight dense GEMM wrapper with the standard matmul ABI.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "A",
+          "source": "activation:a"
         },
         {
-          "name": "head_dim",
-          "source": "dim:head_dim"
+          "name": "B",
+          "source": "weight:_first_weight"
         },
         {
-          "name": "aligned_head_dim",
-          "source": "dim:head_dim"
+          "name": "bias",
+          "source": "weight_f:_bias"
+        },
+        {
+          "cast": "float*",
+          "name": "C",
+          "source": "output:c"
+        },
+        {
+          "name": "M",
+          "source": "dim:_m"
+        },
+        {
+          "name": "N",
+          "source": "dim:_output_dim"
+        },
+        {
+          "name": "K",
+          "source": "dim:_input_dim"
+        }
+      ]
+    },
+    "gemm_nt_f16": {
+      "note": "FP16-weight dense GEMM wrapper with the standard matmul ABI.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "A",
+          "source": "activation:a"
+        },
+        {
+          "name": "B",
+          "source": "weight:_first_weight"
+        },
+        {
+          "name": "bias",
+          "source": "weight_f:_bias"
+        },
+        {
+          "cast": "float*",
+          "name": "C",
+          "source": "output:c"
+        },
+        {
+          "name": "M",
+          "source": "dim:_m"
+        },
+        {
+          "name": "N",
+          "source": "dim:_output_dim"
+        },
+        {
+          "name": "K",
+          "source": "dim:_input_dim"
+        }
+      ]
+    },
+    "gemm_nt_fp32_exact": {
+      "note": "Exact FP32 NT GEMM binding for parity-sensitive matmuls.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "A",
+          "source": "activation:a"
+        },
+        {
+          "name": "B",
+          "source": "weight:_first_weight"
+        },
+        {
+          "name": "bias",
+          "source": "weight_f:_bias"
+        },
+        {
+          "cast": "float*",
+          "name": "C",
+          "source": "output:c"
+        },
+        {
+          "name": "M",
+          "source": "dim:_m"
+        },
+        {
+          "name": "N",
+          "source": "dim:_output_dim"
+        },
+        {
+          "name": "K",
+          "source": "dim:_input_dim"
+        }
+      ]
+    },
+    "gemma4_final_logit_softcap_forward": {
+      "note": "Apply Gemma4 final logit softcapping in-place: tanh(logit / cap) * cap.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "logits",
+          "source": "activation:logits"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "vocab_size",
+          "source": "dim:vocab_size"
+        },
+        {
+          "name": "cap",
+          "source": "dim:final_logit_softcapping"
         }
       ]
     },
@@ -1106,14 +740,14 @@
       "note": "Apply Gemma4 per-layer residual branch using prepared per-layer input stream.",
       "params": [
         {
+          "cast": "float*",
           "name": "hidden",
-          "source": "activation:hidden",
-          "cast": "float*"
+          "source": "activation:hidden"
         },
         {
+          "cast": "const float*",
           "name": "per_layer_input",
-          "source": "activation:per_layer_input",
-          "cast": "const float*"
+          "source": "activation:per_layer_input"
         },
         {
           "name": "inp_gate",
@@ -1157,32 +791,33 @@
         }
       ]
     },
-    "gemma4_per_layer_prepare_forward": {
-      "note": "Prepare Gemma4 per-layer input stream from original embeddings.",
+    "gemma4_per_layer_prepare_bf16_forward": {
+      "note": "Prepare Gemma4 per-layer input stream from BF16 safetensors embeddings.",
       "params": [
         {
+          "cast": "float*",
           "name": "per_layer_input",
-          "source": "output:per_layer_input",
-          "cast": "float*"
+          "source": "output:per_layer_input"
         },
         {
+          "cast": "const float*",
           "name": "hidden",
-          "source": "activation:hidden",
-          "cast": "const float*"
+          "source": "activation:hidden"
         },
         {
+          "cast": "const int32_t*",
           "name": "token_ids",
-          "source": "activation:tokens",
-          "cast": "const int32_t*"
+          "source": "activation:tokens"
         },
         {
+          "cast": "const uint16_t*",
           "name": "per_layer_token_emb",
           "source": "weight:per_layer_token_emb"
         },
         {
+          "cast": "const uint16_t*",
           "name": "per_layer_model_proj",
-          "source": "weight:per_layer_model_proj",
-          "cast": "const uint16_t*"
+          "source": "weight:per_layer_model_proj"
         },
         {
           "name": "per_layer_proj_norm",
@@ -1214,50 +849,432 @@
         }
       ]
     },
-    "gemma4_final_logit_softcap_forward": {
-      "note": "Apply Gemma4 final logit softcapping in-place: tanh(logit / cap) * cap.",
+    "gemma4_per_layer_prepare_forward": {
+      "note": "Prepare Gemma4 per-layer input stream from original embeddings.",
       "params": [
         {
-          "name": "logits",
-          "source": "activation:logits",
-          "cast": "float*"
+          "cast": "float*",
+          "name": "per_layer_input",
+          "source": "output:per_layer_input"
+        },
+        {
+          "cast": "const float*",
+          "name": "hidden",
+          "source": "activation:hidden"
+        },
+        {
+          "cast": "const int32_t*",
+          "name": "token_ids",
+          "source": "activation:tokens"
+        },
+        {
+          "name": "per_layer_token_emb",
+          "source": "weight:per_layer_token_emb"
+        },
+        {
+          "cast": "const uint16_t*",
+          "name": "per_layer_model_proj",
+          "source": "weight:per_layer_model_proj"
+        },
+        {
+          "name": "per_layer_proj_norm",
+          "source": "weight_f:per_layer_proj_norm"
         },
         {
           "name": "tokens",
           "source": "dim:seq_len"
         },
         {
+          "name": "num_layers",
+          "source": "dim:num_layers"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "per_layer_dim",
+          "source": "dim:per_layer_dim"
+        },
+        {
           "name": "vocab_size",
           "source": "dim:vocab_size"
         },
         {
-          "name": "cap",
-          "source": "dim:final_logit_softcapping"
+          "name": "eps",
+          "source": "dim:rms_eps"
         }
       ]
     },
-    "attention_forward_causal_head_major_gqa_flash_strided_gemma4": {
-      "note": "Prefill: all tokens process together with causal mask Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+    "gemma4_v_norm_forward": {
       "params": [
         {
-          "name": "q",
-          "source": "scratch:q_scratch",
-          "cast": "float*"
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
         },
         {
-          "name": "k",
-          "source": "scratch:k_scratch",
-          "cast": "float*"
-        },
-        {
-          "name": "v",
-          "source": "scratch:v_scratch",
-          "cast": "float*"
-        },
-        {
+          "cast": "float*",
           "name": "output",
-          "source": "output:out",
-          "cast": "float*"
+          "source": "output:output"
+        },
+        {
+          "name": "rstd_cache",
+          "source": "null"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "gemv_bf16": {
+      "note": "BF16-weight dense GEMV wrapper with the standard matmul ABI.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "y",
+          "source": "output:y"
+        },
+        {
+          "name": "W",
+          "source": "weight:_first_weight"
+        },
+        {
+          "cast": "const float*",
+          "name": "x",
+          "source": "activation:x"
+        },
+        {
+          "name": "M",
+          "source": "dim:_output_dim"
+        },
+        {
+          "name": "K",
+          "source": "dim:_input_dim"
+        }
+      ]
+    },
+    "im2patch": {
+      "note": "Allow rectangular vision inputs by binding explicit image_height/image_width.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "image",
+          "source": "activation:image"
+        },
+        {
+          "cast": "float*",
+          "name": "patches",
+          "source": "output:patches"
+        },
+        {
+          "name": "C",
+          "source": "dim:vision_channels"
+        },
+        {
+          "name": "H",
+          "source": "dim:image_height"
+        },
+        {
+          "name": "W",
+          "source": "dim:image_width"
+        },
+        {
+          "name": "P",
+          "source": "dim:patch_size"
+        }
+      ]
+    },
+    "kv_cache_store_f16": {
+      "note": "Store K,V into the packed FP16 decode KV cache.",
+      "params": [
+        {
+          "cast": "uint16_t*",
+          "name": "kv_cache_k",
+          "source": "runtime:kv_cache_k_layer_f16"
+        },
+        {
+          "cast": "uint16_t*",
+          "name": "kv_cache_v",
+          "source": "runtime:kv_cache_v_layer_f16"
+        },
+        {
+          "cast": "const float*",
+          "name": "k",
+          "source": "scratch:k_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "v",
+          "source": "scratch:v_scratch"
+        },
+        {
+          "name": "layer",
+          "source": "runtime:layer"
+        },
+        {
+          "name": "pos",
+          "source": "runtime:pos"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "max_seq_len",
+          "source": "dim:max_seq_len"
+        }
+      ]
+    },
+    "layernorm_forward": {
+      "note": "Generic LayerNorm binding with explicit gamma and beta.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
+        },
+        {
+          "alt": [
+            "ln1_gamma",
+            "ln2_gamma",
+            "final_ln_weight",
+            "branch_norm_gamma"
+          ],
+          "name": "gamma",
+          "source": "weight_f:gamma"
+        },
+        {
+          "alt": [
+            "ln1_beta",
+            "ln2_beta",
+            "final_ln_bias",
+            "branch_norm_beta"
+          ],
+          "name": "beta",
+          "source": "weight_f:beta"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
+        },
+        {
+          "name": "mean_cache_slice",
+          "source": "null"
+        },
+        {
+          "name": "rstd_cache_slice",
+          "source": "null"
+        },
+        {
+          "name": "num_tokens_in_slice",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "d_model",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "layernorm_forward_unrolled_slice": {
+      "note": "Generic LayerNorm binding with explicit gamma and beta.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
+        },
+        {
+          "alt": [
+            "ln1_gamma",
+            "ln2_gamma",
+            "final_ln_weight",
+            "branch_norm_gamma"
+          ],
+          "name": "gamma",
+          "source": "weight_f:gamma"
+        },
+        {
+          "alt": [
+            "ln1_beta",
+            "ln2_beta",
+            "final_ln_bias",
+            "branch_norm_beta"
+          ],
+          "name": "beta",
+          "source": "weight_f:beta"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
+        },
+        {
+          "name": "mean_cache_slice",
+          "source": "null"
+        },
+        {
+          "name": "rstd_cache_slice",
+          "source": "null"
+        },
+        {
+          "name": "num_tokens_in_slice",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "d_model",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "layernorm_fp32_exact": {
+      "note": "Exact LayerNorm binding for parity-sensitive templates.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
+        },
+        {
+          "alt": [
+            "ln1_gamma",
+            "ln2_gamma",
+            "final_ln_weight",
+            "branch_norm_gamma"
+          ],
+          "name": "gamma",
+          "source": "weight_f:gamma"
+        },
+        {
+          "alt": [
+            "ln1_beta",
+            "ln2_beta",
+            "final_ln_bias",
+            "branch_norm_beta"
+          ],
+          "name": "beta",
+          "source": "weight_f:beta"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
+        },
+        {
+          "name": "mean_cache",
+          "source": "null"
+        },
+        {
+          "name": "rstd_cache",
+          "source": "null"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "d_model",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "layernorm_naive_serial_matched_precision": {
+      "note": "Direct function-name alias for the exact LayerNorm binding.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
+        },
+        {
+          "alt": [
+            "ln1_gamma",
+            "ln2_gamma",
+            "final_ln_weight",
+            "branch_norm_gamma"
+          ],
+          "name": "gamma",
+          "source": "weight_f:gamma"
+        },
+        {
+          "alt": [
+            "ln1_beta",
+            "ln2_beta",
+            "final_ln_bias",
+            "branch_norm_beta"
+          ],
+          "name": "beta",
+          "source": "weight_f:beta"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
+        },
+        {
+          "name": "mean_cache",
+          "source": "null"
+        },
+        {
+          "name": "rstd_cache",
+          "source": "null"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "d_model",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "mrope_qk_text": {
+      "note": "Text multi-section RoPE driven by runtime token position offset.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "output:q"
+        },
+        {
+          "cast": "float*",
+          "name": "k",
+          "source": "output:k"
         },
         {
           "name": "num_heads",
@@ -1280,33 +1297,76 @@
           "source": "dim:head_dim"
         },
         {
-          "name": "kv_stride_tokens",
-          "source": "dim:max_seq_len"
+          "name": "pos_offset",
+          "source": "runtime:pos"
+        },
+        {
+          "name": "n_dims",
+          "source": "dim:n_dims"
+        },
+        {
+          "name": "section_0",
+          "source": "dim:section_0"
+        },
+        {
+          "name": "section_1",
+          "source": "dim:section_1"
+        },
+        {
+          "name": "section_2",
+          "source": "dim:section_2"
+        },
+        {
+          "name": "section_3",
+          "source": "dim:section_3"
+        },
+        {
+          "name": "n_ctx_orig",
+          "source": "dim:n_ctx_orig"
+        },
+        {
+          "name": "freq_base",
+          "source": "dim:freq_base"
+        },
+        {
+          "name": "freq_scale",
+          "source": "dim:freq_scale"
+        },
+        {
+          "name": "ext_factor",
+          "source": "dim:ext_factor"
+        },
+        {
+          "name": "attn_factor",
+          "source": "dim:attn_factor"
+        },
+        {
+          "name": "beta_fast",
+          "source": "dim:beta_fast"
+        },
+        {
+          "name": "beta_slow",
+          "source": "dim:beta_slow"
         }
       ]
     },
-    "attention_forward_full_head_major_gqa_flash_strided_gemma4": {
-      "note": "Prefill: full / bidirectional attention across the entire sequence Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+    "mrope_qk_vision": {
+      "note": "Vision multi-section RoPE driven by explicit per-token position IDs.",
       "params": [
         {
+          "cast": "float*",
           "name": "q",
-          "source": "scratch:q_scratch",
-          "cast": "float*"
+          "source": "output:q"
         },
         {
+          "cast": "float*",
           "name": "k",
-          "source": "scratch:k_scratch",
-          "cast": "float*"
+          "source": "output:k"
         },
         {
-          "name": "v",
-          "source": "scratch:v_scratch",
-          "cast": "float*"
-        },
-        {
-          "name": "output",
-          "source": "output:out",
-          "cast": "float*"
+          "cast": "const int32_t*",
+          "name": "positions",
+          "source": "activation:positions"
         },
         {
           "name": "num_heads",
@@ -1329,163 +1389,214 @@
           "source": "dim:head_dim"
         },
         {
-          "name": "kv_stride_tokens",
-          "source": "dim:max_seq_len"
+          "name": "n_dims",
+          "source": "dim:n_dims"
+        },
+        {
+          "name": "section_0",
+          "source": "dim:section_0"
+        },
+        {
+          "name": "section_1",
+          "source": "dim:section_1"
+        },
+        {
+          "name": "section_2",
+          "source": "dim:section_2"
+        },
+        {
+          "name": "section_3",
+          "source": "dim:section_3"
+        },
+        {
+          "name": "n_ctx_orig",
+          "source": "dim:n_ctx_orig"
+        },
+        {
+          "name": "freq_base",
+          "source": "dim:freq_base"
+        },
+        {
+          "name": "freq_scale",
+          "source": "dim:freq_scale"
+        },
+        {
+          "name": "ext_factor",
+          "source": "dim:ext_factor"
+        },
+        {
+          "name": "attn_factor",
+          "source": "dim:attn_factor"
+        },
+        {
+          "name": "beta_fast",
+          "source": "dim:beta_fast"
+        },
+        {
+          "name": "beta_slow",
+          "source": "dim:beta_slow"
         }
       ]
     },
-    "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4": {
-      "note": "Prefill: sliding window attention with causal mask Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+    "position_embeddings_add_tiled_2d": {
+      "note": "Add position embeddings to an activation stream already laid out in merged-tile order.",
       "params": [
         {
-          "name": "q",
-          "source": "scratch:q_scratch",
-          "cast": "float*"
+          "cast": "float*",
+          "name": "x",
+          "source": "output:x"
+        },
+        {
+          "cast": "const float*",
+          "name": "position_embd",
+          "source": "weight:pos_emb"
+        },
+        {
+          "name": "grid_h",
+          "source": "dim:vision_grid_h"
+        },
+        {
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "merge_size",
+          "source": "dim:merge_size"
+        },
+        {
+          "name": "source_grid_size",
+          "source": "dim:source_grid_size"
+        }
+      ]
+    },
+    "quantize_row_q8_0": {
+      "note": "Allow vision/footer quantize ops to request batched row emission when rows is present.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "x",
+          "source": "activation:input"
+        },
+        {
+          "cast": "void*",
+          "name": "y",
+          "source": "output:output"
         },
         {
           "name": "k",
-          "source": "scratch:k_scratch",
-          "cast": "float*"
+          "source": "dim:_input_dim"
         },
         {
-          "name": "v",
-          "source": "scratch:v_scratch",
-          "cast": "float*"
+          "name": "rows",
+          "source": "dim:rows"
+        }
+      ]
+    },
+    "quantize_row_q8_k": {
+      "note": "Allow vision/footer quantize ops to request batched row emission when rows is present.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "x",
+          "source": "activation:input"
         },
         {
+          "cast": "void*",
+          "name": "y",
+          "source": "output:output"
+        },
+        {
+          "name": "k",
+          "source": "dim:_input_dim"
+        },
+        {
+          "name": "rows",
+          "source": "dim:rows"
+        }
+      ]
+    },
+    "rmsnorm_forward": {
+      "note": "RMSNorm does not require an rstd cache in v8 runtimes.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
+        },
+        {
+          "alt": [
+            "ln1_gamma",
+            "ln2_gamma",
+            "post_attention_norm",
+            "post_ffn_norm",
+            "v_norm_gamma",
+            "final_ln_weight"
+          ],
+          "name": "gamma",
+          "source": "weight_f:_gamma"
+        },
+        {
+          "cast": "float*",
           "name": "output",
-          "source": "output:out",
-          "cast": "float*"
+          "source": "output:output"
         },
         {
-          "name": "num_heads",
-          "source": "dim:num_heads"
+          "name": "rstd_cache",
+          "source": "null"
         },
         {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
-        },
-        {
-          "name": "num_tokens",
+          "name": "tokens",
           "source": "dim:seq_len"
         },
         {
-          "name": "head_dim",
-          "source": "dim:head_dim"
+          "name": "d_model",
+          "source": "dim:embed_dim"
         },
         {
-          "name": "aligned_head_dim",
-          "source": "dim:head_dim"
+          "name": "aligned_embed_dim",
+          "source": "dim:embed_dim"
         },
         {
-          "name": "kv_stride_tokens",
-          "source": "dim:max_seq_len"
-        },
-        {
-          "name": "sliding_window",
-          "source": "dim:sliding_window"
+          "name": "eps",
+          "source": "dim:rms_eps"
         }
       ]
     },
-    "attention_forward_decode_head_major_gqa_flash_gemma4": {
-      "note": "Decode: single query token attends to KV cache (positions 0..pos) Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
+    "rmsnorm_forward_no_weight": {
       "params": [
         {
-          "name": "q_token",
-          "source": "scratch:q_scratch",
-          "cast": "const float*"
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
         },
         {
-          "name": "k_cache",
-          "source": "runtime:kv_cache_k_layer",
-          "cast": "const float*"
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
         },
         {
-          "name": "v_cache",
-          "source": "runtime:kv_cache_v_layer",
-          "cast": "const float*"
+          "name": "rstd_cache",
+          "source": "null"
         },
         {
-          "name": "out_token",
-          "source": "output:out",
-          "cast": "float*"
+          "name": "tokens",
+          "source": "dim:seq_len"
         },
         {
-          "name": "num_heads",
-          "source": "dim:num_heads"
+          "name": "d_model",
+          "source": "dim:_output_dim"
         },
         {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
+          "name": "aligned_embed_dim",
+          "source": "dim:_output_dim"
         },
         {
-          "name": "kv_tokens",
-          "source": "runtime:kv_tokens"
-        },
-        {
-          "name": "cache_capacity",
-          "source": "dim:max_seq_len"
-        },
-        {
-          "name": "head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "aligned_head_dim",
-          "source": "dim:head_dim"
-        }
-      ]
-    },
-    "attention_forward_decode_head_major_gqa_flash_sliding_gemma4": {
-      "note": "Decode: sliding window attention - single query token attends to last W KV cache entries Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
-      "params": [
-        {
-          "name": "q_token",
-          "source": "scratch:q_scratch",
-          "cast": "const float*"
-        },
-        {
-          "name": "k_cache",
-          "source": "runtime:kv_cache_k_layer",
-          "cast": "const float*"
-        },
-        {
-          "name": "v_cache",
-          "source": "runtime:kv_cache_v_layer",
-          "cast": "const float*"
-        },
-        {
-          "name": "out_token",
-          "source": "output:out",
-          "cast": "float*"
-        },
-        {
-          "name": "num_heads",
-          "source": "dim:num_heads"
-        },
-        {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
-        },
-        {
-          "name": "kv_tokens",
-          "source": "runtime:kv_tokens"
-        },
-        {
-          "name": "cache_capacity",
-          "source": "dim:max_seq_len"
-        },
-        {
-          "name": "head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "aligned_head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "sliding_window",
-          "source": "dim:sliding_window"
+          "name": "eps",
+          "source": "dim:rms_eps"
         }
       ]
     },
@@ -1493,19 +1604,19 @@
       "note": "Gemma4 RoPE uses per-layer frequency base and optional full-attention frequency factors.",
       "params": [
         {
+          "cast": "float*",
           "name": "q",
-          "source": "scratch:q_scratch",
-          "cast": "float*"
+          "source": "scratch:q_scratch"
         },
         {
+          "cast": "float*",
           "name": "k",
-          "source": "scratch:k_scratch",
-          "cast": "float*"
+          "source": "scratch:k_scratch"
         },
         {
+          "cast": "const float*",
           "name": "freq_factors",
-          "source": "weight_f:rope_freqs",
-          "cast": "const float*"
+          "source": "weight_f:rope_freqs"
         },
         {
           "name": "use_freq_factors",
@@ -1545,71 +1656,184 @@
         }
       ]
     },
-    "gemma4_v_norm_forward": {
+    "rowwise_bias_add": {
+      "note": "Explicit in-place rowwise bias binding for vision/header bring-up.",
       "params": [
         {
+          "cast": "float*",
+          "name": "x",
+          "source": "output:x"
+        },
+        {
+          "cast": "const float*",
+          "name": "bias",
+          "source": "weight:bias"
+        },
+        {
+          "name": "rows",
+          "source": "dim:rows"
+        },
+        {
+          "name": "dim",
+          "source": "dim:dim"
+        }
+      ]
+    },
+    "spatial_merge_contiguous_tiled": {
+      "note": "Merge contiguous groups of merge_size^2 tokens from a merged-tile-ordered stream.",
+      "params": [
+        {
+          "cast": "const float*",
           "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
+          "source": "activation:input"
         },
         {
+          "cast": "float*",
           "name": "output",
-          "source": "output:output",
-          "cast": "float*"
+          "source": "output:output"
         },
         {
-          "name": "rstd_cache",
-          "source": "null"
+          "name": "grid_h",
+          "source": "dim:vision_grid_h"
         },
         {
-          "name": "tokens",
-          "source": "dim:seq_len"
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "merge_size",
+          "source": "dim:merge_size"
+        }
+      ]
+    },
+    "split_qkv_packed_head_major_forward": {
+      "note": "Split packed token-major QKV rows into head-major Q/K/V buffers for transformer attention.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "packed_qkv",
+          "source": "activation:packed_qkv"
+        },
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "output:q"
+        },
+        {
+          "cast": "float*",
+          "name": "k",
+          "source": "output:k"
+        },
+        {
+          "cast": "float*",
+          "name": "v",
+          "source": "output:v"
+        },
+        {
+          "name": "rows",
+          "source": "runtime:seq_len"
+        },
+        {
+          "name": "q_dim",
+          "source": "dim:q_dim"
+        },
+        {
+          "name": "k_dim",
+          "source": "dim:k_dim"
+        },
+        {
+          "name": "v_dim",
+          "source": "dim:v_dim"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        }
+      ]
+    },
+    "vision_position_ids_2d_merge": {
+      "note": "Materialize merged-tile vision position IDs for position-driven M-RoPE.",
+      "params": [
+        {
+          "cast": "int32_t*",
+          "name": "positions",
+          "source": "output:positions"
+        },
+        {
+          "name": "grid_h",
+          "source": "dim:vision_grid_h"
+        },
+        {
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "merge_size",
+          "source": "dim:merge_size"
+        }
+      ]
+    },
+    "rope_forward_qk_split_direct_f32": {
+      "note": "Generic split-half direct RoPE with per-layer theta/rotary_dim and optional frequency factors.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "k",
+          "source": "scratch:k_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "freq_factors",
+          "source": "weight_f:rope_freqs"
+        },
+        {
+          "name": "use_freq_factors",
+          "source": "dim:use_rope_freq_factors"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
         },
         {
           "name": "num_kv_heads",
           "source": "dim:num_kv_heads"
         },
         {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
           "name": "head_dim",
           "source": "dim:head_dim"
         },
         {
-          "name": "eps",
-          "source": "dim:rms_eps"
-        }
-      ]
-    },
-    "rmsnorm_forward_no_weight": {
-      "params": [
-        {
-          "name": "input",
-          "source": "activation:input",
-          "cast": "const float*"
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
         },
         {
-          "name": "output",
-          "source": "output:output",
-          "cast": "float*"
+          "name": "pos_offset",
+          "source": "runtime:pos"
         },
         {
-          "name": "rstd_cache",
-          "source": "null"
+          "name": "rotary_dim",
+          "source": "dim:rotary_dim"
         },
         {
-          "name": "tokens",
-          "source": "dim:seq_len"
-        },
-        {
-          "name": "d_model",
-          "source": "dim:_output_dim"
-        },
-        {
-          "name": "aligned_embed_dim",
-          "source": "dim:_output_dim"
-        },
-        {
-          "name": "eps",
-          "source": "dim:rms_eps"
+          "name": "freq_base",
+          "source": "dim:rope_freq_base"
         }
       ]
     }

--- a/version/v8/kernel_maps/rope_forward_qk_gemma4.json
+++ b/version/v8/kernel_maps/rope_forward_qk_gemma4.json
@@ -29,7 +29,16 @@
       "desc": "Key tensor [kv_heads, tokens, head_dim] to be rotated in-place"
     }
   ],
-  "weights": [{"name": "rope_freqs", "dtype": "fp32", "shape": ["rotary_dim/2"], "desc": "Gemma4 full-attention proportional RoPE frequency factors; ignored for sliding layers"}],
+  "weights": [
+    {
+      "name": "rope_freqs",
+      "dtype": "fp32",
+      "shape": [
+        "rotary_dim/2"
+      ],
+      "desc": "Gemma4 full-attention proportional RoPE frequency factors; ignored for sliding layers"
+    }
+  ],
   "activations": [],
   "runtime_buffers": [
     {
@@ -138,8 +147,8 @@
     "notes": "D should be multiple of 64 for optimal SIMD. D is the unpadded dimension; AD is used for alignment."
   },
   "impl": {
-    "function": "rope_forward_qk_gemma4_direct",
-    "c_declaration": "void rope_forward_qk_gemma4_direct(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+    "function": "rope_forward_qk_split_direct_f32",
+    "c_declaration": "void rope_forward_qk_split_direct_f32(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
     "sources": [
       "src/kernels/rope_kernels.c"
     ],
@@ -187,5 +196,5 @@
       }
     ]
   },
-  "notes": "Rotary Position Embedding (RoPE) for queries and keys. Applies rotation in complex plane: x_rot = x * cos(theta) + rotate_half(x) * sin(theta). Only rotates first rotary_dim channels; remaining channels pass through unchanged. Gemma4 variant uses max_rotary_dim as cache row stride so sliding/full layers can share one RoPE cache."
+  "notes": "Compatibility map for Gemma4 templates. The implementation is the generic split-half direct RoPE path, selected by rope_layout=split and rope_param_mode=per_layer_direct in new templates."
 }

--- a/version/v8/kernel_maps/rope_forward_qk_split_direct.json
+++ b/version/v8/kernel_maps/rope_forward_qk_split_direct.json
@@ -1,0 +1,122 @@
+{
+  "id": "rope_forward_qk_split_direct",
+  "op": "rope",
+  "variant": "fp32_head_major_split_half_direct",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor [heads, tokens, head_dim] to be rotated in-place"
+    },
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "D"
+      ],
+      "desc": "Key tensor [kv_heads, tokens, head_dim] to be rotated in-place"
+    }
+  ],
+  "weights": [
+    {
+      "name": "rope_freqs",
+      "dtype": "fp32",
+      "shape": [
+        "rotary_dim/2"
+      ],
+      "desc": "Optional proportional RoPE frequency factors; ignored when use_rope_freq_factors=0"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor after split-half RoPE application"
+    },
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "D"
+      ],
+      "desc": "Key tensor after split-half RoPE application"
+    }
+  ],
+  "dims": [
+    "H",
+    "KV",
+    "T",
+    "D",
+    "rotary_dim"
+  ],
+  "params": [
+    {
+      "name": "aligned_head_dim",
+      "dtype": "int32",
+      "desc": "Aligned head dimension for SIMD"
+    },
+    {
+      "name": "pos_offset",
+      "dtype": "int32",
+      "desc": "Absolute position offset"
+    },
+    {
+      "name": "rotary_dim",
+      "dtype": "int32",
+      "desc": "RoPE rotary dimensions"
+    },
+    {
+      "name": "freq_base",
+      "dtype": "float32",
+      "source": "dim:rope_freq_base",
+      "desc": "Per-layer RoPE theta/base"
+    }
+  ],
+  "impl": {
+    "function": "rope_forward_qk_split_direct_f32",
+    "c_declaration": "void rope_forward_qk_split_direct_f32(float *q, float *k, const float *freq_factors, int use_freq_factors, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+    "sources": [
+      "src/kernels/rope_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_rope.py"
+    ],
+    "parity": [
+      {
+        "kind": "torch",
+        "command": "python version/v8/scripts/gemma4_answer_parity_debug_v8.py --debug-hidden",
+        "tolerance": "1e-5",
+        "notes": "Validated against HF split-half rotate_half semantics for direct per-layer theta RoPE."
+      }
+    ]
+  },
+  "notes": "Generic split-half direct RoPE for models that need per-layer theta/rotary_dim and optional frequency factors instead of one precomputed cache. Gemma4 is the first v8 user, but the contract is model-neutral."
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -2540,6 +2540,7 @@ def _backfill_vision_contract_config(manifest: Dict[str, Any]) -> None:
         else vision_position_contract.get("rope_layout")
     )
     rope_mode = attention_contract.get("rope_mode")
+    rope_param_mode = attention_contract.get("rope_param_mode")
     position_rank = vision_position_contract.get("position_rank")
 
     if image_size > 0:
@@ -2551,6 +2552,8 @@ def _backfill_vision_contract_config(manifest: Dict[str, Any]) -> None:
         config.setdefault("rope_layout", str(rope_layout))
     if rope_mode is not None and str(rope_mode).strip():
         config.setdefault("rope_mode", str(rope_mode))
+    if rope_param_mode is not None and str(rope_param_mode).strip():
+        config.setdefault("rope_param_mode", str(rope_param_mode))
     if position_rank is not None:
         config.setdefault("position_rank", int(position_rank))
 
@@ -2728,7 +2731,10 @@ def apply_layer_attention_dims(op_name: str, params: Dict, layer: int, config: D
     sliding_window = _config_layer_int(config, "layer_sliding_window", layer, int(config.get("sliding_window", 0) or 0))
     rope_kinds = config.get("layer_rope_kind")
     rope_kind = str(rope_kinds[layer]) if isinstance(rope_kinds, list) and 0 <= layer < len(rope_kinds) else ("swa" if sliding_window > 0 else "full")
-    rope_freq_base = float(config.get("rope_theta_swa" if rope_kind == "swa" else "rope_theta", config.get("rope_theta", 10000.0)) or 10000.0)
+    if rope_kind == "swa":
+        rope_freq_base = float(config.get("rope_theta_swa", 10000.0) or 10000.0)
+    else:
+        rope_freq_base = float(config.get("rope_theta", 1000000.0) or 1000000.0)
 
     if op_name == "q_proj":
         params["_output_dim"] = q_dim
@@ -2941,6 +2947,9 @@ def _normalize_manifest_config(config: Dict) -> Dict:
     rope_layout_value = _pick("rope_layout")
     if rope_layout_value is not None and str(rope_layout_value).strip():
         out["rope_layout"] = str(rope_layout_value)
+    rope_param_mode_value = _pick("rope_param_mode")
+    if rope_param_mode_value is not None and str(rope_param_mode_value).strip():
+        out["rope_param_mode"] = str(rope_param_mode_value)
     out["rope_original_context_length"] = int(
         _pick("rope_original_context_length", default=out.get("context_length", 0))
     )
@@ -3178,6 +3187,7 @@ def _normalize_rope_layout_value(value: Any) -> str:
     aliases = {
         "standard": "split",
         "cos_sin_split": "split",
+        "split_half": "split",
         "half": "split",
         "pairwise": "pairwise",
         "interleaved": "pairwise",
@@ -3191,6 +3201,7 @@ def _normalize_rope_layout_value(value: Any) -> str:
 
 def _resolve_rope_qk_kernel(config: Dict, template_kernels: Dict[str, Any]) -> str:
     rope_layout = _normalize_rope_layout_value(config.get("rope_layout"))
+    rope_param_mode = str(config.get("rope_param_mode", "") or "").strip().lower()
     override = str(template_kernels.get("rope_qk", "") or "").strip()
 
     if rope_layout == "pairwise":
@@ -3201,6 +3212,8 @@ def _resolve_rope_qk_kernel(config: Dict, template_kernels: Dict[str, Any]) -> s
     if rope_layout == "split":
         if override and "pairwise" not in override.lower():
             return override
+        if rope_param_mode in {"direct", "per_layer", "per_layer_direct"}:
+            return "rope_forward_qk_split_direct"
         return "rope_forward_qk"
 
     if rope_layout == "multi_section_1d":
@@ -4374,6 +4387,15 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             # The head-major attention projection kernel (ck_attention_project_head_major_quant)
             # was from ckernel_orchestration.c which is not used in v7.
             # Fall through to standard matmul handling below.
+
+            # Gemma4 per-layer prepare is a structured header op, not a
+            # dense projection. It owns BF16/quantized weights internally and
+            # must stay on its dedicated kernel regardless of source dtype.
+            if op == "gemma4_per_layer_prepare":
+                token_dtype = layer_quant.get("per_layer_token_emb", header_quant.get("per_layer_token_emb", ""))
+                if token_dtype == "bf16":
+                    return ["gemma4_per_layer_prepare_bf16_forward"]
+                return ["gemma4_per_layer_prepare_forward"]
 
             # Try fused kernel first (e.g., qkv_projection)
             weight_dtype = layer_quant.get(weight_info[0], "fp32")

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -889,6 +889,41 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
+    if op_name in {"q_proj", "q_gate_proj", "k_proj", "v_proj"} and function == "gemv_bf16":
+        arg_expr_by_name = {}
+        for arg in args:
+            nm = str(arg.get("name", "")).lower()
+            ex = str(arg.get("expr", ""))
+            if nm and ex and nm not in arg_expr_by_name:
+                arg_expr_by_name[nm] = ex
+
+        y_expr = arg_expr_by_name.get("y")
+        w_expr = arg_expr_by_name.get("w")
+        x_expr = arg_expr_by_name.get("x")
+        m_expr = arg_expr_by_name.get("m")
+        k_expr = arg_expr_by_name.get("k")
+        if y_expr and w_expr and x_expr and m_expr and k_expr:
+            if profile:
+                lines.append("    CK_PROFILE_BEGIN();")
+            lines.append("    gemv_bf16(")
+            lines.append(f"        {y_expr},")
+            lines.append(f"        {w_expr},")
+            lines.append(f"        {x_expr},")
+            lines.append(f"        {m_expr},")
+            lines.append(f"        {k_expr}")
+            lines.append("    );")
+            if profile:
+                lines.append(f'    CK_PROFILE_END("decode", "gemv_bf16", "{op_name}", {layer});')
+            raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            hidden_label = "q_proj" if op_name == "q_gate_proj" else op_name
+            lines.append(
+                f'    ck_debug_export_hidden(model, {layer}, "{hidden_label}", '
+                f'(const float*){raw_expr}, {m_expr});'
+            )
+            if seq_idx is not None:
+                lines.append(f"    if (stop_seq == {seq_idx}) return;")
+            return "\n".join(lines)
+
     if op_name == "quantize_out_proj_input" and function == "quantize_row_q8_k":
         arg_expr_by_name = {}
         for arg in args:
@@ -1009,6 +1044,43 @@ def emit_op(
                 lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "logits", {m_expr});')
                 lines.append("        #endif")
             lines.append("    }")
+            if seq_idx is not None:
+                lines.append(f"    if (stop_seq == {seq_idx}) return;")
+            return "\n".join(lines)
+
+    if op_name == "out_proj" and function == "gemv_bf16":
+        arg_expr_by_name = {}
+        for arg in args:
+            nm = str(arg.get("name", "")).lower()
+            ex = str(arg.get("expr", ""))
+            if nm and ex and nm not in arg_expr_by_name:
+                arg_expr_by_name[nm] = ex
+        y_expr = arg_expr_by_name.get("y")
+        w_expr = arg_expr_by_name.get("w")
+        x_expr = arg_expr_by_name.get("x")
+        m_expr = arg_expr_by_name.get("m")
+        k_expr = arg_expr_by_name.get("k")
+        if y_expr and w_expr and x_expr and m_expr and k_expr:
+            lines.append(
+                f"    ck_debug_export_hidden(model, {layer}, \"attn_out\", "
+                f"(const float*)({x_expr}), {k_expr});"
+            )
+            if profile:
+                lines.append("    CK_PROFILE_BEGIN();")
+            lines.append(f"    {function}(")
+            lines.append(f"        {y_expr},")
+            lines.append(f"        {w_expr},")
+            lines.append(f"        {x_expr},")
+            lines.append(f"        {m_expr},")
+            lines.append(f"        {k_expr}")
+            lines.append("    );")
+            if profile:
+                lines.append(f"    CK_PROFILE_END(\"decode\", \"{function}\", \"{op_name}\", {layer});")
+            raw_expr = y_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append(
+                f"    ck_debug_export_hidden(model, {layer}, \"out_proj\", "
+                f"(const float*){raw_expr}, {m_expr});"
+            )
             if seq_idx is not None:
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -148,7 +148,7 @@ def _last_token_row_offset_expr(func_name: str, embed_dim: int) -> Optional[str]
         return f"(size_t)(num_tokens - 1) * (size_t)({embed_dim} / QK_K) * sizeof(block_q8_K)"
     if "q8_0" in fn:
         return f"(size_t)(num_tokens - 1) * (size_t)({embed_dim} / QK8_0) * sizeof(block_q8_0)"
-    if "fp32" in fn or "f32" in fn:
+    if "fp32" in fn or "f32" in fn or "bf16" in fn:
         return f"(size_t)(num_tokens - 1) * (size_t){embed_dim} * sizeof(float)"
     # Conservative default for q8_0-style activation packing.
     row_bytes = _q8_0_row_bytes(embed_dim)
@@ -224,7 +224,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         (const void*)(((const uint8_t*)({input_expr})) + {row_offset_expr}),
         {vocab_size},
         {embed_dim}
-    );"""
+    );
+    ck_debug_export_hidden(model, -1, "logits", (const float*){output_expr}, VOCAB_SIZE);"""
 
     if op_type == "kv_cache_batch_copy":
         # Copy K/V from scratch (head-major after transpose) to KV cache

--- a/version/v8/scripts/compare_gemma4_torch_ck_hidden_v8.py
+++ b/version/v8/scripts/compare_gemma4_torch_ck_hidden_v8.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Compare Gemma4 PyTorch layer-boundary tensors against CK hidden dumps.
+
+This script is intentionally model-file based: pass a local HF/Transformers
+Gemma4 safetensors directory plus a CK_DEBUG_EXPORT_HIDDEN output directory.
+It dumps the PyTorch last-token layer stream and compares labels that CK already
+exports.  The first pass focuses on stable graph boundaries, because those are
+the right places to distinguish stitching bugs from lower-level kernel drift.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _parse_tokens_csv(text: str) -> list[int]:
+    out: list[int] = []
+    for part in text.split(","):
+        part = part.strip()
+        if part:
+            out.append(int(part))
+    if not out:
+        raise SystemExit("--tokens did not contain any token IDs")
+    return out
+
+
+def _to_numpy_f32(x: Any) -> np.ndarray:
+    return x.detach().float().cpu().numpy().astype(np.float32, copy=False)
+
+
+def _compare(a: np.ndarray, b: np.ndarray) -> dict[str, Any]:
+    af = a.reshape(-1).astype(np.float64)
+    bf = b.reshape(-1).astype(np.float64)
+    n = min(int(af.size), int(bf.size))
+    if n <= 0:
+        return {"compared": 0, "error": "empty input"}
+    af = af[:n]
+    bf = bf[:n]
+    diff = af - bf
+    denom = float(np.linalg.norm(af) * np.linalg.norm(bf))
+    max_idx = int(np.argmax(np.abs(diff)))
+    return {
+        "a_size": int(a.size),
+        "b_size": int(b.size),
+        "compared": n,
+        "cosine": float(np.dot(af, bf) / denom) if denom else float("nan"),
+        "rmse": float(np.sqrt(np.mean(diff * diff))),
+        "mean_abs": float(np.mean(np.abs(diff))),
+        "max_abs": float(np.max(np.abs(diff))),
+        "max_idx": max_idx,
+        "torch_at_max": float(af[max_idx]),
+        "ck_at_max": float(bf[max_idx]),
+    }
+
+
+def _ck_name(token_index: int, layer: int, label: str) -> str:
+    if layer < 0:
+        return f"tok_{token_index:04d}_layer_-01_{label}.f32"
+    return f"tok_{token_index:04d}_layer_{layer:03d}_{label}.f32"
+
+
+def _load_ck_vector(ck_dir: Path, ck_token_index: int, layer: int, label: str) -> tuple[np.ndarray, Path] | tuple[None, None]:
+    candidates = [ck_dir / _ck_name(ck_token_index, layer, label)]
+    if not label.endswith("_last"):
+        candidates.append(ck_dir / _ck_name(ck_token_index, layer, f"{label}_last"))
+    for path in candidates:
+        if path.exists():
+            return np.fromfile(path, dtype=np.float32), path
+    return None, None
+
+
+def _torch_dtype(name: str):
+    import torch
+
+    if name == "float32":
+        return torch.float32
+    if name == "bfloat16":
+        return torch.bfloat16
+    if name == "float16":
+        return torch.float16
+    raise ValueError(name)
+
+
+def _load_input_ids(args: argparse.Namespace):
+    import torch
+
+    if args.tokens:
+        ids = _parse_tokens_csv(args.tokens)
+    else:
+        if not args.prompt:
+            raise SystemExit("provide either --tokens or --prompt")
+        try:
+            from transformers import AutoTokenizer
+        except ImportError as exc:
+            raise SystemExit("transformers is required for --prompt tokenization") from exc
+        tok = AutoTokenizer.from_pretrained(args.model, trust_remote_code=args.trust_remote_code)
+        ids = tok(args.prompt, add_special_tokens=not args.no_special_tokens)["input_ids"]
+    if args.max_tokens and len(ids) > args.max_tokens:
+        ids = ids[: int(args.max_tokens)]
+    return torch.tensor([ids], dtype=torch.long), ids
+
+
+def _get_attr_path(obj: Any, path: str) -> Any | None:
+    cur = obj
+    for part in path.split("."):
+        if not hasattr(cur, part):
+            return None
+        cur = getattr(cur, part)
+    return cur
+
+
+def _find_language_layers(model: Any) -> Any | None:
+    for path in ("model.language_model.layers", "language_model.layers", "model.layers"):
+        layers = _get_attr_path(model, path)
+        if layers is not None:
+            return layers
+    return None
+
+
+def _last_token_vec_from_output(x: Any, token_index: int) -> np.ndarray:
+    if isinstance(x, tuple):
+        x = x[0]
+    t = x.detach().float().cpu()
+    if t.ndim == 3:
+        t = t[0, token_index, :]
+    elif t.ndim == 4:
+        # Gemma4 attention internals are usually [B, T, H, D] before
+        # transpose and [B, H, T, D] after transpose. Hooked q/k/v norm
+        # modules use the former; this fallback keeps later attention hooks
+        # usable if Transformers changes one of those local layouts.
+        if t.shape[1] > token_index:
+            t = t[0, token_index, :, :]
+        elif t.shape[2] > token_index:
+            t = t[0, :, token_index, :]
+        else:
+            t = t.reshape(-1)
+    elif t.ndim == 2:
+        t = t[token_index, :]
+    else:
+        t = t.reshape(-1)
+    return t.numpy().astype(np.float32, copy=False)
+
+
+def _maybe_get_logits(outputs: Any) -> np.ndarray | None:
+    logits = getattr(outputs, "logits", None)
+    if logits is None:
+        return None
+    return _to_numpy_f32(logits[0, -1, :])
+
+
+def export_and_compare(args: argparse.Namespace) -> dict[str, Any]:
+    import torch
+    from transformers import AutoModelForCausalLM
+
+    model_dir = Path(args.model)
+    ck_dir = Path(args.ck_hidden_dir)
+    torch_out = Path(args.torch_out) if args.torch_out else None
+    if torch_out:
+        torch_out.mkdir(parents=True, exist_ok=True)
+
+    dtype = _torch_dtype(args.dtype)
+    input_ids, ids = _load_input_ids(args)
+    token_index = int(args.token_index)
+    if token_index < 0:
+        token_index = len(ids) + token_index
+    if token_index < 0 or token_index >= len(ids):
+        raise SystemExit(f"--token-index out of range for {len(ids)} tokens: {args.token_index}")
+    ck_token_index = token_index if args.ck_token_index is None else int(args.ck_token_index)
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_dir,
+        torch_dtype=dtype,
+        device_map=None,
+        low_cpu_mem_usage=True,
+        trust_remote_code=args.trust_remote_code,
+    )
+    model.eval()
+
+    layer_hook_outputs: dict[int, np.ndarray] = {}
+    op_hook_outputs: dict[tuple[int, str], np.ndarray] = {}
+    input_hook_outputs: dict[tuple[int, str], np.ndarray] = {}
+    hook_handles = []
+    if args.layer_source == "hooks":
+        layers = _find_language_layers(model)
+        if layers is None:
+            raise SystemExit("unable to find language model layers for --layer-source hooks")
+        for idx, layer_module in enumerate(layers):
+            def make_hook(layer_idx: int):
+                def hook(_module: Any, _inp: Any, out: Any) -> None:
+                    layer_hook_outputs[layer_idx] = _last_token_vec_from_output(out, token_index)
+                return hook
+            hook_handles.append(layer_module.register_forward_hook(make_hook(idx)))
+            if args.include_op_hooks:
+                op_map = (
+                    ("self_attn.q_proj", "q_proj"),
+                    ("self_attn.k_proj", "k_proj"),
+                    ("self_attn.v_proj", "v_proj"),
+                    ("self_attn.q_norm", "qk_norm_q"),
+                    ("self_attn.k_norm", "qk_norm_k"),
+                    ("self_attn.v_norm", "v_norm"),
+                    ("self_attn.o_proj", "out_proj"),
+                    ("self_attn", "attn_module"),
+                    ("post_attention_layernorm", "post_attn_norm"),
+                    ("pre_feedforward_layernorm", "ffn_norm"),
+                    ("mlp", "mlp_down"),
+                    ("post_feedforward_layernorm", "post_ffn_norm"),
+                    ("post_per_layer_input_norm", "post_per_layer_input_norm"),
+                )
+                for attr, label in op_map:
+                    module = _get_attr_path(layer_module, attr)
+                    if module is None:
+                        continue
+                    def make_op_hook(layer_idx: int, hook_label: str):
+                        def hook(_module: Any, _inp: Any, out: Any) -> None:
+                            op_hook_outputs[(layer_idx, hook_label)] = _last_token_vec_from_output(out, token_index)
+                        return hook
+                    hook_handles.append(module.register_forward_hook(make_op_hook(idx, label)))
+                    if attr == "self_attn.o_proj":
+                        def make_input_hook(layer_idx: int):
+                            def hook(_module: Any, inp: Any) -> None:
+                                if inp:
+                                    input_hook_outputs[(layer_idx, "attn_out")] = _last_token_vec_from_output(inp[0], token_index)
+                            return hook
+                        hook_handles.append(module.register_forward_pre_hook(make_input_hook(idx)))
+
+    with torch.no_grad():
+        outputs = model(
+            input_ids=input_ids,
+            use_cache=False,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+    for handle in hook_handles:
+        handle.remove()
+
+    hidden_states = list(getattr(outputs, "hidden_states", ()) or ())
+    rows: list[dict[str, Any]] = []
+
+    def add_row(label: str, layer: int, torch_vec: np.ndarray, ck_label: str) -> None:
+        if torch_out:
+            torch_vec.astype(np.float32, copy=False).tofile(torch_out / _ck_name(token_index, layer, label))
+        ck_vec, ck_path = _load_ck_vector(ck_dir, ck_token_index, layer, ck_label)
+        row: dict[str, Any] = {
+            "layer": layer,
+            "torch": label,
+            "ck": ck_label,
+            "ck_path": str(ck_path) if ck_path else "",
+            "token_index": token_index,
+            "token_id": int(ids[token_index]),
+            "status": "missing_ck" if ck_vec is None else "ok",
+        }
+        if ck_vec is not None:
+            row.update(_compare(torch_vec, ck_vec))
+        rows.append(row)
+
+    if hidden_states:
+        # hidden_states[0] is post-token-embedding; hidden_states[i+1] is layer i output
+        # in the standard HF decoder API.
+        emb = _to_numpy_f32(hidden_states[0][0, token_index, :])
+        add_row("embedding", -2, emb, args.ck_embedding_label)
+
+    if args.layer_source == "hooks":
+        for layer, label in sorted(input_hook_outputs):
+            add_row(label, layer, input_hook_outputs[(layer, label)], label)
+        for layer, label in sorted(op_hook_outputs):
+            add_row(label, layer, op_hook_outputs[(layer, label)], label)
+        for layer in sorted(layer_hook_outputs):
+            add_row("layer_out", layer, layer_hook_outputs[layer], args.ck_layer_out_label)
+    elif hidden_states:
+        for layer, hs in enumerate(hidden_states[1:]):
+            add_row("layer_out", layer, _to_numpy_f32(hs[0, token_index, :]), args.ck_layer_out_label)
+
+    logits = _maybe_get_logits(outputs)
+    if logits is not None:
+        if torch_out:
+            logits.astype(np.float32, copy=False).tofile(torch_out / _ck_name(token_index, -1, "logits"))
+        ck_logits, ck_logits_path = _load_ck_vector(ck_dir, ck_token_index, -1, "logits")
+        row = {
+            "layer": -1,
+            "torch": "logits",
+            "ck": "logits",
+            "ck_path": str(ck_logits_path) if ck_logits_path else "",
+            "token_index": token_index,
+            "token_id": int(ids[token_index]),
+            "status": "missing_ck" if ck_logits is None else "ok",
+        }
+        if ck_logits is not None:
+            row.update(_compare(logits, ck_logits))
+            row["torch_top1"] = int(np.argmax(logits))
+            row["ck_top1"] = int(np.argmax(ck_logits))
+        rows.append(row)
+
+    first_bad: dict[str, Any] | None = None
+    for row in rows:
+        if row.get("status") != "ok":
+            continue
+        if float(row.get("cosine", 1.0)) < float(args.cosine_threshold) or float(row.get("max_abs", 0.0)) > float(args.max_abs_threshold):
+            first_bad = row
+            break
+
+    return {
+        "model": str(model_dir),
+        "ck_hidden_dir": str(ck_dir),
+        "tokens": ids,
+        "token_index": token_index,
+        "ck_token_index": ck_token_index,
+        "num_rows": len(rows),
+        "first_bad": first_bad,
+        "rows": rows,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, type=Path, help="local HF/Transformers safetensors model directory")
+    ap.add_argument("--ck-hidden-dir", required=True, type=Path, help="directory produced by CK_DEBUG_EXPORT_HIDDEN")
+    ap.add_argument("--tokens", help="comma-separated token IDs; avoids tokenizer/template ambiguity")
+    ap.add_argument("--prompt", help="prompt text to tokenize with the HF tokenizer")
+    ap.add_argument("--no-special-tokens", action="store_true", help="do not add tokenizer special tokens for --prompt")
+    ap.add_argument("--max-tokens", type=int, default=0)
+    ap.add_argument("--token-index", type=int, default=-1, help="PyTorch token row to compare; default is last token")
+    ap.add_argument("--ck-token-index", type=int, help="CK dump token index to read; useful because batched prefill last-row dumps use tok_0000")
+    ap.add_argument("--ck-layer-out-label", default="gemma4_per_layer_embed", help="CK label corresponding to the PyTorch decoder layer output")
+    ap.add_argument("--ck-embedding-label", default="embedding_scaled", help="CK label corresponding to PyTorch embedding hidden state")
+    ap.add_argument("--layer-source", choices=("hooks", "hidden_states"), default="hooks", help="Use decoder-layer module hooks or HF output_hidden_states for layer outputs")
+    ap.add_argument("--include-op-hooks", action="store_true", help="with hook-based layer output, also compare stable Gemma4 submodule boundaries")
+    ap.add_argument("--dtype", choices=("float32", "bfloat16", "float16"), default="float32")
+    ap.add_argument("--trust-remote-code", action="store_true")
+    ap.add_argument("--torch-out", type=Path, help="optional directory for PyTorch .f32 dumps")
+    ap.add_argument("--json-out", type=Path)
+    ap.add_argument("--cosine-threshold", type=float, default=0.999)
+    ap.add_argument("--max-abs-threshold", type=float, default=1e-2)
+    args = ap.parse_args()
+
+    result = export_and_compare(args)
+    text = json.dumps(result, indent=2, sort_keys=True)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -397,7 +397,13 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
     cfg.setdefault("head_dim", text.get("head_dim") or (int(text.get("hidden_size", 0)) // max(1, int(text.get("num_attention_heads", 1)))))
     cfg.setdefault("vocab_size", text.get("vocab_size"))
     cfg.setdefault("context_length", text.get("max_position_embeddings") or text.get("sliding_window"))
-    cfg.setdefault("rope_theta", text.get("rope_theta", 1000000.0))
+    rope_params = text.get("rope_parameters") if isinstance(text.get("rope_parameters"), dict) else {}
+    full_rope = rope_params.get("full_attention") if isinstance(rope_params.get("full_attention"), dict) else {}
+    sliding_rope = rope_params.get("sliding_attention") if isinstance(rope_params.get("sliding_attention"), dict) else {}
+    cfg.setdefault("rope_theta", full_rope.get("rope_theta", text.get("rope_theta", 1000000.0)))
+    cfg.setdefault("rope_theta_swa", sliding_rope.get("rope_theta", 10000.0))
+    cfg.setdefault("rope_layout", "split")
+    cfg.setdefault("rope_param_mode", "per_layer_direct")
     cfg.setdefault("rms_eps", text.get("rms_norm_eps", text.get("rms_norm_epsilon", 1e-6)))
     cfg.setdefault("rms_norm_eps", cfg.get("rms_eps"))
     cfg.setdefault("tie_word_embeddings", bool(text.get("tie_word_embeddings", True)))

--- a/version/v8/scripts/export_ck_hidden_v8.py
+++ b/version/v8/scripts/export_ck_hidden_v8.py
@@ -16,11 +16,17 @@ import ctypes
 import os
 from pathlib import Path
 
-from compare_ck_prefill_decode_logits_v8 import _init_model  # type: ignore
+from compare_ck_prefill_decode_logits_v8 import _extract_logits, _init_model  # type: ignore
 from compare_first_token_logits_v8 import discover_ck_model_dir, parse_tokens_csv  # type: ignore
 
 
-def export_ck_hidden(model_dir: Path, tokens: list[int], out_dir: Path, mode: str = "decode") -> None:
+def export_ck_hidden(
+    model_dir: Path,
+    tokens: list[int],
+    out_dir: Path,
+    mode: str = "decode",
+    prompt_length: int | None = None,
+) -> None:
     model_dir = discover_ck_model_dir(model_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     for old in out_dir.glob("*.f32"):
@@ -41,6 +47,9 @@ def export_ck_hidden(model_dir: Path, tokens: list[int], out_dir: Path, mode: st
     if hasattr(lib, "ck_model_kv_cache_reset"):
         lib.ck_model_kv_cache_reset.argtypes = []
         lib.ck_model_kv_cache_reset.restype = None
+    if hasattr(lib, "ck_model_get_vocab_size"):
+        lib.ck_model_get_vocab_size.argtypes = []
+        lib.ck_model_get_vocab_size.restype = ctypes.c_int
     if hasattr(lib, "ck_model_free"):
         lib.ck_model_free.argtypes = []
         lib.ck_model_free.restype = None
@@ -65,8 +74,42 @@ def export_ck_hidden(model_dir: Path, tokens: list[int], out_dir: Path, mode: st
             rc = lib.ck_model_forward(None)
             if rc != 0:
                 raise RuntimeError(f"ck_model_forward failed rc={rc}")
+        elif mode == "prefill-decode":
+            if not hasattr(lib, "ck_model_embed_tokens") or not hasattr(lib, "ck_model_forward"):
+                raise RuntimeError("ck_model_embed_tokens/ck_model_forward unavailable")
+            if prompt_length is None:
+                raise RuntimeError("--prompt-length is required for --mode prefill-decode")
+            prompt_length = int(prompt_length)
+            if prompt_length <= 0 or prompt_length > len(tokens):
+                raise RuntimeError(f"invalid prompt_length={prompt_length} for {len(tokens)} tokens")
+            arr = (ctypes.c_int32 * prompt_length)(*[int(t) for t in tokens[:prompt_length]])
+            rc = lib.ck_model_embed_tokens(arr, prompt_length)
+            if rc != 0:
+                raise RuntimeError(f"ck_model_embed_tokens failed rc={rc}")
+            rc = lib.ck_model_forward(None)
+            if rc != 0:
+                raise RuntimeError(f"ck_model_forward failed rc={rc}")
+            for tok in tokens[prompt_length:]:
+                rc = lib.ck_model_decode(ctypes.c_int32(int(tok)), None)
+                if rc != 0:
+                    raise RuntimeError(f"ck_model_decode failed rc={rc} token={tok}")
         else:
             raise ValueError(f"unknown mode: {mode}")
+
+        if hasattr(lib, "ck_model_get_vocab_size"):
+            vocab = int(lib.ck_model_get_vocab_size())
+            if vocab > 0:
+                logits, _stride, _active = _extract_logits(lib, vocab, len(tokens))
+                token_indices = []
+                for path in out_dir.glob("tok_*.f32"):
+                    name = path.name
+                    if name.startswith("tok_") and len(name) >= 8:
+                        try:
+                            token_indices.append(int(name[4:8]))
+                        except ValueError:
+                            pass
+                ck_token_index = max(token_indices) if token_indices else 0
+                logits.astype("float32", copy=False).tofile(out_dir / f"tok_{ck_token_index:04d}_layer_-01_logits.f32")
     finally:
         if hasattr(lib, "ck_model_free"):
             lib.ck_model_free()
@@ -77,7 +120,8 @@ def main() -> int:
     ap.add_argument("--model-dir", required=True, type=Path)
     ap.add_argument("--tokens", required=True, help="comma-separated token IDs")
     ap.add_argument("--out-dir", required=True, type=Path)
-    ap.add_argument("--mode", choices=("decode", "prefill"), default="decode")
+    ap.add_argument("--mode", choices=("decode", "prefill", "prefill-decode"), default="decode")
+    ap.add_argument("--prompt-length", type=int, help="number of initial tokens to prefill for --mode prefill-decode")
     args = ap.parse_args()
 
     export_ck_hidden(
@@ -85,6 +129,7 @@ def main() -> int:
         tokens=parse_tokens_csv(args.tokens),
         out_dir=args.out_dir,
         mode=args.mode,
+        prompt_length=args.prompt_length,
     )
     files = sorted(args.out_dir.glob("*.f32"))
     print(f"exported={len(files)} out_dir={args.out_dir}")

--- a/version/v8/scripts/gemma4_answer_parity_debug_v8.py
+++ b/version/v8/scripts/gemma4_answer_parity_debug_v8.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Gemma4 answer-level PyTorch-vs-CK parity/debug harness.
+
+This is deliberately deterministic: it uses the HF tokenizer once, feeds the
+same token IDs to PyTorch and CK, uses greedy argmax generation, and records the
+first generated-token divergence.  When requested, it also exports CK hidden
+snapshots and runs the Gemma4 PyTorch-vs-CK hidden comparator for the exact
+prefix at the divergence point.
+
+Important: current CK Gemma4 artifacts may be Q4 GGUF-derived BUMP, while the
+PyTorch path is BF16 safetensors.  Exact full-answer equality is expected only
+once CK runs the same safetensors/BF16 BUMP weights.  Until then this script is
+used to separate prompt/template/sampler bugs, CK prefill/decode consistency,
+and structural layer drift from ordinary quantization differences.
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from compare_ck_prefill_decode_logits_v8 import _extract_logits, _init_model  # type: ignore
+from compare_first_token_logits_v8 import discover_ck_model_dir  # type: ignore
+
+DEFAULT_PROMPT = "Give me a detailed example of a C, Python, and SQL program."
+
+
+def _torch_dtype(name: str):
+    import torch
+
+    if name == "float32":
+        return torch.float32
+    if name == "bfloat16":
+        return torch.bfloat16
+    if name == "float16":
+        return torch.float16
+    raise ValueError(name)
+
+
+def _topk(logits: np.ndarray, k: int = 10) -> list[dict[str, float | int]]:
+    k = max(1, min(int(k), int(logits.size)))
+    idx = np.argpartition(-logits, k - 1)[:k]
+    idx = idx[np.argsort(-logits[idx])]
+    return [{"token": int(i), "logit": float(logits[int(i)])} for i in idx]
+
+
+def _compare_logits(a: np.ndarray, b: np.ndarray, top_k: int = 20) -> dict[str, Any]:
+    n = min(int(a.size), int(b.size))
+    af = a[:n].astype(np.float64)
+    bf = b[:n].astype(np.float64)
+    diff = af - bf
+    denom = float(np.linalg.norm(af) * np.linalg.norm(bf))
+    a_top = [x["token"] for x in _topk(a, top_k)]
+    b_top = [x["token"] for x in _topk(b, top_k)]
+    return {
+        "top1_a": int(np.argmax(a)),
+        "top1_b": int(np.argmax(b)),
+        "top1_match": int(np.argmax(a)) == int(np.argmax(b)),
+        "cosine": float(np.dot(af, bf) / denom) if denom else float("nan"),
+        "rmse": float(np.sqrt(np.mean(diff * diff))),
+        "mean_abs": float(np.mean(np.abs(diff))),
+        "max_abs": float(np.max(np.abs(diff))),
+        "topk_overlap": int(len(set(a_top).intersection(b_top))),
+        "topk": int(top_k),
+        "a_top": _topk(a, top_k),
+        "b_top": _topk(b, top_k),
+    }
+
+
+def _load_tokenizer(hf_model: Path, trust_remote_code: bool):
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+
+
+def _prompt_tokens(tokenizer: Any, prompt: str, chat_template: bool, add_special_tokens: bool) -> list[int]:
+    if chat_template:
+        messages = [{"role": "user", "content": prompt}]
+        ids = tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=True)
+        if hasattr(ids, "keys") and "input_ids" in ids.keys():
+            ids = ids["input_ids"]
+        elif isinstance(ids, dict):
+            ids = ids.get("input_ids")
+        if hasattr(ids, "tolist"):
+            ids = ids.tolist()
+        if ids and isinstance(ids[0], list):
+            ids = ids[0]
+        return [int(x) for x in ids]
+    return [int(x) for x in tokenizer(prompt, add_special_tokens=add_special_tokens)["input_ids"]]
+
+
+def _decode(tokenizer: Any, token_ids: list[int]) -> str:
+    return tokenizer.decode(token_ids, skip_special_tokens=True)
+
+
+def _run_torch_greedy(
+    hf_model: Path,
+    prompt_tokens: list[int],
+    max_new_tokens: int,
+    dtype: str,
+    trust_remote_code: bool,
+    eos_tokens: set[int],
+) -> dict[str, Any]:
+    import torch
+    from transformers import AutoModelForCausalLM
+
+    model = AutoModelForCausalLM.from_pretrained(
+        hf_model,
+        torch_dtype=_torch_dtype(dtype),
+        low_cpu_mem_usage=True,
+        trust_remote_code=trust_remote_code,
+    )
+    model.eval()
+    device = next(model.parameters()).device
+    input_ids = torch.tensor([prompt_tokens], dtype=torch.long, device=device)
+    generated: list[int] = []
+    step_logits: list[np.ndarray] = []
+    past = None
+    cur = input_ids
+    with torch.no_grad():
+        for step in range(max_new_tokens):
+            out = model(
+                input_ids=cur,
+                past_key_values=past,
+                use_cache=True,
+                return_dict=True,
+            )
+            logits = out.logits[0, -1, :].detach().float().cpu().numpy().astype(np.float32, copy=True)
+            step_logits.append(logits)
+            tok = int(np.argmax(logits))
+            generated.append(tok)
+            if tok in eos_tokens:
+                break
+            past = out.past_key_values
+            cur = torch.tensor([[tok]], dtype=torch.long, device=device)
+    return {"tokens": generated, "logits": step_logits}
+
+
+def _load_ck(model_dir: Path) -> tuple[ctypes.CDLL, int]:
+    model_dir = discover_ck_model_dir(model_dir)
+    lib = ctypes.CDLL(str(model_dir / "libmodel.so"), mode=ctypes.RTLD_GLOBAL)
+    _init_model(lib, model_dir)
+    lib.ck_model_get_vocab_size.argtypes = []
+    lib.ck_model_get_vocab_size.restype = ctypes.c_int
+    vocab = int(lib.ck_model_get_vocab_size())
+    if vocab <= 0:
+        raise RuntimeError(f"invalid CK vocab size: {vocab}")
+    if hasattr(lib, "ck_model_kv_cache_reset"):
+        lib.ck_model_kv_cache_reset.argtypes = []
+        lib.ck_model_kv_cache_reset.restype = None
+    if hasattr(lib, "ck_model_free"):
+        lib.ck_model_free.argtypes = []
+        lib.ck_model_free.restype = None
+    lib.ck_model_embed_tokens.argtypes = [ctypes.POINTER(ctypes.c_int32), ctypes.c_int]
+    lib.ck_model_embed_tokens.restype = ctypes.c_int
+    lib.ck_model_forward.argtypes = [ctypes.POINTER(ctypes.c_float)]
+    lib.ck_model_forward.restype = ctypes.c_int
+    lib.ck_model_decode.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_float)]
+    lib.ck_model_decode.restype = ctypes.c_int
+    return lib, vocab
+
+
+def _run_ck_greedy(
+    ck_model_dir: Path,
+    prompt_tokens: list[int],
+    max_new_tokens: int,
+    eos_tokens: set[int],
+) -> dict[str, Any]:
+    lib, vocab = _load_ck(ck_model_dir)
+    generated: list[int] = []
+    step_logits: list[np.ndarray] = []
+    try:
+        if hasattr(lib, "ck_model_kv_cache_reset"):
+            lib.ck_model_kv_cache_reset()
+        arr = (ctypes.c_int32 * len(prompt_tokens))(*[int(t) for t in prompt_tokens])
+        rc = lib.ck_model_embed_tokens(arr, len(prompt_tokens))
+        if rc != 0:
+            raise RuntimeError(f"ck_model_embed_tokens failed rc={rc}")
+        rc = lib.ck_model_forward(None)
+        if rc != 0:
+            raise RuntimeError(f"ck_model_forward failed rc={rc}")
+        for step in range(max_new_tokens):
+            logits, _stride, _active = _extract_logits(lib, vocab, len(prompt_tokens) + step)
+            step_logits.append(logits)
+            tok = int(np.argmax(logits))
+            generated.append(tok)
+            if tok in eos_tokens:
+                break
+            rc = lib.ck_model_decode(ctypes.c_int32(tok), None)
+            if rc != 0:
+                raise RuntimeError(f"ck_model_decode failed rc={rc} token={tok}")
+    finally:
+        if hasattr(lib, "ck_model_free"):
+            try:
+                lib.ck_model_free()
+            except Exception:
+                pass
+    return {"tokens": generated, "logits": step_logits}
+
+
+def _run_subprocess(cmd: list[str], cwd: Path = REPO_ROOT) -> dict[str, Any]:
+    proc = subprocess.run(cmd, cwd=str(cwd), text=True, capture_output=True, check=False)
+    return {"cmd": cmd, "returncode": proc.returncode, "stdout": proc.stdout, "stderr": proc.stderr}
+
+
+def _hidden_debug(
+    hf_model: Path,
+    ck_model_dir: Path,
+    prefix_tokens: list[int],
+    prompt_token_count: int,
+    out_dir: Path,
+    dtype: str,
+    trust_remote_code: bool,
+    cosine_threshold: float,
+    max_abs_threshold: float,
+) -> dict[str, Any]:
+    ck_hidden = out_dir / "ck_hidden"
+    torch_hidden = out_dir / "torch_hidden"
+    compare_json = out_dir / "hidden_compare.json"
+    token_csv = ",".join(str(t) for t in prefix_tokens)
+    export_mode = "prefill-decode" if len(prefix_tokens) > int(prompt_token_count) else "prefill"
+    export_cmd = [
+        sys.executable,
+        str(SCRIPT_DIR / "export_ck_hidden_v8.py"),
+        "--model-dir",
+        str(ck_model_dir),
+        "--tokens",
+        token_csv,
+        "--out-dir",
+        str(ck_hidden),
+        "--mode",
+        export_mode,
+    ]
+    if export_mode == "prefill-decode":
+        export_cmd.extend(["--prompt-length", str(prompt_token_count)])
+    export_result = _run_subprocess(export_cmd)
+
+    ck_token_index = 0
+    token_re = re.compile(r"tok_(\d+)_")
+    token_indices: list[int] = []
+    for path in ck_hidden.glob("tok_*.f32"):
+        m = token_re.search(path.name)
+        if m:
+            token_indices.append(int(m.group(1)))
+    if token_indices:
+        ck_token_index = max(token_indices)
+
+    compare_cmd = [
+        sys.executable,
+        str(SCRIPT_DIR / "compare_gemma4_torch_ck_hidden_v8.py"),
+        "--model",
+        str(hf_model),
+        "--ck-hidden-dir",
+        str(ck_hidden),
+        "--tokens",
+        token_csv,
+        "--token-index",
+        str(len(prefix_tokens) - 1),
+        "--ck-token-index",
+        str(ck_token_index),
+        "--dtype",
+        dtype,
+        "--torch-out",
+        str(torch_hidden),
+        "--json-out",
+        str(compare_json),
+        "--cosine-threshold",
+        str(cosine_threshold),
+        "--max-abs-threshold",
+        str(max_abs_threshold),
+        "--layer-source",
+        "hooks",
+        "--include-op-hooks",
+    ]
+    if trust_remote_code:
+        compare_cmd.append("--trust-remote-code")
+    compare_result = _run_subprocess(compare_cmd)
+    parsed = None
+    if compare_json.exists():
+        parsed = json.loads(compare_json.read_text(encoding="utf-8"))
+    return {"export_ck_hidden": export_result, "compare_hidden": compare_result, "parsed": parsed}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--hf-model", required=True, type=Path, help="local HF Gemma4 safetensors directory")
+    ap.add_argument("--ck-model-dir", required=True, type=Path, help="CK model runtime directory")
+    ap.add_argument("--prompt", default=DEFAULT_PROMPT)
+    ap.add_argument("--chat-template", action="store_true", help="use tokenizer.apply_chat_template for the user prompt")
+    ap.add_argument("--add-special-tokens", action="store_true", help="only applies when --chat-template is not used")
+    ap.add_argument("--max-new-tokens", type=int, default=96)
+    ap.add_argument("--dtype", choices=("float32", "bfloat16", "float16"), default="bfloat16")
+    ap.add_argument("--trust-remote-code", action="store_true")
+    ap.add_argument("--top-k", type=int, default=10)
+    ap.add_argument("--debug-hidden", action="store_true")
+    ap.add_argument("--debug-prefix", choices=("prompt", "first-divergence"), default="first-divergence")
+    ap.add_argument("--cosine-threshold", type=float, default=0.90)
+    ap.add_argument("--max-abs-threshold", type=float, default=10.0)
+    ap.add_argument("--out-dir", type=Path, default=Path("build/gemma4_answer_parity_debug"))
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    tok = _load_tokenizer(args.hf_model, args.trust_remote_code)
+    prompt_tokens = _prompt_tokens(tok, args.prompt, args.chat_template, args.add_special_tokens)
+    eos_tokens = set(int(x) for x in tok.all_special_ids if x is not None)
+
+    torch_run = _run_torch_greedy(
+        args.hf_model,
+        prompt_tokens,
+        args.max_new_tokens,
+        args.dtype,
+        args.trust_remote_code,
+        eos_tokens,
+    )
+    ck_run = _run_ck_greedy(args.ck_model_dir, prompt_tokens, args.max_new_tokens, eos_tokens)
+
+    steps = min(len(torch_run["tokens"]), len(ck_run["tokens"]))
+    first_divergence = None
+    step_reports: list[dict[str, Any]] = []
+    for i in range(steps):
+        t_tok = int(torch_run["tokens"][i])
+        c_tok = int(ck_run["tokens"][i])
+        cmp = _compare_logits(torch_run["logits"][i], ck_run["logits"][i], args.top_k)
+        row = {
+            "step": i,
+            "torch_token": t_tok,
+            "ck_token": c_tok,
+            "match": t_tok == c_tok,
+            "torch_piece": _decode(tok, [t_tok]),
+            "ck_piece": _decode(tok, [c_tok]),
+            "logits": cmp,
+        }
+        step_reports.append(row)
+        if first_divergence is None and t_tok != c_tok:
+            first_divergence = row
+    if first_divergence is None and len(torch_run["tokens"]) != len(ck_run["tokens"]):
+        first_divergence = {"step": steps, "reason": "different generation lengths"}
+
+    torch_answer = _decode(tok, torch_run["tokens"])
+    ck_answer = _decode(tok, ck_run["tokens"])
+    report: dict[str, Any] = {
+        "hf_model": str(args.hf_model),
+        "ck_model_dir": str(args.ck_model_dir),
+        "prompt": args.prompt,
+        "chat_template": bool(args.chat_template),
+        "prompt_tokens": prompt_tokens,
+        "prompt_token_count": len(prompt_tokens),
+        "dtype": args.dtype,
+        "max_new_tokens": args.max_new_tokens,
+        "torch": {"tokens": torch_run["tokens"], "answer": torch_answer},
+        "ck": {"tokens": ck_run["tokens"], "answer": ck_answer},
+        "first_divergence": first_divergence,
+        "steps": step_reports,
+    }
+
+    if args.debug_hidden:
+        if args.debug_prefix == "prompt" or first_divergence is None or not isinstance(first_divergence.get("step"), int):
+            prefix = list(prompt_tokens)
+        else:
+            div_step = int(first_divergence["step"])
+            # Compare the state used to predict the divergent token.  Up to that
+            # point both systems should have consumed the same generated tokens.
+            prefix = list(prompt_tokens) + [int(t) for t in torch_run["tokens"][:div_step]]
+        report["hidden_debug_prefix_tokens"] = prefix
+        report["hidden_debug"] = _hidden_debug(
+            args.hf_model,
+            args.ck_model_dir,
+            prefix,
+            len(prompt_tokens),
+            args.out_dir / "hidden_debug",
+            args.dtype,
+            args.trust_remote_code,
+            args.cosine_threshold,
+            args.max_abs_threshold,
+        )
+
+    json_out = args.json_out or (args.out_dir / "answer_parity_report.json")
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(f"prompt_tokens={len(prompt_tokens)} torch_new={len(torch_run['tokens'])} ck_new={len(ck_run['tokens'])}")
+    print(f"first_divergence={first_divergence}")
+    print("\n[PyTorch answer]\n" + torch_answer)
+    print("\n[CK answer]\n" + ck_answer)
+    print(f"\nreport={json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/templates/gemma4.json
+++ b/version/v8/templates/gemma4.json
@@ -63,7 +63,8 @@
       "kv_policy_config_key": "layer_kv_policy",
       "kv_source_config_key": "layer_kv_source",
       "sliding_window_config_key": "layer_sliding_window",
-      "rope_kind_config_key": "layer_rope_kind"
+      "rope_kind_config_key": "layer_rope_kind",
+      "rope_param_mode": "per_layer_direct"
     },
     "block_contract": {
       "norm_type": "rmsnorm",
@@ -95,7 +96,7 @@
     }
   },
   "kernels": {
-    "rope_qk": "rope_forward_qk_gemma4",
+    "rope_qk": "rope_forward_qk_split_direct",
     "rope_init": "rope_precompute_cache_split",
     "attn": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
     "attn_sliding": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",


### PR DESCRIPTION
## Summary
- add Gemma4 BF16 safetensors/BUMP kernel bindings and runtime path pieces
- add BF16 embedding/GEMV/GEMM and Gemma4 per-layer prepare entry points
- add split-half direct RoPE path and Gemma4 RoPE binding updates
- add Gemma4 parity/debug helper scripts for BF16 safetensors/BUMP comparison

## Scope
This PR does not claim full Gemma4 validation on the 24GB AVX2 machine. Full Gemma4 inference was intentionally not run here.

Xeon validation note from the patch author: validated on Xeon with Gemma4 BF16 safetensors/BUMP vs PyTorch. Exact parity passed on multiple short/medium prompts. Long generations still show small borderline numerical drift around ~20 generated tokens, but output remains coherent.

## AVX2 Validation
- git apply --check gemma4-bf16-safetensors-rope-parity.patch
- python tests/test_v8_gemma4_scaffold.py could not run exactly because python is not on PATH
- .venv/bin/python tests/test_v8_gemma4_scaffold.py passed: 10 tests OK
- make --no-print-directory build/libckernel_engine.so passed
- staged commit includes only the 21 files from the patch; unrelated local docs/BF16/v6.6 files were left unstaged

## Hooks
- pre-commit v7-kernel-map-contracts passed
- pre-commit v7-regression-fast passed
- pre-commit v8-regression-fast passed
- pre-push build, kernel parity, v8 E2E text smoke, v7 inference, v7 fast regression, v8 fast regression, and training-kernel parity all passed