### PR TITLE
Add Nemotron-H Mamba2 reference kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,7 @@ SRCS    := src/backend_native.c \
 	           src/kernels/recurrent_state_kernels.c \
 	           src/kernels/recurrent_qk_norm_kernels.c \
 	           src/kernels/recurrent_norm_kernels.c \
+	           src/kernels/mamba2_kernels.c \
 	           src/kernels/deltanet_kernels.c \
 	           src/kernels/deepseek_kernels.c \
 	           src/kernels/gemma4_per_layer_embed.c \
@@ -1229,6 +1230,12 @@ test-moe-relu2-expert: $(LIB)
 
 test-moe-relu2-expert-perf: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_moe_relu2_expert.py --benchmark
+
+test-mamba2-reference: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_mamba2_reference.py $(ARGS)
+
+test-mamba2-reference-perf: $(LIB)
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_mamba2_reference.py --benchmark
 
 test-recurrent-split-conv-qkv: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_recurrent_split_conv_qkv.py $(ARGS)
@@ -2986,6 +2993,7 @@ PARITY_SRCS := src/ck_parity_api.c \
 	               src/kernels/recurrent_state_kernels.c \
 	               src/kernels/recurrent_qk_norm_kernels.c \
 	               src/kernels/recurrent_norm_kernels.c \
+	               src/kernels/mamba2_kernels.c \
 	               src/kernels/deltanet_kernels.c \
                src/kernels/fused/prefill_fused_gemm.c \
                src/kernels/fused/mega_fused_outproj_mlp_prefill.c \

--- a/docs/site/_pages/concepts.html
+++ b/docs/site/_pages/concepts.html
@@ -27,6 +27,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
+    <li><a href="#mamba2-reference">Mamba2 Reference Kernels</a></li>
     <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
@@ -575,6 +576,47 @@ y = gamma * x / (rms + eps)
     <h3 style="margin-top: 0;">Why Remove Mean Centering?</h3>
     <p>Research found that the re-centering (subtracting mean) in LayerNorm isn't necessary for good performance. RMSNorm keeps just the scaling, which is what matters for gradient flow.</p>
     <p><strong>Used in:</strong> Llama, Mistral, Qwen, Gemma (most modern LLMs)</p>
+</div>
+
+<hr>
+
+<h2 id="mamba2-reference">Mamba2 Reference Kernels</h2>
+
+<p>Hybrid models such as Nemotron-H include Mamba2-style recurrent layers alongside attention and MoE blocks. These layers are not attention: they maintain a compact state, update it token by token, and use learned decay/input/output terms to produce the next hidden representation.</p>
+
+<div class="img-container svg-viewer" data-title="Mamba2 Decode Reference Path">
+    <img src="assets/concept-mamba2-reference.svg" alt="Mamba2 decode reference kernel flow">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Decode Contract</h3>
+        <pre>
+projected -> split(gate, hidden_bc, dt)
+conv_state = roll_append(conv_state, hidden_bc)
+dt = softplus(dt + dt_bias)
+state = state * exp(dt * A) + dt * B * x
+y = C dot state + D * x
+out = grouped_rmsnorm(y * silu(gate))
+        </pre>
+        <p>The important part is state ownership. CK exposes each step as a named kernel so the runtime can decide where state lives, how it is streamed, and which future optimized kernel replaces the scalar reference.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why Reference First</h3>
+        <p>Mamba2 performance work should not start as a fused black box. The scalar FP32 kernels define exact tensor layout, numerical behavior, and PyTorch parity before SIMD, tiling, chunked scan, or distributed state placement are introduced.</p>
+        <ul>
+            <li><code>mamba2_in_proj_split_f32</code></li>
+            <li><code>mamba2_conv1d_decode_f32</code></li>
+            <li><code>mamba2_dt_softplus_f32</code></li>
+            <li><code>mamba2_selective_state_update_decode_f32</code></li>
+            <li><code>mamba2_rmsnorm_gate_f32</code></li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <p><code>make test-mamba2-reference</code> validates the five decode primitives against PyTorch. <code>make test-mamba2-reference-perf</code> provides a scalar baseline for selective state update. This is enough to harden Nemotron-H decode contracts, but it is not yet the final high-performance chunked prefill selective scan.</p>
 </div>
 
 <hr>

--- a/docs/site/assets/concept-mamba2-reference.svg
+++ b/docs/site/assets/concept-mamba2-reference.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="620" viewBox="0 0 1240 620" role="img" aria-labelledby="title desc">
+  <title id="title">Mamba2 decode reference kernel flow</title>
+  <desc id="desc">A diagram showing Nemotron-H Mamba2 decode as projection split, convolution state update, dt softplus, selective state update, and gated RMSNorm.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#101820"/>
+      <stop offset="1" stop-color="#1a2830"/>
+    </linearGradient>
+    <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#246bfe"/>
+      <stop offset="1" stop-color="#31c7d8"/>
+    </linearGradient>
+    <linearGradient id="green" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1c9d72"/>
+      <stop offset="1" stop-color="#8bd450"/>
+    </linearGradient>
+    <linearGradient id="amber" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#d68a22"/>
+      <stop offset="1" stop-color="#f3c64e"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b7c9d3"/>
+    </marker>
+    <style>
+      .title { font: 800 30px Inter, Segoe UI, sans-serif; fill: #eef7fb; }
+      .sub { font: 500 15px Inter, Segoe UI, sans-serif; fill: #adc4cf; }
+      .box-title { font: 800 18px Inter, Segoe UI, sans-serif; fill: #f7fbfd; }
+      .box-text { font: 500 13px Inter, Segoe UI, sans-serif; fill: #c7d8df; }
+      .mono { font: 700 12px JetBrains Mono, Consolas, monospace; fill: #d7f3ff; }
+      .small { font: 600 12px Inter, Segoe UI, sans-serif; fill: #9fb6c0; }
+    </style>
+  </defs>
+
+  <rect width="1240" height="620" rx="18" fill="url(#bg)"/>
+  <rect x="24" y="24" width="1192" height="572" rx="16" fill="none" stroke="#39505c" stroke-width="2"/>
+
+  <text x="56" y="70" class="title">Nemotron-H / Mamba2 Decode Reference Path</text>
+  <text x="56" y="98" class="sub">CK isolates each recurrent primitive so parity can be hardened before optimized scan/fusion work.</text>
+
+  <rect x="56" y="142" width="180" height="96" rx="10" fill="#182733" stroke="#486575"/>
+  <text x="78" y="174" class="box-title">Input Projection</text>
+  <text x="78" y="202" class="mono">projected[row]</text>
+  <text x="78" y="222" class="small">packed MLP + SSM fields</text>
+
+  <line x1="236" y1="190" x2="292" y2="190" stroke="#b7c9d3" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="304" y="126" width="218" height="128" rx="12" fill="#10283a" stroke="#3797c4"/>
+  <rect x="304" y="126" width="218" height="34" rx="12" fill="url(#blue)"/>
+  <text x="326" y="149" class="box-title">Split Contract</text>
+  <text x="326" y="185" class="mono">mamba2_in_proj_split_f32</text>
+  <text x="326" y="212" class="box-text">gate, hidden+BC, dt</text>
+  <text x="326" y="233" class="box-text">are separated without guessing.</text>
+
+  <line x1="522" y1="190" x2="578" y2="190" stroke="#b7c9d3" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="592" y="126" width="218" height="128" rx="12" fill="#122a24" stroke="#39a982"/>
+  <rect x="592" y="126" width="218" height="34" rx="12" fill="url(#green)"/>
+  <text x="614" y="149" class="box-title">Conv State</text>
+  <text x="614" y="185" class="mono">mamba2_conv1d_decode_f32</text>
+  <text x="614" y="212" class="box-text">roll state, append token,</text>
+  <text x="614" y="233" class="box-text">depthwise conv + SiLU.</text>
+
+  <line x1="810" y1="190" x2="866" y2="190" stroke="#b7c9d3" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="880" y="126" width="218" height="128" rx="12" fill="#30271a" stroke="#d8a33d"/>
+  <rect x="880" y="126" width="218" height="34" rx="12" fill="url(#amber)"/>
+  <text x="902" y="149" class="box-title">dt Transform</text>
+  <text x="902" y="185" class="mono">mamba2_dt_softplus_f32</text>
+  <text x="902" y="212" class="box-text">bias + softplus + clamp</text>
+  <text x="902" y="233" class="box-text">per recurrent head.</text>
+
+  <line x1="989" y1="254" x2="989" y2="306" stroke="#b7c9d3" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="702" y="322" width="278" height="142" rx="12" fill="#132233" stroke="#4f83cc"/>
+  <text x="728" y="356" class="box-title">Selective State Update</text>
+  <text x="728" y="386" class="mono">mamba2_selective_state_update_decode_f32</text>
+  <text x="728" y="416" class="box-text">state = state * exp(dt * A) + dt * B * x</text>
+  <text x="728" y="438" class="box-text">y = C dot state + D * x</text>
+
+  <line x1="702" y1="393" x2="646" y2="393" stroke="#b7c9d3" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="388" y="322" width="244" height="142" rx="12" fill="#162b22" stroke="#53b87d"/>
+  <text x="414" y="356" class="box-title">Gated Norm</text>
+  <text x="414" y="386" class="mono">mamba2_rmsnorm_gate_f32</text>
+  <text x="414" y="416" class="box-text">x * SiLU(gate), grouped RMSNorm,</text>
+  <text x="414" y="438" class="box-text">then learned scale.</text>
+
+  <line x1="388" y1="393" x2="306" y2="393" stroke="#b7c9d3" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="110" y="342" width="180" height="102" rx="10" fill="#182733" stroke="#486575"/>
+  <text x="134" y="376" class="box-title">Output Projection</text>
+  <text x="134" y="406" class="mono">matmul / out_proj</text>
+  <text x="134" y="428" class="small">uses existing GEMM path</text>
+
+  <rect x="56" y="520" width="1128" height="42" rx="8" fill="#0f1b24" stroke="#314653"/>
+  <text x="80" y="547" class="small">Current scope: scalar FP32 decode reference kernels for parity. Future scope: chunked selective scan, packed state layout, and SIMD/threaded kernels.</text>
+</svg>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -966,6 +966,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
+    <li><a href="#mamba2-reference">Mamba2 Reference Kernels</a></li>
     <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
@@ -1518,6 +1519,47 @@ y = gamma * x / (rms + eps)
 
 <hr>
 
+<h2 id="mamba2-reference">Mamba2 Reference Kernels</h2>
+
+<p>Hybrid models such as Nemotron-H include Mamba2-style recurrent layers alongside attention and MoE blocks. These layers are not attention: they maintain a compact state, update it token by token, and use learned decay/input/output terms to produce the next hidden representation.</p>
+
+<div class="img-container svg-viewer" data-title="Mamba2 Decode Reference Path">
+    <img src="assets/concept-mamba2-reference.svg" alt="Mamba2 decode reference kernel flow">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Decode Contract</h3>
+        <pre>
+projected -> split(gate, hidden_bc, dt)
+conv_state = roll_append(conv_state, hidden_bc)
+dt = softplus(dt + dt_bias)
+state = state * exp(dt * A) + dt * B * x
+y = C dot state + D * x
+out = grouped_rmsnorm(y * silu(gate))
+        </pre>
+        <p>The important part is state ownership. CK exposes each step as a named kernel so the runtime can decide where state lives, how it is streamed, and which future optimized kernel replaces the scalar reference.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why Reference First</h3>
+        <p>Mamba2 performance work should not start as a fused black box. The scalar FP32 kernels define exact tensor layout, numerical behavior, and PyTorch parity before SIMD, tiling, chunked scan, or distributed state placement are introduced.</p>
+        <ul>
+            <li><code>mamba2_in_proj_split_f32</code></li>
+            <li><code>mamba2_conv1d_decode_f32</code></li>
+            <li><code>mamba2_dt_softplus_f32</code></li>
+            <li><code>mamba2_selective_state_update_decode_f32</code></li>
+            <li><code>mamba2_rmsnorm_gate_f32</code></li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <p><code>make test-mamba2-reference</code> validates the five decode primitives against PyTorch. <code>make test-mamba2-reference-perf</code> provides a scalar baseline for selective state update. This is enough to harden Nemotron-H decode contracts, but it is not yet the final high-performance chunked prefill selective scan.</p>
+</div>
+
+<hr>
+
 <h2 id="moe-routing">Mixture of Experts: Router + ReLU2 Experts</h2>
 
 <p>MoE layers replace one dense MLP with a pool of experts and a router. For each token row, the router scores experts, selects a small <code>top_k</code> subset, runs only those expert MLPs, and accumulates the weighted result. This is sparse control flow wrapped around dense per-expert math.</p>
@@ -2024,7 +2066,7 @@ With weight tying: W = E  (same matrix!)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-19</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-20</p>
             </div>
         </div>
     </footer>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -1712,6 +1712,61 @@ void recurrent_norm_gate_backward(const float *d_out,
                                   int head_dim,
                                   float eps);
 
+// Nemotron-H/Mamba2 scalar reference kernels.
+// These cover the decode-state contract first; chunked prefill scan is a
+// separate scheduling contract and should not be hidden inside this API.
+void mamba2_in_proj_split_f32(const float *projected,
+                              float *gate,
+                              float *hidden_bc,
+                              float *dt,
+                              int rows,
+                              int d_mlp,
+                              int intermediate_dim,
+                              int conv_dim,
+                              int num_heads);
+
+void mamba2_conv1d_decode_f32(const float *state_in,
+                              const float *x,
+                              const float *weight,
+                              const float *bias,
+                              float *conv_out,
+                              float *state_out,
+                              int rows,
+                              int conv_dim,
+                              int kernel_size);
+
+void mamba2_dt_softplus_f32(const float *dt,
+                            const float *dt_bias,
+                            float *dt_out,
+                            int rows,
+                            int num_heads,
+                            float dt_min,
+                            float dt_max);
+
+void mamba2_selective_state_update_decode_f32(const float *state_in,
+                                              const float *x,
+                                              const float *dt,
+                                              const float *a,
+                                              const float *b,
+                                              const float *c,
+                                              const float *d,
+                                              float *state_out,
+                                              float *y,
+                                              int rows,
+                                              int num_heads,
+                                              int head_dim,
+                                              int state_dim,
+                                              int num_groups);
+
+void mamba2_rmsnorm_gate_f32(const float *x,
+                             const float *gate,
+                             const float *weight,
+                             float *out,
+                             int rows,
+                             int inner_dim,
+                             int group_size,
+                             float eps);
+
 // Apply sigmoid(gate) to the full-attention qwen3.5 gate path and multiply it
 // elementwise with the attention output before the output projection.
 // Layout:

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -260,6 +260,7 @@ TEST_SUITES = {
     "relu2": TestSuite("ReLU2", "kernels", UNITTEST_DIR / "test_relu2.py"),
     "nemotron_router": TestSuite("Nemotron Group-Limited Router", "kernels", UNITTEST_DIR / "test_nemotron_router.py"),
     "moe_relu2_expert": TestSuite("MoE ReLU2 Expert", "kernels", UNITTEST_DIR / "test_moe_relu2_expert.py"),
+    "mamba2_reference": TestSuite("Mamba2 Reference Kernels", "kernels", UNITTEST_DIR / "test_mamba2_reference.py"),
     "vision": TestSuite("Vision", "kernels", UNITTEST_DIR / "test_vision.py"),
     # NOTE: Orchestration test disabled - v6.5 uses generated code with local helpers,
     # not orchestration layer. Use llamacpp-parity-full for quantized kernel validation.
@@ -429,7 +430,7 @@ BENCH_TARGETS = {
 
 # Quick subset for fast validation
 QUICK_TESTS = [
-    "gemm", "relu", "relu2", "nemotron_router", "moe_relu2_expert", "softmax", "rmsnorm", "attention", "attention_sliding",
+    "gemm", "relu", "relu2", "nemotron_router", "moe_relu2_expert", "mamba2_reference", "softmax", "rmsnorm", "attention", "attention_sliding",
     "deltanet_backward",
     "relu_bf16", "rmsnorm_bf16",
     "q4k_kernels",

--- a/src/kernels/mamba2_kernels.c
+++ b/src/kernels/mamba2_kernels.c
@@ -1,0 +1,209 @@
+#include "ckernel_engine.h"
+
+#include <math.h>
+#include <string.h>
+
+static inline float mamba2_sigmoid_f32(float x) {
+    if (x >= 0.0f) {
+        const float z = expf(-x);
+        return 1.0f / (1.0f + z);
+    }
+    {
+        const float z = expf(x);
+        return z / (1.0f + z);
+    }
+}
+
+static inline float mamba2_silu_f32(float x) {
+    return x * mamba2_sigmoid_f32(x);
+}
+
+static inline float mamba2_softplus_f32(float x) {
+    if (x > 20.0f) {
+        return x;
+    }
+    if (x < -20.0f) {
+        return expf(x);
+    }
+    return log1pf(expf(x));
+}
+
+void mamba2_in_proj_split_f32(const float *projected,
+                              float *gate,
+                              float *hidden_bc,
+                              float *dt,
+                              int rows,
+                              int d_mlp,
+                              int intermediate_dim,
+                              int conv_dim,
+                              int num_heads) {
+    if (!projected || !gate || !hidden_bc || !dt ||
+        rows <= 0 || d_mlp < 0 || intermediate_dim <= 0 || conv_dim <= 0 || num_heads <= 0) {
+        return;
+    }
+
+    const int projection_dim = 2 * d_mlp + intermediate_dim + conv_dim + num_heads;
+    const int gate_offset = 2 * d_mlp;
+    const int hidden_bc_offset = gate_offset + intermediate_dim;
+    const int dt_offset = hidden_bc_offset + conv_dim;
+
+    for (int row = 0; row < rows; ++row) {
+        const float *src = projected + (size_t)row * (size_t)projection_dim;
+        memcpy(gate + (size_t)row * (size_t)intermediate_dim,
+               src + gate_offset,
+               (size_t)intermediate_dim * sizeof(float));
+        memcpy(hidden_bc + (size_t)row * (size_t)conv_dim,
+               src + hidden_bc_offset,
+               (size_t)conv_dim * sizeof(float));
+        memcpy(dt + (size_t)row * (size_t)num_heads,
+               src + dt_offset,
+               (size_t)num_heads * sizeof(float));
+    }
+}
+
+void mamba2_conv1d_decode_f32(const float *state_in,
+                              const float *x,
+                              const float *weight,
+                              const float *bias,
+                              float *conv_out,
+                              float *state_out,
+                              int rows,
+                              int conv_dim,
+                              int kernel_size) {
+    if (!state_in || !x || !weight || !conv_out || !state_out ||
+        rows <= 0 || conv_dim <= 0 || kernel_size <= 0) {
+        return;
+    }
+
+    for (int row = 0; row < rows; ++row) {
+        for (int ch = 0; ch < conv_dim; ++ch) {
+            const size_t base = ((size_t)row * (size_t)conv_dim + (size_t)ch) * (size_t)kernel_size;
+            for (int k = 0; k < kernel_size - 1; ++k) {
+                state_out[base + (size_t)k] = state_in[base + (size_t)k + 1u];
+            }
+            state_out[base + (size_t)kernel_size - 1u] =
+                x[(size_t)row * (size_t)conv_dim + (size_t)ch];
+
+            float acc = bias ? bias[ch] : 0.0f;
+            for (int k = 0; k < kernel_size; ++k) {
+                acc += state_out[base + (size_t)k] *
+                       weight[(size_t)ch * (size_t)kernel_size + (size_t)k];
+            }
+            conv_out[(size_t)row * (size_t)conv_dim + (size_t)ch] = mamba2_silu_f32(acc);
+        }
+    }
+}
+
+void mamba2_dt_softplus_f32(const float *dt,
+                            const float *dt_bias,
+                            float *dt_out,
+                            int rows,
+                            int num_heads,
+                            float dt_min,
+                            float dt_max) {
+    if (!dt || !dt_out || rows <= 0 || num_heads <= 0) {
+        return;
+    }
+
+    for (int row = 0; row < rows; ++row) {
+        for (int h = 0; h < num_heads; ++h) {
+            float v = dt[(size_t)row * (size_t)num_heads + (size_t)h];
+            if (dt_bias) {
+                v += dt_bias[h];
+            }
+            v = mamba2_softplus_f32(v);
+            if (dt_min < dt_max) {
+                if (v < dt_min) {
+                    v = dt_min;
+                } else if (v > dt_max) {
+                    v = dt_max;
+                }
+            }
+            dt_out[(size_t)row * (size_t)num_heads + (size_t)h] = v;
+        }
+    }
+}
+
+void mamba2_selective_state_update_decode_f32(const float *state_in,
+                                              const float *x,
+                                              const float *dt,
+                                              const float *a,
+                                              const float *b,
+                                              const float *c,
+                                              const float *d,
+                                              float *state_out,
+                                              float *y,
+                                              int rows,
+                                              int num_heads,
+                                              int head_dim,
+                                              int state_dim,
+                                              int num_groups) {
+    if (!state_in || !x || !dt || !a || !b || !c || !d || !state_out || !y ||
+        rows <= 0 || num_heads <= 0 || head_dim <= 0 || state_dim <= 0 || num_groups <= 0) {
+        return;
+    }
+
+    for (int row = 0; row < rows; ++row) {
+        for (int h = 0; h < num_heads; ++h) {
+            const int group = (int)(((long long)h * (long long)num_groups) / (long long)num_heads);
+            const float dt_h = dt[(size_t)row * (size_t)num_heads + (size_t)h];
+            const float d_a = expf(dt_h * a[h]);
+            const float d_h = d[h];
+            const float *b_row = b + ((size_t)row * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
+            const float *c_row = c + ((size_t)row * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
+
+            for (int hd = 0; hd < head_dim; ++hd) {
+                const size_t x_idx = ((size_t)row * (size_t)num_heads + (size_t)h) * (size_t)head_dim + (size_t)hd;
+                const float x_val = x[x_idx];
+                const size_t state_base =
+                    (((size_t)row * (size_t)num_heads + (size_t)h) * (size_t)head_dim + (size_t)hd) *
+                    (size_t)state_dim;
+                float acc = 0.0f;
+                for (int s = 0; s < state_dim; ++s) {
+                    const size_t si = state_base + (size_t)s;
+                    const float new_state = state_in[si] * d_a + dt_h * b_row[s] * x_val;
+                    state_out[si] = new_state;
+                    acc += new_state * c_row[s];
+                }
+                y[x_idx] = acc + d_h * x_val;
+            }
+        }
+    }
+}
+
+void mamba2_rmsnorm_gate_f32(const float *x,
+                             const float *gate,
+                             const float *weight,
+                             float *out,
+                             int rows,
+                             int inner_dim,
+                             int group_size,
+                             float eps) {
+    if (!x || !gate || !weight || !out || rows <= 0 || inner_dim <= 0 || group_size <= 0) {
+        return;
+    }
+
+    for (int row = 0; row < rows; ++row) {
+        const float *x_row = x + (size_t)row * (size_t)inner_dim;
+        const float *gate_row = gate + (size_t)row * (size_t)inner_dim;
+        float *out_row = out + (size_t)row * (size_t)inner_dim;
+
+        for (int start = 0; start < inner_dim; start += group_size) {
+            int end = start + group_size;
+            if (end > inner_dim) {
+                end = inner_dim;
+            }
+            const int count = end - start;
+            float ms = 0.0f;
+            for (int col = start; col < end; ++col) {
+                const float gated = x_row[col] * mamba2_silu_f32(gate_row[col]);
+                ms += gated * gated;
+            }
+            const float inv_rms = 1.0f / sqrtf(ms / (float)count + eps);
+            for (int col = start; col < end; ++col) {
+                const float gated = x_row[col] * mamba2_silu_f32(gate_row[col]);
+                out_row[col] = gated * inv_rms * weight[col];
+            }
+        }
+    }
+}

--- a/tests/test_v8_model_contract_inspector.py
+++ b/tests/test_v8_model_contract_inspector.py
@@ -46,11 +46,17 @@ class ModelContractInspectorTests(unittest.TestCase):
         self.assertEqual(report["status"], "bringup_required")
         self.assertEqual(report["layer_kind_counts"], {"attention": 1, "mamba": 5, "moe": 4})
         self.assertIn("mamba_selective_scan", report["missing_ops"])
-        self.assertIn("relu2_mlp", report["missing_ops"])
-        self.assertIn("shared_expert_mlp", report["missing_ops"])
+        self.assertNotIn("mamba_in_proj_split", report["missing_ops"])
+        self.assertNotIn("mamba_conv1d_state_update", report["missing_ops"])
+        self.assertNotIn("mamba_dt_softplus", report["missing_ops"])
+        self.assertNotIn("mamba_rmsnorm_gate", report["missing_ops"])
+        self.assertNotIn("mamba_out_proj", report["missing_ops"])
+        self.assertNotIn("relu2_mlp", report["missing_ops"])
+        self.assertNotIn("shared_expert_mlp", report["missing_ops"])
         self.assertNotIn("group_limited_topk_router", report["missing_ops"])
         self.assertNotIn("moe_relu2_expert_mlp", report["missing_ops"])
-        self.assertIn("safetensors_to_bump_mapping", report["missing_ops"])
+        self.assertNotIn("safetensors_to_bump_mapping", report["missing_ops"])
+        self.assertNotIn("v8_template_contract", report["missing_ops"])
 
     def test_safetensors_index_audit_classifies_nemotron_families(self) -> None:
         index = {

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -219,3 +219,132 @@ def test_qwen35_safetensors_to_bump_smoke(tmp_path: Path) -> None:
     assert "final_ln_weight" in names
     assert "output.weight" not in names
     assert (out / "weights.bump").stat().st_size > 0
+
+
+
+def test_nemotron_h_safetensors_to_bump_dry_run_maps_hybrid_mamba_attention_moe(tmp_path: Path) -> None:
+    torch, st = _require_torch_safetensors()
+    checkpoint = tmp_path / "nemotron_h"
+    out = tmp_path / "out_nemotron_h"
+    checkpoint.mkdir()
+    out.mkdir()
+
+    config = {
+        "architectures": ["NemotronHForCausalLM"],
+        "model_type": "nemotron_h",
+        "num_hidden_layers": 4,
+        "hidden_size": 8,
+        "intermediate_size": 6,
+        "moe_intermediate_size": 6,
+        "moe_shared_expert_intermediate_size": 12,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "vocab_size": 32,
+        "max_position_embeddings": 128,
+        "hybrid_override_pattern": "M*E-",
+        "mamba_num_heads": 2,
+        "mamba_head_dim": 4,
+        "ssm_state_size": 3,
+        "conv_kernel": 4,
+        "n_groups": 2,
+        "chunk_size": 8,
+        "n_routed_experts": 4,
+        "num_experts_per_tok": 2,
+        "n_group": 1,
+        "topk_group": 1,
+        "norm_topk_prob": True,
+        "routed_scaling_factor": 2.5,
+        "mlp_hidden_act": "relu2",
+        "tie_word_embeddings": False,
+        "attention_bias": False,
+        "mlp_bias": False,
+        "rope_theta": 10000.0,
+        "layer_norm_epsilon": 1e-5,
+    }
+    (checkpoint / "config.json").write_text(json.dumps(config) + "\n", encoding="utf-8")
+
+    tensors = {
+        "backbone.embeddings.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+        "backbone.norm_f.weight": torch.ones(8, dtype=torch.float32),
+        "lm_head.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+    }
+    # Layer 0: Mamba2
+    tensors.update({
+        "backbone.layers.0.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.0.mixer.in_proj.weight": torch.randn(34, 8, dtype=torch.bfloat16),
+        "backbone.layers.0.mixer.conv1d.weight": torch.randn(20, 1, 4, dtype=torch.float32),
+        "backbone.layers.0.mixer.conv1d.bias": torch.randn(20, dtype=torch.float32),
+        "backbone.layers.0.mixer.dt_bias": torch.randn(2, dtype=torch.float32),
+        "backbone.layers.0.mixer.A_log": torch.randn(2, dtype=torch.float32),
+        "backbone.layers.0.mixer.D": torch.randn(2, dtype=torch.float32),
+        "backbone.layers.0.mixer.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.0.mixer.out_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+    })
+    # Layer 1: attention
+    tensors.update({
+        "backbone.layers.1.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.1.mixer.q_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "backbone.layers.1.mixer.k_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+        "backbone.layers.1.mixer.v_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+        "backbone.layers.1.mixer.o_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+    })
+    # Layer 2: MoE
+    tensors.update({
+        "backbone.layers.2.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.2.mixer.gate.weight": torch.randn(4, 8, dtype=torch.float32),
+        "backbone.layers.2.mixer.gate.e_score_correction_bias": torch.randn(4, dtype=torch.float32),
+        "backbone.layers.2.mixer.shared_experts.up_proj.weight": torch.randn(12, 8, dtype=torch.bfloat16),
+        "backbone.layers.2.mixer.shared_experts.down_proj.weight": torch.randn(8, 12, dtype=torch.bfloat16),
+    })
+    for expert in range(4):
+        tensors[f"backbone.layers.2.mixer.experts.{expert}.up_proj.weight"] = torch.randn(6, 8, dtype=torch.bfloat16)
+        tensors[f"backbone.layers.2.mixer.experts.{expert}.down_proj.weight"] = torch.randn(8, 6, dtype=torch.bfloat16)
+    # Layer 3: dense ReLU2 MLP
+    tensors.update({
+        "backbone.layers.3.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.3.mixer.up_proj.weight": torch.randn(6, 8, dtype=torch.bfloat16),
+        "backbone.layers.3.mixer.down_proj.weight": torch.randn(8, 6, dtype=torch.bfloat16),
+    })
+
+    st.save_file(tensors, checkpoint / "model.safetensors")
+    script = Path("version/v8/scripts/convert_safetensors_to_bump_v8.py")
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(out / "weights.bump"),
+            "--config-out",
+            str(out / "config.json"),
+            "--manifest-out",
+            str(out / "weights_manifest.json"),
+            "--arch",
+            "auto",
+            "--dry-run",
+        ],
+        check=True,
+    )
+
+    manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
+    audit = json.loads((out / "conversion_audit.json").read_text(encoding="utf-8"))
+    cfg = json.loads((out / "config.json").read_text(encoding="utf-8"))
+    names = [entry["name"] for entry in manifest["entries"]]
+    assert manifest["model"] == "nemotron_h"
+    assert audit["verdict"] == "pass"
+    assert audit["unmapped_source_tensors"] == []
+    assert cfg["layer_kinds"] == ["mamba", "attention", "moe", "mlp"]
+    assert cfg["layer_state_policy"] == ["mamba2", "none", "none", "none"]
+    assert cfg["layer_moe_policy"] == ["none", "none", "routed_relu2", "none"]
+    assert "layer.0.mamba_in_proj" in names
+    assert "layer.0.mamba_conv1d" in names
+    assert "layer.1.attn_q" in names
+    assert "layer.2.moe_router" in names
+    assert "layer.2.moe_router_bias" in names
+    assert "layer.2.moe_expert.3.up" in names
+    assert "layer.2.moe_shared_up" in names
+    assert "layer.3.mlp_up" in names
+    assert "output.weight" in names
+    assert any(row["target"] == "layer.0.mamba_a" and row["transform"] == "neg_exp_a_log" for row in audit["transforms"])

--- a/unittest/test_mamba2_reference.py
+++ b/unittest/test_mamba2_reference.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""PyTorch parity tests for scalar Nemotron-H/Mamba2 reference kernels."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import sys
+import time
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import torch
+except Exception as exc:  # pragma: no cover
+    print(f"[SKIP] torch not available: {exc}")
+    sys.exit(0)
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_PATH = ROOT / "build" / "libckernel_engine.so"
+if not LIB_PATH.exists():  # pragma: no cover
+    print("[SKIP] libckernel_engine.so not found")
+    sys.exit(0)
+
+LIB = ctypes.CDLL(str(LIB_PATH))
+fptr = ctypes.POINTER(ctypes.c_float)
+
+LIB.mamba2_in_proj_split_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.mamba2_in_proj_split_f32.restype = None
+LIB.mamba2_conv1d_decode_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.mamba2_conv1d_decode_f32.restype = None
+LIB.mamba2_dt_softplus_f32.argtypes = [fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_float, ctypes.c_float]
+LIB.mamba2_dt_softplus_f32.restype = None
+LIB.mamba2_selective_state_update_decode_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.mamba2_selective_state_update_decode_f32.restype = None
+LIB.mamba2_rmsnorm_gate_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_float]
+LIB.mamba2_rmsnorm_gate_f32.restype = None
+
+
+def _fptr(a: np.ndarray) -> ctypes.POINTER(ctypes.c_float):
+    return a.ctypes.data_as(fptr)
+
+
+def _np(x: torch.Tensor) -> np.ndarray:
+    return np.ascontiguousarray(x.detach().cpu().numpy().astype(np.float32))
+
+
+class TestMamba2Reference(unittest.TestCase):
+    def test_in_proj_split_matches_torch(self) -> None:
+        rows, d_mlp, inter, conv_dim, heads = 3, 5, 8, 14, 4
+        torch.manual_seed(1)
+        projected = torch.randn(rows, 2 * d_mlp + inter + conv_dim + heads, dtype=torch.float32)
+        _, _, gate_ref, hidden_bc_ref, dt_ref = projected.split([d_mlp, d_mlp, inter, conv_dim, heads], dim=-1)
+        projected_np = _np(projected)
+        gate = np.empty((rows, inter), dtype=np.float32)
+        hidden_bc = np.empty((rows, conv_dim), dtype=np.float32)
+        dt = np.empty((rows, heads), dtype=np.float32)
+        LIB.mamba2_in_proj_split_f32(_fptr(projected_np), _fptr(gate), _fptr(hidden_bc), _fptr(dt), rows, d_mlp, inter, conv_dim, heads)
+        np.testing.assert_allclose(gate, _np(gate_ref), atol=0.0, rtol=0.0)
+        np.testing.assert_allclose(hidden_bc, _np(hidden_bc_ref), atol=0.0, rtol=0.0)
+        np.testing.assert_allclose(dt, _np(dt_ref), atol=0.0, rtol=0.0)
+
+    def test_conv1d_decode_matches_torch(self) -> None:
+        rows, conv_dim, kernel = 2, 11, 4
+        torch.manual_seed(2)
+        state = torch.randn(rows, conv_dim, kernel, dtype=torch.float32) * 0.2
+        x = torch.randn(rows, conv_dim, dtype=torch.float32) * 0.2
+        weight = torch.randn(conv_dim, kernel, dtype=torch.float32) * 0.3
+        bias = torch.randn(conv_dim, dtype=torch.float32) * 0.1
+        state_ref = torch.roll(state, shifts=-1, dims=-1)
+        state_ref[:, :, -1] = x
+        conv_ref = torch.nn.functional.silu((state_ref * weight.unsqueeze(0)).sum(dim=-1) + bias)
+        state_np, x_np, weight_np, bias_np = map(_np, (state, x, weight, bias))
+        conv = np.empty((rows, conv_dim), dtype=np.float32)
+        state_out = np.empty((rows, conv_dim, kernel), dtype=np.float32)
+        LIB.mamba2_conv1d_decode_f32(_fptr(state_np), _fptr(x_np), _fptr(weight_np), _fptr(bias_np), _fptr(conv), _fptr(state_out), rows, conv_dim, kernel)
+        np.testing.assert_allclose(state_out, _np(state_ref), atol=0.0, rtol=0.0)
+        np.testing.assert_allclose(conv, _np(conv_ref), atol=1e-6, rtol=0.0)
+
+    def test_dt_softplus_matches_torch(self) -> None:
+        rows, heads = 4, 7
+        torch.manual_seed(3)
+        dt = torch.randn(rows, heads, dtype=torch.float32)
+        bias = torch.randn(heads, dtype=torch.float32) * 0.2
+        ref = torch.nn.functional.softplus(dt + bias).clamp(0.01, 2.0)
+        dt_np, bias_np = map(_np, (dt, bias))
+        out = np.empty((rows, heads), dtype=np.float32)
+        LIB.mamba2_dt_softplus_f32(_fptr(dt_np), _fptr(bias_np), _fptr(out), rows, heads, ctypes.c_float(0.01), ctypes.c_float(2.0))
+        np.testing.assert_allclose(out, _np(ref), atol=1e-6, rtol=0.0)
+
+    def test_selective_state_update_decode_matches_torch(self) -> None:
+        rows, heads, head_dim, state_dim, groups = 2, 6, 5, 4, 3
+        torch.manual_seed(4)
+        state = torch.randn(rows, heads, head_dim, state_dim, dtype=torch.float32) * 0.1
+        x = torch.randn(rows, heads, head_dim, dtype=torch.float32) * 0.2
+        dt = torch.rand(rows, heads, dtype=torch.float32) * 0.3 + 0.01
+        a = -(torch.rand(heads, dtype=torch.float32) * 0.5 + 0.1)
+        b = torch.randn(rows, groups, state_dim, dtype=torch.float32) * 0.2
+        c = torch.randn(rows, groups, state_dim, dtype=torch.float32) * 0.2
+        d = torch.randn(heads, dtype=torch.float32) * 0.05
+        state_ref = torch.empty_like(state)
+        y_ref = torch.empty_like(x)
+        for r in range(rows):
+            for h in range(heads):
+                g = h * groups // heads
+                decay = torch.exp(dt[r, h] * a[h])
+                for hd in range(head_dim):
+                    new_state = state[r, h, hd] * decay + dt[r, h] * b[r, g] * x[r, h, hd]
+                    state_ref[r, h, hd] = new_state
+                    y_ref[r, h, hd] = (new_state * c[r, g]).sum() + d[h] * x[r, h, hd]
+        arrays = list(map(_np, (state, x, dt, a, b, c, d)))
+        state_out = np.empty((rows, heads, head_dim, state_dim), dtype=np.float32)
+        y = np.empty((rows, heads, head_dim), dtype=np.float32)
+        LIB.mamba2_selective_state_update_decode_f32(*map(_fptr, arrays), _fptr(state_out), _fptr(y), rows, heads, head_dim, state_dim, groups)
+        np.testing.assert_allclose(state_out, _np(state_ref), atol=1e-6, rtol=0.0)
+        np.testing.assert_allclose(y, _np(y_ref), atol=1e-6, rtol=0.0)
+
+    def test_rmsnorm_gate_matches_torch_grouped_after_gate(self) -> None:
+        rows, inner_dim, group_size = 3, 24, 6
+        torch.manual_seed(5)
+        x = torch.randn(rows, inner_dim, dtype=torch.float32) * 0.2
+        gate = torch.randn(rows, inner_dim, dtype=torch.float32) * 0.2
+        weight = torch.randn(inner_dim, dtype=torch.float32) * 0.2 + 1.0
+        gated = x * torch.nn.functional.silu(gate)
+        chunks = []
+        for start in range(0, inner_dim, group_size):
+            chunk = gated[:, start:start + group_size]
+            inv = torch.rsqrt(chunk.square().mean(dim=-1, keepdim=True) + 1e-5)
+            chunks.append(chunk * inv * weight[start:start + group_size])
+        ref = torch.cat(chunks, dim=-1)
+        x_np, gate_np, weight_np = map(_np, (x, gate, weight))
+        out = np.empty((rows, inner_dim), dtype=np.float32)
+        LIB.mamba2_rmsnorm_gate_f32(_fptr(x_np), _fptr(gate_np), _fptr(weight_np), _fptr(out), rows, inner_dim, group_size, ctypes.c_float(1e-5))
+        np.testing.assert_allclose(out, _np(ref), atol=1e-6, rtol=0.0)
+
+
+def _time_us(fn, iterations: int) -> float:
+    start = time.perf_counter()
+    for _ in range(iterations):
+        fn()
+    return (time.perf_counter() - start) * 1.0e6 / max(1, iterations)
+
+
+def run_benchmark() -> None:
+    rows, heads, head_dim, state_dim, groups = 4, 64, 64, 128, 8
+    rng = np.random.default_rng(23)
+    state = np.ascontiguousarray((0.02 * rng.standard_normal((rows, heads, head_dim, state_dim))).astype(np.float32))
+    x = np.ascontiguousarray((0.02 * rng.standard_normal((rows, heads, head_dim))).astype(np.float32))
+    dt = np.ascontiguousarray((0.01 + 0.1 * rng.random((rows, heads))).astype(np.float32))
+    a = np.ascontiguousarray((-(0.1 + 0.5 * rng.random(heads))).astype(np.float32))
+    b = np.ascontiguousarray((0.02 * rng.standard_normal((rows, groups, state_dim))).astype(np.float32))
+    c = np.ascontiguousarray((0.02 * rng.standard_normal((rows, groups, state_dim))).astype(np.float32))
+    d = np.ascontiguousarray((0.01 * rng.standard_normal(heads)).astype(np.float32))
+    state_out = np.empty_like(state)
+    y = np.empty_like(x)
+
+    def ck_step() -> None:
+        LIB.mamba2_selective_state_update_decode_f32(
+            _fptr(state), _fptr(x), _fptr(dt), _fptr(a), _fptr(b), _fptr(c), _fptr(d),
+            _fptr(state_out), _fptr(y), rows, heads, head_dim, state_dim, groups
+        )
+
+    ck_step()
+    ck_us = _time_us(ck_step, 20)
+    elems = rows * heads * head_dim * state_dim
+    print("kernel                                  elems        ck_us")
+    print(f"mamba2_selective_state_update_decode {elems:10d} {ck_us:10.3f}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--benchmark", action="store_true")
+    args, remaining = ap.parse_known_args()
+    if args.benchmark:
+        run_benchmark()
+    else:
+        sys.argv = [sys.argv[0], *remaining]
+        unittest.main(verbosity=2)

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,7 +5,7 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 152,
+      "total": 157,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -36,6 +36,11 @@
         "kv_cache_store": 2,
         "layernorm": 2,
         "logits_store_indexed": 1,
+        "mamba_conv1d_state_update": 1,
+        "mamba_dt_softplus": 1,
+        "mamba_in_proj_split": 1,
+        "mamba_rmsnorm_gate": 1,
+        "mamba_selective_state_update_decode": 1,
         "moe_relu2_expert_mlp": 2,
         "optimizer": 4,
         "position_embeddings": 2,
@@ -9566,6 +9571,631 @@
       "notes": "Copy logits from scratch buffer to position-indexed location in logits buffer. Used in decode mode to place single-token logits at the correct sequence position. This allows codegen to be 'dumb' - just emit kernel calls, no runtime if-statements.",
       "name": "logits_copy_to_position",
       "_source_file": "logits_copy_to_position.json"
+    },
+    {
+      "id": "mamba2_conv1d_decode_f32",
+      "op": "mamba_conv1d_state_update",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "state_in",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "C",
+            "K"
+          ]
+        },
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "C"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "weight",
+          "dtype": "fp32",
+          "shape": [
+            "C",
+            "K"
+          ]
+        },
+        {
+          "name": "bias",
+          "dtype": "fp32",
+          "shape": [
+            "C"
+          ]
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "conv_out",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "C"
+          ]
+        },
+        {
+          "name": "state_out",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "C",
+            "K"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "C",
+        "K"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "mamba2_conv1d_decode_f32",
+        "c_declaration": "void mamba2_conv1d_decode_f32(const float *state_in, const float *x, const float *weight, const float *bias, float *conv_out, float *state_out, int rows, int conv_dim, int kernel_size);",
+        "sources": [
+          "src/kernels/mamba2_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_mamba2_reference.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+            "tolerance": "1e-6"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-mamba2-reference-perf"
+          }
+        ]
+      },
+      "name": "mamba2_conv1d_decode_f32",
+      "_source_file": "mamba2_conv1d_decode_f32.json"
+    },
+    {
+      "id": "mamba2_dt_softplus_f32",
+      "op": "mamba_dt_softplus",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "dt",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "dt_bias",
+          "dtype": "fp32",
+          "shape": [
+            "H"
+          ]
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "dt_out",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "H"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "mamba2_dt_softplus_f32",
+        "c_declaration": "void mamba2_dt_softplus_f32(const float *dt, const float *dt_bias, float *dt_out, int rows, int num_heads, float dt_min, float dt_max);",
+        "sources": [
+          "src/kernels/mamba2_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_mamba2_reference.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+            "tolerance": "1e-6"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-mamba2-reference-perf"
+          }
+        ]
+      },
+      "name": "mamba2_dt_softplus_f32",
+      "_source_file": "mamba2_dt_softplus_f32.json"
+    },
+    {
+      "id": "mamba2_in_proj_split_f32",
+      "op": "mamba_in_proj_split",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "projected",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "P"
+          ]
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "gate",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "I"
+          ]
+        },
+        {
+          "name": "hidden_bc",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "C"
+          ]
+        },
+        {
+          "name": "dt",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "DMLP",
+        "I",
+        "C",
+        "H"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "mamba2_in_proj_split_f32",
+        "c_declaration": "void mamba2_in_proj_split_f32(const float *projected, float *gate, float *hidden_bc, float *dt, int rows, int d_mlp, int intermediate_dim, int conv_dim, int num_heads);",
+        "sources": [
+          "src/kernels/mamba2_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_mamba2_reference.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+            "tolerance": "1e-6"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-mamba2-reference-perf"
+          }
+        ]
+      },
+      "name": "mamba2_in_proj_split_f32",
+      "_source_file": "mamba2_in_proj_split_f32.json"
+    },
+    {
+      "id": "mamba2_rmsnorm_gate_f32",
+      "op": "mamba_rmsnorm_gate",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "I"
+          ]
+        },
+        {
+          "name": "gate",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "I"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "weight",
+          "dtype": "fp32",
+          "shape": [
+            "I"
+          ]
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "I"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "I",
+        "G"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "mamba2_rmsnorm_gate_f32",
+        "c_declaration": "void mamba2_rmsnorm_gate_f32(const float *x, const float *gate, const float *weight, float *out, int rows, int inner_dim, int group_size, float eps);",
+        "sources": [
+          "src/kernels/mamba2_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_mamba2_reference.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+            "tolerance": "1e-6"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-mamba2-reference-perf"
+          }
+        ]
+      },
+      "name": "mamba2_rmsnorm_gate_f32",
+      "_source_file": "mamba2_rmsnorm_gate_f32.json"
+    },
+    {
+      "id": "mamba2_selective_state_update_decode_f32",
+      "op": "mamba_selective_state_update_decode",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "state_in",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H",
+            "D",
+            "S"
+          ]
+        },
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H",
+            "D"
+          ]
+        },
+        {
+          "name": "dt",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "B",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "G",
+            "S"
+          ]
+        },
+        {
+          "name": "C",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "G",
+            "S"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "A",
+          "dtype": "fp32",
+          "shape": [
+            "H"
+          ]
+        },
+        {
+          "name": "D",
+          "dtype": "fp32",
+          "shape": [
+            "H"
+          ]
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "state_out",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H",
+            "D",
+            "S"
+          ]
+        },
+        {
+          "name": "y",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H",
+            "D"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "R",
+        "H",
+        "D",
+        "S",
+        "G"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "row"
+        ],
+        "preferred": {
+          "prefill": "row",
+          "decode": "row"
+        },
+        "strategies": [
+          {
+            "name": "row",
+            "partition_dim": "R",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "mamba2_selective_state_update_decode_f32",
+        "c_declaration": "void mamba2_selective_state_update_decode_f32(const float *state_in, const float *x, const float *dt, const float *a, const float *b, const float *c, const float *d, float *state_out, float *y, int rows, int num_heads, int head_dim, int state_dim, int num_groups);",
+        "sources": [
+          "src/kernels/mamba2_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_mamba2_reference.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+            "tolerance": "1e-6"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-mamba2-reference-perf"
+          }
+        ]
+      },
+      "name": "mamba2_selective_state_update_decode_f32",
+      "_source_file": "mamba2_selective_state_update_decode_f32.json"
     },
     {
       "id": "mega_fused_attention_decode",

--- a/version/v8/kernel_maps/mamba2_conv1d_decode_f32.json
+++ b/version/v8/kernel_maps/mamba2_conv1d_decode_f32.json
@@ -1,0 +1,129 @@
+{
+  "id": "mamba2_conv1d_decode_f32",
+  "op": "mamba_conv1d_state_update",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "state_in",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "C",
+        "K"
+      ]
+    },
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "C"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "weight",
+      "dtype": "fp32",
+      "shape": [
+        "C",
+        "K"
+      ]
+    },
+    {
+      "name": "bias",
+      "dtype": "fp32",
+      "shape": [
+        "C"
+      ]
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "conv_out",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "C"
+      ]
+    },
+    {
+      "name": "state_out",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "C",
+        "K"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "C",
+    "K"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "mamba2_conv1d_decode_f32",
+    "c_declaration": "void mamba2_conv1d_decode_f32(const float *state_in, const float *x, const float *weight, const float *bias, float *conv_out, float *state_out, int rows, int conv_dim, int kernel_size);",
+    "sources": [
+      "src/kernels/mamba2_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_mamba2_reference.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+        "tolerance": "1e-6"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-mamba2-reference-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/mamba2_dt_softplus_f32.json
+++ b/version/v8/kernel_maps/mamba2_dt_softplus_f32.json
@@ -1,0 +1,102 @@
+{
+  "id": "mamba2_dt_softplus_f32",
+  "op": "mamba_dt_softplus",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "dt",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "dt_bias",
+      "dtype": "fp32",
+      "shape": [
+        "H"
+      ]
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "dt_out",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "H"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "mamba2_dt_softplus_f32",
+    "c_declaration": "void mamba2_dt_softplus_f32(const float *dt, const float *dt_bias, float *dt_out, int rows, int num_heads, float dt_min, float dt_max);",
+    "sources": [
+      "src/kernels/mamba2_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_mamba2_reference.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+        "tolerance": "1e-6"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-mamba2-reference-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/mamba2_in_proj_split_f32.json
+++ b/version/v8/kernel_maps/mamba2_in_proj_split_f32.json
@@ -1,0 +1,113 @@
+{
+  "id": "mamba2_in_proj_split_f32",
+  "op": "mamba_in_proj_split",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "projected",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "P"
+      ]
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "gate",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "I"
+      ]
+    },
+    {
+      "name": "hidden_bc",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "C"
+      ]
+    },
+    {
+      "name": "dt",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "DMLP",
+    "I",
+    "C",
+    "H"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "mamba2_in_proj_split_f32",
+    "c_declaration": "void mamba2_in_proj_split_f32(const float *projected, float *gate, float *hidden_bc, float *dt, int rows, int d_mlp, int intermediate_dim, int conv_dim, int num_heads);",
+    "sources": [
+      "src/kernels/mamba2_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_mamba2_reference.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+        "tolerance": "1e-6"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-mamba2-reference-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/mamba2_rmsnorm_gate_f32.json
+++ b/version/v8/kernel_maps/mamba2_rmsnorm_gate_f32.json
@@ -1,0 +1,111 @@
+{
+  "id": "mamba2_rmsnorm_gate_f32",
+  "op": "mamba_rmsnorm_gate",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "I"
+      ]
+    },
+    {
+      "name": "gate",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "I"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "weight",
+      "dtype": "fp32",
+      "shape": [
+        "I"
+      ]
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "I"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "I",
+    "G"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "mamba2_rmsnorm_gate_f32",
+    "c_declaration": "void mamba2_rmsnorm_gate_f32(const float *x, const float *gate, const float *weight, float *out, int rows, int inner_dim, int group_size, float eps);",
+    "sources": [
+      "src/kernels/mamba2_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_mamba2_reference.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+        "tolerance": "1e-6"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-mamba2-reference-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/mamba2_selective_state_update_decode_f32.json
+++ b/version/v8/kernel_maps/mamba2_selective_state_update_decode_f32.json
@@ -1,0 +1,160 @@
+{
+  "id": "mamba2_selective_state_update_decode_f32",
+  "op": "mamba_selective_state_update_decode",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "state_in",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H",
+        "D",
+        "S"
+      ]
+    },
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H",
+        "D"
+      ]
+    },
+    {
+      "name": "dt",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "B",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "G",
+        "S"
+      ]
+    },
+    {
+      "name": "C",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "G",
+        "S"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "A",
+      "dtype": "fp32",
+      "shape": [
+        "H"
+      ]
+    },
+    {
+      "name": "D",
+      "dtype": "fp32",
+      "shape": [
+        "H"
+      ]
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "state_out",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H",
+        "D",
+        "S"
+      ]
+    },
+    {
+      "name": "y",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H",
+        "D"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "R",
+    "H",
+    "D",
+    "S",
+    "G"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "row"
+    ],
+    "preferred": {
+      "prefill": "row",
+      "decode": "row"
+    },
+    "strategies": [
+      {
+        "name": "row",
+        "partition_dim": "R",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "mamba2_selective_state_update_decode_f32",
+    "c_declaration": "void mamba2_selective_state_update_decode_f32(const float *state_in, const float *x, const float *dt, const float *a, const float *b, const float *c, const float *d, float *state_out, float *y, int rows, int num_heads, int head_dim, int state_dim, int num_groups);",
+    "sources": [
+      "src/kernels/mamba2_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_mamba2_reference.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+        "tolerance": "1e-6"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-mamba2-reference-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -315,6 +315,91 @@ def _qwen35_text_refs(config: dict[str, Any], headers: dict[str, HeaderTensor]) 
     return refs
 
 
+def _parse_nemotron_h_pattern(pattern: str, num_layers: int) -> list[str]:
+    mapping = {"M": "mamba", "*": "attention", "-": "mlp", "E": "moe"}
+    chars = [ch for ch in str(pattern or "").strip() if not ch.isspace()]
+    if not chars:
+        return ["mamba"] * num_layers
+    if len(chars) != num_layers:
+        raise SystemExit(f"Nemotron-H hybrid_override_pattern length {len(chars)} != num_layers {num_layers}")
+    try:
+        return [mapping[ch] for ch in chars]
+    except KeyError as exc:
+        raise SystemExit(f"Unsupported Nemotron-H layer pattern character: {exc.args[0]!r}") from exc
+
+
+def _nemotron_h_text_refs(config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef]:
+    text = config.get("text_config") if isinstance(config.get("text_config"), dict) else config
+    num_layers = int(text.get("num_hidden_layers") or config.get("num_layers") or 0)
+    hidden = int(text.get("hidden_size") or config.get("hidden_size") or 0)
+    intermediate = int(text.get("intermediate_size") or config.get("intermediate_size") or 0)
+    moe_intermediate = int(text.get("moe_intermediate_size") or intermediate)
+    shared_intermediate = int(text.get("moe_shared_expert_intermediate_size") or moe_intermediate)
+    n_experts = int(text.get("n_routed_experts") or 0)
+    layer_kinds = list(config.get("layer_kinds") or _parse_nemotron_h_pattern(str(text.get("hybrid_override_pattern") or ""), num_layers))
+    if num_layers <= 0 or hidden <= 0 or intermediate <= 0:
+        raise SystemExit("Nemotron-H config missing num_hidden_layers/hidden_size/intermediate_size")
+    if len(layer_kinds) != num_layers:
+        raise SystemExit(f"Nemotron-H layer_kinds length {len(layer_kinds)} != num_layers {num_layers}")
+
+    refs: list[TensorRef] = [
+        TensorRef("token_emb", (_require_existing(headers, ("backbone.embeddings.weight", "model.embed_tokens.weight"), "token_emb"),)),
+    ]
+
+    for layer, kind in enumerate(layer_kinds):
+        pfx = f"backbone.layers.{layer}"
+        refs.append(TensorRef(f"layer.{layer}.block_norm", (_require_existing(headers, (f"{pfx}.norm.weight",), f"layer {layer} block norm"),), dtype="fp32"))
+        mp = f"{pfx}.mixer"
+        if kind == "mamba":
+            refs.extend([
+                TensorRef(f"layer.{layer}.mamba_in_proj", (_require_existing(headers, (f"{mp}.in_proj.weight",), f"layer {layer} mamba in_proj"),)),
+                TensorRef(f"layer.{layer}.mamba_conv1d", (_require_existing(headers, (f"{mp}.conv1d.weight",), f"layer {layer} mamba conv1d"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.mamba_conv1d_bias", (_require_existing(headers, (f"{mp}.conv1d.bias",), f"layer {layer} mamba conv1d bias"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.mamba_dt_bias", (_require_existing(headers, (f"{mp}.dt_bias",), f"layer {layer} mamba dt_bias"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.mamba_a", (_require_existing(headers, (f"{mp}.A_log",), f"layer {layer} mamba A_log"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.mamba_d", (_require_existing(headers, (f"{mp}.D",), f"layer {layer} mamba D"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.mamba_norm", (_require_existing(headers, (f"{mp}.norm.weight",), f"layer {layer} mamba norm"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.mamba_out_proj", (_require_existing(headers, (f"{mp}.out_proj.weight",), f"layer {layer} mamba out_proj"),)),
+            ])
+        elif kind == "attention":
+            refs.extend([
+                TensorRef(f"layer.{layer}.attn_q", (_require_existing(headers, (f"{mp}.q_proj.weight",), f"layer {layer} q_proj"),)),
+                TensorRef(f"layer.{layer}.attn_k", (_require_existing(headers, (f"{mp}.k_proj.weight",), f"layer {layer} k_proj"),)),
+                TensorRef(f"layer.{layer}.attn_v", (_require_existing(headers, (f"{mp}.v_proj.weight",), f"layer {layer} v_proj"),)),
+                TensorRef(f"layer.{layer}.attn_o", (_require_existing(headers, (f"{mp}.o_proj.weight",), f"layer {layer} o_proj"),)),
+            ])
+        elif kind == "mlp":
+            refs.extend([
+                TensorRef(f"layer.{layer}.mlp_up", (_require_existing(headers, (f"{mp}.up_proj.weight",), f"layer {layer} mlp up_proj"),)),
+                TensorRef(f"layer.{layer}.mlp_down", (_require_existing(headers, (f"{mp}.down_proj.weight",), f"layer {layer} mlp down_proj"),)),
+            ])
+        elif kind == "moe":
+            if n_experts <= 0:
+                raise SystemExit("Nemotron-H MoE layer requires n_routed_experts")
+            refs.extend([
+                TensorRef(f"layer.{layer}.moe_router", (_require_existing(headers, (f"{mp}.gate.weight",), f"layer {layer} moe router"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.moe_router_bias", (_require_existing(headers, (f"{mp}.gate.e_score_correction_bias",), f"layer {layer} moe router correction bias"),), dtype="fp32"),
+            ])
+            for expert in range(n_experts):
+                refs.extend([
+                    TensorRef(f"layer.{layer}.moe_expert.{expert}.up", (_require_existing(headers, (f"{mp}.experts.{expert}.up_proj.weight",), f"layer {layer} expert {expert} up_proj"),)),
+                    TensorRef(f"layer.{layer}.moe_expert.{expert}.down", (_require_existing(headers, (f"{mp}.experts.{expert}.down_proj.weight",), f"layer {layer} expert {expert} down_proj"),)),
+                ])
+            refs.extend([
+                TensorRef(f"layer.{layer}.moe_shared_up", (_require_existing(headers, (f"{mp}.shared_experts.up_proj.weight",), f"layer {layer} shared expert up_proj"),)),
+                TensorRef(f"layer.{layer}.moe_shared_down", (_require_existing(headers, (f"{mp}.shared_experts.down_proj.weight",), f"layer {layer} shared expert down_proj"),)),
+            ])
+        else:
+            raise SystemExit(f"Unsupported Nemotron-H layer kind at {layer}: {kind}")
+
+    refs.append(TensorRef("final_ln_weight", (_require_existing(headers, ("backbone.norm_f.weight", "model.norm.weight"), "final norm"),), dtype="fp32"))
+    refs.append(TensorRef("final_ln_bias", (), dtype="fp32", synth="zeros_fp32", shape=(hidden,)))
+    lm_head = _first_existing(headers, ("lm_head.weight", "backbone.lm_head.weight"))
+    if lm_head is not None:
+        refs.append(TensorRef("output.weight", (lm_head,)))
+    return refs
+
+
 def _first_existing(headers: dict[str, HeaderTensor], names: Iterable[str]) -> str | None:
     for name in names:
         if name in headers:
@@ -431,6 +516,8 @@ def _infer_arch(hf: dict[str, Any]) -> str:
         return "qwen2"
     if "llama" in mt:
         return "llama"
+    if "nemotron_h" in mt or "nemotron-h" in mt:
+        return "nemotron_h"
     return mt
 
 
@@ -439,6 +526,8 @@ def _refs_for_arch(arch: str, config: dict[str, Any], headers: dict[str, HeaderT
         return _gemma4_text_refs(config, headers)
     if arch == "qwen35":
         return _qwen35_text_refs(config, headers)
+    if arch == "nemotron_h":
+        return _nemotron_h_text_refs(config, headers)
     if arch in {"llama", "qwen2", "qwen3", "gemma3"}:
         return _llama_family_text_refs(config, headers)
     raise SystemExit(f"Unsupported safetensors arch for v8 importer: {arch}")
@@ -479,6 +568,44 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
     cfg.setdefault("rms_eps", text.get("rms_norm_eps", text.get("rms_norm_epsilon", 1e-6)))
     cfg.setdefault("rms_norm_eps", cfg.get("rms_eps"))
     cfg.setdefault("tie_word_embeddings", bool(text.get("tie_word_embeddings", True)))
+    if arch == "nemotron_h":
+        layer_kinds = _parse_nemotron_h_pattern(str(text.get("hybrid_override_pattern") or ""), int(cfg.get("num_layers") or 0))
+        cfg.update({
+            "model": "nemotron_h",
+            "arch": "nemotron_h",
+            "model_type": "nemotron_h",
+            "layer_kinds": layer_kinds,
+            "hybrid_block_pattern": layer_kinds[:],
+            "layer_state_policy": ["mamba2" if k == "mamba" else "none" for k in layer_kinds],
+            "layer_attention_policy": ["full_attention" if k == "attention" else "none" for k in layer_kinds],
+            "layer_recurrent_policy": ["mamba2" if k == "mamba" else "none" for k in layer_kinds],
+            "layer_moe_policy": ["routed_relu2" if k == "moe" else "none" for k in layer_kinds],
+            "layer_mlp_policy": ["relu2" if k == "mlp" else "none" for k in layer_kinds],
+            "layer_kv_policy": ["attention_kv_cache" if k == "attention" else "none" for k in layer_kinds],
+            "intermediate_dim": int(text.get("intermediate_size") or 0),
+            "mamba_num_heads": int(text.get("mamba_num_heads") or 0),
+            "mamba_head_dim": int(text.get("mamba_head_dim") or 0),
+            "ssm_state_size": int(text.get("ssm_state_size") or 0),
+            "ssm_conv_kernel": int(text.get("conv_kernel") or 0),
+            "ssm_group_count": int(text.get("n_groups") or 0),
+            "chunk_size": int(text.get("chunk_size") or 0),
+            "mamba_conv_dim": int((text.get("mamba_num_heads") or 0) * (text.get("mamba_head_dim") or 0) + 2 * (text.get("n_groups") or 0) * (text.get("ssm_state_size") or 0)),
+            "mamba_projection_size": int(2 * (text.get("intermediate_size") or 0) + (text.get("mamba_num_heads") or 0) * (text.get("mamba_head_dim") or 0) + ((text.get("mamba_num_heads") or 0) * (text.get("mamba_head_dim") or 0) + 2 * (text.get("n_groups") or 0) * (text.get("ssm_state_size") or 0)) + (text.get("mamba_num_heads") or 0)),
+            "moe_intermediate_size": int(text.get("moe_intermediate_size") or 0),
+            "moe_shared_expert_intermediate_size": int(text.get("moe_shared_expert_intermediate_size") or 0),
+            "n_routed_experts": int(text.get("n_routed_experts") or 0),
+            "num_experts_per_tok": int(text.get("num_experts_per_tok") or 0),
+            "n_group": int(text.get("n_group") or text.get("n_groups") or 0),
+            "topk_group": int(text.get("topk_group") or 0),
+            "norm_topk_prob": bool(text.get("norm_topk_prob", True)),
+            "routed_scaling_factor": float(text.get("routed_scaling_factor") or 1.0),
+            "rope_layout": "split",
+            "rope_theta": float(text.get("rope_theta") or 10000.0),
+            "has_attention_biases": bool(text.get("attention_bias", False)),
+            "has_qk_norm": False,
+            "prefill_policy": "batched",
+        })
+
     if arch == "qwen35":
         headers = _load_safetensors_headers(model_dir)
         q_gate_proj_dim = 0
@@ -601,7 +728,7 @@ def _is_qwen35_shifted_norm_ref(ref: TensorRef) -> bool:
 
 
 def _ref_transform(ref: TensorRef) -> str | None:
-    if ref.ck_name.endswith(".ssm_a"):
+    if ref.ck_name.endswith(".ssm_a") or ref.ck_name.endswith(".mamba_a"):
         return "neg_exp_a_log"
     if _is_qwen35_shifted_norm_ref(ref):
         return "qwen35_norm_plus_one"
@@ -697,7 +824,7 @@ def main() -> int:
     ap.add_argument("--output", required=True, type=Path, help="output weights.bump")
     ap.add_argument("--config-out", required=True, type=Path)
     ap.add_argument("--manifest-out", required=True, type=Path)
-    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35"])
+    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h"])
     ap.add_argument("--config-template", type=Path, help="existing v8 config/manifest to reuse explicit runtime policy")
     ap.add_argument("--dtype", default="preserve", choices=["preserve", "bf16", "fp32"])
     ap.add_argument("--dry-run", action="store_true", help="validate mapping and write JSON reports only; do not write BUMP")
@@ -764,6 +891,9 @@ def main() -> int:
         else:
             quant_summary[e["name"]] = e["dtype"]
 
+    def _int_or_zero(value: Any) -> int:
+        return int(value or 0)
+
     manifest = {
         "version": 5,
         "model": arch,
@@ -776,14 +906,14 @@ def main() -> int:
         "config": config,
         "template": template,
         "quant_summary": quant_summary,
-        "num_layers": int(config.get("num_layers", 0)),
-        "embed_dim": int(config.get("embed_dim", 0)),
-        "num_heads": int(config.get("num_heads", 0)),
-        "num_kv_heads": int(config.get("num_kv_heads", 0)),
-        "head_dim": int(config.get("head_dim", 0)),
-        "intermediate_size": int(config.get("intermediate_size", 0)),
-        "vocab_size": int(config.get("vocab_size", 0)),
-        "context_length": int(config.get("context_length", 0) or 0),
+        "num_layers": _int_or_zero(config.get("num_layers")),
+        "embed_dim": _int_or_zero(config.get("embed_dim")),
+        "num_heads": _int_or_zero(config.get("num_heads")),
+        "num_kv_heads": _int_or_zero(config.get("num_kv_heads")),
+        "head_dim": _int_or_zero(config.get("head_dim")),
+        "intermediate_size": _int_or_zero(config.get("intermediate_size")),
+        "vocab_size": _int_or_zero(config.get("vocab_size")),
+        "context_length": _int_or_zero(config.get("context_length")),
         "has_attention_biases": False,
         "has_qk_norm": True,
         "source_audit": audit,
@@ -840,19 +970,19 @@ def main() -> int:
         f.write(b"BUMPWGT5")
         f.write(struct.pack("<I", BUMP_VERSION_V5))
         f.write(struct.pack("<I", 1))
-        f.write(struct.pack("<I", int(config.get("num_layers", 0))))
-        f.write(struct.pack("<I", int(config.get("vocab_size", 0))))
-        f.write(struct.pack("<I", int(config.get("embed_dim", 0))))
-        f.write(struct.pack("<I", int(config.get("intermediate_size", 0))))
-        f.write(struct.pack("<I", int(config.get("context_length", 0) or 0)))
-        f.write(struct.pack("<I", int(config.get("num_heads", 0))))
-        f.write(struct.pack("<I", int(config.get("num_kv_heads", 0))))
-        f.write(struct.pack("<I", int(config.get("head_dim", 0))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("num_layers"))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("vocab_size"))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("embed_dim"))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("intermediate_size"))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("context_length"))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("num_heads"))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("num_kv_heads"))))
+        f.write(struct.pack("<I", _int_or_zero(config.get("head_dim"))))
         for value in (
-            int(config.get("embed_dim", 0)),
-            int(config.get("head_dim", 0)),
-            int(config.get("intermediate_size", 0)),
-            int(config.get("context_length", 0) or 0),
+            _int_or_zero(config.get("embed_dim")),
+            _int_or_zero(config.get("head_dim")),
+            _int_or_zero(config.get("intermediate_size")),
+            _int_or_zero(config.get("context_length")),
         ):
             f.write(struct.pack("<Q", value))
         f.write(struct.pack("<I", 0))

--- a/version/v8/scripts/inspect_model_contract_v8.py
+++ b/version/v8/scripts/inspect_model_contract_v8.py
@@ -18,7 +18,7 @@ from typing import Any
 
 
 SUPPORTED_DENSE_ARCHES = {"llama", "qwen2", "qwen3", "gemma3"}
-SUPPORTED_HYBRID_ARCHES = {"qwen35", "gemma4"}
+SUPPORTED_HYBRID_ARCHES = {"qwen35", "gemma4", "nemotron_h"}
 
 
 def _load_config(path: Path) -> dict[str, Any]:
@@ -149,10 +149,15 @@ def _required_ops(arch: str, config: dict[str, Any], layer_kinds: list[str]) -> 
 
 def _missing_ops(arch: str, required_ops: list[str]) -> list[str]:
     missing = []
+    mamba_decode_covered = {
+        "mamba_in_proj_split",
+        "mamba_conv1d_state_update",
+        "mamba_dt_softplus",
+        "mamba_rmsnorm_gate",
+        "mamba_out_proj",
+    }
     for op in required_ops:
-        if op.startswith("mamba_") or op == "relu2_mlp":
-            missing.append(op)
-        if op == "shared_expert_mlp":
+        if op.startswith("mamba_") and op not in mamba_decode_covered:
             missing.append(op)
     if arch == "cohere":
         missing.append("cohere_tensor_name_mapping_audit")
@@ -199,7 +204,8 @@ def _notes(arch: str, config: dict[str, Any], layer_kinds: list[str], missing_op
         notes.append("Nemotron-H is a hybrid Mamba/attention decoder; CK DeltaNet kernels are not a substitute for Mamba selective scan.")
         notes.append(f"hybrid_override_pattern={text.get('hybrid_override_pattern')}")
         notes.append(f"mamba heads={text.get('mamba_num_heads')} head_dim={text.get('mamba_head_dim')} state={text.get('ssm_state_size')} conv_kernel={text.get('conv_kernel')}")
-        notes.append(f"MLP activation={text.get('mlp_hidden_act')}; relu2 needs an explicit forward/backward contract.")
+        notes.append("Mamba2 decode split/conv/dt/state-update/gated-norm reference kernels exist; full chunked prefill selective scan remains separate.")
+        notes.append(f"MLP activation={text.get('mlp_hidden_act')}; ReLU2 primitive exists, dense/shared MLP lowering uses matmul -> relu2 -> matmul.")
     if arch == "cohere":
         notes.append("Cohere Command configs are gated in this environment; require config/weight access before mapping tensor names.")
         notes.append("Likely first target is dense decoder mapping/audit before any new math kernels.")

--- a/version/v8/templates/nemotron_h.json
+++ b/version/v8/templates/nemotron_h.json
@@ -1,0 +1,144 @@
+{
+  "version": 2,
+  "name": "nemotron_h",
+  "family": "nemotron_h",
+  "flags": {
+    "use_qkv_bias": false,
+    "attention_bias": false,
+    "activation": "relu2",
+    "rope": "rope",
+    "tokenizer": "bpe",
+    "has_qk_norm": false,
+    "prefill_policy": "batched",
+    "hybrid_block_pattern": "config.hybrid_override_pattern"
+  },
+  "contract": {
+    "tokenizer_contract": {
+      "tokenizer_type": "bpe",
+      "bos_policy": "model_defined",
+      "eos_policy": "model_defined",
+      "special_tokens": {
+        "source": "manifest_or_hf"
+      }
+    },
+    "chat_contract": {
+      "version": 1,
+      "name": "nemotron_h",
+      "raw_prompt_allowed": true,
+      "turn_prefix": "{role}: ",
+      "turn_suffix": "\n",
+      "assistant_generation_prefix": "assistant: ",
+      "role_labels": {
+        "system": "system",
+        "user": "user",
+        "assistant": "assistant"
+      },
+      "system_prompt_mode": "dedicated_turn",
+      "system_prompt_separator": "\n\n",
+      "default_system_prompt": "",
+      "inject_default_system_prompt": false,
+      "stop_text_markers": [],
+      "token_stop_markers": [],
+      "template_markers": [],
+      "min_response_tokens": 8
+    },
+    "attention_contract": {
+      "rope_layout": "split",
+      "rope_type": "rope",
+      "qk_norm": false,
+      "kv_layout": "layer_major_kv_cache",
+      "attn_variant": "hybrid_mamba_attention_moe",
+      "layer_policy_config_key": "layer_kinds",
+      "layer_kind_config_key": "layer_kinds",
+      "state_policy_config_key": "layer_state_policy",
+      "attention_policy_config_key": "layer_attention_policy",
+      "recurrent_policy_config_key": "layer_recurrent_policy",
+      "moe_policy_config_key": "layer_moe_policy",
+      "kv_policy_config_key": "layer_kv_policy"
+    },
+    "block_contract": {
+      "norm_type": "rmsnorm",
+      "block_norm": "pre_norm_then_residual_add",
+      "body_type": "hybrid_mamba_attention_moe",
+      "activation": "relu2",
+      "mlp_formula": "up -> relu2 -> down",
+      "moe_formula": "router(sigmoid) -> group_limited_topk -> routed_relu2_experts + shared_relu2_expert",
+      "mamba_formula": "in_proj -> conv1d/silu -> selective_scan -> gated_rmsnorm -> out_proj",
+      "qkv_bias": false
+    },
+    "logits_contract": {
+      "final_norm": "rmsnorm",
+      "lm_head": "output_weight",
+      "logits_layout": "auto"
+    },
+    "quant_contract": {
+      "kernel_select": "weight_dtype_registry",
+      "activation_dtype": "fp32_or_bf16_path",
+      "per_tensor_mixed_quant": true
+    },
+    "runtime_invariants": {
+      "required_call_args": {}
+    }
+  },
+  "sequence": [
+    "decoder"
+  ],
+  "block_types": {
+    "decoder": {
+      "sequence": [
+        "header",
+        "body",
+        "footer"
+      ],
+      "header": [
+        "bpe_tokenizer",
+        "dense_embedding_lookup"
+      ],
+      "body": {
+        "type": "hybrid_mamba_attention_moe",
+        "kind_config_key": "layer_kinds",
+        "ops_by_kind": {
+          "mamba": [
+            "block_rmsnorm",
+            "mamba_in_proj",
+            "mamba_conv1d_silu",
+            "mamba_selective_scan",
+            "mamba_rmsnorm_gate",
+            "mamba_out_proj",
+            "residual_add"
+          ],
+          "attention": [
+            "block_rmsnorm",
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "rope_qk",
+            "attn",
+            "out_proj",
+            "residual_add"
+          ],
+          "mlp": [
+            "block_rmsnorm",
+            "mlp_up",
+            "relu2",
+            "mlp_down",
+            "residual_add"
+          ],
+          "moe": [
+            "block_rmsnorm",
+            "moe_router",
+            "group_limited_topk_router",
+            "moe_relu2_expert_mlp",
+            "shared_relu2_expert_mlp",
+            "residual_add"
+          ]
+        }
+      },
+      "footer": [
+        "final_rmsnorm",
+        "lm_head",
+        "logits"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add scalar FP32 Mamba2/Nemotron-H decode reference kernels
- add PyTorch parity and perf coverage for Mamba2 split, conv state, dt softplus, selective state update, and gated RMSNorm
- add v8 kernel map entries and nightly runner coverage
- add Nemotron-H safetensors-to-BUMP dry-run mapping/template support
- document the Mamba2 decode reference path with a concepts section and SVG diagram

## Validation
- make build/libckernel_engine.so
- make test-mamba2-reference
- make test-mamba2-reference-perf
- make test-nemotron-router
- make test-moe-relu2-expert
- .venv/bin/python -m unittest tests.test_v8_model_contract_inspector
- make v8-kernel-map-contracts
- .venv/bin/python version/v8/scripts/convert_safetensors_to_bump_v8.py --help
- direct Nemotron-H safetensors dry-run smoke
- bash docs/site/build.sh
- pre-commit v7/v8 fast regression
- pre-push build, kernel parity, v8 E2E smoke, v7 inference, v7/v8 fast regression, training-kernel parity

Note: pytest is not installed in this local venv, so the pytest wrapper was not run directly; the new Nemotron-H safetensors dry-run test body was executed directly with torch/safetensors available.