### PR TITLE
Add Gemma4 smoke docs, Qwen3.5 safetensors fixes, and Nemotron MoE kernels

### DIFF
--- a/src/ck_parity_api.c
+++ b/src/ck_parity_api.c
@@ -123,7 +123,8 @@ extern void recurrent_dt_gate_forward(
     const float *a,
     float *gate,
     int rows,
-    int dim);
+    int num_heads,
+    int state_dim);
 extern void recurrent_conv_state_update_forward(
     const float *state_in,
     const float *q,
@@ -783,7 +784,7 @@ void ck_test_recurrent_dt_gate(const float *alpha,
                                int rows,
                                int dim)
 {
-    recurrent_dt_gate_forward(alpha, dt_bias, a, gate, rows, dim);
+    recurrent_dt_gate_forward(alpha, dt_bias, a, gate, rows, 1, dim);
 }
 
 void ck_test_recurrent_conv_state_update(const float *state_in,


### PR DESCRIPTION
## Summary
- add Gemma4 high-memory smoke docs/nightly wiring
- add Qwen3.5 safetensors recurrent correctness fixes
- add Nemotron group-limited router and MoE ReLU2 expert kernels with tests/perf coverage
- fix llama.cpp recurrent dt-gate parity wrapper after the shape-aware signature change

## Validation
- make build/libckernel_engine.so
- make test-nemotron-router
- make test-nemotron-router-perf
- make test-moe-relu2-expert
- make test-moe-relu2-expert-perf
- make llamacpp-parity-nightly
- pre-commit v7/v8 fast regression
- pre-push build, kernel parity, v8 E2E smoke, v7 inference, v7/v8 fast regression, training-kernel parity