### PR TITLE
feat(v8): add Nemotron router and MoE ReLU2 expert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1218,6 +1218,18 @@ test-relu2: $(LIB)
 test-relu2-perf: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_relu2.py --benchmark
 
+test-nemotron-router: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_nemotron_router.py $(ARGS)
+
+test-nemotron-router-perf: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_nemotron_router.py --benchmark
+
+test-moe-relu2-expert: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_moe_relu2_expert.py $(ARGS)
+
+test-moe-relu2-expert-perf: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_moe_relu2_expert.py --benchmark
+
 test-recurrent-split-conv-qkv: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_recurrent_split_conv_qkv.py $(ARGS)
 

--- a/docs/MODEL_COMPATIBILITY_ATLAS.md
+++ b/docs/MODEL_COMPATIBILITY_ATLAS.md
@@ -55,7 +55,7 @@ Required new CK contracts before full Nematron-H inference:
 - `mamba_rmsnorm_gate`
 - `mamba_out_proj`
 - `relu2_mlp` forward and backward
-- `topk_router`, `topk_softmax`, expert dispatch/combine, and shared expert MLP contracts
+- group-limited top-k router and routed ReLU2 expert dispatch/combine are covered by scalar reference kernels; shared expert MLP wiring is still missing
 - Nematron-H safetensors-to-BUMP mapping with strict all-weight coverage
 - Nematron-H template/layer policy for `mamba` vs attention layers
 

--- a/docs/site/_pages/concepts.html
+++ b/docs/site/_pages/concepts.html
@@ -27,6 +27,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
+    <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
 </ul>
@@ -574,6 +575,51 @@ y = gamma * x / (rms + eps)
     <h3 style="margin-top: 0;">Why Remove Mean Centering?</h3>
     <p>Research found that the re-centering (subtracting mean) in LayerNorm isn't necessary for good performance. RMSNorm keeps just the scaling, which is what matters for gradient flow.</p>
     <p><strong>Used in:</strong> Llama, Mistral, Qwen, Gemma (most modern LLMs)</p>
+</div>
+
+<hr>
+
+<h2 id="moe-routing">Mixture of Experts: Router + ReLU2 Experts</h2>
+
+<p>MoE layers replace one dense MLP with a pool of experts and a router. For each token row, the router scores experts, selects a small <code>top_k</code> subset, runs only those expert MLPs, and accumulates the weighted result. This is sparse control flow wrapped around dense per-expert math.</p>
+
+<div class="img-container svg-viewer" data-title="Nemotron-style MoE Router and ReLU2 Experts">
+    <img src="assets/concept-moe-router-relu2.svg" alt="Nemotron-style MoE router and ReLU2 expert flow">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Group-Limited Top-K Router</h3>
+        <pre>
+scores = sigmoid(router_logits + correction_bias)
+groups = partition(experts, n_group)
+active_groups = topk(group_scores, topk_group)
+experts = topk(scores inside active_groups, top_k)
+weights = normalize(scores[experts])
+        </pre>
+        <p>The router is not just a matrix multiply. It includes bias correction, group selection, top-k selection, optional normalization, and a scaling factor before expert dispatch.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Routed ReLU2 Expert</h3>
+        <pre>
+for selected expert e:
+  h1 = hidden @ W_up[e].T
+  h2 = relu2(h1)
+  y  = h2 @ W_down[e].T
+  output += routing_weight[e] * y
+        </pre>
+        <p>The active experts are dense kernels. CK now has scalar reference coverage for the routed ReLU2 expert path, including backward parity and a performance benchmark.</p>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <ul>
+        <li><code>nemotron_group_limited_topk_router_f32</code> for group-limited routing.</li>
+        <li><code>moe_relu2_expert_forward_f32</code> and <code>moe_relu2_expert_backward_f32</code> for routed expert execution.</li>
+        <li><code>make test-nemotron-router</code>, <code>make test-moe-relu2-expert</code>, and <code>make test-moe-relu2-expert-perf</code> for parity and speed checks.</li>
+    </ul>
+    <p>On local AVX2 validation, the group-limited router microbenchmark measured CK at about <strong>3.5x faster</strong> than the PyTorch reference, and the ReLU2 expert benchmark measured roughly <strong>28-32x faster</strong> for the tested shapes. That does not mean full Nemotron inference is solved; it means these specific MoE primitives are now isolated, tested, and fast enough to build on.</p>
 </div>
 
 <hr>

--- a/docs/site/assets/concept-moe-router-relu2.svg
+++ b/docs/site/assets/concept-moe-router-relu2.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="620" viewBox="0 0 1180 620" role="img" aria-labelledby="title desc">
+  <title id="title">Nemotron-style MoE router and ReLU2 expert flow</title>
+  <desc id="desc">Diagram showing hidden rows flowing through router logits, group-limited top-k expert selection, routed ReLU2 experts, and weighted output accumulation.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#07111f"/>
+      <stop offset="0.55" stop-color="#0d1b2a"/>
+      <stop offset="1" stop-color="#13243a"/>
+    </linearGradient>
+    <linearGradient id="router" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#12304f"/>
+      <stop offset="1" stop-color="#0f5f83"/>
+    </linearGradient>
+    <linearGradient id="expert" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2b1b08"/>
+      <stop offset="1" stop-color="#8a4b06"/>
+    </linearGradient>
+    <linearGradient id="accum" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0e3329"/>
+      <stop offset="1" stop-color="#15735d"/>
+    </linearGradient>
+    <filter id="shadow" x="-15%" y="-20%" width="130%" height="145%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.28"/>
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0 0 L10 5 L0 10z" fill="#8bd3ff"/>
+    </marker>
+  </defs>
+
+  <rect width="1180" height="620" fill="url(#bg)"/>
+  <g opacity="0.22" stroke="#26364f" stroke-width="1">
+    <path d="M0 90H1180M0 180H1180M0 270H1180M0 360H1180M0 450H1180M0 540H1180"/>
+    <path d="M100 0V620M200 0V620M300 0V620M400 0V620M500 0V620M600 0V620M700 0V620M800 0V620M900 0V620M1000 0V620M1100 0V620"/>
+  </g>
+
+  <text x="54" y="58" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">MoE routing is sparse control flow over dense expert kernels</text>
+  <text x="54" y="88" fill="#9fb6d8" font-family="Inter, Arial, sans-serif" font-size="15">Nemotron-style layers score experts, constrain selection by group, run only top-k experts, then accumulate weighted outputs.</text>
+
+  <g transform="translate(55 150)" filter="url(#shadow)">
+    <rect x="0" y="0" width="150" height="95" rx="10" fill="#101b2d" stroke="#2d405f"/>
+    <text x="28" y="35" fill="#e5f2ff" font-family="JetBrains Mono, Consolas, monospace" font-size="15">hidden</text>
+    <text x="22" y="60" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">[rows, hidden]</text>
+  </g>
+
+  <g transform="translate(250 122)" filter="url(#shadow)">
+    <rect x="0" y="0" width="205" height="150" rx="12" fill="url(#router)" stroke="#38bdf8"/>
+    <text x="26" y="34" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Router</text>
+    <text x="26" y="60" fill="#dff5ff" font-family="JetBrains Mono, Consolas, monospace" font-size="13">scores + bias</text>
+    <text x="26" y="84" fill="#dff5ff" font-family="JetBrains Mono, Consolas, monospace" font-size="13">sigmoid(scores)</text>
+    <line x1="24" y1="100" x2="180" y2="100" stroke="#8bd3ff" opacity="0.5"/>
+    <text x="26" y="126" fill="#b8e7ff" font-family="JetBrains Mono, Consolas, monospace" font-size="12">nemotron_group_limited</text>
+  </g>
+
+  <g transform="translate(505 115)" filter="url(#shadow)">
+    <rect x="0" y="0" width="220" height="165" rx="12" fill="#111827" stroke="#50627f"/>
+    <text x="24" y="34" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Group-limited top-k</text>
+    <text x="24" y="61" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">split experts into groups</text>
+    <text x="24" y="85" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">choose top groups</text>
+    <text x="24" y="109" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">choose top-k experts</text>
+    <rect x="24" y="126" width="76" height="24" rx="6" fill="#12304f" stroke="#38bdf8"/>
+    <text x="42" y="143" fill="#dff5ff" font-family="JetBrains Mono, Consolas, monospace" font-size="12">idx</text>
+    <rect x="112" y="126" width="84" height="24" rx="6" fill="#1d2a3d" stroke="#8bd3ff"/>
+    <text x="127" y="143" fill="#dff5ff" font-family="JetBrains Mono, Consolas, monospace" font-size="12">weight</text>
+  </g>
+
+  <g transform="translate(782 84)" filter="url(#shadow)">
+    <rect x="0" y="0" width="170" height="88" rx="10" fill="url(#expert)" stroke="#f59e0b"/>
+    <text x="28" y="32" fill="#fff7ed" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Expert e0</text>
+    <text x="22" y="58" fill="#fde68a" font-family="JetBrains Mono, Consolas, monospace" font-size="12">up -> relu2 -> down</text>
+
+    <rect x="0" y="115" width="170" height="88" rx="10" fill="url(#expert)" stroke="#f59e0b"/>
+    <text x="28" y="147" fill="#fff7ed" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Expert e7</text>
+    <text x="22" y="173" fill="#fde68a" font-family="JetBrains Mono, Consolas, monospace" font-size="12">up -> relu2 -> down</text>
+
+    <rect x="0" y="230" width="170" height="88" rx="10" fill="#24180a" stroke="#9a6b1a" stroke-dasharray="5 4"/>
+    <text x="32" y="262" fill="#b6a37a" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Expert eN</text>
+    <text x="22" y="288" fill="#95856b" font-family="JetBrains Mono, Consolas, monospace" font-size="12">not selected</text>
+  </g>
+
+  <g transform="translate(1000 164)" filter="url(#shadow)">
+    <rect x="0" y="0" width="130" height="125" rx="12" fill="url(#accum)" stroke="#34d399"/>
+    <text x="25" y="35" fill="#ecfdf5" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Accumulate</text>
+    <text x="20" y="65" fill="#d1fae5" font-family="JetBrains Mono, Consolas, monospace" font-size="12">out += w_i</text>
+    <text x="20" y="88" fill="#d1fae5" font-family="JetBrains Mono, Consolas, monospace" font-size="12">     * expert_i</text>
+  </g>
+
+  <g stroke="#8bd3ff" stroke-width="2.2" fill="none" marker-end="url(#arrow)">
+    <path d="M205 198H250"/>
+    <path d="M455 198H505"/>
+    <path d="M725 198C750 198 750 130 782 130"/>
+    <path d="M725 198C750 198 750 245 782 245"/>
+    <path d="M952 130C980 130 980 190 1000 190"/>
+    <path d="M952 245C980 245 980 235 1000 235"/>
+  </g>
+
+  <g transform="translate(80 438)">
+    <rect x="0" y="0" width="1020" height="105" rx="12" fill="#08111f" stroke="#24344f"/>
+    <text x="26" y="32" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Why this matters for CK</text>
+    <text x="26" y="60" fill="#9fb6d8" font-family="Inter, Arial, sans-serif" font-size="14">The router is control-heavy: top-k selection, group filtering, normalization, and sparse expert dispatch. CPUs handle this branching and irregular memory pattern naturally.</text>
+    <text x="26" y="84" fill="#9fb6d8" font-family="Inter, Arial, sans-serif" font-size="14">The selected experts are dense kernels: CK keeps those as explicit C entry points, so each slow piece can be profiled and replaced independently.</text>
+  </g>
+
+  <text x="590" y="585" fill="#49617f" font-family="JetBrains Mono, Consolas, monospace" font-size="12" text-anchor="middle">C-Kernel-Engine | group-limited router + ReLU2 expert dispatch</text>
+</svg>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -966,6 +966,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
+    <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
 </ul>
@@ -1513,6 +1514,51 @@ y = gamma * x / (rms + eps)
     <h3 style="margin-top: 0;">Why Remove Mean Centering?</h3>
     <p>Research found that the re-centering (subtracting mean) in LayerNorm isn't necessary for good performance. RMSNorm keeps just the scaling, which is what matters for gradient flow.</p>
     <p><strong>Used in:</strong> Llama, Mistral, Qwen, Gemma (most modern LLMs)</p>
+</div>
+
+<hr>
+
+<h2 id="moe-routing">Mixture of Experts: Router + ReLU2 Experts</h2>
+
+<p>MoE layers replace one dense MLP with a pool of experts and a router. For each token row, the router scores experts, selects a small <code>top_k</code> subset, runs only those expert MLPs, and accumulates the weighted result. This is sparse control flow wrapped around dense per-expert math.</p>
+
+<div class="img-container svg-viewer" data-title="Nemotron-style MoE Router and ReLU2 Experts">
+    <img src="assets/concept-moe-router-relu2.svg" alt="Nemotron-style MoE router and ReLU2 expert flow">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Group-Limited Top-K Router</h3>
+        <pre>
+scores = sigmoid(router_logits + correction_bias)
+groups = partition(experts, n_group)
+active_groups = topk(group_scores, topk_group)
+experts = topk(scores inside active_groups, top_k)
+weights = normalize(scores[experts])
+        </pre>
+        <p>The router is not just a matrix multiply. It includes bias correction, group selection, top-k selection, optional normalization, and a scaling factor before expert dispatch.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Routed ReLU2 Expert</h3>
+        <pre>
+for selected expert e:
+  h1 = hidden @ W_up[e].T
+  h2 = relu2(h1)
+  y  = h2 @ W_down[e].T
+  output += routing_weight[e] * y
+        </pre>
+        <p>The active experts are dense kernels. CK now has scalar reference coverage for the routed ReLU2 expert path, including backward parity and a performance benchmark.</p>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <ul>
+        <li><code>nemotron_group_limited_topk_router_f32</code> for group-limited routing.</li>
+        <li><code>moe_relu2_expert_forward_f32</code> and <code>moe_relu2_expert_backward_f32</code> for routed expert execution.</li>
+        <li><code>make test-nemotron-router</code>, <code>make test-moe-relu2-expert</code>, and <code>make test-moe-relu2-expert-perf</code> for parity and speed checks.</li>
+    </ul>
+    <p>On local AVX2 validation, the group-limited router microbenchmark measured CK at about <strong>3.5x faster</strong> than the PyTorch reference, and the ReLU2 expert benchmark measured roughly <strong>28-32x faster</strong> for the tested shapes. That does not mean full Nemotron inference is solved; it means these specific MoE primitives are now isolated, tested, and fast enough to build on.</p>
 </div>
 
 <hr>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -2137,6 +2137,35 @@ void moe_accumulate_expert_f32(float *output,
                                float routing_weight,
                                int hidden_dim);
 
+// Routed MoE expert MLP: output += weight * down(relu2(up(hidden))).
+void moe_relu2_expert_forward_f32(const float *hidden,
+                                  const int *indices,
+                                  const float *routing_weights,
+                                  const float *expert_up,
+                                  const float *expert_down,
+                                  float *output,
+                                  int rows,
+                                  int hidden_dim,
+                                  int intermediate_dim,
+                                  int n_experts,
+                                  int top_k);
+
+void moe_relu2_expert_backward_f32(const float *d_output,
+                                   const float *hidden,
+                                   const int *indices,
+                                   const float *routing_weights,
+                                   const float *expert_up,
+                                   const float *expert_down,
+                                   float *d_hidden,
+                                   float *d_routing_weights,
+                                   float *d_expert_up,
+                                   float *d_expert_down,
+                                   int rows,
+                                   int hidden_dim,
+                                   int intermediate_dim,
+                                   int n_experts,
+                                   int top_k);
+
 // =============================================================================
 // Top-K selection kernels (for MoE router dispatch)
 // =============================================================================
@@ -2171,6 +2200,19 @@ void topk_batched_f32(const float *scores,
                       int k,
                       int *indices,
                       float *weights);
+
+// Nemotron-H/DeepSeek-style group-limited MoE router over sigmoid scores.
+void nemotron_group_limited_topk_router_f32(const float *scores,
+                                            const float *correction_bias,
+                                            int *indices,
+                                            float *weights,
+                                            int rows,
+                                            int n_experts,
+                                            int top_k,
+                                            int n_group,
+                                            int topk_group,
+                                            int norm_topk_prob,
+                                            float routed_scaling_factor);
 
 // Argmax (top-1)
 int argmax_f32(const float *scores, int n);

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -258,6 +258,8 @@ TEST_SUITES = {
     "lm_head_litmus": TestSuite("LM Head Litmus", "kernels", UNITTEST_DIR / "test_lm_head_litmus.py"),
     "deepseek_reference": TestSuite("DeepSeek Reference Kernels", "kernels", UNITTEST_DIR / "test_deepseek_reference_kernels.py"),
     "relu2": TestSuite("ReLU2", "kernels", UNITTEST_DIR / "test_relu2.py"),
+    "nemotron_router": TestSuite("Nemotron Group-Limited Router", "kernels", UNITTEST_DIR / "test_nemotron_router.py"),
+    "moe_relu2_expert": TestSuite("MoE ReLU2 Expert", "kernels", UNITTEST_DIR / "test_moe_relu2_expert.py"),
     "vision": TestSuite("Vision", "kernels", UNITTEST_DIR / "test_vision.py"),
     # NOTE: Orchestration test disabled - v6.5 uses generated code with local helpers,
     # not orchestration layer. Use llamacpp-parity-full for quantized kernel validation.
@@ -427,7 +429,7 @@ BENCH_TARGETS = {
 
 # Quick subset for fast validation
 QUICK_TESTS = [
-    "gemm", "relu", "relu2", "softmax", "rmsnorm", "attention", "attention_sliding",
+    "gemm", "relu", "relu2", "nemotron_router", "moe_relu2_expert", "softmax", "rmsnorm", "attention", "attention_sliding",
     "deltanet_backward",
     "relu_bf16", "rmsnorm_bf16",
     "q4k_kernels",

--- a/src/kernels/axpy_kernels.c
+++ b/src/kernels/axpy_kernels.c
@@ -260,3 +260,159 @@ void moe_accumulate_expert_f32(float *output,
 {
     axpy_f32(output, expert_output, routing_weight, hidden_dim);
 }
+
+
+/* =============================================================================
+ * Routed MoE expert MLP with ReLU2 activation.
+ *
+ * expert_up   layout: [n_experts, intermediate_dim, hidden_dim]
+ * expert_down layout: [n_experts, hidden_dim, intermediate_dim]
+ * output      layout: [rows, hidden_dim]
+ * ============================================================================= */
+static inline size_t ck_moe_up_idx(int e, int i, int h, int intermediate_dim, int hidden_dim)
+{
+    return ((size_t)e * (size_t)intermediate_dim + (size_t)i) * (size_t)hidden_dim + (size_t)h;
+}
+
+static inline size_t ck_moe_down_idx(int e, int h, int i, int hidden_dim, int intermediate_dim)
+{
+    return ((size_t)e * (size_t)hidden_dim + (size_t)h) * (size_t)intermediate_dim + (size_t)i;
+}
+
+void moe_relu2_expert_forward_f32(const float *hidden,
+                                  const int *indices,
+                                  const float *routing_weights,
+                                  const float *expert_up,
+                                  const float *expert_down,
+                                  float *output,
+                                  int rows,
+                                  int hidden_dim,
+                                  int intermediate_dim,
+                                  int n_experts,
+                                  int top_k)
+{
+    if (!hidden || !indices || !routing_weights || !expert_up || !expert_down || !output ||
+        rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0 || n_experts <= 0 || top_k <= 0) {
+        return;
+    }
+
+    const size_t out_count = (size_t)rows * (size_t)hidden_dim;
+    for (size_t p = 0; p < out_count; ++p) output[p] = 0.0f;
+
+    float pre[intermediate_dim];
+    float act[intermediate_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        float *y = output + (size_t)r * (size_t)hidden_dim;
+        for (int slot = 0; slot < top_k; ++slot) {
+            const int e = indices[(size_t)r * (size_t)top_k + (size_t)slot];
+            if (e < 0 || e >= n_experts) continue;
+            const float route_w = routing_weights[(size_t)r * (size_t)top_k + (size_t)slot];
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                float v = 0.0f;
+                for (int h = 0; h < hidden_dim; ++h) {
+                    v += expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] * x[h];
+                }
+                pre[i] = v;
+                act[i] = (v > 0.0f) ? v * v : 0.0f;
+            }
+
+            for (int h = 0; h < hidden_dim; ++h) {
+                float v = 0.0f;
+                for (int i = 0; i < intermediate_dim; ++i) {
+                    v += expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)] * act[i];
+                }
+                y[h] += route_w * v;
+            }
+        }
+    }
+}
+
+void moe_relu2_expert_backward_f32(const float *d_output,
+                                   const float *hidden,
+                                   const int *indices,
+                                   const float *routing_weights,
+                                   const float *expert_up,
+                                   const float *expert_down,
+                                   float *d_hidden,
+                                   float *d_routing_weights,
+                                   float *d_expert_up,
+                                   float *d_expert_down,
+                                   int rows,
+                                   int hidden_dim,
+                                   int intermediate_dim,
+                                   int n_experts,
+                                   int top_k)
+{
+    if (!d_output || !hidden || !indices || !routing_weights || !expert_up || !expert_down ||
+        !d_hidden || !d_routing_weights || !d_expert_up || !d_expert_down ||
+        rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0 || n_experts <= 0 || top_k <= 0) {
+        return;
+    }
+
+    for (size_t p = 0; p < (size_t)rows * (size_t)hidden_dim; ++p) d_hidden[p] = 0.0f;
+    for (size_t p = 0; p < (size_t)rows * (size_t)top_k; ++p) d_routing_weights[p] = 0.0f;
+    for (size_t p = 0; p < (size_t)n_experts * (size_t)intermediate_dim * (size_t)hidden_dim; ++p) d_expert_up[p] = 0.0f;
+    for (size_t p = 0; p < (size_t)n_experts * (size_t)hidden_dim * (size_t)intermediate_dim; ++p) d_expert_down[p] = 0.0f;
+
+    float pre[intermediate_dim];
+    float act[intermediate_dim];
+    float d_act[intermediate_dim];
+    float d_pre[intermediate_dim];
+    float expert_out[hidden_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        const float *dy = d_output + (size_t)r * (size_t)hidden_dim;
+        float *dx = d_hidden + (size_t)r * (size_t)hidden_dim;
+
+        for (int slot = 0; slot < top_k; ++slot) {
+            const int e = indices[(size_t)r * (size_t)top_k + (size_t)slot];
+            if (e < 0 || e >= n_experts) continue;
+            const float route_w = routing_weights[(size_t)r * (size_t)top_k + (size_t)slot];
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                float v = 0.0f;
+                for (int h = 0; h < hidden_dim; ++h) {
+                    v += expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] * x[h];
+                }
+                pre[i] = v;
+                act[i] = (v > 0.0f) ? v * v : 0.0f;
+                d_act[i] = 0.0f;
+            }
+
+            for (int h = 0; h < hidden_dim; ++h) {
+                float v = 0.0f;
+                for (int i = 0; i < intermediate_dim; ++i) {
+                    v += expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)] * act[i];
+                }
+                expert_out[h] = v;
+            }
+
+            float d_route = 0.0f;
+            for (int h = 0; h < hidden_dim; ++h) {
+                const float d_expert_out = dy[h] * route_w;
+                d_route += dy[h] * expert_out[h];
+                for (int i = 0; i < intermediate_dim; ++i) {
+                    d_expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)] += d_expert_out * act[i];
+                    d_act[i] += d_expert_out * expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)];
+                }
+            }
+            d_routing_weights[(size_t)r * (size_t)top_k + (size_t)slot] += d_route;
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                d_pre[i] = (pre[i] > 0.0f) ? d_act[i] * 2.0f * pre[i] : 0.0f;
+            }
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                const float dpi = d_pre[i];
+                for (int h = 0; h < hidden_dim; ++h) {
+                    d_expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] += dpi * x[h];
+                    dx[h] += dpi * expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)];
+                }
+            }
+        }
+    }
+}

--- a/src/kernels/topk_kernels.c
+++ b/src/kernels/topk_kernels.c
@@ -340,3 +340,127 @@ int argmax_f32(const float *scores, int n)
 
     return max_idx;
 }
+
+
+/* =============================================================================
+ * Group-limited MoE router for Nemotron-H/DeepSeek-style routed experts.
+ *
+ * Contract:
+ *   scores          [rows, n_experts] sigmoid router scores
+ *   correction_bias [n_experts] optional score correction used only for choice
+ *   indices         [rows, top_k]
+ *   weights         [rows, top_k]
+ *
+ * Selection matches the HF/Nemotron policy:
+ *   choice_scores = scores + correction_bias
+ *   group_scores = sum(top2(choice_scores within group))
+ *   selected_groups = topk(group_scores, topk_group)
+ *   selected_experts = topk(choice_scores masked to selected groups, top_k)
+ *   weights = gather(scores, selected_experts)
+ *   if norm_topk_prob: weights /= sum(weights) + 1e-20
+ *   weights *= routed_scaling_factor
+ * ============================================================================= */
+static void ck_topk_insert_desc(int idx, float val, int *indices, float *values, int k)
+{
+    for (int pos = 0; pos < k; ++pos) {
+        if (indices[pos] < 0 || val > values[pos] || (val == values[pos] && idx < indices[pos])) {
+            for (int j = k - 1; j > pos; --j) {
+                indices[j] = indices[j - 1];
+                values[j] = values[j - 1];
+            }
+            indices[pos] = idx;
+            values[pos] = val;
+            return;
+        }
+    }
+}
+
+void nemotron_group_limited_topk_router_f32(const float *scores,
+                                            const float *correction_bias,
+                                            int *indices,
+                                            float *weights,
+                                            int rows,
+                                            int n_experts,
+                                            int top_k,
+                                            int n_group,
+                                            int topk_group,
+                                            int norm_topk_prob,
+                                            float routed_scaling_factor)
+{
+    if (!scores || !indices || !weights || rows <= 0 || n_experts <= 0 ||
+        top_k <= 0 || n_group <= 0 || topk_group <= 0) {
+        return;
+    }
+    if (top_k > n_experts) top_k = n_experts;
+    if (n_group > n_experts) n_group = n_experts;
+    if (topk_group > n_group) topk_group = n_group;
+    const int experts_per_group = n_experts / n_group;
+    if (experts_per_group <= 0 || experts_per_group * n_group != n_experts) {
+        return;
+    }
+
+    for (int r = 0; r < rows; ++r) {
+        const float *row_scores = scores + (size_t)r * (size_t)n_experts;
+        int *row_indices = indices + (size_t)r * (size_t)top_k;
+        float *row_weights = weights + (size_t)r * (size_t)top_k;
+
+        int selected_groups[topk_group];
+        float selected_group_scores[topk_group];
+        for (int i = 0; i < topk_group; ++i) {
+            selected_groups[i] = -1;
+            selected_group_scores[i] = -FLT_MAX;
+        }
+
+        for (int g = 0; g < n_group; ++g) {
+            float best0 = -FLT_MAX;
+            float best1 = -FLT_MAX;
+            const int start = g * experts_per_group;
+            for (int j = 0; j < experts_per_group; ++j) {
+                const int e = start + j;
+                const float v = row_scores[e] + (correction_bias ? correction_bias[e] : 0.0f);
+                if (v > best0) {
+                    best1 = best0;
+                    best0 = v;
+                } else if (v > best1) {
+                    best1 = v;
+                }
+            }
+            const float group_score = best0 + ((experts_per_group >= 2) ? best1 : 0.0f);
+            ck_topk_insert_desc(g, group_score, selected_groups, selected_group_scores, topk_group);
+        }
+
+        int out_idx[top_k];
+        float out_choice[top_k];
+        for (int i = 0; i < top_k; ++i) {
+            out_idx[i] = -1;
+            out_choice[i] = -FLT_MAX;
+        }
+
+        for (int sg = 0; sg < topk_group; ++sg) {
+            const int g = selected_groups[sg];
+            if (g < 0) continue;
+            const int start = g * experts_per_group;
+            for (int j = 0; j < experts_per_group; ++j) {
+                const int e = start + j;
+                const float v = row_scores[e] + (correction_bias ? correction_bias[e] : 0.0f);
+                ck_topk_insert_desc(e, v, out_idx, out_choice, top_k);
+            }
+        }
+
+        float denom = 1.0e-20f;
+        for (int i = 0; i < top_k; ++i) {
+            const int e = out_idx[i];
+            const float w = (e >= 0 && e < n_experts) ? row_scores[e] : 0.0f;
+            row_indices[i] = e;
+            row_weights[i] = w;
+            denom += w;
+        }
+        for (int i = 0; i < top_k; ++i) {
+            float w = row_weights[i];
+            if (norm_topk_prob) {
+                w /= denom;
+            }
+            row_weights[i] = w * routed_scaling_factor;
+        }
+    }
+}

--- a/tests/test_v8_model_contract_inspector.py
+++ b/tests/test_v8_model_contract_inspector.py
@@ -47,8 +47,9 @@ class ModelContractInspectorTests(unittest.TestCase):
         self.assertEqual(report["layer_kind_counts"], {"attention": 1, "mamba": 5, "moe": 4})
         self.assertIn("mamba_selective_scan", report["missing_ops"])
         self.assertIn("relu2_mlp", report["missing_ops"])
-        self.assertIn("topk_router", report["missing_ops"])
-        self.assertIn("moe_expert_dispatch", report["missing_ops"])
+        self.assertIn("shared_expert_mlp", report["missing_ops"])
+        self.assertNotIn("group_limited_topk_router", report["missing_ops"])
+        self.assertNotIn("moe_relu2_expert_mlp", report["missing_ops"])
         self.assertIn("safetensors_to_bump_mapping", report["missing_ops"])
 
     def test_safetensors_index_audit_classifies_nemotron_families(self) -> None:

--- a/unittest/test_moe_relu2_expert.py
+++ b/unittest/test_moe_relu2_expert.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""PyTorch parity test for routed ReLU2 MoE expert MLP."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import time
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import torch
+except Exception as exc:  # pragma: no cover
+    print(f"[SKIP] torch not available: {exc}")
+    sys.exit(0)
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_PATH = ROOT / "build" / "libckernel_engine.so"
+if not LIB_PATH.exists():  # pragma: no cover
+    print("[SKIP] libckernel_engine.so not found")
+    sys.exit(0)
+
+LIB = ctypes.CDLL(str(LIB_PATH))
+fptr = ctypes.POINTER(ctypes.c_float)
+iptr = ctypes.POINTER(ctypes.c_int)
+LIB.moe_relu2_expert_forward_f32.argtypes = [fptr, iptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.moe_relu2_expert_forward_f32.restype = None
+LIB.moe_relu2_expert_backward_f32.argtypes = [fptr, fptr, iptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.moe_relu2_expert_backward_f32.restype = None
+
+
+def _fptr(a: np.ndarray) -> ctypes.POINTER(ctypes.c_float):
+    return a.ctypes.data_as(fptr)
+
+
+def _iptr(a: np.ndarray) -> ctypes.POINTER(ctypes.c_int):
+    return a.ctypes.data_as(iptr)
+
+
+def torch_moe(hidden, indices, weights, expert_up, expert_down):
+    rows, hidden_dim = hidden.shape
+    top_k = indices.shape[1]
+    out = torch.zeros_like(hidden)
+    for r in range(rows):
+        for s in range(top_k):
+            e = int(indices[r, s])
+            pre = torch.matmul(expert_up[e], hidden[r])
+            act = torch.relu(pre).square()
+            expert_out = torch.matmul(expert_down[e], act)
+            out[r] = out[r] + weights[r, s] * expert_out
+    return out
+
+
+class TestMoERelu2Expert(unittest.TestCase):
+    def _run_case(self, rows: int, hidden_dim: int, intermediate_dim: int, n_experts: int, top_k: int, seed: int) -> None:
+        rng = np.random.default_rng(seed)
+        hidden_np = (0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32)
+        up_np = (0.15 * rng.standard_normal((n_experts, intermediate_dim, hidden_dim))).astype(np.float32)
+        down_np = (0.15 * rng.standard_normal((n_experts, hidden_dim, intermediate_dim))).astype(np.float32)
+        idx_np = np.empty((rows, top_k), dtype=np.int32)
+        for r in range(rows):
+            idx_np[r] = rng.choice(n_experts, size=top_k, replace=False).astype(np.int32)
+        w_raw = rng.random((rows, top_k)).astype(np.float32)
+        weights_np = np.ascontiguousarray(w_raw / w_raw.sum(axis=1, keepdims=True))
+        d_out_np = (0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32)
+
+        ck_out = np.empty_like(hidden_np)
+        LIB.moe_relu2_expert_forward_f32(_fptr(hidden_np), _iptr(idx_np), _fptr(weights_np), _fptr(up_np), _fptr(down_np), _fptr(ck_out), rows, hidden_dim, intermediate_dim, n_experts, top_k)
+
+        ck_dh = np.empty_like(hidden_np)
+        ck_dw = np.empty_like(weights_np)
+        ck_dup = np.empty_like(up_np)
+        ck_ddown = np.empty_like(down_np)
+        LIB.moe_relu2_expert_backward_f32(_fptr(d_out_np), _fptr(hidden_np), _iptr(idx_np), _fptr(weights_np), _fptr(up_np), _fptr(down_np), _fptr(ck_dh), _fptr(ck_dw), _fptr(ck_dup), _fptr(ck_ddown), rows, hidden_dim, intermediate_dim, n_experts, top_k)
+
+        hidden = torch.tensor(hidden_np, dtype=torch.float32, requires_grad=True)
+        up = torch.tensor(up_np, dtype=torch.float32, requires_grad=True)
+        down = torch.tensor(down_np, dtype=torch.float32, requires_grad=True)
+        weights = torch.tensor(weights_np, dtype=torch.float32, requires_grad=True)
+        indices = torch.tensor(idx_np, dtype=torch.long)
+        ref = torch_moe(hidden, indices, weights, up, down)
+        ref.backward(torch.tensor(d_out_np, dtype=torch.float32))
+
+        np.testing.assert_allclose(ck_out, ref.detach().numpy(), atol=2e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dh, hidden.grad.detach().numpy(), atol=2e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dw, weights.grad.detach().numpy(), atol=2e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dup, up.grad.detach().numpy(), atol=2e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_ddown, down.grad.detach().numpy(), atol=2e-6, rtol=0.0)
+
+    def test_small_experts(self) -> None:
+        self._run_case(rows=4, hidden_dim=8, intermediate_dim=12, n_experts=5, top_k=3, seed=5)
+
+    def test_nano_shape_tiny_batch(self) -> None:
+        self._run_case(rows=3, hidden_dim=16, intermediate_dim=10, n_experts=8, top_k=4, seed=13)
+
+
+def _time_us(fn, iterations: int) -> float:
+    start = time.perf_counter()
+    for _ in range(iterations):
+        fn()
+    return (time.perf_counter() - start) * 1.0e6 / max(1, iterations)
+
+
+def run_benchmark() -> None:
+    rows, hidden_dim, intermediate_dim, n_experts, top_k = 16, 64, 48, 16, 4
+    rng = np.random.default_rng(41)
+    hidden = np.ascontiguousarray((0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32))
+    up = np.ascontiguousarray((0.12 * rng.standard_normal((n_experts, intermediate_dim, hidden_dim))).astype(np.float32))
+    down = np.ascontiguousarray((0.12 * rng.standard_normal((n_experts, hidden_dim, intermediate_dim))).astype(np.float32))
+    idx = np.empty((rows, top_k), dtype=np.int32)
+    for r in range(rows):
+        idx[r] = rng.choice(n_experts, size=top_k, replace=False).astype(np.int32)
+    w = rng.random((rows, top_k)).astype(np.float32)
+    weights = np.ascontiguousarray(w / w.sum(axis=1, keepdims=True))
+    out = np.empty_like(hidden)
+    th = torch.tensor(hidden, dtype=torch.float32)
+    tu = torch.tensor(up, dtype=torch.float32)
+    td = torch.tensor(down, dtype=torch.float32)
+    tw = torch.tensor(weights, dtype=torch.float32)
+    ti = torch.tensor(idx, dtype=torch.long)
+
+    def ck_step() -> None:
+        LIB.moe_relu2_expert_forward_f32(_fptr(hidden), _iptr(idx), _fptr(weights), _fptr(up), _fptr(down), _fptr(out), rows, hidden_dim, intermediate_dim, n_experts, top_k)
+
+    def torch_step() -> None:
+        torch_moe(th, ti, tw, tu, td)
+
+    ck_step(); torch_step()
+    torch_us = _time_us(torch_step, 100)
+    ck_us = _time_us(ck_step, 100)
+    print("kernel                    pytorch_us      ck_us       speedup")
+    print(f"moe_relu2_expert_forward {torch_us:10.3f} {ck_us:10.3f} {torch_us / max(ck_us, 1e-12):8.2f}x")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--benchmark", action="store_true")
+    args, remaining = ap.parse_known_args()
+    if args.benchmark:
+        run_benchmark()
+    else:
+        sys.argv = [sys.argv[0], *remaining]
+        unittest.main(verbosity=2)

--- a/unittest/test_nemotron_router.py
+++ b/unittest/test_nemotron_router.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""PyTorch parity test for Nemotron-H group-limited MoE router."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import time
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import torch
+except Exception as exc:  # pragma: no cover
+    print(f"[SKIP] torch not available: {exc}")
+    sys.exit(0)
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_PATH = ROOT / "build" / "libckernel_engine.so"
+if not LIB_PATH.exists():  # pragma: no cover
+    print("[SKIP] libckernel_engine.so not found")
+    sys.exit(0)
+
+LIB = ctypes.CDLL(str(LIB_PATH))
+fptr = ctypes.POINTER(ctypes.c_float)
+iptr = ctypes.POINTER(ctypes.c_int)
+LIB.nemotron_group_limited_topk_router_f32.argtypes = [
+    fptr, fptr, iptr, fptr,
+    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+    ctypes.c_int, ctypes.c_float,
+]
+LIB.nemotron_group_limited_topk_router_f32.restype = None
+
+
+def _fptr(a: np.ndarray) -> ctypes.POINTER(ctypes.c_float):
+    return a.ctypes.data_as(fptr)
+
+
+def _iptr(a: np.ndarray) -> ctypes.POINTER(ctypes.c_int):
+    return a.ctypes.data_as(iptr)
+
+
+def torch_router(scores: torch.Tensor, bias: torch.Tensor, top_k: int, n_group: int, topk_group: int, norm: bool, scale: float):
+    rows, n_experts = scores.shape
+    choice = scores + bias.unsqueeze(0)
+    group_scores = choice.view(rows, n_group, n_experts // n_group).topk(2, dim=-1, largest=True, sorted=True)[0].sum(dim=-1)
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, largest=True, sorted=True)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = group_mask.unsqueeze(-1).expand(rows, n_group, n_experts // n_group).reshape(rows, n_experts)
+    masked_choice = choice.masked_fill(~score_mask.bool(), 0.0)
+    indices = torch.topk(masked_choice, k=top_k, dim=-1, largest=True, sorted=True)[1]
+    weights = scores.gather(1, indices)
+    if norm:
+        weights = weights / (weights.sum(dim=-1, keepdim=True) + 1e-20)
+    return indices, weights * scale
+
+
+def _time_us(fn, iterations: int) -> float:
+    start = time.perf_counter()
+    for _ in range(iterations):
+        fn()
+    return (time.perf_counter() - start) * 1.0e6 / max(1, iterations)
+
+
+def run_benchmark() -> None:
+    torch.set_num_threads(1)
+    rows, n_experts, top_k, n_group, topk_group = 512, 128, 6, 8, 3
+    rng = np.random.default_rng(301)
+    logits = (0.7 * rng.standard_normal((rows, n_experts))).astype(np.float32)
+    scores = np.ascontiguousarray(1.0 / (1.0 + np.exp(-logits)))
+    bias = np.ascontiguousarray((0.05 * rng.standard_normal(n_experts)).astype(np.float32))
+    ck_idx = np.empty((rows, top_k), dtype=np.int32)
+    ck_w = np.empty((rows, top_k), dtype=np.float32)
+    ts = torch.tensor(scores, dtype=torch.float32)
+    tb = torch.tensor(bias, dtype=torch.float32)
+
+    def torch_step() -> None:
+        torch_router(ts, tb, top_k, n_group, topk_group, True, 1.0)
+
+    def ck_step() -> None:
+        LIB.nemotron_group_limited_topk_router_f32(
+            _fptr(scores), _fptr(bias), _iptr(ck_idx), _fptr(ck_w),
+            rows, n_experts, top_k, n_group, topk_group, 1, ctypes.c_float(1.0),
+        )
+
+    torch_step()
+    ck_step()
+    torch_us = _time_us(torch_step, 200)
+    ck_us = _time_us(ck_step, 200)
+    print("kernel                            pytorch_us      ck_us       speedup")
+    print(f"nemotron_group_limited_router {torch_us:12.3f} {ck_us:10.3f} {torch_us / max(ck_us, 1e-12):8.2f}x")
+
+
+class TestNemotronRouter(unittest.TestCase):
+    def _run_case(self, rows: int, n_experts: int, top_k: int, n_group: int, topk_group: int, norm: bool, scale: float, seed: int) -> None:
+        rng = np.random.default_rng(seed)
+        logits = (0.7 * rng.standard_normal((rows, n_experts))).astype(np.float32)
+        scores = 1.0 / (1.0 + np.exp(-logits))
+        bias = (0.05 * rng.standard_normal(n_experts)).astype(np.float32)
+        ck_idx = np.empty((rows, top_k), dtype=np.int32)
+        ck_w = np.empty((rows, top_k), dtype=np.float32)
+        LIB.nemotron_group_limited_topk_router_f32(
+            _fptr(np.ascontiguousarray(scores)),
+            _fptr(np.ascontiguousarray(bias)),
+            _iptr(ck_idx),
+            _fptr(ck_w),
+            rows, n_experts, top_k, n_group, topk_group, int(norm), ctypes.c_float(scale),
+        )
+        ref_idx, ref_w = torch_router(
+            torch.tensor(scores, dtype=torch.float32),
+            torch.tensor(bias, dtype=torch.float32),
+            top_k, n_group, topk_group, norm, scale,
+        )
+        np.testing.assert_array_equal(ck_idx, ref_idx.numpy().astype(np.int32))
+        np.testing.assert_allclose(ck_w, ref_w.numpy(), atol=1e-6, rtol=0.0)
+
+    def test_nano_like_router(self) -> None:
+        self._run_case(rows=7, n_experts=128, top_k=6, n_group=8, topk_group=3, norm=True, scale=1.0, seed=23)
+
+    def test_no_norm_scaled_router(self) -> None:
+        self._run_case(rows=5, n_experts=16, top_k=4, n_group=4, topk_group=2, norm=False, scale=0.7, seed=31)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--benchmark", action="store_true")
+    args, remaining = ap.parse_known_args()
+    if args.benchmark:
+        run_benchmark()
+    else:
+        sys.argv = [sys.argv[0], *remaining]
+        unittest.main(verbosity=2)

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,7 +5,7 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 149,
+      "total": 152,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -32,9 +32,11 @@
         "gemma4_per_layer_embed": 1,
         "gemma4_per_layer_prepare": 2,
         "gemv": 14,
+        "group_limited_topk_router": 1,
         "kv_cache_store": 2,
         "layernorm": 2,
         "logits_store_indexed": 1,
+        "moe_relu2_expert_mlp": 2,
         "optimizer": 4,
         "position_embeddings": 2,
         "position_ids": 1,
@@ -10693,6 +10695,302 @@
       "_source_file": "memcpy.json"
     },
     {
+      "id": "moe_relu2_expert_backward_f32",
+      "op": "moe_relu2_expert_mlp",
+      "variant": "fp32",
+      "modes": {
+        "inference": false,
+        "training": true,
+        "backward": true
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "d_output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "expert_up",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_down",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "d_hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "d_routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "d_expert_up",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "d_expert_down",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "H",
+        "I",
+        "E",
+        "K"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "moe_relu2_expert_backward_f32",
+        "c_declaration": "void moe_relu2_expert_backward_f32(const float *d_output, const float *hidden, const int *indices, const float *routing_weights, const float *expert_up, const float *expert_down, float *d_hidden, float *d_routing_weights, float *d_expert_up, float *d_expert_down, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_relu2_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_relu2_expert.py",
+            "tolerance": "2e-5"
+          }
+        ]
+      },
+      "name": "moe_relu2_expert_backward_f32",
+      "_source_file": "moe_relu2_expert_backward_f32.json"
+    },
+    {
+      "id": "moe_relu2_expert_forward_f32",
+      "op": "moe_relu2_expert_mlp",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "expert_up",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_down",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "H",
+        "I",
+        "E",
+        "K"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "moe_relu2_expert_forward_f32",
+        "c_declaration": "void moe_relu2_expert_forward_f32(const float *hidden, const int *indices, const float *routing_weights, const float *expert_up, const float *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_relu2_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_relu2_expert.py",
+            "tolerance": "2e-5"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-moe-relu2-expert-perf"
+          }
+        ]
+      },
+      "name": "moe_relu2_expert_forward_f32",
+      "_source_file": "moe_relu2_expert_forward_f32.json"
+    },
+    {
       "id": "mrope_qk_text",
       "op": "rope",
       "variant": "fp32_head_major_text_mrope",
@@ -10987,6 +11285,130 @@
       "notes": "Vision multi-section RoPE for Q/K using four position streams and head-major activations.",
       "name": "mrope_qk_vision",
       "_source_file": "mrope_qk_vision.json"
+    },
+    {
+      "id": "nemotron_group_limited_topk_router_f32",
+      "op": "group_limited_topk_router",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "scores",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "E"
+          ]
+        },
+        {
+          "name": "correction_bias",
+          "dtype": "fp32",
+          "shape": [
+            "E"
+          ],
+          "optional": true
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "E",
+        "K",
+        "G",
+        "TG"
+      ],
+      "params": [
+        {
+          "name": "norm_topk_prob",
+          "dtype": "i32"
+        },
+        {
+          "name": "routed_scaling_factor",
+          "dtype": "fp32"
+        }
+      ],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "nemotron_group_limited_topk_router_f32",
+        "c_declaration": "void nemotron_group_limited_topk_router_f32(const float *scores, const float *correction_bias, int *indices, float *weights, int rows, int n_experts, int top_k, int n_group, int topk_group, int norm_topk_prob, float routed_scaling_factor);",
+        "sources": [
+          "src/kernels/topk_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_nemotron_router.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_nemotron_router.py",
+            "tolerance": "1e-6"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-nemotron-router-perf"
+          }
+        ]
+      },
+      "name": "nemotron_group_limited_topk_router_f32",
+      "_source_file": "nemotron_group_limited_topk_router_f32.json"
     },
     {
       "id": "position_embeddings_add",

--- a/version/v8/kernel_maps/moe_relu2_expert_backward_f32.json
+++ b/version/v8/kernel_maps/moe_relu2_expert_backward_f32.json
@@ -1,0 +1,160 @@
+{
+  "id": "moe_relu2_expert_backward_f32",
+  "op": "moe_relu2_expert_mlp",
+  "variant": "fp32",
+  "modes": {
+    "inference": false,
+    "training": true,
+    "backward": true
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "d_output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "indices",
+      "dtype": "i32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "expert_up",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_down",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "d_hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "d_routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "d_expert_up",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "d_expert_down",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "H",
+    "I",
+    "E",
+    "K"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "moe_relu2_expert_backward_f32",
+    "c_declaration": "void moe_relu2_expert_backward_f32(const float *d_output, const float *hidden, const int *indices, const float *routing_weights, const float *expert_up, const float *expert_down, float *d_hidden, float *d_routing_weights, float *d_expert_up, float *d_expert_down, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_relu2_expert.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_moe_relu2_expert.py",
+        "tolerance": "2e-5"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/moe_relu2_expert_forward_f32.json
+++ b/version/v8/kernel_maps/moe_relu2_expert_forward_f32.json
@@ -1,0 +1,132 @@
+{
+  "id": "moe_relu2_expert_forward_f32",
+  "op": "moe_relu2_expert_mlp",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "indices",
+      "dtype": "i32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "expert_up",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_down",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "H",
+    "I",
+    "E",
+    "K"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "moe_relu2_expert_forward_f32",
+    "c_declaration": "void moe_relu2_expert_forward_f32(const float *hidden, const int *indices, const float *routing_weights, const float *expert_up, const float *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_relu2_expert.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_moe_relu2_expert.py",
+        "tolerance": "2e-5"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-moe-relu2-expert-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/nemotron_group_limited_topk_router_f32.json
+++ b/version/v8/kernel_maps/nemotron_group_limited_topk_router_f32.json
@@ -1,0 +1,122 @@
+{
+  "id": "nemotron_group_limited_topk_router_f32",
+  "op": "group_limited_topk_router",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "scores",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "E"
+      ]
+    },
+    {
+      "name": "correction_bias",
+      "dtype": "fp32",
+      "shape": [
+        "E"
+      ],
+      "optional": true
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "indices",
+      "dtype": "i32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "E",
+    "K",
+    "G",
+    "TG"
+  ],
+  "params": [
+    {
+      "name": "norm_topk_prob",
+      "dtype": "i32"
+    },
+    {
+      "name": "routed_scaling_factor",
+      "dtype": "fp32"
+    }
+  ],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "nemotron_group_limited_topk_router_f32",
+    "c_declaration": "void nemotron_group_limited_topk_router_f32(const float *scores, const float *correction_bias, int *indices, float *weights, int rows, int n_experts, int top_k, int n_group, int topk_group, int norm_topk_prob, float routed_scaling_factor);",
+    "sources": [
+      "src/kernels/topk_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_nemotron_router.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_nemotron_router.py",
+        "tolerance": "1e-6"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-nemotron-router-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/scripts/inspect_model_contract_v8.py
+++ b/version/v8/scripts/inspect_model_contract_v8.py
@@ -133,10 +133,8 @@ def _required_ops(arch: str, config: dict[str, Any], layer_kinds: list[str]) -> 
         })
     if any(kind == "moe" for kind in layer_kinds):
         ops.update({
-            "topk_router",
-            "topk_softmax",
-            "moe_expert_dispatch",
-            "moe_expert_combine",
+            "group_limited_topk_router",
+            "moe_relu2_expert_mlp",
             "shared_expert_mlp",
         })
     act = str(_text_config(config).get("mlp_hidden_act") or _text_config(config).get("hidden_act") or "").lower()
@@ -154,7 +152,7 @@ def _missing_ops(arch: str, required_ops: list[str]) -> list[str]:
     for op in required_ops:
         if op.startswith("mamba_") or op == "relu2_mlp":
             missing.append(op)
-        if op in {"topk_router", "topk_softmax", "moe_expert_dispatch", "moe_expert_combine", "shared_expert_mlp"}:
+        if op == "shared_expert_mlp":
             missing.append(op)
     if arch == "cohere":
         missing.append("cohere_tensor_name_mapping_audit")


### PR DESCRIPTION
Why: add scalar reference coverage for Nemotron-style group-limited routing and routed ReLU2 expert execution, plus documentation explaining the MoE routing dataflow.

Test: make build/libckernel_engine.so; make test-nemotron-router; make test-nemotron-router-perf; make test-moe-relu2-expert; make test-moe-relu2-expert-perf; .venv/bin/python -m unittest tests.test_v8_model_contract_inspector; make v8-kernel-map-contracts; bash docs/site/build.sh.