### PR TITLE
fix(v8): add Qwen3.5 safetensors recurrent correctness

### DIFF
--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -1545,7 +1545,8 @@ void recurrent_dt_gate_forward(const float *alpha,
                                const float *a,
                                float *gate,
                                int rows,
-                               int dim);
+                               int num_heads,
+                               int state_dim);
 
 // Backward for recurrent_dt_gate_forward.
 // Layout:
@@ -1556,6 +1557,20 @@ void recurrent_dt_gate_forward(const float *alpha,
 //   d_alpha   : [rows, dim]
 //   d_dt_bias : [dim]
 //   d_a       : [dim]
+// Expanded Qwen3.5/KDA-style dt gate.
+// Layout:
+//   alpha   : [rows, num_heads]
+//   dt_bias : [num_heads]
+//   a       : [num_heads, state_dim] (already converted to -exp(A_log))
+//   gate    : [rows, num_heads * state_dim]
+void recurrent_dt_gate_expanded_forward(const float *alpha,
+                                        const float *dt_bias,
+                                        const float *a,
+                                        float *gate,
+                                        int rows,
+                                        int num_heads,
+                                        int state_dim);
+
 void recurrent_dt_gate_backward(const float *d_gate,
                                 const float *alpha,
                                 const float *dt_bias,
@@ -1695,14 +1710,15 @@ void recurrent_norm_gate_backward(const float *d_out,
 // Apply sigmoid(gate) to the full-attention qwen3.5 gate path and multiply it
 // elementwise with the attention output before the output projection.
 // Layout:
-//   x      : [rows, dim]
-//   gate   : [rows, dim]
-//   out    : [rows, dim]
+//   x      : [rows, num_heads * state_dim]
+//   gate   : [rows, num_heads * state_dim]
+//   out    : [rows, num_heads * state_dim]
 void attn_gate_sigmoid_mul_forward(const float *x,
                                    const float *gate,
                                    float *out,
                                    int rows,
-                                   int dim);
+                                   int num_heads,
+                                   int state_dim);
 
 void attn_gate_sigmoid_mul_backward(const float *d_out,
                                     const float *x,
@@ -1710,7 +1726,8 @@ void attn_gate_sigmoid_mul_backward(const float *d_out,
                                     float *d_x,
                                     float *d_gate,
                                     int rows,
-                                    int dim);
+                                    int num_heads,
+                                    int state_dim);
 
 void gated_deltanet_autoregressive_forward(const float *q,
                                            const float *k,

--- a/src/ck_parity_api.c
+++ b/src/ck_parity_api.c
@@ -102,7 +102,8 @@ extern void attn_gate_sigmoid_mul_forward(
     const float *gate,
     float *out,
     int rows,
-    int dim);
+    int num_heads,
+    int state_dim);
 
 /* Recurrent packed QKV split kernel (from recurrent_split_kernels.c) */
 extern void recurrent_split_qkv_forward(
@@ -839,7 +840,7 @@ void ck_test_attn_gate_sigmoid_mul(const float *x,
                                    int rows,
                                    int dim)
 {
-    attn_gate_sigmoid_mul_forward(x, gate, out, rows, dim);
+    attn_gate_sigmoid_mul_forward(x, gate, out, rows, 1, dim);
 }
 
 void ck_test_recurrent_norm_gate(const float *x,

--- a/src/kernels/deltanet_kernels.c
+++ b/src/kernels/deltanet_kernels.c
@@ -280,14 +280,13 @@ void gated_deltanet_autoregressive_forward_avx(const float *q,
         float *state_cur = state_out + (size_t)h * state_stride;
         float *out_head = out + (size_t)h * vec_stride;
 
-        const float beta_s = ck_deltanet_sigmoidf(beta[h]);
         const float gate = expf(g[h]);
+        const float beta_s = ck_deltanet_sigmoidf(beta[h]);
 
         /* q and k arrive pre-normalized by recurrent_qk_l2_norm. */
         ck_deltanet_scale_rows_avx(q_head, q_hat, state_dim, q_scale);
         ck_deltanet_scale_rows_avx(k_head, k_hat, state_dim, 1.0f);
 
-        const __m256 gate_v = _mm256_set1_ps(gate);
         const __m256 beta_v = _mm256_set1_ps(beta_s);
         const __m256 zero_v = _mm256_setzero_ps();
 
@@ -304,6 +303,7 @@ void gated_deltanet_autoregressive_forward_avx(const float *q,
         for (int row = 0; row < state_dim; ++row) {
             const size_t row_off = (size_t)row * (size_t)state_dim;
             const __m256 k_hat_v = _mm256_set1_ps(k_hat[row]);
+            const __m256 gate_v = _mm256_set1_ps(gate);
 
             col = 0;
             for (; col + 8 <= state_dim; col += 8) {
@@ -396,14 +396,13 @@ void gated_deltanet_autoregressive_forward_avx2(const float *q,
         float *state_cur = state_out + (size_t)h * state_stride;
         float *out_head = out + (size_t)h * vec_stride;
 
-        const float beta_s = ck_deltanet_sigmoidf(beta[h]);
         const float gate = expf(g[h]);
+        const float beta_s = ck_deltanet_sigmoidf(beta[h]);
 
         /* q and k arrive pre-normalized by recurrent_qk_l2_norm. */
         ck_deltanet_scale_rows_avx(q_head, q_hat, state_dim, q_scale);
         ck_deltanet_scale_rows_avx(k_head, k_hat, state_dim, 1.0f);
 
-        const __m256 gate_v = _mm256_set1_ps(gate);
         const __m256 beta_v = _mm256_set1_ps(beta_s);
         const __m256 zero_v = _mm256_setzero_ps();
 
@@ -423,13 +422,15 @@ void gated_deltanet_autoregressive_forward_avx2(const float *q,
             const size_t row1_off = (size_t)(row + 1) * (size_t)state_dim;
             const __m256 k0_v = _mm256_set1_ps(k_hat[row]);
             const __m256 k1_v = _mm256_set1_ps(k_hat[row + 1]);
+            const __m256 gate0_v = _mm256_set1_ps(gate);
+            const __m256 gate1_v = _mm256_set1_ps(gate);
 
             col = 0;
             for (; col + 8 <= state_dim; col += 8) {
                 __m256 prev0_v = _mm256_loadu_ps(state_prev + row0_off + (size_t)col);
                 __m256 prev1_v = _mm256_loadu_ps(state_prev + row1_off + (size_t)col);
-                __m256 cur0_v = _mm256_mul_ps(prev0_v, gate_v);
-                __m256 cur1_v = _mm256_mul_ps(prev1_v, gate_v);
+                __m256 cur0_v = _mm256_mul_ps(prev0_v, gate0_v);
+                __m256 cur1_v = _mm256_mul_ps(prev1_v, gate1_v);
                 __m256 kv_v = _mm256_loadu_ps(kv_mem + col);
                 kv_v = ck_deltanet_fmadd256(cur0_v, k0_v, kv_v);
                 kv_v = ck_deltanet_fmadd256(cur1_v, k1_v, kv_v);
@@ -448,6 +449,7 @@ void gated_deltanet_autoregressive_forward_avx2(const float *q,
         for (; row < state_dim; ++row) {
             const size_t row_off = (size_t)row * (size_t)state_dim;
             const __m256 k_hat_v = _mm256_set1_ps(k_hat[row]);
+            const __m256 gate_v = _mm256_set1_ps(gate);
             col = 0;
             for (; col + 8 <= state_dim; col += 8) {
                 __m256 prev_v = _mm256_loadu_ps(state_prev + row_off + (size_t)col);
@@ -578,14 +580,13 @@ void gated_deltanet_autoregressive_forward_avx512(const float *q,
         float *state_cur = state_out + (size_t)h * state_stride;
         float *out_head = out + (size_t)h * vec_stride;
 
-        const float beta_s = ck_deltanet_sigmoidf(beta[h]);
         const float gate = expf(g[h]);
+        const float beta_s = ck_deltanet_sigmoidf(beta[h]);
 
         /* q and k arrive pre-normalized by recurrent_qk_l2_norm. */
         ck_deltanet_scale_rows_avx512(q_head, q_hat, state_dim, q_scale);
         ck_deltanet_scale_rows_avx512(k_head, k_hat, state_dim, 1.0f);
 
-        const __m512 gate_v = _mm512_set1_ps(gate);
         const __m512 beta_v = _mm512_set1_ps(beta_s);
         const __m512 zero_v = _mm512_setzero_ps();
 
@@ -602,6 +603,7 @@ void gated_deltanet_autoregressive_forward_avx512(const float *q,
         for (int row = 0; row < state_dim; ++row) {
             const size_t row_off = (size_t)row * (size_t)state_dim;
             const __m512 k_hat_v = _mm512_set1_ps(k_hat[row]);
+            const __m512 gate_v = _mm512_set1_ps(gate);
             col = 0;
             for (; col + 16 <= state_dim; col += 16) {
                 __m512 prev_v = _mm512_loadu_ps(state_prev + row_off + (size_t)col);

--- a/src/kernels/hybrid_attention_kernels.c
+++ b/src/kernels/hybrid_attention_kernels.c
@@ -96,7 +96,9 @@ void attn_gate_sigmoid_mul_forward(const float *x,
                                    const float *gate,
                                    float *out,
                                    int rows,
-                                   int dim) {
+                                   int num_heads,
+                                   int state_dim) {
+    const int dim = num_heads * state_dim;
     for (int row = 0; row < rows; ++row) {
         const float *x_row = x + (size_t) row * (size_t) dim;
         const float *gate_row = gate + (size_t) row * (size_t) dim;
@@ -113,7 +115,9 @@ void attn_gate_sigmoid_mul_backward(const float *d_out,
                                     float *d_x,
                                     float *d_gate,
                                     int rows,
-                                    int dim) {
+                                    int num_heads,
+                                    int state_dim) {
+    const int dim = num_heads * state_dim;
     for (int row = 0; row < rows; ++row) {
         const float *d_out_row = d_out + (size_t) row * (size_t) dim;
         const float *x_row = x + (size_t) row * (size_t) dim;

--- a/src/kernels/recurrent_gate_kernels.c
+++ b/src/kernels/recurrent_gate_kernels.c
@@ -28,13 +28,36 @@ void recurrent_dt_gate_forward(const float *alpha,
                                const float *a,
                                float *gate,
                                int rows,
-                               int dim) {
+                               int num_heads,
+                               int state_dim) {
+    const int dim = num_heads * state_dim;
     for (int row = 0; row < rows; ++row) {
         const float *alpha_row = alpha + (size_t) row * (size_t) dim;
         float *gate_row = gate + (size_t) row * (size_t) dim;
         for (int col = 0; col < dim; ++col) {
             const float x = alpha_row[col] + dt_bias[col];
             gate_row[col] = recurrent_softplus(x) * a[col];
+        }
+    }
+}
+
+void recurrent_dt_gate_expanded_forward(const float *alpha,
+                                        const float *dt_bias,
+                                        const float *a,
+                                        float *gate,
+                                        int rows,
+                                        int num_heads,
+                                        int state_dim) {
+    for (int row = 0; row < rows; ++row) {
+        const float *alpha_row = alpha + (size_t) row * (size_t) num_heads;
+        float *gate_row = gate + (size_t) row * (size_t) num_heads * (size_t) state_dim;
+        for (int h = 0; h < num_heads; ++h) {
+            const float sp = recurrent_softplus(alpha_row[h] + dt_bias[h]);
+            const float *a_head = a + (size_t) h * (size_t) state_dim;
+            float *gate_head = gate_row + (size_t) h * (size_t) state_dim;
+            for (int col = 0; col < state_dim; ++col) {
+                gate_head[col] = sp * a_head[col];
+            }
         }
     }
 }

--- a/tests/test_deltanet_registry_v7.py
+++ b/tests/test_deltanet_registry_v7.py
@@ -174,7 +174,8 @@ class TestDeltaNetRegistryV7(unittest.TestCase):
                 "a",
                 "gate",
                 "rows",
-                "dim",
+                "num_heads",
+                "state_dim",
             ],
         )
 
@@ -250,7 +251,8 @@ class TestDeltaNetRegistryV7(unittest.TestCase):
                 "gate",
                 "out",
                 "rows",
-                "dim",
+                "num_heads",
+                "state_dim",
             ],
         )
 

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -80,10 +80,142 @@ def test_qwen3_safetensors_to_bump_smoke(tmp_path: Path) -> None:
     )
 
     manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
+    audit = json.loads((out / "conversion_audit.json").read_text(encoding="utf-8"))
     names = [entry["name"] for entry in manifest["entries"]]
     assert manifest["model"] == "qwen3"
+    assert audit["verdict"] == "pass"
+    assert audit["unmapped_source_tensors"] == []
     assert names[0] == "token_emb"
     assert "layer.0.q_norm" in names
     assert "layer.0.k_norm" in names
     assert names[-1] == "output.weight"
+    assert (out / "weights.bump").stat().st_size > 0
+
+
+def test_qwen35_safetensors_to_bump_smoke(tmp_path: Path) -> None:
+    torch, st = _require_torch_safetensors()
+    checkpoint = tmp_path / "qwen35"
+    out = tmp_path / "out_qwen35"
+    checkpoint.mkdir()
+    out.mkdir()
+
+    layer_types = ["linear_attention", "linear_attention", "linear_attention", "full_attention"]
+    (checkpoint / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "model_type": "qwen3_5",
+                "tie_word_embeddings": True,
+                "text_config": {
+                    "model_type": "qwen3_5_text",
+                    "num_hidden_layers": 4,
+                    "hidden_size": 8,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 1,
+                    "head_dim": 4,
+                    "vocab_size": 32,
+                    "max_position_embeddings": 64,
+                    "full_attention_interval": 4,
+                    "layer_types": layer_types,
+                    "linear_conv_kernel_dim": 4,
+                    "linear_key_head_dim": 4,
+                    "linear_num_key_heads": 2,
+                    "linear_num_value_heads": 2,
+                    "linear_value_head_dim": 4,
+                    "rms_norm_eps": 1e-6,
+                    "tie_word_embeddings": True,
+                    "rope_parameters": {
+                        "rope_theta": 10000000.0,
+                        "partial_rotary_factor": 0.25,
+                        "mrope_section": [1, 1, 0],
+                        "rope_type": "default",
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    tensors = {
+        "model.language_model.embed_tokens.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+        "model.language_model.norm.weight": torch.ones(8, dtype=torch.float32),
+    }
+    for layer, kind in enumerate(layer_types):
+        prefix = f"model.language_model.layers.{layer}"
+        tensors[f"{prefix}.input_layernorm.weight"] = torch.ones(8, dtype=torch.float32)
+        tensors[f"{prefix}.post_attention_layernorm.weight"] = torch.ones(8, dtype=torch.float32)
+        tensors[f"{prefix}.mlp.gate_proj.weight"] = torch.randn(16, 8, dtype=torch.bfloat16)
+        tensors[f"{prefix}.mlp.up_proj.weight"] = torch.randn(16, 8, dtype=torch.bfloat16)
+        tensors[f"{prefix}.mlp.down_proj.weight"] = torch.randn(8, 16, dtype=torch.bfloat16)
+        if kind == "linear_attention":
+            tensors[f"{prefix}.linear_attn.in_proj_qkv.weight"] = torch.randn(24, 8, dtype=torch.bfloat16)
+            tensors[f"{prefix}.linear_attn.in_proj_z.weight"] = torch.randn(8, 8, dtype=torch.bfloat16)
+            tensors[f"{prefix}.linear_attn.in_proj_a.weight"] = torch.randn(8, 8, dtype=torch.bfloat16)
+            tensors[f"{prefix}.linear_attn.in_proj_b.weight"] = torch.randn(8, 8, dtype=torch.bfloat16)
+            tensors[f"{prefix}.linear_attn.conv1d.weight"] = torch.randn(24, 1, 4, dtype=torch.float32)
+            tensors[f"{prefix}.linear_attn.dt_bias"] = torch.randn(8, dtype=torch.float32)
+            tensors[f"{prefix}.linear_attn.A_log"] = torch.randn(8, 4, dtype=torch.float32)
+            tensors[f"{prefix}.linear_attn.norm.weight"] = torch.ones(8, dtype=torch.float32)
+            tensors[f"{prefix}.linear_attn.out_proj.weight"] = torch.randn(8, 8, dtype=torch.bfloat16)
+        else:
+            tensors[f"{prefix}.self_attn.q_proj.weight"] = torch.randn(16, 8, dtype=torch.bfloat16)
+            tensors[f"{prefix}.self_attn.k_proj.weight"] = torch.randn(4, 8, dtype=torch.bfloat16)
+            tensors[f"{prefix}.self_attn.v_proj.weight"] = torch.randn(4, 8, dtype=torch.bfloat16)
+            tensors[f"{prefix}.self_attn.o_proj.weight"] = torch.randn(8, 16, dtype=torch.bfloat16)
+            tensors[f"{prefix}.self_attn.q_norm.weight"] = torch.ones(4, dtype=torch.float32)
+            tensors[f"{prefix}.self_attn.k_norm.weight"] = torch.ones(4, dtype=torch.float32)
+
+    st.save_file(tensors, checkpoint / "model.safetensors")
+
+    script = Path("version/v8/scripts/convert_safetensors_to_bump_v8.py")
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(out / "weights.bump"),
+            "--config-out",
+            str(out / "config.json"),
+            "--manifest-out",
+            str(out / "weights_manifest.json"),
+            "--arch",
+            "auto",
+        ],
+        check=True,
+    )
+
+    manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
+    audit = json.loads((out / "conversion_audit.json").read_text(encoding="utf-8"))
+    config = json.loads((out / "config.json").read_text(encoding="utf-8"))
+    names = [entry["name"] for entry in manifest["entries"]]
+    assert manifest["model"] == "qwen35"
+    assert audit["verdict"] == "pass"
+    assert audit["unmapped_source_tensors"] == []
+    assert any(row["target"] == "layer.0.ssm_a" and row["transform"] == "neg_exp_a_log" for row in audit["transforms"])
+    assert any(row["target"] == "layer.0.attn_norm" and row["transform"] == "qwen35_norm_plus_one" for row in audit["transforms"])
+    assert any(row["target"] == "layer.3.attn_q_norm" and row["transform"] == "qwen35_norm_plus_one" for row in audit["transforms"])
+    assert any(row["target"] == "final_ln_weight" and row["transform"] == "qwen35_norm_plus_one" for row in audit["transforms"])
+    assert not any(row["target"] == "layer.0.ssm_norm" and row.get("transform") == "qwen35_norm_plus_one" for row in audit["transforms"])
+    assert config["layer_kinds"] == ["recurrent", "recurrent", "recurrent", "full_attention"]
+    assert config["layer_recurrent_policy"] == ["deltanet", "deltanet", "deltanet", "none"]
+    assert config["attn_q_gate_proj_dim"] == 16
+    assert config["attn_out_dim"] == 8
+    assert config["q_dim"] == 8
+    assert config["k_dim"] == 8
+    assert config["v_dim"] == 8
+    assert config["gate_dim"] == 8
+    dtypes = {entry["name"]: entry["dtype"] for entry in manifest["entries"]}
+    assert dtypes["layer.0.ssm_conv1d"] == "fp32"
+    assert "layer.0.attn_qkv" in names
+    assert "layer.0.ssm_alpha" in names
+    assert "layer.0.ssm_beta" in names
+    assert "layer.0.ssm_conv1d" in names
+    assert "layer.3.attn_q_gate" in names
+    assert "layer.3.attn_q_norm" in names
+    assert "final_ln_weight" in names
+    assert "output.weight" not in names
     assert (out / "weights.bump").stat().st_size > 0

--- a/unittest/test_attn_gate_sigmoid_mul.py
+++ b/unittest/test_attn_gate_sigmoid_mul.py
@@ -16,6 +16,7 @@ LIB.attn_gate_sigmoid_mul_forward.argtypes = [
     ctypes.POINTER(ctypes.c_float),
     ctypes.c_int,
     ctypes.c_int,
+    ctypes.c_int,
 ]
 LIB.attn_gate_sigmoid_mul_forward.restype = None
 
@@ -25,6 +26,7 @@ LIB.attn_gate_sigmoid_mul_backward.argtypes = [
     ctypes.POINTER(ctypes.c_float),
     ctypes.POINTER(ctypes.c_float),
     ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
     ctypes.c_int,
     ctypes.c_int,
 ]
@@ -37,7 +39,8 @@ def _ptr(arr: np.ndarray):
 
 def main() -> None:
     torch.manual_seed(0)
-    rows, dim = 9, 128
+    rows, num_heads, state_dim = 9, 4, 32
+    dim = num_heads * state_dim
     x = torch.randn(rows, dim, dtype=torch.float32)
     gate = torch.randn(rows, dim, dtype=torch.float32)
     ref_out = x * torch.sigmoid(gate)
@@ -45,7 +48,7 @@ def main() -> None:
     x_np = x.numpy().copy()
     gate_np = gate.numpy().copy()
     out_np = np.zeros((rows, dim), dtype=np.float32)
-    LIB.attn_gate_sigmoid_mul_forward(_ptr(x_np), _ptr(gate_np), _ptr(out_np), rows, dim)
+    LIB.attn_gate_sigmoid_mul_forward(_ptr(x_np), _ptr(gate_np), _ptr(out_np), rows, num_heads, state_dim)
     np.testing.assert_allclose(out_np, ref_out.numpy(), rtol=1e-6, atol=1e-6)
 
     d_out = torch.randn(rows, dim, dtype=torch.float32)
@@ -62,7 +65,8 @@ def main() -> None:
         _ptr(d_x_np),
         _ptr(d_gate_np),
         rows,
-        dim,
+        num_heads,
+        state_dim,
     )
     np.testing.assert_allclose(d_x_np, ref_d_x.numpy(), rtol=1e-6, atol=1e-6)
     np.testing.assert_allclose(d_gate_np, ref_d_gate.numpy(), rtol=1e-6, atol=1e-6)

--- a/unittest/test_recurrent_dt_gate.py
+++ b/unittest/test_recurrent_dt_gate.py
@@ -46,6 +46,7 @@ def _load_lib() -> ctypes.CDLL | None:
                 ctypes.POINTER(ctypes.c_float),
                 ctypes.c_int,
                 ctypes.c_int,
+                ctypes.c_int,
             ]
             fwd.restype = None
 
@@ -62,6 +63,19 @@ def _load_lib() -> ctypes.CDLL | None:
                 ctypes.c_int,
             ]
             bwd.restype = None
+
+            if hasattr(lib, "recurrent_dt_gate_expanded_forward"):
+                expanded = lib.recurrent_dt_gate_expanded_forward
+                expanded.argtypes = [
+                    ctypes.POINTER(ctypes.c_float),
+                    ctypes.POINTER(ctypes.c_float),
+                    ctypes.POINTER(ctypes.c_float),
+                    ctypes.POINTER(ctypes.c_float),
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                ]
+                expanded.restype = None
             return lib
     return None
 
@@ -96,6 +110,7 @@ class TestRecurrentDTGateParity(unittest.TestCase):
             _as_ptr(a),
             _as_ptr(ck_gate),
             rows,
+            1,
             dim,
         )
 
@@ -140,6 +155,34 @@ class TestRecurrentDTGateParity(unittest.TestCase):
 
     def test_qwen35_like_case(self) -> None:
         self._run_case(rows=7, dim=16, seed=29)
+
+    def test_qwen35_expanded_vector_gate_forward(self) -> None:
+        if not hasattr(LIB, "recurrent_dt_gate_expanded_forward"):
+            self.skipTest("recurrent_dt_gate_expanded_forward not exported")
+        rows = 3
+        heads = 16
+        state_dim = 128
+        rng = np.random.default_rng(41)
+        alpha = (0.30 * rng.standard_normal((rows, heads))).astype(np.float32)
+        dt_bias = (0.20 * rng.standard_normal(heads)).astype(np.float32)
+        a = (0.25 * rng.standard_normal((heads, state_dim))).astype(np.float32)
+        ck_gate = np.zeros((rows, heads * state_dim), dtype=np.float32)
+
+        LIB.recurrent_dt_gate_expanded_forward(
+            _as_ptr(alpha),
+            _as_ptr(dt_bias),
+            _as_ptr(a),
+            _as_ptr(ck_gate),
+            rows,
+            heads,
+            state_dim,
+        )
+
+        t_alpha = torch.tensor(alpha, dtype=torch.float32)
+        t_dt_bias = torch.tensor(dt_bias, dtype=torch.float32)
+        t_a = torch.tensor(a, dtype=torch.float32)
+        torch_gate = (F.softplus(t_alpha + t_dt_bias).unsqueeze(-1) * t_a).reshape(rows, heads * state_dim).numpy()
+        np.testing.assert_allclose(ck_gate, torch_gate, atol=self.atol_forward, rtol=0.0)
 
 
 if __name__ == "__main__":

--- a/version/v7/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v7/kernel_maps/KERNEL_REGISTRY.json
@@ -1578,7 +1578,7 @@
       },
       "impl": {
         "function": "attn_gate_sigmoid_mul_forward",
-        "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int dim);",
+        "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int num_heads, int state_dim);",
         "sources": [
           "src/kernels/hybrid_attention_kernels.c"
         ],
@@ -9500,7 +9500,7 @@
       },
       "impl": {
         "function": "recurrent_dt_gate_forward",
-        "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int dim);",
+        "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int num_heads, int state_dim);",
         "sources": [
           "src/kernels/recurrent_gate_kernels.c"
         ],

--- a/version/v7/kernel_maps/attn_gate_sigmoid_mul_forward.json
+++ b/version/v7/kernel_maps/attn_gate_sigmoid_mul_forward.json
@@ -37,7 +37,7 @@
   },
   "impl": {
     "function": "attn_gate_sigmoid_mul_forward",
-    "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int dim);",
+    "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int num_heads, int state_dim);",
     "sources": ["src/kernels/hybrid_attention_kernels.c"],
     "variants": [
       {"name": "ref", "requires": [], "compile_flags": []}

--- a/version/v7/kernel_maps/kernel_bindings.json
+++ b/version/v7/kernel_maps/kernel_bindings.json
@@ -1173,8 +1173,12 @@
           "source": "runtime:seq_len"
         },
         {
-          "name": "dim",
+          "name": "num_heads",
           "source": "dim:gate_dim"
+        },
+        {
+          "name": "state_dim",
+          "source": "dim:ssm_state_size"
         }
       ]
     },
@@ -1221,8 +1225,12 @@
           "source": "runtime:seq_len"
         },
         {
-          "name": "dim",
+          "name": "num_heads",
           "source": "dim:gate_dim"
+        },
+        {
+          "name": "state_dim",
+          "source": "dim:ssm_state_size"
         }
       ]
     },
@@ -1269,8 +1277,12 @@
           "source": "runtime:seq_len"
         },
         {
-          "name": "dim",
+          "name": "num_heads",
           "source": "dim:gate_dim"
+        },
+        {
+          "name": "state_dim",
+          "source": "dim:ssm_state_size"
         }
       ]
     },
@@ -1495,7 +1507,8 @@
         {"name": "gate", "source": "activation:gate", "cast": "const float*"},
         {"name": "out", "source": "output:out", "cast": "float*"},
         {"name": "rows", "source": "runtime:seq_len"},
-        {"name": "dim", "source": "dim:attn_out_dim"}
+        {"name": "num_heads", "source": "dim:num_heads"},
+        {"name": "state_dim", "source": "dim:head_dim"}
       ]
     },
     "attn_gate_sigmoid_mul_backward": {
@@ -1507,7 +1520,8 @@
         {"name": "d_x", "source": "output:d_x", "cast": "float*"},
         {"name": "d_gate", "source": "output:d_gate", "cast": "float*"},
         {"name": "rows", "source": "runtime:seq_len"},
-        {"name": "dim", "source": "dim:attn_out_dim"}
+        {"name": "num_heads", "source": "dim:num_heads"},
+        {"name": "state_dim", "source": "dim:head_dim"}
       ]
     },
     "attn_gate_sigmoid_mul_backward_f32": {
@@ -1519,7 +1533,8 @@
         {"name": "d_x", "source": "output:d_x", "cast": "float*"},
         {"name": "d_gate", "source": "output:d_gate", "cast": "float*"},
         {"name": "rows", "source": "runtime:seq_len"},
-        {"name": "dim", "source": "dim:attn_out_dim"}
+        {"name": "num_heads", "source": "dim:num_heads"},
+        {"name": "state_dim", "source": "dim:head_dim"}
       ]
     },
     "ssm_conv1d_forward": {

--- a/version/v7/kernel_maps/recurrent_dt_gate_forward.json
+++ b/version/v7/kernel_maps/recurrent_dt_gate_forward.json
@@ -39,7 +39,7 @@
   },
   "impl": {
     "function": "recurrent_dt_gate_forward",
-    "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int dim);",
+    "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int num_heads, int state_dim);",
     "sources": ["src/kernels/recurrent_gate_kernels.c"],
     "variants": [
       {"name": "ref", "requires": [], "compile_flags": []}

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -3,7 +3,7 @@
     "description": "Kernel registry generated from v8 kernel maps",
     "version": "v8",
     "generated_by": "ck_run_v8.py",
-    "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
+    "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
       "total": 147,
       "by_op": {
@@ -2828,7 +2828,7 @@
       },
       "impl": {
         "function": "attn_gate_sigmoid_mul_forward",
-        "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int dim);",
+        "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int num_heads, int state_dim);",
         "sources": [
           "src/kernels/hybrid_attention_kernels.c"
         ],
@@ -12233,9 +12233,9 @@
           "dtype": "fp32",
           "shape": [
             "R",
-            "D"
+            "H"
           ],
-          "desc": "Per-row recurrent alpha values"
+          "desc": "Per-row, per-head recurrent alpha values"
         }
       ],
       "weights": [
@@ -12243,17 +12243,18 @@
           "name": "dt_bias",
           "dtype": "fp32",
           "shape": [
-            "D"
+            "H"
           ],
-          "desc": "Per-dimension dt bias"
+          "desc": "Per-head dt bias"
         },
         {
           "name": "a",
           "dtype": "fp32",
           "shape": [
-            "D"
+            "H",
+            "S"
           ],
-          "desc": "Per-dimension recurrent A scale"
+          "desc": "Per-head/per-state recurrent A scale, converted to -exp(A_log)"
         }
       ],
       "activations": [],
@@ -12263,15 +12264,16 @@
           "dtype": "fp32",
           "shape": [
             "R",
-            "D"
+            "H*S"
           ],
-          "desc": "DeltaNet gate rows after dt transform"
+          "desc": "Expanded DeltaNet vector gate rows"
         }
       ],
       "scratch": [],
       "dims": [
         "R",
-        "D"
+        "H",
+        "S"
       ],
       "params": [],
       "parallelization": {
@@ -12295,11 +12297,11 @@
         ]
       },
       "constraints": {
-        "notes": "Applies softplus(alpha + dt_bias) * a row-wise."
+        "notes": "Applies softplus(alpha + dt_bias) * a and expands [R,H] to [R,H*S]."
       },
       "impl": {
         "function": "recurrent_dt_gate_forward",
-        "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int dim);",
+        "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int num_heads, int state_dim);",
         "sources": [
           "src/kernels/recurrent_gate_kernels.c"
         ],
@@ -12330,7 +12332,7 @@
           }
         ]
       },
-      "notes": "Explicit recurrent dt gate transform used before the DeltaNet core.",
+      "notes": "Scalar recurrent dt gate transform used before Qwen3.5 DeltaNet core.",
       "name": "recurrent_dt_gate_forward",
       "_source_file": "recurrent_dt_gate_forward.json"
     },

--- a/version/v8/kernel_maps/attn_gate_sigmoid_mul_forward.json
+++ b/version/v8/kernel_maps/attn_gate_sigmoid_mul_forward.json
@@ -37,7 +37,7 @@
   },
   "impl": {
     "function": "attn_gate_sigmoid_mul_forward",
-    "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int dim);",
+    "c_declaration": "void attn_gate_sigmoid_mul_forward(const float *x, const float *gate, float *out, int rows, int num_heads, int state_dim);",
     "sources": ["src/kernels/hybrid_attention_kernels.c"],
     "variants": [
       {"name": "ref", "requires": [], "compile_flags": []}

--- a/version/v8/kernel_maps/kernel_bindings.json
+++ b/version/v8/kernel_maps/kernel_bindings.json
@@ -1147,11 +1147,11 @@
       ]
     },
     "recurrent_dt_gate_forward": {
-      "note": "Apply softplus(alpha + dt_bias) * a row-wise for the recurrent DeltaNet gate.",
+      "note": "Apply softplus(alpha + dt_bias) * a row-wise for the recurrent DeltaNet scalar gate.",
       "params": [
         {
           "name": "alpha",
-          "source": "activation:alpha",
+          "source": "activation:recurrent_alpha",
           "cast": "const float*"
         },
         {
@@ -1166,16 +1166,20 @@
         },
         {
           "name": "gate",
-          "source": "output:gate",
+          "source": "output:recurrent_g",
           "cast": "float*"
         },
         {
           "name": "rows",
-          "source": "runtime:seq_len"
+          "source": "dim:seq_len"
         },
         {
-          "name": "dim",
+          "name": "num_heads",
           "source": "dim:gate_dim"
+        },
+        {
+          "name": "state_dim",
+          "source": "dim:ssm_state_size"
         }
       ]
     },
@@ -1222,8 +1226,12 @@
           "source": "runtime:seq_len"
         },
         {
-          "name": "dim",
+          "name": "num_heads",
           "source": "dim:gate_dim"
+        },
+        {
+          "name": "state_dim",
+          "source": "dim:ssm_state_size"
         }
       ]
     },
@@ -1270,8 +1278,12 @@
           "source": "runtime:seq_len"
         },
         {
-          "name": "dim",
+          "name": "num_heads",
           "source": "dim:gate_dim"
+        },
+        {
+          "name": "state_dim",
+          "source": "dim:ssm_state_size"
         }
       ]
     },
@@ -1496,7 +1508,8 @@
         {"name": "gate", "source": "activation:gate", "cast": "const float*"},
         {"name": "out", "source": "output:out", "cast": "float*"},
         {"name": "rows", "source": "runtime:seq_len"},
-        {"name": "dim", "source": "dim:attn_out_dim"}
+        {"name": "num_heads", "source": "dim:num_heads"},
+        {"name": "state_dim", "source": "dim:head_dim"}
       ]
     },
     "attn_gate_sigmoid_mul_backward": {
@@ -1508,7 +1521,8 @@
         {"name": "d_x", "source": "output:d_x", "cast": "float*"},
         {"name": "d_gate", "source": "output:d_gate", "cast": "float*"},
         {"name": "rows", "source": "runtime:seq_len"},
-        {"name": "dim", "source": "dim:attn_out_dim"}
+        {"name": "num_heads", "source": "dim:num_heads"},
+        {"name": "state_dim", "source": "dim:head_dim"}
       ]
     },
     "attn_gate_sigmoid_mul_backward_f32": {
@@ -1520,7 +1534,8 @@
         {"name": "d_x", "source": "output:d_x", "cast": "float*"},
         {"name": "d_gate", "source": "output:d_gate", "cast": "float*"},
         {"name": "rows", "source": "runtime:seq_len"},
-        {"name": "dim", "source": "dim:attn_out_dim"}
+        {"name": "num_heads", "source": "dim:num_heads"},
+        {"name": "state_dim", "source": "dim:head_dim"}
       ]
     },
     "ssm_conv1d_forward": {

--- a/version/v8/kernel_maps/recurrent_dt_gate_forward.json
+++ b/version/v8/kernel_maps/recurrent_dt_gate_forward.json
@@ -8,45 +8,95 @@
     "output": "fp32"
   },
   "inputs": [
-    {"name": "alpha", "dtype": "fp32", "shape": ["R", "D"], "desc": "Per-row recurrent alpha values"}
+    {
+      "name": "alpha",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ],
+      "desc": "Per-row, per-head recurrent alpha values"
+    }
   ],
   "weights": [
-    {"name": "dt_bias", "dtype": "fp32", "shape": ["D"], "desc": "Per-dimension dt bias"},
-    {"name": "a", "dtype": "fp32", "shape": ["D"], "desc": "Per-dimension recurrent A scale"}
+    {
+      "name": "dt_bias",
+      "dtype": "fp32",
+      "shape": [
+        "H"
+      ],
+      "desc": "Per-head dt bias"
+    },
+    {
+      "name": "a",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "S"
+      ],
+      "desc": "Per-head/per-state recurrent A scale, converted to -exp(A_log)"
+    }
   ],
   "activations": [],
   "outputs": [
-    {"name": "gate", "dtype": "fp32", "shape": ["R", "D"], "desc": "DeltaNet gate rows after dt transform"}
+    {
+      "name": "gate",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H*S"
+      ],
+      "desc": "Expanded DeltaNet vector gate rows"
+    }
   ],
   "scratch": [],
-  "dims": ["R", "D"],
+  "dims": [
+    "R",
+    "H",
+    "S"
+  ],
   "params": [],
   "parallelization": {
-    "supported": ["row"],
-    "preferred": {"prefill": "row", "decode": "row"},
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
     "strategies": [
       {
         "name": "row",
         "partition_dim": "R",
         "param_style": "range",
-        "range": {"min_chunk": 1},
+        "range": {
+          "min_chunk": 1
+        },
         "notes": "Each row can be transformed independently."
       }
     ]
   },
   "constraints": {
-    "notes": "Applies softplus(alpha + dt_bias) * a row-wise."
+    "notes": "Applies softplus(alpha + dt_bias) * a and expands [R,H] to [R,H*S]."
   },
   "impl": {
     "function": "recurrent_dt_gate_forward",
-    "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int dim);",
-    "sources": ["src/kernels/recurrent_gate_kernels.c"],
+    "c_declaration": "void recurrent_dt_gate_forward(const float *alpha, const float *dt_bias, const float *a, float *gate, int rows, int num_heads, int state_dim);",
+    "sources": [
+      "src/kernels/recurrent_gate_kernels.c"
+    ],
     "variants": [
-      {"name": "ref", "requires": [], "compile_flags": []}
+      {
+        "name": "ref",
+        "requires": [],
+        "compile_flags": []
+      }
     ]
   },
   "tests": {
-    "unit": ["unittest/test_recurrent_dt_gate.py"],
+    "unit": [
+      "unittest/test_recurrent_dt_gate.py"
+    ],
     "parity": [
       {
         "kind": "pytorch",
@@ -62,5 +112,5 @@
       }
     ]
   },
-  "notes": "Explicit recurrent dt gate transform used before the DeltaNet core."
+  "notes": "Scalar recurrent dt gate transform used before Qwen3.5 DeltaNet core."
 }

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -1752,7 +1752,8 @@ def build_activation_specs(config: Dict[str, Any], mode: str, context_len: int, 
     )):
         packed_dim = max(recurrent_q + recurrent_k + recurrent_v, recurrent_inner)
         packed_size = seq_len * packed_dim * 4
-        gate_size = seq_len * recurrent_inner * 4
+        recurrent_inner_size = seq_len * recurrent_inner * 4
+        gate_size = seq_len * recurrent_gate * 4
         beta_size = seq_len * recurrent_gate * 4
         q_size = seq_len * recurrent_q * 4
         k_size = seq_len * recurrent_k * 4
@@ -1765,9 +1766,9 @@ def build_activation_specs(config: Dict[str, Any], mode: str, context_len: int, 
         conv_state_size = num_layers * conv_state_stride
         ssm_state_size = num_layers * ssm_state_stride
         add("recurrent_packed", packed_size, f"[{seq_len}, {packed_dim}]")
-        add("recurrent_z", gate_size, f"[{seq_len}, {recurrent_inner}]")
-        add("recurrent_normed", gate_size, f"[{seq_len}, {recurrent_inner}]")
-        add("recurrent_g", beta_size, f"[{seq_len}, {recurrent_gate}]")
+        add("recurrent_z", recurrent_inner_size, f"[{seq_len}, {recurrent_inner}]")
+        add("recurrent_normed", recurrent_inner_size, f"[{seq_len}, {recurrent_inner}]")
+        add("recurrent_g", gate_size, f"[{seq_len}, {recurrent_gate}]")
         add("recurrent_beta", beta_size, f"[{seq_len}, {recurrent_gate}]")
         add("recurrent_q", q_size, f"[{seq_len}, {recurrent_q}]")
         add("recurrent_k", k_size, f"[{seq_len}, {recurrent_k}]")
@@ -2716,7 +2717,48 @@ def _config_layer_int(config: Dict, key: str, layer: int, default: int) -> int:
 
 def apply_layer_attention_dims(op_name: str, params: Dict, layer: int, config: Dict) -> None:
     """Apply explicit per-layer attention dimensions for architectures that need them."""
-    if str(config.get("model", "")).lower() != "gemma4" or layer < 0:
+    model_lc = str(config.get("model", "")).lower()
+    if layer < 0:
+        return
+    if model_lc == "qwen35":
+        embed_dim = int(config.get("embed_dim", 0) or 0)
+        num_heads = int(config.get("num_heads", 1) or 1)
+        num_kv_heads = int(config.get("num_kv_heads", num_heads) or num_heads)
+        head_dim = int(config.get("head_dim", 0) or 0)
+        q_dim = int(config.get("attn_out_dim", num_heads * head_dim) or (num_heads * head_dim))
+        k_dim = int(num_kv_heads * head_dim)
+        v_dim = int(num_kv_heads * head_dim)
+        rotary_dim = int(config.get("mrope_n_dims", config.get("rotary_dim", head_dim)) or head_dim)
+        rope_freq_base = float(config.get("rope_theta", 1000000.0) or 1000000.0)
+        if op_name == "q_gate_proj":
+            params["_output_dim"] = int(config.get("q_gate_proj_dim", config.get("attn_q_gate_proj_dim", q_dim * 2)) or (q_dim * 2))
+            params["_input_dim"] = embed_dim
+        elif op_name == "k_proj":
+            params["_output_dim"] = k_dim
+            params["_input_dim"] = embed_dim
+            params["output_dim"] = k_dim
+        elif op_name == "v_proj":
+            params["_output_dim"] = v_dim
+            params["_input_dim"] = embed_dim
+            params["output_dim"] = v_dim
+        elif op_name == "out_proj":
+            params["_output_dim"] = embed_dim
+            params["_input_dim"] = q_dim
+            params["input_dim"] = q_dim
+        elif op_name in ("qk_norm", "rope_qk", "kv_cache_store", "attn", "attn_sliding"):
+            params["head_dim"] = head_dim
+            params["q_head_dim"] = head_dim
+            params["k_head_dim"] = head_dim
+            params["v_head_dim"] = head_dim
+            params["q_dim"] = q_dim
+            params["k_dim"] = k_dim
+            params["v_dim"] = v_dim
+            params["rotary_dim"] = rotary_dim
+            params["n_dims"] = rotary_dim
+            params["rope_freq_base"] = rope_freq_base
+            params["use_rope_freq_factors"] = 1 if op_name == "rope_qk" else 0
+        return
+    if model_lc != "gemma4":
         return
 
     embed_dim = int(config.get("embed_dim", 0) or 0)
@@ -6863,7 +6905,8 @@ def generate_memory_layout(
     )):
         packed_dim = max(recurrent_q + recurrent_k + recurrent_v, recurrent_inner)
         packed_size = seq_len * packed_dim * 4
-        gate_size = seq_len * recurrent_inner * 4
+        recurrent_inner_size = seq_len * recurrent_inner * 4
+        gate_size = seq_len * recurrent_gate * 4
         beta_size = seq_len * recurrent_gate * 4
         rq_size = seq_len * recurrent_q * 4
         rk_size = seq_len * recurrent_k * 4
@@ -6876,9 +6919,9 @@ def generate_memory_layout(
         conv_state_size = num_layers * conv_state_stride
         ssm_state_size = num_layers * ssm_state_stride
         add_buffer("recurrent_packed", packed_size, f"[{seq_len}, {packed_dim}]")
-        add_buffer("recurrent_z", gate_size, f"[{seq_len}, {recurrent_inner}]")
-        add_buffer("recurrent_normed", gate_size, f"[{seq_len}, {recurrent_inner}]")
-        add_buffer("recurrent_g", beta_size, f"[{seq_len}, {recurrent_gate}]")
+        add_buffer("recurrent_z", recurrent_inner_size, f"[{seq_len}, {recurrent_inner}]")
+        add_buffer("recurrent_normed", recurrent_inner_size, f"[{seq_len}, {recurrent_inner}]")
+        add_buffer("recurrent_g", gate_size, f"[{seq_len}, {recurrent_gate}]")
         add_buffer("recurrent_beta", beta_size, f"[{seq_len}, {recurrent_gate}]")
         add_buffer("recurrent_q", rq_size, f"[{seq_len}, {recurrent_q}]")
         add_buffer("recurrent_k", rk_size, f"[{seq_len}, {recurrent_k}]")

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -1601,10 +1601,11 @@ def emit_op(
             _hidden_count("m", "n", "rows", "dim", default="0"),
         )
     elif op_name == "recurrent_dt_gate":
+        gate_count = _mul_expr(_hidden_arg("rows"), _hidden_arg("num_heads"), _hidden_arg("state_dim")) or _mul_expr(_hidden_arg("rows"), _hidden_arg("dim"))
         _emit_hidden_export(
             _hidden_arg("gate", "output", "out"),
             "gate",
-            _mul_expr(_hidden_arg("rows"), _hidden_arg("dim")),
+            gate_count,
         )
     elif op_name == "recurrent_conv_state_update":
         q_dim = _hidden_arg("q_dim")
@@ -1954,7 +1955,8 @@ def emit_op(
         elif op_name == "recurrent_beta_proj":
             _emit_dump(_get_arg("output", "out", "c", "y"), "beta", m_dim or n_dim)
         elif op_name == "recurrent_dt_gate":
-            _emit_dump(_get_arg("gate", "output", "out"), "gate", _mul_expr(_get_arg("rows"), _get_arg("dim")))
+            gate_count = _mul_expr(_get_arg("rows"), _get_arg("num_heads"), _get_arg("state_dim")) or _mul_expr(_get_arg("rows"), _get_arg("dim"))
+            _emit_dump(_get_arg("gate", "output", "out"), "gate", gate_count)
         elif op_name == "recurrent_conv_state_update":
             q_dim = _get_arg("q_dim")
             k_dim = _get_arg("k_dim")

--- a/version/v8/scripts/compare_qwen35_safetensors_ck_hidden_v8.py
+++ b/version/v8/scripts/compare_qwen35_safetensors_ck_hidden_v8.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""
+Compare Qwen3.5 safetensors math against CK hidden dumps.
+
+This is a diagnostic runner, not a full PyTorch model wrapper.  It reconstructs
+the Qwen3.5 text recurrent path directly from safetensors and compares each
+token/layer intermediate against CK_DEBUG_EXPORT_HIDDEN files.  The goal is to
+find the first stateful divergence after single-token parity already passes.
+"""
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from safetensors import safe_open
+
+
+def _load_config(checkpoint: Path) -> dict[str, Any]:
+    cfg = json.loads((checkpoint / "config.json").read_text(encoding="utf-8"))
+    return cfg.get("text_config") if isinstance(cfg.get("text_config"), dict) else cfg
+
+
+def _load_tensors(checkpoint: Path) -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    for path in sorted(checkpoint.glob("*.safetensors")):
+        with safe_open(path, framework="pt", device="cpu") as handle:
+            for key in handle.keys():
+                tensors[key] = handle.get_tensor(key).to(torch.float32)
+    if not tensors:
+        raise FileNotFoundError(f"no safetensors files found under {checkpoint}")
+    return tensors
+
+
+def _prefix(tensors: dict[str, torch.Tensor]) -> str:
+    if any(k.startswith("model.language_model.") for k in tensors):
+        return "model.language_model."
+    if any(k.startswith("model.") for k in tensors):
+        return "model."
+    return ""
+
+
+def _rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + eps) * weight
+
+
+def _linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return torch.mv(weight, x)
+
+
+def _silu(x: torch.Tensor) -> torch.Tensor:
+    return x * torch.sigmoid(x)
+
+
+def _softplus(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.softplus(x)
+
+
+def _l2_norm_heads(x: torch.Tensor, head_dim: int, eps: float) -> torch.Tensor:
+    y = x.reshape(-1, head_dim)
+    y = y * torch.rsqrt(torch.sum(y * y, dim=1, keepdim=True) + eps)
+    return y.reshape_as(x)
+
+
+def _recurrent_norm_gate(x: torch.Tensor, gate: torch.Tensor, weight: torch.Tensor, num_heads: int, head_dim: int, eps: float) -> torch.Tensor:
+    xh = x.reshape(num_heads, head_dim)
+    gh = gate.reshape(num_heads, head_dim)
+    ms = torch.mean(xh * xh, dim=1, keepdim=True)
+    return (xh * torch.rsqrt(ms + eps) * weight.reshape(1, head_dim) * _silu(gh)).reshape(-1)
+
+
+
+def _mrope_yarn_corr_dim(n_dims: int, n_ctx_orig: int, n_rot: float, base: float) -> float:
+    return n_dims * math.log(float(n_ctx_orig) / (n_rot * 2.0 * math.pi)) / (2.0 * math.log(base))
+
+
+def _mrope_yarn_corr_dims(n_dims: int, n_ctx_orig: int, freq_base: float, beta_fast: float, beta_slow: float) -> tuple[float, float]:
+    start = math.floor(_mrope_yarn_corr_dim(n_dims, n_ctx_orig, beta_fast, freq_base))
+    end = math.ceil(_mrope_yarn_corr_dim(n_dims, n_ctx_orig, beta_slow, freq_base))
+    return max(0.0, float(start)), min(float(n_dims - 1), float(end))
+
+
+def _mrope_yarn(theta_extrap: float, freq_scale: float, corr_dims: tuple[float, float], chan: int, ext_factor: float, attn_factor: float) -> tuple[float, float]:
+    theta_interp = freq_scale * theta_extrap
+    theta = theta_interp
+    mscale = attn_factor
+    if ext_factor != 0.0:
+        y = (float(chan) - corr_dims[0]) / max(0.001, corr_dims[1] - corr_dims[0])
+        ramp_mix = (1.0 - min(1.0, max(0.0, y))) * ext_factor
+        theta = theta_interp * (1.0 - ramp_mix) + theta_extrap * ramp_mix
+        mscale *= 1.0 + 0.1 * math.log(1.0 / max(freq_scale, 1e-6))
+    return math.cos(theta) * mscale, math.sin(theta) * mscale
+
+
+def _mrope_text_one(x: torch.Tensor, position: int, head_dim: int, n_dims: int, sections: list[int], freq_base: float) -> torch.Tensor:
+    y = x.clone().reshape(-1, head_dim)
+    if n_dims * 2 > head_dim:
+        n_dims = head_dim // 2
+    sec_w = sections[0] + sections[1]
+    sec_e = sec_w + sections[2]
+    sect_dims = sum(sections)
+    theta_scale = freq_base ** (-2.0 / float(n_dims))
+    corr_dims = _mrope_yarn_corr_dims(n_dims, 32768, freq_base, 32.0, 1.0)
+    for row in range(y.shape[0]):
+        theta_t = float(position)
+        theta_h = float(position)
+        theta_w = float(position)
+        theta_e = 0.0
+        for chan in range(n_dims):
+            sector = chan % sect_dims if sect_dims > 0 else chan
+            theta = theta_t
+            if sector >= sections[0] and sector < sec_w:
+                theta = theta_h
+            elif sector >= sec_w and sector < sec_e:
+                theta = theta_w
+            elif sector >= sec_e:
+                theta = theta_e
+            c, si = _mrope_yarn(theta, 1.0, corr_dims, chan, 0.0, 1.0)
+            x0 = float(y[row, chan])
+            x1 = float(y[row, chan + n_dims])
+            y[row, chan] = x0 * c - x1 * si
+            y[row, chan + n_dims] = x0 * si + x1 * c
+            theta_t *= theta_scale
+            theta_h *= theta_scale
+            theta_w *= theta_scale
+            theta_e *= theta_scale
+    return y.reshape(-1)
+
+def _stats(a: torch.Tensor, b: torch.Tensor) -> dict[str, float]:
+    a = a.reshape(-1).to(torch.float32)
+    b = b.reshape(-1).to(torch.float32)
+    n = min(a.numel(), b.numel())
+    if n == 0:
+        return {"max": math.inf, "mean": math.inf, "cos": 0.0}
+    a = a[:n]
+    b = b[:n]
+    d = torch.abs(a - b)
+    denom = torch.linalg.vector_norm(a) * torch.linalg.vector_norm(b)
+    cos = float(torch.dot(a, b) / denom) if float(denom) > 0.0 else 0.0
+    return {"max": float(torch.max(d)), "mean": float(torch.mean(d)), "cos": cos}
+
+
+def _read_ck(hidden_dir: Path, tok: int, layer: int, label: str) -> torch.Tensor | None:
+    path = hidden_dir / f"tok_{tok:04d}_layer_{layer:03d}_{label}.f32"
+    if not path.exists():
+        return None
+    arr = np.fromfile(path, dtype=np.float32)
+    return torch.from_numpy(arr.copy())
+
+
+def _compare(
+    hidden_dir: Path,
+    tok: int,
+    layer: int,
+    label: str,
+    value: torch.Tensor,
+    rows: list[dict[str, Any]],
+    fail_max: float,
+    fail_cos: float,
+) -> bool:
+    ck = _read_ck(hidden_dir, tok, layer, label)
+    if ck is None:
+        return False
+    st = _stats(value.reshape(-1), ck.reshape(-1))
+    row = {
+        "token_index": tok,
+        "layer": layer,
+        "label": label,
+        "shape": list(value.shape),
+        "ck_values": int(ck.numel()),
+        **st,
+    }
+    rows.append(row)
+    return st["max"] > fail_max or st["cos"] < fail_cos
+
+
+class Qwen35RecurrentComparator:
+    def __init__(self, checkpoint: Path, hidden_dir: Path, tokens: list[int], fail_max: float, fail_cos: float) -> None:
+        self.checkpoint = checkpoint
+        self.hidden_dir = hidden_dir
+        self.tokens = tokens
+        self.fail_max = fail_max
+        self.fail_cos = fail_cos
+        self.cfg = _load_config(checkpoint)
+        self.tensors = _load_tensors(checkpoint)
+        self.pfx = _prefix(self.tensors)
+        self.eps = float(self.cfg.get("rms_norm_eps", 1e-6))
+        self.hidden_size = int(self.cfg["hidden_size"])
+        self.layer_types = [str(x) for x in self.cfg.get("layer_types", [])]
+        self.num_layers = int(self.cfg["num_hidden_layers"])
+        self.conv_kernel = int(self.cfg.get("linear_conv_kernel_dim", 4))
+        self.head_dim = int(self.cfg.get("linear_key_head_dim", self.cfg.get("head_dim", 128)))
+        self.num_heads = int(self.cfg.get("linear_num_key_heads", 1))
+        self.inner = int(self.cfg.get("linear_num_value_heads", self.num_heads)) * int(self.cfg.get("linear_value_head_dim", self.head_dim))
+        self.conv_channels = self.num_heads * self.head_dim * 2 + self.inner
+        self.conv_state = {
+            layer: torch.zeros(self.conv_channels, self.conv_kernel - 1, dtype=torch.float32)
+            for layer, kind in enumerate(self.layer_types)
+            if kind != "full_attention"
+        }
+        self.ssm_state = {
+            layer: torch.zeros(self.num_heads, self.head_dim, self.head_dim, dtype=torch.float32)
+            for layer, kind in enumerate(self.layer_types)
+            if kind != "full_attention"
+        }
+        self.attn_k_cache: dict[int, list[torch.Tensor]] = {layer: [] for layer, kind in enumerate(self.layer_types) if kind == "full_attention"}
+        self.attn_v_cache: dict[int, list[torch.Tensor]] = {layer: [] for layer, kind in enumerate(self.layer_types) if kind == "full_attention"}
+
+    def w(self, name: str) -> torch.Tensor:
+        key = self.pfx + name
+        if key not in self.tensors:
+            raise KeyError(key)
+        value = self.tensors[key]
+        # Match llama.cpp/Qwen3.5 conversion: HF stores most norm weights
+        # offset by -1. The recurrent linear_attn.norm.weight is not shifted.
+        if name.endswith("norm.weight") and not name.endswith("linear_attn.norm.weight"):
+            return value + 1.0
+        return value
+
+    def _layer_prefix(self, layer: int) -> str:
+        return f"layers.{layer}."
+
+    def _recurrent_layer(self, x: torch.Tensor, token_index: int, layer: int, rows: list[dict[str, Any]]) -> tuple[torch.Tensor, bool]:
+        lp = self._layer_prefix(layer)
+        norm = _rmsnorm(x, self.w(lp + "input_layernorm.weight"), self.eps)
+
+        qkv = _linear(norm, self.w(lp + "linear_attn.in_proj_qkv.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "linear_attn_qkv_mixed", qkv, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        z = _linear(norm, self.w(lp + "linear_attn.in_proj_z.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "z", z, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        alpha = _linear(norm, self.w(lp + "linear_attn.in_proj_a.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "alpha", alpha, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        beta = _linear(norm, self.w(lp + "linear_attn.in_proj_b.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "beta", beta, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        conv_x = torch.cat([self.conv_state[layer], qkv.reshape(self.conv_channels, 1)], dim=1)
+        if _compare(self.hidden_dir, token_index, layer, "conv_input", conv_x, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        kernel = self.w(lp + "linear_attn.conv1d.weight").reshape(self.conv_channels, self.conv_kernel)
+        conv_raw = torch.sum(conv_x * kernel, dim=1)
+        if _compare(self.hidden_dir, token_index, layer, "conv_output_raw", conv_raw, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        conv = _silu(conv_raw)
+        if _compare(self.hidden_dir, token_index, layer, "conv_output_silu", conv, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        q = conv[: self.num_heads * self.head_dim].clone()
+        k0 = self.num_heads * self.head_dim
+        k = conv[k0 : k0 + self.num_heads * self.head_dim].clone()
+        v = conv[k0 + self.num_heads * self.head_dim :].clone()
+        if _compare(self.hidden_dir, token_index, layer, "q_conv", q, rows, self.fail_max, self.fail_cos):
+            return x, True
+        if _compare(self.hidden_dir, token_index, layer, "k_conv", k, rows, self.fail_max, self.fail_cos):
+            return x, True
+        if _compare(self.hidden_dir, token_index, layer, "v_conv_predelta", v, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        q = _l2_norm_heads(q, self.head_dim, self.eps)
+        k = _l2_norm_heads(k, self.head_dim, self.eps)
+        if _compare(self.hidden_dir, token_index, layer, "q_conv_predelta", q, rows, self.fail_max, self.fail_cos):
+            return x, True
+        if _compare(self.hidden_dir, token_index, layer, "k_conv_predelta", k, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        ssm_a = -torch.exp(self.w(lp + "linear_attn.A_log")).reshape(self.num_heads)
+        g = _softplus(alpha + self.w(lp + "linear_attn.dt_bias")) * ssm_a
+        decay = torch.exp(g)
+        beta_s = torch.sigmoid(beta)
+        qh = q.reshape(self.num_heads, self.head_dim) / math.sqrt(float(self.head_dim))
+        kh = k.reshape(self.num_heads, self.head_dim)
+        vh = v.reshape(self.num_heads, self.head_dim)
+        state_prev = self.ssm_state[layer]
+        state_cur = torch.empty_like(state_prev)
+        attn = torch.empty_like(vh)
+        for h in range(self.num_heads):
+            s = state_prev[h] * decay[h]
+            kv_mem = torch.mv(s.T, kh[h])
+            delta = (vh[h] - kv_mem) * beta_s[h]
+            s = s + torch.outer(kh[h], delta)
+            state_cur[h] = s
+            attn[h] = torch.mv(s.T, qh[h])
+        attn_flat = attn.reshape(-1)
+        if _compare(self.hidden_dir, token_index, layer, "attn_output", attn_flat, rows, self.fail_max, self.fail_cos):
+            return x, True
+        if _compare(self.hidden_dir, token_index, layer, "new_state", state_cur, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        final = _recurrent_norm_gate(attn_flat, z, self.w(lp + "linear_attn.norm.weight"), self.num_heads, self.head_dim, self.eps)
+        if _compare(self.hidden_dir, token_index, layer, "final_output", final, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        attn_out = _linear(final, self.w(lp + "linear_attn.out_proj.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "linear_attn_out", attn_out, rows, self.fail_max, self.fail_cos):
+            return x, True
+        x = x + attn_out
+        if _compare(self.hidden_dir, token_index, layer, "after_attn", x, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        post = _rmsnorm(x, self.w(lp + "post_attention_layernorm.weight"), self.eps)
+        if _compare(self.hidden_dir, token_index, layer, "post_attn_norm", post, rows, self.fail_max, self.fail_cos):
+            return x, True
+        gate = _linear(post, self.w(lp + "mlp.gate_proj.weight"))
+        up = _linear(post, self.w(lp + "mlp.up_proj.weight"))
+        swiglu = _silu(gate) * up
+        if _compare(self.hidden_dir, token_index, layer, "mlp_swiglu", swiglu, rows, self.fail_max, self.fail_cos):
+            return x, True
+        down = _linear(swiglu, self.w(lp + "mlp.down_proj.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "mlp_down", down, rows, self.fail_max, self.fail_cos):
+            return x, True
+        x = x + down
+        if _compare(self.hidden_dir, token_index, layer, "layer_out", x, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        self.conv_state[layer] = conv_x[:, 1:].clone()
+        self.ssm_state[layer] = state_cur.clone()
+        return x, False
+
+
+    def _full_attention_prefix(self, x: torch.Tensor, token_index: int, layer: int, rows: list[dict[str, Any]]) -> tuple[torch.Tensor, bool]:
+        lp = self._layer_prefix(layer)
+        num_heads = int(self.cfg.get("num_attention_heads", 1))
+        num_kv_heads = int(self.cfg.get("num_key_value_heads", 1))
+        head_dim = int(self.cfg.get("head_dim", self.hidden_size // max(1, num_heads)))
+        norm = _rmsnorm(x, self.w(lp + "input_layernorm.weight"), self.eps)
+
+        q_gate = _linear(norm, self.w(lp + "self_attn.q_proj.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "q_proj", q_gate, rows, self.fail_max, self.fail_cos):
+            return x, True
+        qg = q_gate.reshape(num_heads, 2, head_dim)
+        q = qg[:, 0, :].reshape(-1).clone()
+
+        k = _linear(norm, self.w(lp + "self_attn.k_proj.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "k_proj", k, rows, self.fail_max, self.fail_cos):
+            return x, True
+        v = _linear(norm, self.w(lp + "self_attn.v_proj.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "v_proj", v, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        q = _rmsnorm(q.reshape(num_heads, head_dim), self.w(lp + "self_attn.q_norm.weight"), self.eps).reshape(-1)
+        k = _rmsnorm(k.reshape(num_kv_heads, head_dim), self.w(lp + "self_attn.k_norm.weight"), self.eps).reshape(-1)
+        if _compare(self.hidden_dir, token_index, layer, "qk_norm_q", q, rows, self.fail_max, self.fail_cos):
+            return x, True
+        if _compare(self.hidden_dir, token_index, layer, "qk_norm_k", k, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        rope_params = self.cfg.get("rope_parameters") if isinstance(self.cfg.get("rope_parameters"), dict) else {}
+        sections = [int(v) for v in (rope_params.get("mrope_section") or [11, 11, 10])]
+        if len(sections) == 3:
+            sections.append(0)
+        n_dims = int(sum(sections))
+        freq_base = float(rope_params.get("rope_theta", self.cfg.get("rope_theta", 10000000.0)))
+        q_rope = _mrope_text_one(q, token_index, head_dim, n_dims, sections, freq_base)
+        k_rope = _mrope_text_one(k, token_index, head_dim, n_dims, sections, freq_base)
+        if _compare(self.hidden_dir, token_index, layer, "rope_q", q_rope, rows, self.fail_max, self.fail_cos):
+            return x, True
+        if _compare(self.hidden_dir, token_index, layer, "rope_k", k_rope, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        qh = q_rope.reshape(num_heads, head_dim)
+        kh = k_rope.reshape(num_kv_heads, head_dim)
+        vh = v.reshape(num_kv_heads, head_dim)
+        self.attn_k_cache[layer].append(kh.clone())
+        self.attn_v_cache[layer].append(vh.clone())
+        k_cache = torch.stack(self.attn_k_cache[layer], dim=0)
+        v_cache = torch.stack(self.attn_v_cache[layer], dim=0)
+        group = max(1, num_heads // max(1, num_kv_heads))
+        attn = torch.empty((num_heads, head_dim), dtype=torch.float32)
+        scale = 1.0 / math.sqrt(float(head_dim))
+        for h in range(num_heads):
+            kv_h = min(num_kv_heads - 1, h // group)
+            scores = torch.mv(k_cache[:, kv_h, :], qh[h]) * scale
+            probs = torch.softmax(scores, dim=0)
+            attn[h] = torch.sum(probs.reshape(-1, 1) * v_cache[:, kv_h, :], dim=0)
+        attn_flat = (attn.reshape(-1) * torch.sigmoid(qg[:, 1, :].reshape(-1))).reshape(-1)
+        if _compare(self.hidden_dir, token_index, layer, "attn_out", attn_flat, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        out = _linear(attn_flat, self.w(lp + "self_attn.o_proj.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "out_proj", out, rows, self.fail_max, self.fail_cos):
+            return x, True
+        x = x + out
+        if _compare(self.hidden_dir, token_index, layer, "after_attn", x, rows, self.fail_max, self.fail_cos):
+            return x, True
+
+        post = _rmsnorm(x, self.w(lp + "post_attention_layernorm.weight"), self.eps)
+        if _compare(self.hidden_dir, token_index, layer, "post_attn_norm", post, rows, self.fail_max, self.fail_cos):
+            return x, True
+        gate_proj = _linear(post, self.w(lp + "mlp.gate_proj.weight"))
+        up_proj = _linear(post, self.w(lp + "mlp.up_proj.weight"))
+        swiglu = _silu(gate_proj) * up_proj
+        if _compare(self.hidden_dir, token_index, layer, "mlp_swiglu", swiglu, rows, self.fail_max, self.fail_cos):
+            return x, True
+        down = _linear(swiglu, self.w(lp + "mlp.down_proj.weight"))
+        if _compare(self.hidden_dir, token_index, layer, "mlp_down", down, rows, self.fail_max, self.fail_cos):
+            return x, True
+        x = x + down
+        if _compare(self.hidden_dir, token_index, layer, "layer_out", x, rows, self.fail_max, self.fail_cos):
+            return x, True
+        return x, False
+
+    def run(self, stop_at_full_attention: bool, max_layer: int | None = None) -> dict[str, Any]:
+        rows: list[dict[str, Any]] = []
+        token_emb = self.w("embed_tokens.weight")
+        first_failure: dict[str, Any] | None = None
+        for tok_i, tok in enumerate(self.tokens):
+            x = token_emb[int(tok)].clone()
+            layer_limit = self.num_layers if max_layer is None else min(self.num_layers, int(max_layer))
+            for layer in range(layer_limit):
+                kind = self.layer_types[layer] if layer < len(self.layer_types) else "linear_attention"
+                if kind == "full_attention":
+                    x, failed = self._full_attention_prefix(x, tok_i, layer, rows)
+                    if failed:
+                        first_failure = rows[-1]
+                        return {"first_failure": first_failure, "comparisons": rows}
+                    continue
+                x, failed = self._recurrent_layer(x, tok_i, layer, rows)
+                if failed:
+                    first_failure = rows[-1]
+                    return {"first_failure": first_failure, "comparisons": rows}
+        return {"first_failure": first_failure, "comparisons": rows}
+
+
+def _parse_tokens_csv(value: str) -> list[int]:
+    out = [int(x.strip()) for x in value.split(",") if x.strip()]
+    if not out:
+        raise argparse.ArgumentTypeError("token list is empty")
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Compare Qwen3.5 safetensors recurrent hidden stream against CK dumps")
+    ap.add_argument("--checkpoint", required=True, type=Path, help="HF safetensors checkpoint directory")
+    ap.add_argument("--ck-hidden-dir", required=True, type=Path, help="CK_DEBUG_EXPORT_HIDDEN output directory")
+    ap.add_argument("--tokens", required=True, type=_parse_tokens_csv, help="comma-separated token IDs matching the CK dump")
+    ap.add_argument("--fail-max", type=float, default=5e-3)
+    ap.add_argument("--fail-cos", type=float, default=0.999)
+    ap.add_argument("--json-out", type=Path)
+    ap.add_argument("--stop-at-full-attention", action="store_true", default=True)
+    ap.add_argument("--max-layer", type=int, help="compare only layers [0, max_layer) so recurrent state can be isolated before full attention")
+    args = ap.parse_args()
+
+    comp = Qwen35RecurrentComparator(
+        checkpoint=args.checkpoint,
+        hidden_dir=args.ck_hidden_dir,
+        tokens=args.tokens,
+        fail_max=args.fail_max,
+        fail_cos=args.fail_cos,
+    )
+    result = comp.run(stop_at_full_attention=args.stop_at_full_attention, max_layer=args.max_layer)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(json.dumps(result["first_failure"], indent=2, sort_keys=True))
+    print(f"comparisons={len(result['comparisons'])}")
+    return 1 if result["first_failure"] and result["first_failure"].get("label") != "full_attention_not_implemented" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 """Convert HF safetensors language weights into v8 BUMPWGT5 artifacts.
 
 This is a BUMP-first importer.  GGUF and safetensors are source formats; CK
-runtime consumes weights.bump + sidecars.  The first supported target is the
-Gemma4 text/language model path, using CK-internal manifest names so existing
-v8 IR/codegen can consume the result.
+runtime consumes weights.bump + sidecars.  Supported targets map source tensor
+names into CK-internal manifest names so existing v8 IR/codegen can consume
+safetensors and GGUF through the same BUMP runtime contract.
 """
 
 import argparse
@@ -40,6 +40,7 @@ from convert_gguf_to_bump_v8 import (  # type: ignore
     _inject_runtime_config_defaults,
     apply_model_contract_overrides,
     build_bumpv5_metadata,
+    build_qwen35_execution_plan,
     calculate_manifest_hash,
     calculate_metadata_hash,
     calculate_template_hash,
@@ -253,6 +254,67 @@ def _gemma4_text_refs(config: dict[str, Any], headers: dict[str, HeaderTensor]) 
     return refs
 
 
+def _qwen35_text_refs(config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef]:
+    text = config.get("text_config") if isinstance(config.get("text_config"), dict) else config
+    num_layers = int(config.get("num_layers") or config.get("num_hidden_layers") or text.get("num_hidden_layers") or 0)
+    embed_dim = int(config.get("embed_dim") or config.get("hidden_size") or text.get("hidden_size") or 0)
+    intermediate = int(config.get("intermediate_size") or text.get("intermediate_size") or 0)
+    num_heads = int(config.get("num_heads") or text.get("num_attention_heads") or 0)
+    num_kv_heads = int(config.get("num_kv_heads") or text.get("num_key_value_heads") or 0)
+    head_dim = int(config.get("head_dim") or text.get("head_dim") or (embed_dim // max(1, num_heads)))
+    if num_layers <= 0 or embed_dim <= 0 or intermediate <= 0 or num_heads <= 0:
+        raise SystemExit("Qwen3.5 config missing num_layers/embed_dim/intermediate_size/num_heads")
+
+    prefix = "model.language_model."
+    layer_types = list(config.get("layer_types") or text.get("layer_types") or [])
+    if layer_types and len(layer_types) != num_layers:
+        raise SystemExit(f"Qwen3.5 layer_types length {len(layer_types)} != num_layers {num_layers}")
+
+    refs: list[TensorRef] = [
+        TensorRef("token_emb", (_require_existing(headers, (f"{prefix}embed_tokens.weight",), "token_emb"),)),
+    ]
+
+    for layer in range(num_layers):
+        layer_prefix = f"{prefix}layers.{layer}"
+        layer_type = str(layer_types[layer] if layer_types else ("full_attention" if (layer + 1) % 4 == 0 else "linear_attention"))
+        refs.extend([
+            TensorRef(f"layer.{layer}.attn_norm", (_require_existing(headers, (f"{layer_prefix}.input_layernorm.weight",), f"layer {layer} input norm"),), dtype="fp32"),
+            TensorRef(f"layer.{layer}.post_attention_norm", (_require_existing(headers, (f"{layer_prefix}.post_attention_layernorm.weight",), f"layer {layer} post attention norm"),), dtype="fp32"),
+            TensorRef(f"layer.{layer}.ffn_gate", (_require_existing(headers, (f"{layer_prefix}.mlp.gate_proj.weight",), f"layer {layer} gate_proj"),)),
+            TensorRef(f"layer.{layer}.ffn_up", (_require_existing(headers, (f"{layer_prefix}.mlp.up_proj.weight",), f"layer {layer} up_proj"),)),
+            TensorRef(f"layer.{layer}.ffn_down", (_require_existing(headers, (f"{layer_prefix}.mlp.down_proj.weight",), f"layer {layer} down_proj"),)),
+        ])
+        if layer_type in {"linear_attention", "recurrent"}:
+            refs.extend([
+                TensorRef(f"layer.{layer}.attn_qkv", (_require_existing(headers, (f"{layer_prefix}.linear_attn.in_proj_qkv.weight",), f"layer {layer} recurrent qkv"),)),
+                TensorRef(f"layer.{layer}.attn_gate", (_require_existing(headers, (f"{layer_prefix}.linear_attn.in_proj_z.weight",), f"layer {layer} recurrent gate"),)),
+                TensorRef(f"layer.{layer}.ssm_alpha", (_require_existing(headers, (f"{layer_prefix}.linear_attn.in_proj_a.weight",), f"layer {layer} recurrent alpha"),)),
+                TensorRef(f"layer.{layer}.ssm_beta", (_require_existing(headers, (f"{layer_prefix}.linear_attn.in_proj_b.weight",), f"layer {layer} recurrent beta"),)),
+                TensorRef(f"layer.{layer}.ssm_conv1d", (_require_existing(headers, (f"{layer_prefix}.linear_attn.conv1d.weight",), f"layer {layer} recurrent conv1d"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.ssm_dt_bias", (_require_existing(headers, (f"{layer_prefix}.linear_attn.dt_bias",), f"layer {layer} recurrent dt bias"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.ssm_a", (_require_existing(headers, (f"{layer_prefix}.linear_attn.A_log",), f"layer {layer} recurrent A_log"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.ssm_norm", (_require_existing(headers, (f"{layer_prefix}.linear_attn.norm.weight",), f"layer {layer} recurrent norm"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.ssm_out", (_require_existing(headers, (f"{layer_prefix}.linear_attn.out_proj.weight",), f"layer {layer} recurrent out"),)),
+            ])
+        elif layer_type == "full_attention":
+            refs.extend([
+                TensorRef(f"layer.{layer}.attn_q_gate", (_require_existing(headers, (f"{layer_prefix}.self_attn.q_proj.weight",), f"layer {layer} q_proj"),)),
+                TensorRef(f"layer.{layer}.attn_k", (_require_existing(headers, (f"{layer_prefix}.self_attn.k_proj.weight",), f"layer {layer} k_proj"),)),
+                TensorRef(f"layer.{layer}.attn_v", (_require_existing(headers, (f"{layer_prefix}.self_attn.v_proj.weight",), f"layer {layer} v_proj"),)),
+                TensorRef(f"layer.{layer}.attn_output", (_require_existing(headers, (f"{layer_prefix}.self_attn.o_proj.weight",), f"layer {layer} o_proj"),)),
+                TensorRef(f"layer.{layer}.attn_q_norm", (_require_existing(headers, (f"{layer_prefix}.self_attn.q_norm.weight",), f"layer {layer} q_norm"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.attn_k_norm", (_require_existing(headers, (f"{layer_prefix}.self_attn.k_norm.weight",), f"layer {layer} k_norm"),), dtype="fp32"),
+            ])
+        else:
+            raise SystemExit(f"Unsupported Qwen3.5 layer_type at layer {layer}: {layer_type}")
+
+    refs.append(TensorRef("final_ln_weight", (_require_existing(headers, (f"{prefix}norm.weight",), "final norm"),), dtype="fp32"))
+    lm_head = _first_existing(headers, ("lm_head.weight", f"{prefix}lm_head.weight"))
+    if lm_head is not None:
+        refs.append(TensorRef("output.weight", (lm_head,)))
+    return refs
+
+
 def _first_existing(headers: dict[str, HeaderTensor], names: Iterable[str]) -> str | None:
     for name in names:
         if name in headers:
@@ -361,6 +423,8 @@ def _infer_arch(hf: dict[str, Any]) -> str:
         return "gemma4"
     if "gemma" in mt and "3" in mt:
         return "gemma3"
+    if "qwen3_5" in mt or "qwen3.5" in mt or "qwen35" in mt:
+        return "qwen35"
     if "qwen3" in mt:
         return "qwen3"
     if "qwen2" in mt or mt == "qwen":
@@ -373,6 +437,8 @@ def _infer_arch(hf: dict[str, Any]) -> str:
 def _refs_for_arch(arch: str, config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef]:
     if arch == "gemma4":
         return _gemma4_text_refs(config, headers)
+    if arch == "qwen35":
+        return _qwen35_text_refs(config, headers)
     if arch in {"llama", "qwen2", "qwen3", "gemma3"}:
         return _llama_family_text_refs(config, headers)
     raise SystemExit(f"Unsupported safetensors arch for v8 importer: {arch}")
@@ -400,13 +466,93 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
     rope_params = text.get("rope_parameters") if isinstance(text.get("rope_parameters"), dict) else {}
     full_rope = rope_params.get("full_attention") if isinstance(rope_params.get("full_attention"), dict) else {}
     sliding_rope = rope_params.get("sliding_attention") if isinstance(rope_params.get("sliding_attention"), dict) else {}
-    cfg.setdefault("rope_theta", full_rope.get("rope_theta", text.get("rope_theta", 1000000.0)))
+    rope_parameters = text.get("rope_parameters") if isinstance(text.get("rope_parameters"), dict) else {}
+    cfg.setdefault("rope_theta", full_rope.get("rope_theta", rope_parameters.get("rope_theta", text.get("rope_theta", 1000000.0))))
     cfg.setdefault("rope_theta_swa", sliding_rope.get("rope_theta", 10000.0))
-    cfg.setdefault("rope_layout", "split")
+    mrope_sections_raw = rope_parameters.get("mrope_section") or []
+    rope_interleaved = bool(rope_parameters.get("mrope_interleaved", False))
+    if mrope_sections_raw:
+        cfg.setdefault("rope_layout", "multi_section_1d")
+    else:
+        cfg.setdefault("rope_layout", "pairwise" if rope_interleaved else "split")
     cfg.setdefault("rope_param_mode", "per_layer_direct")
     cfg.setdefault("rms_eps", text.get("rms_norm_eps", text.get("rms_norm_epsilon", 1e-6)))
     cfg.setdefault("rms_norm_eps", cfg.get("rms_eps"))
     cfg.setdefault("tie_word_embeddings", bool(text.get("tie_word_embeddings", True)))
+    if arch == "qwen35":
+        headers = _load_safetensors_headers(model_dir)
+        q_gate_proj_dim = 0
+        attn_out_dim = 0
+        recurrent_q_dim = int(text.get("linear_num_key_heads", 0) or 0) * int(text.get("linear_key_head_dim", 0) or 0)
+        recurrent_k_dim = recurrent_q_dim
+        recurrent_v_dim = int(text.get("linear_num_value_heads", 0) or 0) * int(text.get("linear_value_head_dim", 0) or 0)
+        ssm_time_step_rank = 0
+        for name, h in headers.items():
+            if name.endswith(".self_attn.q_proj.weight") and len(h.shape) >= 2:
+                q_gate_proj_dim = int(h.shape[0])
+                if q_gate_proj_dim % 2 == 0:
+                    attn_out_dim = q_gate_proj_dim // 2
+            elif name.endswith(".linear_attn.in_proj_qkv.weight") and len(h.shape) >= 2:
+                total = int(h.shape[0])
+                if recurrent_q_dim <= 0 or recurrent_k_dim <= 0 or recurrent_v_dim <= 0:
+                    recurrent_q_dim = total // 3
+                    recurrent_k_dim = total // 3
+                    recurrent_v_dim = total - recurrent_q_dim - recurrent_k_dim
+            elif name.endswith(".linear_attn.in_proj_a.weight") and len(h.shape) >= 2:
+                ssm_time_step_rank = max(ssm_time_step_rank, int(h.shape[0]))
+        if attn_out_dim <= 0:
+            attn_out_dim = int(text.get("num_attention_heads", cfg.get("num_heads", 0))) * int(text.get("head_dim", cfg.get("head_dim", 0)))
+        if q_gate_proj_dim <= 0:
+            q_gate_proj_dim = attn_out_dim * 2
+        if ssm_time_step_rank <= 0:
+            ssm_time_step_rank = int(text.get("linear_num_key_heads") or text.get("linear_num_value_heads") or 0)
+
+        layer_types = [str(x) for x in (text.get("layer_types") or [])]
+        layer_kinds = ["full_attention" if x == "full_attention" else "recurrent" for x in layer_types]
+        if not layer_kinds:
+            n_layers = int(cfg.get("num_layers") or 0)
+            interval = int(text.get("full_attention_interval") or 4)
+            layer_kinds = ["full_attention" if (i + 1) % interval == 0 else "recurrent" for i in range(n_layers)]
+        execution_plan = build_qwen35_execution_plan(layer_kinds)
+        cfg.update({
+            "model": "qwen35",
+            "arch": "qwen35",
+            "model_type": "qwen35",
+            "attn_out_dim": int(attn_out_dim),
+            "attn_q_gate_proj_dim": int(q_gate_proj_dim),
+            "intermediate_dim": int(cfg.get("intermediate_size") or 0),
+            "max_seq_len": int(cfg.get("context_length") or 0),
+            "rotary_dim": int(int(text.get("head_dim", cfg.get("head_dim", 0))) * float(rope_parameters.get("partial_rotary_factor", 1.0))),
+            "has_qk_norm": any(kind == "full_attention" for kind in layer_kinds),
+            "has_attention_biases": False,
+            "layer_types": layer_types,
+            "layer_kinds": layer_kinds,
+            "hybrid_block_pattern": layer_kinds[:],
+            "layer_execution_plan": execution_plan["layer_execution_plan"],
+            "layer_state_policy": execution_plan["layer_state_policy"],
+            "layer_attention_policy": execution_plan["layer_attention_policy"],
+            "layer_recurrent_policy": execution_plan["layer_recurrent_policy"],
+            "layer_kv_policy": execution_plan["layer_kv_policy"],
+            "prefill_policy": "batched",
+            "full_attention_interval": int(text.get("full_attention_interval") or 4),
+            "ssm_conv_kernel": int(text.get("linear_conv_kernel_dim") or 4),
+            "ssm_state_size": int(text.get("linear_key_head_dim") or max(1, recurrent_q_dim)),
+            "ssm_group_count": int(text.get("linear_num_key_heads") or max(1, recurrent_q_dim // max(1, int(text.get("linear_key_head_dim") or recurrent_q_dim)))),
+            "ssm_time_step_rank": int(ssm_time_step_rank),
+            "ssm_inner_size": int(recurrent_v_dim),
+            "q_dim": int(recurrent_q_dim),
+            "k_dim": int(recurrent_k_dim),
+            "v_dim": int(recurrent_v_dim),
+            "gate_dim": int(ssm_time_step_rank),
+            "ssm_conv_channels": int(recurrent_q_dim + recurrent_k_dim + recurrent_v_dim),
+            "recurrent_num_heads": int(ssm_time_step_rank),
+            "recurrent_head_dim": int(recurrent_v_dim // max(1, ssm_time_step_rank)) if ssm_time_step_rank else int(text.get("linear_key_head_dim") or 0),
+            "sampler_defaults": {"repeat_penalty": 1.12, "repeat_last_n": 96, "no_repeat_ngram_size": 4},
+        })
+        mrope = list(rope_parameters.get("mrope_section") or [])
+        if mrope:
+            cfg["mrope_sections"] = [int(v) for v in mrope] + ([0] if len(mrope) == 3 else [])
+            cfg["mrope_n_dims"] = int(sum(int(v) for v in mrope))
     cfg = _inject_runtime_config_defaults(cfg, arch)
     if arch == "gemma4" and "layer_kinds" not in cfg:
         raise SystemExit("Gemma4 safetensors conversion currently requires --config-template with explicit layer_kinds/shared KV policy")
@@ -436,6 +582,80 @@ def _entry_size_from_header(ref: TensorRef, headers: dict[str, HeaderTensor], dt
     return out_dtype or "fp32", total, out_shape
 
 
+def _is_qwen35_shifted_norm_ref(ref: TensorRef) -> bool:
+    if not ref.source_names:
+        return False
+    src = ref.source_names[0]
+    if not src.endswith("norm.weight"):
+        return False
+    # llama.cpp shifts Qwen3.5 norm weights by +1, except the recurrent
+    # linear_attn.norm.weight used inside the DeltaNet norm-gate.
+    if src.endswith("linear_attn.norm.weight"):
+        return False
+    return ref.ck_name == "final_ln_weight" or ref.ck_name.endswith((
+        ".attn_norm",
+        ".post_attention_norm",
+        ".attn_q_norm",
+        ".attn_k_norm",
+    ))
+
+
+def _ref_transform(ref: TensorRef) -> str | None:
+    if ref.ck_name.endswith(".ssm_a"):
+        return "neg_exp_a_log"
+    if _is_qwen35_shifted_norm_ref(ref):
+        return "qwen35_norm_plus_one"
+    return None
+
+
+def _ignored_source_tensor(arch: str, name: str) -> str | None:
+    if name.startswith("mtp.") or name.startswith("model.mtp."):
+        return "mtp_decoder_block_not_in_main_pass"
+    if arch == "qwen35" and (name.startswith("model.visual.") or name.startswith("visual.")):
+        return "vision_tower_not_in_decoder_pass"
+    if arch == "qwen35" and name.startswith("model.vision_model."):
+        return "vision_tower_not_in_decoder_pass"
+    return None
+
+
+def _build_source_audit(arch: str, headers: dict[str, HeaderTensor], refs: list[TensorRef]) -> dict[str, Any]:
+    consumed: dict[str, list[str]] = {}
+    synthetic: list[str] = []
+    transforms: list[dict[str, str]] = []
+    for ref in refs:
+        transform = _ref_transform(ref)
+        if ref.source_names:
+            for src in ref.source_names:
+                consumed.setdefault(src, []).append(ref.ck_name)
+                if transform:
+                    transforms.append({"source": src, "target": ref.ck_name, "transform": transform})
+        else:
+            synthetic.append(ref.ck_name)
+    ignored: list[dict[str, str]] = []
+    unmapped: list[str] = []
+    for name in sorted(headers):
+        if name in consumed:
+            continue
+        reason = _ignored_source_tensor(arch, name)
+        if reason:
+            ignored.append({"source": name, "reason": reason})
+        else:
+            unmapped.append(name)
+    return {
+        "arch": arch,
+        "source_tensor_count": len(headers),
+        "consumed_source_count": len(consumed),
+        "consumed_source_tensors": sorted(consumed),
+        "source_to_targets": {name: sorted(targets) for name, targets in sorted(consumed.items())},
+        "entry_count": len(refs),
+        "synthetic_entries": synthetic,
+        "ignored_source_tensors": ignored,
+        "unmapped_source_tensors": unmapped,
+        "transforms": transforms,
+        "verdict": "fail" if unmapped else "pass",
+    }
+
+
 def _write_ref(w: HashingWriter, model_dir: Path, headers: dict[str, HeaderTensor], ref: TensorRef, dtype_policy: str) -> tuple[str, int, list[int]]:
     if ref.synth:
         data, dt, shape = _synth_bytes(ref.synth, ref.shape or (), dtype_policy)
@@ -446,6 +666,13 @@ def _write_ref(w: HashingWriter, model_dir: Path, headers: dict[str, HeaderTenso
     out_shape: list[int] = []
     for src in ref.source_names:
         t = _load_tensor(model_dir, headers, src)
+        transform = _ref_transform(ref)
+        if transform == "neg_exp_a_log":
+            import torch
+            t = -torch.exp(t.to(dtype=torch.float32))
+        elif transform == "qwen35_norm_plus_one":
+            import torch
+            t = t.to(dtype=torch.float32) + 1.0
         policy = ref.dtype or dtype_policy
         data, dt, shape = _torch_to_bytes(t, policy)
         w.write(data)
@@ -470,10 +697,12 @@ def main() -> int:
     ap.add_argument("--output", required=True, type=Path, help="output weights.bump")
     ap.add_argument("--config-out", required=True, type=Path)
     ap.add_argument("--manifest-out", required=True, type=Path)
-    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3"])
+    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35"])
     ap.add_argument("--config-template", type=Path, help="existing v8 config/manifest to reuse explicit runtime policy")
     ap.add_argument("--dtype", default="preserve", choices=["preserve", "bf16", "fp32"])
     ap.add_argument("--dry-run", action="store_true", help="validate mapping and write JSON reports only; do not write BUMP")
+    ap.add_argument("--audit-out", type=Path, help="write safetensors source coverage audit JSON; default is manifest directory/conversion_audit.json")
+    ap.add_argument("--allow-unmapped", action="store_true", help="allow non-ignored source tensors to remain unmapped")
     args = ap.parse_args()
 
     model_dir = args.checkpoint.resolve()
@@ -497,18 +726,30 @@ def main() -> int:
             continue
         dt, size, shape = _entry_size_from_header(ref, headers, args.dtype)
         dtype_table.append(_dtype_code(dt))
-        entries_preview.append({
+        preview_entry = {
             "name": ref.ck_name,
             "dtype": dt,
             "file_offset": offset,
             "size": size,
             "source_name": "+".join(ref.source_names) if ref.source_names else f"synthetic:{ref.synth}",
             "shape": shape,
-        })
+        }
+        transform = _ref_transform(ref)
+        if transform:
+            preview_entry["transform"] = transform
+        entries_preview.append(preview_entry)
         offset += size
     if missing:
         uniq = sorted(set(missing))
         raise SystemExit("Missing required safetensors tensors:\n  " + "\n  ".join(uniq[:80]))
+
+    audit = _build_source_audit(arch, headers, refs)
+    audit_out = args.audit_out or (args.manifest_out.parent / "conversion_audit.json")
+    audit_out.parent.mkdir(parents=True, exist_ok=True)
+    audit_out.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if audit["unmapped_source_tensors"] and not args.allow_unmapped:
+        sample = "\n  ".join(audit["unmapped_source_tensors"][:80])
+        raise SystemExit(f"Unmapped safetensors source tensors; see {audit_out}:\n  {sample}")
 
     template = apply_model_contract_overrides(
         load_template_for_arch(arch),
@@ -545,6 +786,7 @@ def main() -> int:
         "context_length": int(config.get("context_length", 0) or 0),
         "has_attention_biases": False,
         "has_qk_norm": True,
+        "source_audit": audit,
         "entries": entries_preview,
     }
 
@@ -572,14 +814,18 @@ def main() -> int:
             start = current_offset
             dt, size, shape = _write_ref(w, model_dir, headers, ref, args.dtype)
             current_offset += size
-            entries.append({
+            entry = {
                 "name": ref.ck_name,
                 "dtype": dt,
                 "file_offset": start,
                 "size": size,
                 "source_name": "+".join(ref.source_names) if ref.source_names else f"synthetic:{ref.synth}",
                 "shape": shape,
-            })
+            }
+            transform = _ref_transform(ref)
+            if transform:
+                entry["transform"] = transform
+            entries.append(entry)
         checksum = w.digest()
         manifest["entries"] = entries
         args.manifest_out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")


### PR DESCRIPTION
Why: map Qwen3.5 safetensors into the v8 BUMP runtime with audited norm transforms and synchronize recurrent DeltaNet kernel contracts for explicit head/state dimensions.

Test: py_compile for safetensors importer/comparator/tests; make build/libckernel_engine.so; make v7-kernel-map-contracts; recurrent dt-gate, qk-l2-norm, split-conv-qkv, and attention-gate parity tests; pre-commit v7/v8 fast regression passed.