### PR TITLE
feat(v8): add Nemotron ReLU2 coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1212,6 +1212,12 @@ test-recurrent-conv-state-update: $(LIB)
 test-recurrent-silu: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_recurrent_silu.py $(ARGS)
 
+test-relu2: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_relu2.py $(ARGS)
+
+test-relu2-perf: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_relu2.py --benchmark
+
 test-recurrent-split-conv-qkv: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_recurrent_split_conv_qkv.py $(ARGS)
 

--- a/docs/MODEL_COMPATIBILITY_ATLAS.md
+++ b/docs/MODEL_COMPATIBILITY_ATLAS.md
@@ -1,0 +1,84 @@
+# CK Model Compatibility Atlas
+
+This is the reference-first workflow for adding new model families to C-Kernel-Engine.
+GGUF and safetensors are source formats; CK runtime should converge on BUMP plus
+explicit sidecar contracts.  New model work should start by proving the graph and
+kernel contract before optimizing speed.
+
+## Bring-up order
+
+1. Inspect `config.json`.
+2. Classify the layer pattern and required kernels.
+3. Add safetensors-to-BUMP mapping with full source tensor coverage audit.
+4. Run single-token and multi-token hidden/logit parity against PyTorch or a known
+   reference.
+5. Add GGUF conversion only after the BUMP graph contract is understood.
+6. Optimize shared hot kernels after correctness is stable.
+
+Use:
+
+```bash
+.venv/bin/python version/v8/scripts/inspect_model_contract_v8.py /path/to/config.json
+```
+
+The script is intentionally conservative: unsupported architectures should fail
+closed with a list of missing kernels/templates.
+
+## Current Families
+
+| Family | Status | First target | Notes |
+| --- | --- | --- | --- |
+| Qwen2/Qwen3/Gemma3/Llama-style dense decoders | Supported at contract level | parity and perf | Uses standard attention + MLP path. |
+| Qwen3.5 text | Bring-up active, usable | safetensors + GGUF parity | Hybrid DeltaNet/full-attention decoder. Safetensors require Qwen3.5 norm `+1` transform except `linear_attn.norm.weight`. |
+| Gemma4 text | Bring-up active, usable | GGUF/safetensors parity | Hybrid full/sliding attention with per-layer embedding and per-layer RoPE control. |
+| Nematron-H | Not yet lowerable | Mamba kernels | Hybrid Mamba/attention decoder. Existing DeltaNet kernels are not a substitute for Mamba selective scan. |
+| Cohere Command-style models | Needs config access | tensor-name mapping audit | Main public checkpoints are gated in this environment. Start with config/weights access, then determine whether dense decoder mapping is enough. |
+
+## Nematron-H Gap
+
+Observed public config properties:
+
+- `model_type: nemotron_h`
+- `architectures: ["NemotronHForCausalLM"]`
+- `hybrid_override_pattern` as one character per layer. Current Nano uses `M` = Mamba2, `*` = attention, `E` = MoE, and `-` = dense MLP.
+- Mamba parameters: `mamba_num_heads`, `mamba_head_dim`, `ssm_state_size`, `time_step_rank`, `conv_kernel`
+- MLP activation: `relu2`
+- MoE parameters: routed experts, shared expert, top-k routing, group-limited expert selection
+- Attention parameters: normal GQA-style attention heads/KV heads
+
+Required new CK contracts before full Nematron-H inference:
+
+- `mamba_in_proj_split`
+- `mamba_conv1d_state_update`
+- `mamba_dt_softplus`
+- `mamba_selective_scan`
+- `mamba_rmsnorm_gate`
+- `mamba_out_proj`
+- `relu2_mlp` forward and backward
+- `topk_router`, `topk_softmax`, expert dispatch/combine, and shared expert MLP contracts
+- Nematron-H safetensors-to-BUMP mapping with strict all-weight coverage
+- Nematron-H template/layer policy for `mamba` vs attention layers
+
+The first implementation should be scalar FP32/BF16 parity-first, then optimized
+with AVX/AVX-512/AMX only after hidden-stream parity is stable.
+
+## Cohere Gap
+
+Cohere Command repositories were gated during this run, including `config.json`.
+Do not guess the tensor names.  Once access is available:
+
+1. Run the contract inspector on `config.json`.
+2. Dump safetensors headers only.
+3. Compare tensor names against the existing Llama-family importer.
+4. If the graph is dense attention + GLU MLP, add a Cohere-specific name mapper
+   and audit test before adding new math.
+5. If the graph has custom attention, sliding windows, logit scaling, or unusual
+   norms, model those explicitly in sidecar config.
+
+## Why This Matters
+
+CK should be able to say: given a kernel composition, embedding size, layer
+pattern, and training contract, the DSL compiler can build a model independent
+of PyTorch, llama.cpp, or Unsloth.  Compatibility with diverse model families is
+evidence that the architecture is kernel/template-driven rather than hardcoded
+to one lineage.

--- a/docs/site/_pages/concepts.html
+++ b/docs/site/_pages/concepts.html
@@ -27,7 +27,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
-    <li><a href="#activations">Activations: SwiGLU, GeGLU, GELU</a></li>
+    <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
 </ul>
 
@@ -578,9 +578,35 @@ y = gamma * x / (rms + eps)
 
 <hr>
 
-<h2 id="activations">Activations: SwiGLU, GeGLU, GELU</h2>
+<h2 id="activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</h2>
 
-<p>Activation functions introduce non-linearity. Modern LLMs use gated activations (SwiGLU, GeGLU) for better gradient flow and expressivity.</p>
+<p>Activation functions introduce non-linearity. Modern LLMs often use gated activations (SwiGLU, GeGLU), while some Nemotron-family MLP blocks use simpler squared activations such as ReLU2. CK treats these as first-class kernels because each activation has a different forward/backward contract.</p>
+
+<div class="img-container svg-viewer" data-title="ReLU2 Activation">
+    <img src="assets/concept-relu2.svg" alt="ReLU and ReLU2 activation comparison">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">ReLU and ReLU2</h3>
+        <pre>
+ReLU(x)  = max(0, x)
+ReLU2(x) = max(0, x)^2
+
+d ReLU2 / dx = 2x if x &gt; 0 else 0
+        </pre>
+        <p>ReLU2 keeps the same negative-value mask as ReLU, but positive activations grow quadratically. The backward kernel must use the original input value, not only a binary mask.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why CK Has a Dedicated Kernel</h3>
+        <p>It is small math, but it appears across large MLP tensors where memory traffic and branch handling matter. A dedicated forward/backward pair lets CK validate exact PyTorch parity and benchmark the CPU path directly.</p>
+        <ul>
+            <li><code>relu2_forward_fp32</code> for activation output</li>
+            <li><code>relu2_backward_fp32</code> for gradient propagation</li>
+            <li><code>make test-relu2</code> and <code>make test-relu2-perf</code> for coverage</li>
+        </ul>
+    </div>
+</div>
 
 <div class="img-container svg-viewer" data-title="SwiGLU: Gated Linear Unit">
     <img src="assets/kernel-swiglu.svg" alt="SwiGLU Activation">

--- a/docs/site/assets/concept-relu2.svg
+++ b/docs/site/assets/concept-relu2.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="560" viewBox="0 0 1100 560" role="img" aria-labelledby="title desc">
+  <title id="title">ReLU and ReLU2 activation comparison</title>
+  <desc id="desc">A visual comparison of ReLU and ReLU2 forward curves, gradients, and kernel dataflow.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#07111f"/>
+      <stop offset="0.55" stop-color="#0f1b2d"/>
+      <stop offset="1" stop-color="#17243a"/>
+    </linearGradient>
+    <linearGradient id="relu2Fill" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0" stop-color="#f59e0b" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#f59e0b" stop-opacity="0.62"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000000" flood-opacity="0.25"/>
+    </filter>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7dd3fc"/>
+    </marker>
+  </defs>
+
+  <rect width="1100" height="560" rx="0" fill="url(#bg)"/>
+  <g opacity="0.28" stroke="#26364f" stroke-width="1">
+    <path d="M0 80H1100M0 160H1100M0 240H1100M0 320H1100M0 400H1100M0 480H1100"/>
+    <path d="M100 0V560M200 0V560M300 0V560M400 0V560M500 0V560M600 0V560M700 0V560M800 0V560M900 0V560M1000 0V560"/>
+  </g>
+
+  <text x="50" y="58" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">ReLU2: small activation, real kernel contract</text>
+  <text x="50" y="88" fill="#9fb6d8" font-family="Inter, Arial, sans-serif" font-size="15">Forward: y = max(0, x)^2. Backward: dy/dx = 2x for x &gt; 0, else 0.</text>
+
+  <g transform="translate(55 125)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="470" height="330" rx="10" fill="#0b1220" stroke="#23334f"/>
+    <text x="24" y="34" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Forward curve</text>
+    <text x="24" y="58" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">ReLU is linear. ReLU2 grows quadratically.</text>
+
+    <g transform="translate(55 72)">
+      <line x1="0" y1="210" x2="360" y2="210" stroke="#6b7d99" stroke-width="2" marker-end="url(#arrowBlue)"/>
+      <line x1="160" y1="250" x2="160" y2="20" stroke="#6b7d99" stroke-width="2" marker-end="url(#arrowBlue)"/>
+      <text x="350" y="235" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">x</text>
+      <text x="135" y="20" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">y</text>
+
+      <path d="M 0 210 L 160 210 L 330 40" fill="none" stroke="#38bdf8" stroke-width="4" stroke-linecap="round"/>
+      <path d="M 0 210 L 160 210 C 205 205 255 145 330 35" fill="none" stroke="#f59e0b" stroke-width="5" stroke-linecap="round"/>
+      <path d="M 160 210 C 205 205 255 145 330 35 L 330 210 Z" fill="url(#relu2Fill)"/>
+
+      <g font-family="JetBrains Mono, Consolas, monospace" font-size="13">
+        <rect x="225" y="78" width="110" height="26" rx="6" fill="#10243a" stroke="#38bdf8"/>
+        <text x="238" y="96" fill="#7dd3fc">ReLU(x)</text>
+        <rect x="228" y="112" width="115" height="26" rx="6" fill="#2a1b08" stroke="#f59e0b"/>
+        <text x="241" y="130" fill="#fbbf24">ReLU2(x)</text>
+      </g>
+      <text x="122" y="230" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">0</text>
+    </g>
+  </g>
+
+  <g transform="translate(575 125)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="470" height="330" rx="10" fill="#0b1220" stroke="#23334f"/>
+    <text x="24" y="34" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Backward signal</text>
+    <text x="24" y="58" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">ReLU2 keeps the same zero mask, but positive gradients scale with x.</text>
+
+    <g transform="translate(50 84)">
+      <rect x="0" y="0" width="370" height="58" rx="10" fill="#111c2f" stroke="#2b3b55"/>
+      <text x="20" y="24" fill="#e5f2ff" font-family="JetBrains Mono, Consolas, monospace" font-size="14">if x &lt;= 0: y = 0, grad = 0</text>
+      <text x="20" y="46" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">same branch behavior as ReLU</text>
+
+      <rect x="0" y="82" width="370" height="84" rx="10" fill="#20170b" stroke="#f59e0b"/>
+      <text x="20" y="108" fill="#fbbf24" font-family="JetBrains Mono, Consolas, monospace" font-size="14">if x &gt; 0: y = x * x</text>
+      <text x="20" y="132" fill="#fde68a" font-family="JetBrains Mono, Consolas, monospace" font-size="14">d_x = d_y * 2 * x</text>
+      <text x="20" y="154" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="13">The backward kernel needs x, not only the output mask.</text>
+
+      <g transform="translate(0 198)">
+        <rect x="0" y="0" width="96" height="42" rx="8" fill="#1e293b" stroke="#334155"/>
+        <text x="24" y="27" fill="#e5f2ff" font-family="JetBrains Mono, Consolas, monospace" font-size="13">x</text>
+        <line x1="96" y1="21" x2="145" y2="21" stroke="#7dd3fc" stroke-width="2" marker-end="url(#arrowBlue)"/>
+        <rect x="145" y="0" width="110" height="42" rx="8" fill="#2a1b08" stroke="#f59e0b"/>
+        <text x="166" y="27" fill="#fbbf24" font-family="JetBrains Mono, Consolas, monospace" font-size="13">relu2</text>
+        <line x1="255" y1="21" x2="304" y2="21" stroke="#7dd3fc" stroke-width="2" marker-end="url(#arrowBlue)"/>
+        <rect x="304" y="0" width="66" height="42" rx="8" fill="#1e293b" stroke="#334155"/>
+        <text x="326" y="27" fill="#e5f2ff" font-family="JetBrains Mono, Consolas, monospace" font-size="13">y</text>
+      </g>
+    </g>
+  </g>
+
+  <g transform="translate(60 490)">
+    <rect x="0" y="0" width="980" height="42" rx="10" fill="#08111f" stroke="#24344f"/>
+    <text x="22" y="27" fill="#9fb6d8" font-family="Inter, Arial, sans-serif" font-size="14">
+      CK coverage: fp32 forward/backward kernels, PyTorch parity, performance benchmark, nightly quick suite, and v8 kernel-map registry entries.
+    </text>
+  </g>
+</svg>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -966,7 +966,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
-    <li><a href="#activations">Activations: SwiGLU, GeGLU, GELU</a></li>
+    <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
 </ul>
 
@@ -1517,9 +1517,35 @@ y = gamma * x / (rms + eps)
 
 <hr>
 
-<h2 id="activations">Activations: SwiGLU, GeGLU, GELU</h2>
+<h2 id="activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</h2>
 
-<p>Activation functions introduce non-linearity. Modern LLMs use gated activations (SwiGLU, GeGLU) for better gradient flow and expressivity.</p>
+<p>Activation functions introduce non-linearity. Modern LLMs often use gated activations (SwiGLU, GeGLU), while some Nemotron-family MLP blocks use simpler squared activations such as ReLU2. CK treats these as first-class kernels because each activation has a different forward/backward contract.</p>
+
+<div class="img-container svg-viewer" data-title="ReLU2 Activation">
+    <img src="assets/concept-relu2.svg" alt="ReLU and ReLU2 activation comparison">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">ReLU and ReLU2</h3>
+        <pre>
+ReLU(x)  = max(0, x)
+ReLU2(x) = max(0, x)^2
+
+d ReLU2 / dx = 2x if x &gt; 0 else 0
+        </pre>
+        <p>ReLU2 keeps the same negative-value mask as ReLU, but positive activations grow quadratically. The backward kernel must use the original input value, not only a binary mask.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why CK Has a Dedicated Kernel</h3>
+        <p>It is small math, but it appears across large MLP tensors where memory traffic and branch handling matter. A dedicated forward/backward pair lets CK validate exact PyTorch parity and benchmark the CPU path directly.</p>
+        <ul>
+            <li><code>relu2_forward_fp32</code> for activation output</li>
+            <li><code>relu2_backward_fp32</code> for gradient propagation</li>
+            <li><code>make test-relu2</code> and <code>make test-relu2-perf</code> for coverage</li>
+        </ul>
+    </div>
+</div>
 
 <div class="img-container svg-viewer" data-title="SwiGLU: Gated Linear Unit">
     <img src="assets/kernel-swiglu.svg" alt="SwiGLU Activation">

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -1101,6 +1101,11 @@ void geglu_backward_bf16_mixed(const uint16_t *x,
 	                   const float *d_output,
 	                   float *d_input,
 	                   size_t n);
+	void relu2_forward(const float *input, float *output, size_t n);
+	void relu2_backward(const float *input,
+	                    const float *d_output,
+	                    float *d_input,
+	                    size_t n);
 
 	void relu_forward_bf16(const uint16_t *input, uint16_t *output, size_t n);
 	void relu_forward_inplace_bf16(uint16_t *data, size_t n);

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -257,6 +257,7 @@ TEST_SUITES = {
     "optimizer": TestSuite("Optimizer (AdamW/SGD)", "training", UNITTEST_DIR / "test_optimizer.py"),
     "lm_head_litmus": TestSuite("LM Head Litmus", "kernels", UNITTEST_DIR / "test_lm_head_litmus.py"),
     "deepseek_reference": TestSuite("DeepSeek Reference Kernels", "kernels", UNITTEST_DIR / "test_deepseek_reference_kernels.py"),
+    "relu2": TestSuite("ReLU2", "kernels", UNITTEST_DIR / "test_relu2.py"),
     "vision": TestSuite("Vision", "kernels", UNITTEST_DIR / "test_vision.py"),
     # NOTE: Orchestration test disabled - v6.5 uses generated code with local helpers,
     # not orchestration layer. Use llamacpp-parity-full for quantized kernel validation.
@@ -426,7 +427,7 @@ BENCH_TARGETS = {
 
 # Quick subset for fast validation
 QUICK_TESTS = [
-    "gemm", "relu", "softmax", "rmsnorm", "attention", "attention_sliding",
+    "gemm", "relu", "relu2", "softmax", "rmsnorm", "attention", "attention_sliding",
     "deltanet_backward",
     "relu_bf16", "rmsnorm_bf16",
     "q4k_kernels",

--- a/src/kernels/relu_kernels.c
+++ b/src/kernels/relu_kernels.c
@@ -114,3 +114,67 @@ void relu_backward(const float *input,
         d_input[i] = (input[i] > 0.0f) ? d_output[i] : 0.0f;
     }
 }
+
+
+/* ReLU2 forward: y = max(0, x)^2 */
+void relu2_forward(const float *input, float *output, size_t n)
+{
+    size_t i = 0;
+
+#if defined(__AVX512F__)
+    const __m512 vzero = _mm512_setzero_ps();
+    for (; i + 15 < n; i += 16) {
+        const __m512 vx = _mm512_loadu_ps(input + i);
+        const __m512 vr = _mm512_max_ps(vx, vzero);
+        _mm512_storeu_ps(output + i, _mm512_mul_ps(vr, vr));
+    }
+#elif defined(__AVX2__) || defined(__AVX__)
+    const __m256 vzero = _mm256_setzero_ps();
+    for (; i + 7 < n; i += 8) {
+        const __m256 vx = _mm256_loadu_ps(input + i);
+        const __m256 vr = _mm256_max_ps(vx, vzero);
+        _mm256_storeu_ps(output + i, _mm256_mul_ps(vr, vr));
+    }
+#endif
+
+    for (; i < n; ++i) {
+        const float x = input[i];
+        output[i] = (x > 0.0f) ? x * x : 0.0f;
+    }
+}
+
+/* ReLU2 backward: dx = dy * 2*x when x > 0, else 0 */
+void relu2_backward(const float *input,
+                    const float *d_output,
+                    float *d_input,
+                    size_t n)
+{
+    size_t i = 0;
+
+#if defined(__AVX512F__)
+    const __m512 vzero = _mm512_setzero_ps();
+    const __m512 vtwo = _mm512_set1_ps(2.0f);
+    for (; i + 15 < n; i += 16) {
+        const __m512 vx = _mm512_loadu_ps(input + i);
+        const __m512 vdy = _mm512_loadu_ps(d_output + i);
+        const __mmask16 mask = _mm512_cmp_ps_mask(vx, vzero, _CMP_GT_OQ);
+        const __m512 vdx = _mm512_mul_ps(_mm512_mul_ps(vtwo, vx), vdy);
+        _mm512_storeu_ps(d_input + i, _mm512_maskz_mov_ps(mask, vdx));
+    }
+#elif defined(__AVX2__) || defined(__AVX__)
+    const __m256 vzero = _mm256_setzero_ps();
+    const __m256 vtwo = _mm256_set1_ps(2.0f);
+    for (; i + 7 < n; i += 8) {
+        const __m256 vx = _mm256_loadu_ps(input + i);
+        const __m256 vdy = _mm256_loadu_ps(d_output + i);
+        const __m256 mask = _mm256_cmp_ps(vx, vzero, _CMP_GT_OQ);
+        const __m256 vdx = _mm256_mul_ps(_mm256_mul_ps(vtwo, vx), vdy);
+        _mm256_storeu_ps(d_input + i, _mm256_and_ps(mask, vdx));
+    }
+#endif
+
+    for (; i < n; ++i) {
+        const float x = input[i];
+        d_input[i] = (x > 0.0f) ? d_output[i] * 2.0f * x : 0.0f;
+    }
+}

--- a/tests/test_v8_model_contract_inspector.py
+++ b/tests/test_v8_model_contract_inspector.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "version/v8/scripts/inspect_model_contract_v8.py"
+AUDIT_SCRIPT = REPO / "version/v8/scripts/audit_safetensors_index_v8.py"
+
+
+class ModelContractInspectorTests(unittest.TestCase):
+    def test_nemotron_h_reports_mamba_kernel_gap(self) -> None:
+        cfg = {
+            "architectures": ["NemotronHForCausalLM"],
+            "model_type": "nemotron_h",
+            "hidden_size": 4096,
+            "intermediate_size": 21504,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "num_hidden_layers": 10,
+            "hybrid_override_pattern": "MEMEM*EMEM",
+            "mamba_num_heads": 128,
+            "mamba_head_dim": 64,
+            "ssm_state_size": 128,
+            "conv_kernel": 4,
+            "mlp_hidden_act": "relu2",
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "config.json"
+            path.write_text(json.dumps(cfg), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), str(path)],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["arch"], "nemotron_h")
+        self.assertEqual(report["status"], "bringup_required")
+        self.assertEqual(report["layer_kind_counts"], {"attention": 1, "mamba": 5, "moe": 4})
+        self.assertIn("mamba_selective_scan", report["missing_ops"])
+        self.assertIn("relu2_mlp", report["missing_ops"])
+        self.assertIn("topk_router", report["missing_ops"])
+        self.assertIn("moe_expert_dispatch", report["missing_ops"])
+        self.assertIn("safetensors_to_bump_mapping", report["missing_ops"])
+
+    def test_safetensors_index_audit_classifies_nemotron_families(self) -> None:
+        index = {
+            "metadata": {"total_parameters": 123, "total_size": 456},
+            "weight_map": {
+                "backbone.embeddings.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.0.norm.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.0.mixer.in_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.0.mixer.conv1d.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.0.mixer.out_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.1.norm.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.1.mixer.q_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.1.mixer.k_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.1.mixer.v_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.1.mixer.o_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.2.norm.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.2.mixer.gate.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.2.mixer.gate.e_score_correction_bias": "model-00001-of-00001.safetensors",
+                "backbone.layers.2.mixer.experts.0.up_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.2.mixer.experts.0.down_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.2.mixer.shared_experts.up_proj.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.2.mixer.shared_experts.down_proj.weight": "model-00001-of-00001.safetensors",
+                "lm_head.weight": "model-00001-of-00001.safetensors",
+            },
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "model.safetensors.index.json"
+            path.write_text(json.dumps(index), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(AUDIT_SCRIPT), str(path)],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+            )
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["families"]["mamba"], 3)
+        self.assertEqual(report["families"]["attention"], 4)
+        self.assertEqual(report["families"]["moe_router"], 2)
+        self.assertEqual(report["families"]["moe_expert"], 2)
+        self.assertEqual(report["families"]["moe_shared_expert"], 2)
+        self.assertEqual(report["layers"]["2"]["expert_count"], 1)
+
+    def test_qwen3_dense_config_is_supported_at_contract_level(self) -> None:
+        cfg = {
+            "architectures": ["Qwen3ForCausalLM"],
+            "model_type": "qwen3",
+            "hidden_size": 1024,
+            "intermediate_size": 3072,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "num_hidden_layers": 4,
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "config.json"
+            path.write_text(json.dumps(cfg), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), str(path)],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+            )
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["arch"], "qwen3")
+        self.assertEqual(report["status"], "supported")
+        self.assertEqual(report["layer_kind_counts"], {"attention": 4})
+        self.assertEqual(report["missing_ops"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittest/test_relu2.py
+++ b/unittest/test_relu2.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""PyTorch parity test for relu2 activation."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import time
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import torch
+except Exception as exc:  # pragma: no cover
+    print(f"[SKIP] torch not available: {exc}")
+    sys.exit(0)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_PATH = ROOT / "build" / "libckernel_engine.so"
+if not LIB_PATH.exists():  # pragma: no cover
+    print("[SKIP] libckernel_engine.so not found")
+    sys.exit(0)
+
+LIB = ctypes.CDLL(str(LIB_PATH))
+fptr = ctypes.POINTER(ctypes.c_float)
+LIB.relu2_forward.argtypes = [fptr, fptr, ctypes.c_size_t]
+LIB.relu2_forward.restype = None
+LIB.relu2_backward.argtypes = [fptr, fptr, fptr, ctypes.c_size_t]
+LIB.relu2_backward.restype = None
+
+
+def _as_ptr(arr: np.ndarray) -> ctypes.POINTER(ctypes.c_float):
+    return arr.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+
+
+def _time_us(fn, iterations: int) -> float:
+    start = time.perf_counter()
+    for _ in range(iterations):
+        fn()
+    return (time.perf_counter() - start) * 1.0e6 / max(1, iterations)
+
+
+def run_benchmark() -> None:
+    torch.set_num_threads(1)
+    shapes = [
+        ("tiny", (4096,), 2000),
+        ("nemotron_mlp", (13, 1856), 500),
+        ("prefill_tile", (512, 1856), 50),
+    ]
+    rng = np.random.default_rng(101)
+    print("kernel                pytorch_us      ck_us       speedup")
+    for name, shape, iterations in shapes:
+        x = (0.5 * rng.standard_normal(shape)).astype(np.float32)
+        d_out = (0.25 * rng.standard_normal(shape)).astype(np.float32)
+        ck_out = np.zeros_like(x)
+        ck_dx = np.zeros_like(x)
+        tx = torch.tensor(x, dtype=torch.float32, requires_grad=True)
+        td = torch.tensor(d_out, dtype=torch.float32)
+
+        def torch_step() -> None:
+            if tx.grad is not None:
+                tx.grad.zero_()
+            out = torch.relu(tx).square()
+            out.backward(td)
+
+        def ck_step() -> None:
+            LIB.relu2_forward(_as_ptr(x), _as_ptr(ck_out), x.size)
+            LIB.relu2_backward(_as_ptr(x), _as_ptr(d_out), _as_ptr(ck_dx), x.size)
+
+        torch_step()
+        ck_step()
+        torch_us = _time_us(torch_step, iterations)
+        ck_us = _time_us(ck_step, iterations)
+        speedup = torch_us / max(ck_us, 1e-12)
+        print(f"relu2_{name:<12} {torch_us:10.3f} {ck_us:10.3f} {speedup:8.2f}x")
+
+
+class TestReLU2(unittest.TestCase):
+    def setUp(self) -> None:
+        torch.set_num_threads(1)
+
+    def _run_case(self, shape: tuple[int, ...], seed: int) -> None:
+        rng = np.random.default_rng(seed)
+        x = (0.5 * rng.standard_normal(shape)).astype(np.float32)
+        d_out = (0.25 * rng.standard_normal(shape)).astype(np.float32)
+        ck_out = np.zeros_like(x)
+        ck_dx = np.zeros_like(x)
+
+        LIB.relu2_forward(_as_ptr(x), _as_ptr(ck_out), x.size)
+        LIB.relu2_backward(_as_ptr(x), _as_ptr(d_out), _as_ptr(ck_dx), x.size)
+
+        tx = torch.tensor(x, dtype=torch.float32, requires_grad=True)
+        out = torch.relu(tx).square()
+        out.backward(torch.tensor(d_out, dtype=torch.float32))
+
+        np.testing.assert_allclose(ck_out, out.detach().numpy(), atol=1e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dx, tx.grad.detach().numpy(), atol=1e-6, rtol=0.0)
+
+    def test_vector(self) -> None:
+        self._run_case((4097,), 3)
+
+    def test_token_major_matrix(self) -> None:
+        self._run_case((13, 1856), 11)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--benchmark", action="store_true")
+    args, remaining = ap.parse_known_args()
+    if args.benchmark:
+        run_benchmark()
+    else:
+        sys.argv = [sys.argv[0], *remaining]
+        unittest.main(verbosity=2)

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -3,9 +3,9 @@
     "description": "Kernel registry generated from v8 kernel maps",
     "version": "v8",
     "generated_by": "ck_run_v8.py",
-    "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
+    "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 147,
+      "total": 149,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -52,6 +52,7 @@
         "recurrent_split_conv_qkv": 2,
         "recurrent_split_qkv": 1,
         "recurrent_split_qkv_backward": 1,
+        "relu2": 2,
         "residual_add": 1,
         "residual_save": 1,
         "rmsnorm": 2,
@@ -13512,6 +13513,187 @@
       "notes": "Explicit split kernel for recurrent packed QKV rows.",
       "name": "recurrent_split_qkv_forward",
       "_source_file": "recurrent_split_qkv_forward.json"
+    },
+    {
+      "id": "relu2_backward_f32",
+      "op": "relu2",
+      "variant": "backward_fp32",
+      "modes": {
+        "inference": false,
+        "training": true,
+        "backward": true
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ]
+        },
+        {
+          "name": "d_out",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ]
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "d_x",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "N"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "element"
+        ],
+        "preferred": {
+          "prefill": "element",
+          "decode": "element"
+        },
+        "strategies": [
+          {
+            "name": "element",
+            "partition_dim": "N",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 256
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "relu2_backward",
+        "c_declaration": "void relu2_backward(const float *input, const float *d_output, float *d_input, size_t n);",
+        "sources": [
+          "src/kernels/relu_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "simd_or_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_relu2.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_relu2.py",
+            "tolerance": "1e-6"
+          }
+        ]
+      },
+      "name": "relu2_backward_f32",
+      "_source_file": "relu2_backward.json"
+    },
+    {
+      "id": "relu2_forward",
+      "op": "relu2",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ]
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "N"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "element"
+        ],
+        "preferred": {
+          "prefill": "element",
+          "decode": "element"
+        },
+        "strategies": [
+          {
+            "name": "element",
+            "partition_dim": "N",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 256
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "relu2_forward",
+        "c_declaration": "void relu2_forward(const float *input, float *output, size_t n);",
+        "sources": [
+          "src/kernels/relu_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "simd_or_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_relu2.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_relu2.py",
+            "tolerance": "1e-6"
+          }
+        ]
+      },
+      "name": "relu2_forward",
+      "_source_file": "relu2_forward.json"
     },
     {
       "id": "residual_add_backward_f32",

--- a/version/v8/kernel_maps/relu2_backward.json
+++ b/version/v8/kernel_maps/relu2_backward.json
@@ -1,0 +1,92 @@
+{
+  "id": "relu2_backward_f32",
+  "op": "relu2",
+  "variant": "backward_fp32",
+  "modes": {
+    "inference": false,
+    "training": true,
+    "backward": true
+  },
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ]
+    },
+    {
+      "name": "d_out",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ]
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "d_x",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "N"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "element"
+    ],
+    "preferred": {
+      "prefill": "element",
+      "decode": "element"
+    },
+    "strategies": [
+      {
+        "name": "element",
+        "partition_dim": "N",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 256
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "relu2_backward",
+    "c_declaration": "void relu2_backward(const float *input, const float *d_output, float *d_input, size_t n);",
+    "sources": [
+      "src/kernels/relu_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "simd_or_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_relu2.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_relu2.py",
+        "tolerance": "1e-6"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/relu2_forward.json
+++ b/version/v8/kernel_maps/relu2_forward.json
@@ -1,0 +1,85 @@
+{
+  "id": "relu2_forward",
+  "op": "relu2",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ]
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "N"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "element"
+    ],
+    "preferred": {
+      "prefill": "element",
+      "decode": "element"
+    },
+    "strategies": [
+      {
+        "name": "element",
+        "partition_dim": "N",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 256
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "relu2_forward",
+    "c_declaration": "void relu2_forward(const float *input, float *output, size_t n);",
+    "sources": [
+      "src/kernels/relu_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "simd_or_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_relu2.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_relu2.py",
+        "tolerance": "1e-6"
+      }
+    ]
+  }
+}

--- a/version/v8/scripts/audit_safetensors_index_v8.py
+++ b/version/v8/scripts/audit_safetensors_index_v8.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Audit a safetensors index without downloading or opening weight shards."""
+
+import argparse
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+EXPERT_RE = re.compile(r"\.experts\.(\d+)\.")
+
+
+def _load_index(path: Path) -> dict[str, Any]:
+    if path.is_dir():
+        path = path / "model.safetensors.index.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "weight_map" not in data:
+        raise SystemExit(f"{path} is not a safetensors index with weight_map")
+    return data
+
+
+def _family(name: str) -> str:
+    if name in {"lm_head.weight", "backbone.embeddings.weight", "model.embed_tokens.weight"}:
+        return name
+    if ".mixer." not in name:
+        return "other"
+    tail = name.split(".mixer.", 1)[1]
+    if tail.startswith("self_attn.") or tail in {"q_proj.weight", "k_proj.weight", "v_proj.weight", "o_proj.weight"}:
+        return "attention"
+    if tail.startswith("experts."):
+        return "moe_expert"
+    if tail.startswith("shared_experts."):
+        return "moe_shared_expert"
+    if tail.startswith("gate."):
+        return "moe_router"
+    if tail in {"up_proj.weight", "down_proj.weight"}:
+        return "dense_mlp"
+    if tail.startswith(("in_proj.", "out_proj.", "conv1d.", "dt_bias", "A_log", "D", "norm.")):
+        return "mamba"
+    return "mixer_other"
+
+
+def audit_index(path: Path) -> dict[str, Any]:
+    data = _load_index(path)
+    wm = data["weight_map"]
+    families = Counter(_family(name) for name in wm)
+    layers: dict[int, Counter[str]] = defaultdict(Counter)
+    expert_ids: dict[int, set[int]] = defaultdict(set)
+    shards = Counter(wm.values())
+    for name in wm:
+        m = LAYER_RE.search(name)
+        if not m:
+            continue
+        layer = int(m.group(1))
+        fam = _family(name)
+        layers[layer][fam] += 1
+        em = EXPERT_RE.search(name)
+        if em:
+            expert_ids[layer].add(int(em.group(1)))
+    layer_summary = {
+        str(layer): {
+            "families": dict(sorted(counter.items())),
+            "expert_count": len(expert_ids.get(layer, set())),
+        }
+        for layer, counter in sorted(layers.items())
+    }
+    return {
+        "metadata": data.get("metadata", {}),
+        "tensor_count": len(wm),
+        "shard_count": len(shards),
+        "shards": dict(sorted(shards.items())),
+        "families": dict(sorted(families.items())),
+        "layer_count": len(layers),
+        "layers": layer_summary,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Audit safetensors index tensor families without loading shards")
+    ap.add_argument("index", type=Path, help="model.safetensors.index.json or directory")
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+    report = audit_index(args.index)
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/inspect_model_contract_v8.py
+++ b/version/v8/scripts/inspect_model_contract_v8.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Inspect a HF-style model config and summarize the CK v8 bring-up contract.
+
+This is intentionally config-first.  It does not download weights and it does
+not pretend unsupported architectures are compatible.  The output is a small
+JSON report that says which layer families and kernels CK can already lower,
+and which kernels/templates must be added before safetensors->BUMP conversion
+should be attempted.
+"""
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_DENSE_ARCHES = {"llama", "qwen2", "qwen3", "gemma3"}
+SUPPORTED_HYBRID_ARCHES = {"qwen35", "gemma4"}
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    if path.is_dir():
+        path = path / "config.json"
+    if not path.exists():
+        raise FileNotFoundError(path)
+    text = path.read_text(encoding="utf-8").replace("Infinity", "1e100")
+    return json.loads(text)
+
+
+def _text_config(config: dict[str, Any]) -> dict[str, Any]:
+    return config.get("text_config") if isinstance(config.get("text_config"), dict) else config
+
+
+def _infer_arch(config: dict[str, Any]) -> str:
+    text = _text_config(config)
+    model_type = str(text.get("model_type") or config.get("model_type") or "").lower()
+    architectures = " ".join(str(x).lower() for x in config.get("architectures", []))
+    if "qwen3_5" in model_type or "qwen3.5" in model_type or "qwen35" in model_type:
+        return "qwen35"
+    if "nemotron_h" in model_type or "nemotronh" in architectures:
+        return "nemotron_h"
+    if "cohere" in model_type or "cohere" in architectures or "command" in model_type:
+        return "cohere"
+    if "gemma" in model_type and "4" in model_type:
+        return "gemma4"
+    if "gemma" in model_type and "3" in model_type:
+        return "gemma3"
+    if "qwen3" in model_type:
+        return "qwen3"
+    if "qwen2" in model_type or model_type == "qwen":
+        return "qwen2"
+    if "llama" in model_type:
+        return "llama"
+    return model_type or "unknown"
+
+
+def _parse_nemotron_h_pattern(pattern: str, num_layers: int) -> list[str]:
+    """Parse Nemotron-H per-layer pattern characters into CK layer labels.
+
+    NVIDIA's config code defines the pattern as one character per layer:
+    M = Mamba2, * = attention, - = dense MLP, E = MoE.  The hyphen is a layer
+    kind, not a separator.
+    """
+    mapping = {"M": "mamba", "*": "attention", "-": "mlp", "E": "moe"}
+    chars = [ch for ch in str(pattern).strip() if not ch.isspace()]
+    kinds = [mapping.get(ch, "unknown") for ch in chars]
+    if num_layers > 0 and len(kinds) != num_layers:
+        kinds.extend(["unspecified"] * max(0, num_layers - len(kinds)))
+        kinds = kinds[:num_layers]
+    return kinds
+
+
+def _generic_dense_layers(config: dict[str, Any]) -> list[str]:
+    text = _text_config(config)
+    n = int(text.get("num_hidden_layers") or 0)
+    return ["attention"] * n
+
+
+def _qwen35_layers(config: dict[str, Any]) -> list[str]:
+    text = _text_config(config)
+    layer_types = [str(x) for x in text.get("layer_types", [])]
+    if layer_types:
+        return ["attention" if x == "full_attention" else "deltanet" for x in layer_types]
+    n = int(text.get("num_hidden_layers") or 0)
+    interval = int(text.get("full_attention_interval") or 4)
+    return ["attention" if (i + 1) % interval == 0 else "deltanet" for i in range(n)]
+
+
+def _gemma4_layers(config: dict[str, Any]) -> list[str]:
+    text = _text_config(config)
+    layer_kinds = text.get("layer_kinds") or config.get("layer_kinds")
+    if isinstance(layer_kinds, list):
+        return [str(x) for x in layer_kinds]
+    n = int(text.get("num_hidden_layers") or 0)
+    return ["attention_or_sliding_attention"] * n
+
+
+def _layer_kinds(arch: str, config: dict[str, Any]) -> list[str]:
+    text = _text_config(config)
+    if arch == "nemotron_h":
+        return _parse_nemotron_h_pattern(str(text.get("hybrid_override_pattern") or ""), int(text.get("num_hidden_layers") or 0))
+    if arch == "qwen35":
+        return _qwen35_layers(config)
+    if arch == "gemma4":
+        return _gemma4_layers(config)
+    return _generic_dense_layers(config)
+
+
+def _required_ops(arch: str, config: dict[str, Any], layer_kinds: list[str]) -> list[str]:
+    ops = {"embedding", "rmsnorm", "matmul", "residual_add", "logits"}
+    if any(kind in {"attention", "full_attention", "sliding_attention", "attention_or_sliding_attention"} for kind in layer_kinds):
+        ops.update({"attention", "rope"})
+    if any(kind == "deltanet" for kind in layer_kinds):
+        ops.update({
+            "recurrent_dt_gate",
+            "recurrent_conv_state_update",
+            "ssm_conv1d",
+            "recurrent_qk_l2_norm",
+            "gated_deltanet",
+            "recurrent_norm_gate",
+        })
+    if any(kind == "mamba" for kind in layer_kinds):
+        ops.update({
+            "mamba_in_proj_split",
+            "mamba_conv1d_state_update",
+            "mamba_dt_softplus",
+            "mamba_selective_scan",
+            "mamba_rmsnorm_gate",
+            "mamba_out_proj",
+        })
+    if any(kind == "moe" for kind in layer_kinds):
+        ops.update({
+            "topk_router",
+            "topk_softmax",
+            "moe_expert_dispatch",
+            "moe_expert_combine",
+            "shared_expert_mlp",
+        })
+    act = str(_text_config(config).get("mlp_hidden_act") or _text_config(config).get("hidden_act") or "").lower()
+    if act == "relu2":
+        ops.add("relu2_mlp")
+    else:
+        ops.add("swiglu_or_geglu")
+    if arch == "gemma4":
+        ops.update({"gemma4_per_layer_embed", "gemma4_final_logit_softcap"})
+    return sorted(ops)
+
+
+def _missing_ops(arch: str, required_ops: list[str]) -> list[str]:
+    missing = []
+    for op in required_ops:
+        if op.startswith("mamba_") or op == "relu2_mlp":
+            missing.append(op)
+        if op in {"topk_router", "topk_softmax", "moe_expert_dispatch", "moe_expert_combine", "shared_expert_mlp"}:
+            missing.append(op)
+    if arch == "cohere":
+        missing.append("cohere_tensor_name_mapping_audit")
+    if arch not in SUPPORTED_DENSE_ARCHES | SUPPORTED_HYBRID_ARCHES:
+        missing.append("v8_template_contract")
+        missing.append("safetensors_to_bump_mapping")
+    return sorted(set(missing))
+
+
+def inspect_config(config: dict[str, Any]) -> dict[str, Any]:
+    text = _text_config(config)
+    arch = _infer_arch(config)
+    layer_kinds = _layer_kinds(arch, config)
+    required_ops = _required_ops(arch, config, layer_kinds)
+    missing_ops = _missing_ops(arch, required_ops)
+    status = "supported" if not missing_ops else "bringup_required"
+    return {
+        "arch": arch,
+        "model_type": text.get("model_type") or config.get("model_type"),
+        "architectures": config.get("architectures", []),
+        "status": status,
+        "num_layers": int(text.get("num_hidden_layers") or len(layer_kinds) or 0),
+        "hidden_size": int(text.get("hidden_size") or 0),
+        "intermediate_size": int(text.get("intermediate_size") or 0),
+        "num_attention_heads": int(text.get("num_attention_heads") or 0),
+        "num_key_value_heads": int(text.get("num_key_value_heads") or 0),
+        "layer_kind_counts": dict(sorted(Counter(layer_kinds).items())),
+        "required_ops": required_ops,
+        "missing_ops": missing_ops,
+        "notes": _notes(arch, config, layer_kinds, missing_ops),
+    }
+
+
+def _notes(arch: str, config: dict[str, Any], layer_kinds: list[str], missing_ops: list[str]) -> list[str]:
+    text = _text_config(config)
+    notes: list[str] = []
+    if arch == "nemotron_h":
+        pattern_chars = [ch for ch in str(text.get("hybrid_override_pattern") or "").strip() if not ch.isspace()]
+        if int(text.get("num_hidden_layers") or 0) and len(pattern_chars) != int(text.get("num_hidden_layers") or 0):
+            notes.append(
+                f"hybrid_override_pattern describes {len(pattern_chars)} layers but num_hidden_layers={text.get('num_hidden_layers')}; "
+                "confirm whether the pattern repeats or whether checkpoint code expands it."
+            )
+        notes.append("Nemotron-H is a hybrid Mamba/attention decoder; CK DeltaNet kernels are not a substitute for Mamba selective scan.")
+        notes.append(f"hybrid_override_pattern={text.get('hybrid_override_pattern')}")
+        notes.append(f"mamba heads={text.get('mamba_num_heads')} head_dim={text.get('mamba_head_dim')} state={text.get('ssm_state_size')} conv_kernel={text.get('conv_kernel')}")
+        notes.append(f"MLP activation={text.get('mlp_hidden_act')}; relu2 needs an explicit forward/backward contract.")
+    if arch == "cohere":
+        notes.append("Cohere Command configs are gated in this environment; require config/weight access before mapping tensor names.")
+        notes.append("Likely first target is dense decoder mapping/audit before any new math kernels.")
+    if not missing_ops:
+        notes.append("Config-level contract has no known missing op, but weight-name audit and hidden parity are still required.")
+    return notes
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Inspect a model config and report CK v8 compatibility contract")
+    ap.add_argument("config", type=Path, help="config.json or model directory")
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+
+    report = inspect_config(_load_config(args.config))
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0 if report["status"] == "supported" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Why: add ReLU2 forward/backward kernels, Nemotron compatibility inspection, safetensors index audit tooling, nightly coverage, and concepts documentation for the activation contract.

Test: make test-relu2; make test-relu2-perf; py_compile for relu2/nightly/audit/inspector tests; nightly runner list includes relu2; unittest tests.test_v8_model_contract_inspector; make v8-kernel-map-contracts; docs/site/build.sh.