### PR TITLE
feat(v8): add Nemotron-H Mamba2 reference kernels

### DIFF
--- a/docs/site/_pages/concepts.html
+++ b/docs/site/_pages/concepts.html
@@ -609,6 +609,7 @@ out = grouped_rmsnorm(y * silu(gate))
             <li><code>mamba2_conv1d_decode_f32</code></li>
             <li><code>mamba2_dt_softplus_f32</code></li>
             <li><code>mamba2_selective_state_update_decode_f32</code></li>
+            <li><code>mamba2_selective_scan_f32</code></li>
             <li><code>mamba2_rmsnorm_gate_f32</code></li>
         </ul>
     </div>
@@ -616,7 +617,7 @@ out = grouped_rmsnorm(y * silu(gate))
 
 <div class="card card-green">
     <h3 style="margin-top: 0;">Current CK Coverage</h3>
-    <p><code>make test-mamba2-reference</code> validates the five decode primitives against PyTorch. <code>make test-mamba2-reference-perf</code> provides a scalar baseline for selective state update. This is enough to harden Nemotron-H decode contracts, but it is not yet the final high-performance chunked prefill selective scan.</p>
+    <p><code>make test-mamba2-reference</code> validates the decode primitives and scalar sequence scan against PyTorch. It also checks that full sequence scan matches repeated decode updates. <code>make test-mamba2-reference-perf</code> provides a scalar baseline for selective state update. This is enough to harden Nemotron-H recurrent contracts, but it is not yet the final high-performance chunked/SIMD selective scan.</p>
 </div>
 
 <hr>

--- a/docs/site/assets/concept-mamba2-reference.svg
+++ b/docs/site/assets/concept-mamba2-reference.svg
@@ -93,5 +93,5 @@
   <text x="134" y="428" class="small">uses existing GEMM path</text>
 
   <rect x="56" y="520" width="1128" height="42" rx="8" fill="#0f1b24" stroke="#314653"/>
-  <text x="80" y="547" class="small">Current scope: scalar FP32 decode reference kernels for parity. Future scope: chunked selective scan, packed state layout, and SIMD/threaded kernels.</text>
+  <text x="80" y="547" class="small">Current scope: scalar FP32 decode + sequence scan reference kernels for parity. Future scope: chunked scan, packed state layout, and SIMD/threaded kernels.</text>
 </svg>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -1548,6 +1548,7 @@ out = grouped_rmsnorm(y * silu(gate))
             <li><code>mamba2_conv1d_decode_f32</code></li>
             <li><code>mamba2_dt_softplus_f32</code></li>
             <li><code>mamba2_selective_state_update_decode_f32</code></li>
+            <li><code>mamba2_selective_scan_f32</code></li>
             <li><code>mamba2_rmsnorm_gate_f32</code></li>
         </ul>
     </div>
@@ -1555,7 +1556,7 @@ out = grouped_rmsnorm(y * silu(gate))
 
 <div class="card card-green">
     <h3 style="margin-top: 0;">Current CK Coverage</h3>
-    <p><code>make test-mamba2-reference</code> validates the five decode primitives against PyTorch. <code>make test-mamba2-reference-perf</code> provides a scalar baseline for selective state update. This is enough to harden Nemotron-H decode contracts, but it is not yet the final high-performance chunked prefill selective scan.</p>
+    <p><code>make test-mamba2-reference</code> validates the decode primitives and scalar sequence scan against PyTorch. It also checks that full sequence scan matches repeated decode updates. <code>make test-mamba2-reference-perf</code> provides a scalar baseline for selective state update. This is enough to harden Nemotron-H recurrent contracts, but it is not yet the final high-performance chunked/SIMD selective scan.</p>
 </div>
 
 <hr>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -1758,6 +1758,22 @@ void mamba2_selective_state_update_decode_f32(const float *state_in,
                                               int state_dim,
                                               int num_groups);
 
+void mamba2_selective_scan_f32(const float *state_init,
+                               const float *x,
+                               const float *dt,
+                               const float *a,
+                               const float *b,
+                               const float *c,
+                               const float *d,
+                               float *state_out,
+                               float *y,
+                               int batch,
+                               int seq_len,
+                               int num_heads,
+                               int head_dim,
+                               int state_dim,
+                               int num_groups);
+
 void mamba2_rmsnorm_gate_f32(const float *x,
                              const float *gate,
                              const float *weight,

--- a/src/kernels/mamba2_kernels.c
+++ b/src/kernels/mamba2_kernels.c
@@ -171,6 +171,59 @@ void mamba2_selective_state_update_decode_f32(const float *state_in,
     }
 }
 
+
+void mamba2_selective_scan_f32(const float *state_init,
+                               const float *x,
+                               const float *dt,
+                               const float *a,
+                               const float *b,
+                               const float *c,
+                               const float *d,
+                               float *state_out,
+                               float *y,
+                               int batch,
+                               int seq_len,
+                               int num_heads,
+                               int head_dim,
+                               int state_dim,
+                               int num_groups) {
+    if (!state_init || !x || !dt || !a || !b || !c || !d || !state_out || !y ||
+        batch <= 0 || seq_len <= 0 || num_heads <= 0 || head_dim <= 0 || state_dim <= 0 || num_groups <= 0) {
+        return;
+    }
+
+    const size_t state_per_batch = (size_t)num_heads * (size_t)head_dim * (size_t)state_dim;
+    memcpy(state_out, state_init, (size_t)batch * state_per_batch * sizeof(float));
+
+    for (int bs = 0; bs < batch; ++bs) {
+        float *state_batch = state_out + (size_t)bs * state_per_batch;
+        for (int t = 0; t < seq_len; ++t) {
+            for (int h = 0; h < num_heads; ++h) {
+                const int group = (int)(((long long)h * (long long)num_groups) / (long long)num_heads);
+                const float dt_h = dt[((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_heads + (size_t)h];
+                const float d_a = expf(dt_h * a[h]);
+                const float d_h = d[h];
+                const float *b_row = b + (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
+                const float *c_row = c + (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
+
+                for (int hd = 0; hd < head_dim; ++hd) {
+                    const size_t x_idx = (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_heads + (size_t)h) * (size_t)head_dim + (size_t)hd;
+                    const float x_val = x[x_idx];
+                    const size_t state_base = ((size_t)h * (size_t)head_dim + (size_t)hd) * (size_t)state_dim;
+                    float acc = 0.0f;
+                    for (int st = 0; st < state_dim; ++st) {
+                        const size_t si = state_base + (size_t)st;
+                        const float new_state = state_batch[si] * d_a + dt_h * b_row[st] * x_val;
+                        state_batch[si] = new_state;
+                        acc += new_state * c_row[st];
+                    }
+                    y[x_idx] = acc + d_h * x_val;
+                }
+            }
+        }
+    }
+}
+
 void mamba2_rmsnorm_gate_f32(const float *x,
                              const float *gate,
                              const float *weight,

--- a/tests/test_v8_model_contract_inspector.py
+++ b/tests/test_v8_model_contract_inspector.py
@@ -14,7 +14,7 @@ AUDIT_SCRIPT = REPO / "version/v8/scripts/audit_safetensors_index_v8.py"
 
 
 class ModelContractInspectorTests(unittest.TestCase):
-    def test_nemotron_h_reports_mamba_kernel_gap(self) -> None:
+    def test_nemotron_h_reports_supported_config_after_mamba2_reference_kernels(self) -> None:
         cfg = {
             "architectures": ["NemotronHForCausalLM"],
             "model_type": "nemotron_h",
@@ -40,12 +40,12 @@ class ModelContractInspectorTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-        self.assertEqual(proc.returncode, 2, proc.stderr)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
         report = json.loads(proc.stdout)
         self.assertEqual(report["arch"], "nemotron_h")
-        self.assertEqual(report["status"], "bringup_required")
+        self.assertEqual(report["status"], "supported")
         self.assertEqual(report["layer_kind_counts"], {"attention": 1, "mamba": 5, "moe": 4})
-        self.assertIn("mamba_selective_scan", report["missing_ops"])
+        self.assertEqual(report["missing_ops"], [])
         self.assertNotIn("mamba_in_proj_split", report["missing_ops"])
         self.assertNotIn("mamba_conv1d_state_update", report["missing_ops"])
         self.assertNotIn("mamba_dt_softplus", report["missing_ops"])

--- a/unittest/test_mamba2_reference.py
+++ b/unittest/test_mamba2_reference.py
@@ -35,6 +35,8 @@ LIB.mamba2_dt_softplus_f32.argtypes = [fptr, fptr, fptr, ctypes.c_int, ctypes.c_
 LIB.mamba2_dt_softplus_f32.restype = None
 LIB.mamba2_selective_state_update_decode_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
 LIB.mamba2_selective_state_update_decode_f32.restype = None
+LIB.mamba2_selective_scan_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.mamba2_selective_scan_f32.restype = None
 LIB.mamba2_rmsnorm_gate_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_float]
 LIB.mamba2_rmsnorm_gate_f32.restype = None
 
@@ -116,6 +118,66 @@ class TestMamba2Reference(unittest.TestCase):
         LIB.mamba2_selective_state_update_decode_f32(*map(_fptr, arrays), _fptr(state_out), _fptr(y), rows, heads, head_dim, state_dim, groups)
         np.testing.assert_allclose(state_out, _np(state_ref), atol=1e-6, rtol=0.0)
         np.testing.assert_allclose(y, _np(y_ref), atol=1e-6, rtol=0.0)
+
+
+    def test_selective_scan_matches_torch_sequence(self) -> None:
+        batch, seq, heads, head_dim, state_dim, groups = 2, 5, 6, 4, 3, 3
+        torch.manual_seed(6)
+        state0 = torch.randn(batch, heads, head_dim, state_dim, dtype=torch.float32) * 0.1
+        x = torch.randn(batch, seq, heads, head_dim, dtype=torch.float32) * 0.2
+        dt = torch.rand(batch, seq, heads, dtype=torch.float32) * 0.3 + 0.01
+        a = -(torch.rand(heads, dtype=torch.float32) * 0.5 + 0.1)
+        b = torch.randn(batch, seq, groups, state_dim, dtype=torch.float32) * 0.2
+        c = torch.randn(batch, seq, groups, state_dim, dtype=torch.float32) * 0.2
+        d = torch.randn(heads, dtype=torch.float32) * 0.05
+
+        state_ref = state0.clone()
+        y_ref = torch.empty_like(x)
+        for bs in range(batch):
+            for t in range(seq):
+                for h in range(heads):
+                    g = h * groups // heads
+                    decay = torch.exp(dt[bs, t, h] * a[h])
+                    for hd in range(head_dim):
+                        new_state = state_ref[bs, h, hd] * decay + dt[bs, t, h] * b[bs, t, g] * x[bs, t, h, hd]
+                        state_ref[bs, h, hd] = new_state
+                        y_ref[bs, t, h, hd] = (new_state * c[bs, t, g]).sum() + d[h] * x[bs, t, h, hd]
+
+        arrays = list(map(_np, (state0, x, dt, a, b, c, d)))
+        state_out = np.empty((batch, heads, head_dim, state_dim), dtype=np.float32)
+        y = np.empty((batch, seq, heads, head_dim), dtype=np.float32)
+        LIB.mamba2_selective_scan_f32(*map(_fptr, arrays), _fptr(state_out), _fptr(y), batch, seq, heads, head_dim, state_dim, groups)
+        np.testing.assert_allclose(state_out, _np(state_ref), atol=1e-6, rtol=0.0)
+        np.testing.assert_allclose(y, _np(y_ref), atol=1e-6, rtol=0.0)
+
+    def test_selective_scan_matches_repeated_decode_kernel(self) -> None:
+        batch, seq, heads, head_dim, state_dim, groups = 2, 4, 4, 3, 5, 2
+        rng = np.random.default_rng(77)
+        state0 = np.ascontiguousarray((0.1 * rng.standard_normal((batch, heads, head_dim, state_dim))).astype(np.float32))
+        x = np.ascontiguousarray((0.2 * rng.standard_normal((batch, seq, heads, head_dim))).astype(np.float32))
+        dt = np.ascontiguousarray((0.01 + 0.3 * rng.random((batch, seq, heads))).astype(np.float32))
+        a = np.ascontiguousarray((-(0.1 + 0.5 * rng.random(heads))).astype(np.float32))
+        b = np.ascontiguousarray((0.2 * rng.standard_normal((batch, seq, groups, state_dim))).astype(np.float32))
+        c = np.ascontiguousarray((0.2 * rng.standard_normal((batch, seq, groups, state_dim))).astype(np.float32))
+        d = np.ascontiguousarray((0.05 * rng.standard_normal(heads)).astype(np.float32))
+        scan_state = np.empty_like(state0)
+        scan_y = np.empty_like(x)
+        LIB.mamba2_selective_scan_f32(_fptr(state0), _fptr(x), _fptr(dt), _fptr(a), _fptr(b), _fptr(c), _fptr(d), _fptr(scan_state), _fptr(scan_y), batch, seq, heads, head_dim, state_dim, groups)
+
+        decode_state = state0.copy()
+        decode_y = np.empty_like(x)
+        for t in range(seq):
+            next_state = np.empty_like(decode_state)
+            y_t = np.empty((batch, heads, head_dim), dtype=np.float32)
+            LIB.mamba2_selective_state_update_decode_f32(
+                _fptr(decode_state), _fptr(np.ascontiguousarray(x[:, t])), _fptr(np.ascontiguousarray(dt[:, t])),
+                _fptr(a), _fptr(np.ascontiguousarray(b[:, t])), _fptr(np.ascontiguousarray(c[:, t])), _fptr(d),
+                _fptr(next_state), _fptr(y_t), batch, heads, head_dim, state_dim, groups,
+            )
+            decode_state = next_state
+            decode_y[:, t] = y_t
+        np.testing.assert_allclose(scan_state, decode_state, atol=0.0, rtol=0.0)
+        np.testing.assert_allclose(scan_y, decode_y, atol=1e-7, rtol=0.0)
 
     def test_rmsnorm_gate_matches_torch_grouped_after_gate(self) -> None:
         rows, inner_dim, group_size = 3, 24, 6

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,7 +5,7 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 157,
+      "total": 158,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -40,6 +40,7 @@
         "mamba_dt_softplus": 1,
         "mamba_in_proj_split": 1,
         "mamba_rmsnorm_gate": 1,
+        "mamba_selective_scan": 1,
         "mamba_selective_state_update_decode": 1,
         "moe_relu2_expert_mlp": 2,
         "optimizer": 4,
@@ -10034,6 +10035,174 @@
       },
       "name": "mamba2_rmsnorm_gate_f32",
       "_source_file": "mamba2_rmsnorm_gate_f32.json"
+    },
+    {
+      "id": "mamba2_selective_scan_f32",
+      "op": "mamba_selective_scan",
+      "variant": "fp32_scalar_reference",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "state_init",
+          "dtype": "fp32",
+          "shape": [
+            "B",
+            "H",
+            "D",
+            "S"
+          ]
+        },
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "B",
+            "T",
+            "H",
+            "D"
+          ]
+        },
+        {
+          "name": "dt",
+          "dtype": "fp32",
+          "shape": [
+            "B",
+            "T",
+            "H"
+          ]
+        },
+        {
+          "name": "B",
+          "dtype": "fp32",
+          "shape": [
+            "B",
+            "T",
+            "G",
+            "S"
+          ]
+        },
+        {
+          "name": "C",
+          "dtype": "fp32",
+          "shape": [
+            "B",
+            "T",
+            "G",
+            "S"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "A",
+          "dtype": "fp32",
+          "shape": [
+            "H"
+          ]
+        },
+        {
+          "name": "D",
+          "dtype": "fp32",
+          "shape": [
+            "H"
+          ]
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "state_out",
+          "dtype": "fp32",
+          "shape": [
+            "B",
+            "H",
+            "D",
+            "S"
+          ]
+        },
+        {
+          "name": "y",
+          "dtype": "fp32",
+          "shape": [
+            "B",
+            "T",
+            "H",
+            "D"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "B",
+        "T",
+        "H",
+        "D",
+        "S",
+        "G"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "batch"
+        ],
+        "preferred": {
+          "prefill": "batch",
+          "decode": "batch"
+        },
+        "strategies": [
+          {
+            "name": "batch",
+            "partition_dim": "B",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            }
+          }
+        ]
+      },
+      "impl": {
+        "function": "mamba2_selective_scan_f32",
+        "c_declaration": "void mamba2_selective_scan_f32(const float *state_init, const float *x, const float *dt, const float *a, const float *b, const float *c, const float *d, float *state_out, float *y, int batch, int seq_len, int num_heads, int head_dim, int state_dim, int num_groups);",
+        "sources": [
+          "src/kernels/mamba2_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_mamba2_reference.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+            "tolerance": "1e-6"
+          }
+        ],
+        "performance": [
+          {
+            "kind": "pytorch",
+            "command": "make test-mamba2-reference-perf"
+          }
+        ]
+      },
+      "name": "mamba2_selective_scan_f32",
+      "_source_file": "mamba2_selective_scan_f32.json"
     },
     {
       "id": "mamba2_selective_state_update_decode_f32",

--- a/version/v8/kernel_maps/mamba2_selective_scan_f32.json
+++ b/version/v8/kernel_maps/mamba2_selective_scan_f32.json
@@ -1,0 +1,166 @@
+{
+  "id": "mamba2_selective_scan_f32",
+  "op": "mamba_selective_scan",
+  "variant": "fp32_scalar_reference",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "state_init",
+      "dtype": "fp32",
+      "shape": [
+        "B",
+        "H",
+        "D",
+        "S"
+      ]
+    },
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": [
+        "B",
+        "T",
+        "H",
+        "D"
+      ]
+    },
+    {
+      "name": "dt",
+      "dtype": "fp32",
+      "shape": [
+        "B",
+        "T",
+        "H"
+      ]
+    },
+    {
+      "name": "B",
+      "dtype": "fp32",
+      "shape": [
+        "B",
+        "T",
+        "G",
+        "S"
+      ]
+    },
+    {
+      "name": "C",
+      "dtype": "fp32",
+      "shape": [
+        "B",
+        "T",
+        "G",
+        "S"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "A",
+      "dtype": "fp32",
+      "shape": [
+        "H"
+      ]
+    },
+    {
+      "name": "D",
+      "dtype": "fp32",
+      "shape": [
+        "H"
+      ]
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "state_out",
+      "dtype": "fp32",
+      "shape": [
+        "B",
+        "H",
+        "D",
+        "S"
+      ]
+    },
+    {
+      "name": "y",
+      "dtype": "fp32",
+      "shape": [
+        "B",
+        "T",
+        "H",
+        "D"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "B",
+    "T",
+    "H",
+    "D",
+    "S",
+    "G"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "batch"
+    ],
+    "preferred": {
+      "prefill": "batch",
+      "decode": "batch"
+    },
+    "strategies": [
+      {
+        "name": "batch",
+        "partition_dim": "B",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        }
+      }
+    ]
+  },
+  "impl": {
+    "function": "mamba2_selective_scan_f32",
+    "c_declaration": "void mamba2_selective_scan_f32(const float *state_init, const float *x, const float *dt, const float *a, const float *b, const float *c, const float *d, float *state_out, float *y, int batch, int seq_len, int num_heads, int head_dim, int state_dim, int num_groups);",
+    "sources": [
+      "src/kernels/mamba2_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_mamba2_reference.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_mamba2_reference.py",
+        "tolerance": "1e-6"
+      }
+    ],
+    "performance": [
+      {
+        "kind": "pytorch",
+        "command": "make test-mamba2-reference-perf"
+      }
+    ]
+  }
+}

--- a/version/v8/scripts/inspect_model_contract_v8.py
+++ b/version/v8/scripts/inspect_model_contract_v8.py
@@ -155,6 +155,7 @@ def _missing_ops(arch: str, required_ops: list[str]) -> list[str]:
         "mamba_dt_softplus",
         "mamba_rmsnorm_gate",
         "mamba_out_proj",
+        "mamba_selective_scan",
     }
     for op in required_ops:
         if op.startswith("mamba_") and op not in mamba_decode_covered:
@@ -204,7 +205,7 @@ def _notes(arch: str, config: dict[str, Any], layer_kinds: list[str], missing_op
         notes.append("Nemotron-H is a hybrid Mamba/attention decoder; CK DeltaNet kernels are not a substitute for Mamba selective scan.")
         notes.append(f"hybrid_override_pattern={text.get('hybrid_override_pattern')}")
         notes.append(f"mamba heads={text.get('mamba_num_heads')} head_dim={text.get('mamba_head_dim')} state={text.get('ssm_state_size')} conv_kernel={text.get('conv_kernel')}")
-        notes.append("Mamba2 decode split/conv/dt/state-update/gated-norm reference kernels exist; full chunked prefill selective scan remains separate.")
+        notes.append("Mamba2 decode split/conv/dt/state-update/gated-norm reference kernels exist; full selective scan has a scalar reference; chunk-optimized scan remains future performance work.")
         notes.append(f"MLP activation={text.get('mlp_hidden_act')}; ReLU2 primitive exists, dense/shared MLP lowering uses matmul -> relu2 -> matmul.")
     if arch == "cohere":
         notes.append("Cohere Command configs are gated in this environment; require config/weight access before mapping tensor names.")


### PR DESCRIPTION
## Summary
- add scalar FP32 Nemotron-H/Mamba2 reference kernels, including selective state update and full selective scan
- add PyTorch parity coverage plus scan-vs-repeated-decode equivalence tests
- wire Mamba2 kernel maps, registry entries, and model contract inspector support so Nemotron Nano reports supported
- update concepts docs and SVG to describe the reference coverage and remaining optimized-kernel work

## Validation
- make build/libckernel_engine.so
- make test-mamba2-reference
- make test-mamba2-reference-perf
- .venv/bin/python -m unittest tests.test_v8_model_contract_inspector
- make v8-kernel-map-contracts
- bash docs/site/build.sh
- pre-commit v7/v8 fast regressions
- pre-push build, parity, v8 E2E, v7 inference, v7/v8 fast regressions, training-kernel parity