### PR TITLE
fix(v8): add Nemotron Mamba2 guardrails

### DIFF
--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -2221,6 +2221,39 @@ void moe_relu2_expert_forward_f32(const float *hidden,
                                   int n_experts,
                                   int top_k);
 
+void moe_relu2_expert_forward_q5_0_q8_0(const float *hidden,
+                                        const int *indices,
+                                        const float *routing_weights,
+                                        const void *expert_up,
+                                        const void *expert_down,
+                                        float *output,
+                                        int rows,
+                                        int hidden_dim,
+                                        int intermediate_dim,
+                                        int n_experts,
+                                        int top_k);
+
+void moe_relu2_expert_forward_q5_0_q5_0(const float *hidden,
+                                        const int *indices,
+                                        const float *routing_weights,
+                                        const void *expert_up,
+                                        const void *expert_down,
+                                        float *output,
+                                        int rows,
+                                        int hidden_dim,
+                                        int intermediate_dim,
+                                        int n_experts,
+                                        int top_k);
+
+void moe_relu2_shared_forward_q5_1_q8_0(const float *hidden,
+                                        const float *routed,
+                                        const void *shared_up,
+                                        const void *shared_down,
+                                        float *output,
+                                        int rows,
+                                        int hidden_dim,
+                                        int intermediate_dim);
+
 void moe_relu2_expert_backward_f32(const float *d_output,
                                    const float *hidden,
                                    const int *indices,
@@ -2793,6 +2826,17 @@ void embedding_forward(const int32_t *token_ids,
                        int add_pos);
 
 void embedding_forward_q4_k(const int32_t *token_ids,
+                            int token_count,
+                            int vocab_size,
+                            const void *token_embeddings,
+                            const float *pos_embeddings,
+                            float *output,
+                            int embed_dim,
+                            int aligned_embed_dim,
+                            int context_window,
+                            int add_pos);
+
+void embedding_forward_q5_0(const int32_t *token_ids,
                             int token_count,
                             int vocab_size,
                             const void *token_embeddings,

--- a/src/kernels/axpy_kernels.c
+++ b/src/kernels/axpy_kernels.c
@@ -23,6 +23,12 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include "ckernel_engine.h"
+#include "ckernel_dtype.h"
 
 #ifdef __AVX512F__
 #include <immintrin.h>
@@ -279,6 +285,47 @@ static inline size_t ck_moe_down_idx(int e, int h, int i, int hidden_dim, int in
     return ((size_t)e * (size_t)hidden_dim + (size_t)h) * (size_t)intermediate_dim + (size_t)i;
 }
 
+static int ck_moe_debug_enabled(void)
+{
+    const char *v = getenv("CK_DEBUG_MOE");
+    return v && v[0] && v[0] != '0';
+}
+
+static void ck_moe_debug_finite(const char *name, const float *x, size_t n)
+{
+    if (!ck_moe_debug_enabled() || !x) {
+        return;
+    }
+    size_t finite = 0;
+    size_t nan = 0;
+    size_t inf = 0;
+    float min_v = 0.0f;
+    float max_v = 0.0f;
+    int have = 0;
+    for (size_t i = 0; i < n; ++i) {
+        const float v = x[i];
+        if (isnan(v)) {
+            ++nan;
+        } else if (isinf(v)) {
+            ++inf;
+        } else {
+            ++finite;
+            if (!have || v < min_v) min_v = v;
+            if (!have || v > max_v) max_v = v;
+            have = 1;
+        }
+    }
+    fprintf(stderr,
+            "[CK_DEBUG_MOE] %s finite=%zu/%zu nan=%zu inf=%zu min=%g max=%g\n",
+            name,
+            finite,
+            n,
+            nan,
+            inf,
+            have ? min_v : 0.0f,
+            have ? max_v : 0.0f);
+}
+
 void moe_relu2_expert_forward_f32(const float *hidden,
                                   const int *indices,
                                   const float *routing_weights,
@@ -326,6 +373,238 @@ void moe_relu2_expert_forward_f32(const float *hidden,
                 }
                 y[h] += route_w * v;
             }
+        }
+    }
+}
+
+
+void moe_relu2_expert_forward_q5_0_q8_0(const float *hidden,
+                                        const int *indices,
+                                        const float *routing_weights,
+                                        const void *expert_up,
+                                        const void *expert_down,
+                                        float *output,
+                                        int rows,
+                                        int hidden_dim,
+                                        int intermediate_dim,
+                                        int n_experts,
+                                        int top_k)
+{
+    if (!hidden || !indices || !routing_weights || !expert_up || !expert_down || !output ||
+        rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0 || n_experts <= 0 || top_k <= 0) {
+        return;
+    }
+
+    const size_t out_count = (size_t)rows * (size_t)hidden_dim;
+    for (size_t p = 0; p < out_count; ++p) output[p] = 0.0f;
+
+    const size_t up_row_bytes = ck_dtype_row_bytes(CK_DT_Q5_0, (size_t)hidden_dim);
+    const size_t down_row_bytes = ck_dtype_row_bytes(CK_DT_Q8_0, (size_t)intermediate_dim);
+    const uint8_t *up_base = (const uint8_t *)expert_up;
+    const uint8_t *down_base = (const uint8_t *)expert_down;
+
+    float up_row[hidden_dim];
+    float down_row[intermediate_dim];
+    float act[intermediate_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        float *y = output + (size_t)r * (size_t)hidden_dim;
+        if (ck_moe_debug_enabled() && r == 0) {
+            fprintf(stderr,
+                    "[CK_DEBUG_MOE] routed_q5q8 rows=%d hidden=%d intermediate=%d experts=%d top_k=%d up_row_bytes=%zu down_row_bytes=%zu\n",
+                    rows,
+                    hidden_dim,
+                    intermediate_dim,
+                    n_experts,
+                    top_k,
+                    up_row_bytes,
+                    down_row_bytes);
+            fprintf(stderr, "[CK_DEBUG_MOE] routed slots:");
+            for (int dbg_slot = 0; dbg_slot < top_k; ++dbg_slot) {
+                fprintf(stderr,
+                        " (%d,%g)",
+                        indices[(size_t)r * (size_t)top_k + (size_t)dbg_slot],
+                        routing_weights[(size_t)r * (size_t)top_k + (size_t)dbg_slot]);
+            }
+            fprintf(stderr, "\n");
+            ck_moe_debug_finite("routed.hidden[0]", x, (size_t)hidden_dim);
+            ck_moe_debug_finite("routed.hidden_all", hidden, (size_t)rows * (size_t)hidden_dim);
+        }
+        for (int slot = 0; slot < top_k; ++slot) {
+            const int e = indices[(size_t)r * (size_t)top_k + (size_t)slot];
+            if (e < 0 || e >= n_experts) continue;
+            const float route_w = routing_weights[(size_t)r * (size_t)top_k + (size_t)slot];
+            const uint8_t *expert_up_base = up_base + (size_t)e * (size_t)intermediate_dim * up_row_bytes;
+            const uint8_t *expert_down_base = down_base + (size_t)e * (size_t)hidden_dim * down_row_bytes;
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                dequant_q5_0_row(expert_up_base + (size_t)i * up_row_bytes, up_row, (size_t)hidden_dim);
+                float v = 0.0f;
+                for (int h = 0; h < hidden_dim; ++h) v += up_row[h] * x[h];
+                act[i] = (v > 0.0f) ? v * v : 0.0f;
+            }
+
+            for (int h = 0; h < hidden_dim; ++h) {
+                dequant_q8_0_row(expert_down_base + (size_t)h * down_row_bytes, down_row, (size_t)intermediate_dim);
+                float v = 0.0f;
+                for (int i = 0; i < intermediate_dim; ++i) v += down_row[i] * act[i];
+                y[h] += route_w * v;
+            }
+        }
+        if (ck_moe_debug_enabled() && r == 0) {
+            ck_moe_debug_finite("routed.output[0]", y, (size_t)hidden_dim);
+            ck_moe_debug_finite("routed.output_all", output, (size_t)rows * (size_t)hidden_dim);
+        }
+    }
+}
+
+
+void moe_relu2_expert_forward_q5_0_q5_0(const float *hidden,
+                                        const int *indices,
+                                        const float *routing_weights,
+                                        const void *expert_up,
+                                        const void *expert_down,
+                                        float *output,
+                                        int rows,
+                                        int hidden_dim,
+                                        int intermediate_dim,
+                                        int n_experts,
+                                        int top_k)
+{
+    if (!hidden || !indices || !routing_weights || !expert_up || !expert_down || !output ||
+        rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0 || n_experts <= 0 || top_k <= 0) {
+        return;
+    }
+
+    const size_t out_count = (size_t)rows * (size_t)hidden_dim;
+    for (size_t p = 0; p < out_count; ++p) output[p] = 0.0f;
+
+    const size_t up_row_bytes = ck_dtype_row_bytes(CK_DT_Q5_0, (size_t)hidden_dim);
+    const size_t down_row_bytes = ck_dtype_row_bytes(CK_DT_Q5_0, (size_t)intermediate_dim);
+    const uint8_t *up_base = (const uint8_t *)expert_up;
+    const uint8_t *down_base = (const uint8_t *)expert_down;
+
+    float up_row[hidden_dim];
+    float down_row[intermediate_dim];
+    float act[intermediate_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        float *y = output + (size_t)r * (size_t)hidden_dim;
+        if (ck_moe_debug_enabled() && r == 0) {
+            fprintf(stderr,
+                    "[CK_DEBUG_MOE] routed_q5q5 rows=%d hidden=%d intermediate=%d experts=%d top_k=%d up_row_bytes=%zu down_row_bytes=%zu\n",
+                    rows,
+                    hidden_dim,
+                    intermediate_dim,
+                    n_experts,
+                    top_k,
+                    up_row_bytes,
+                    down_row_bytes);
+            fprintf(stderr, "[CK_DEBUG_MOE] routed slots:");
+            for (int dbg_slot = 0; dbg_slot < top_k; ++dbg_slot) {
+                fprintf(stderr,
+                        " (%d,%g)",
+                        indices[(size_t)r * (size_t)top_k + (size_t)dbg_slot],
+                        routing_weights[(size_t)r * (size_t)top_k + (size_t)dbg_slot]);
+            }
+            fprintf(stderr, "\n");
+            ck_moe_debug_finite("routed.hidden[0]", x, (size_t)hidden_dim);
+            ck_moe_debug_finite("routed.hidden_all", hidden, (size_t)rows * (size_t)hidden_dim);
+        }
+        for (int slot = 0; slot < top_k; ++slot) {
+            const int e = indices[(size_t)r * (size_t)top_k + (size_t)slot];
+            if (e < 0 || e >= n_experts) continue;
+            const float route_w = routing_weights[(size_t)r * (size_t)top_k + (size_t)slot];
+            const uint8_t *expert_up_base = up_base + (size_t)e * (size_t)intermediate_dim * up_row_bytes;
+            const uint8_t *expert_down_base = down_base + (size_t)e * (size_t)hidden_dim * down_row_bytes;
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                dequant_q5_0_row(expert_up_base + (size_t)i * up_row_bytes, up_row, (size_t)hidden_dim);
+                float v = 0.0f;
+                for (int h = 0; h < hidden_dim; ++h) v += up_row[h] * x[h];
+                act[i] = (v > 0.0f) ? v * v : 0.0f;
+            }
+
+            for (int h = 0; h < hidden_dim; ++h) {
+                dequant_q5_0_row(expert_down_base + (size_t)h * down_row_bytes, down_row, (size_t)intermediate_dim);
+                float v = 0.0f;
+                for (int i = 0; i < intermediate_dim; ++i) v += down_row[i] * act[i];
+                y[h] += route_w * v;
+            }
+        }
+        if (ck_moe_debug_enabled() && r == 0) {
+            ck_moe_debug_finite("routed.output[0]", y, (size_t)hidden_dim);
+            ck_moe_debug_finite("routed.output_all", output, (size_t)rows * (size_t)hidden_dim);
+        }
+    }
+}
+
+void moe_relu2_shared_forward_q5_1_q8_0(const float *hidden,
+                                        const float *routed,
+                                        const void *shared_up,
+                                        const void *shared_down,
+                                        float *output,
+                                        int rows,
+                                        int hidden_dim,
+                                        int intermediate_dim)
+{
+    if (!hidden || !shared_up || !shared_down || !output || rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0) {
+        return;
+    }
+
+    const size_t up_row_bytes = ck_dtype_row_bytes(CK_DT_Q5_1, (size_t)hidden_dim);
+    const size_t down_row_bytes = ck_dtype_row_bytes(CK_DT_Q8_0, (size_t)intermediate_dim);
+    const uint8_t *up_base = (const uint8_t *)shared_up;
+    const uint8_t *down_base = (const uint8_t *)shared_down;
+
+    float up_row[hidden_dim];
+    float down_row[intermediate_dim];
+    float act[intermediate_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        const float *route = routed ? (routed + (size_t)r * (size_t)hidden_dim) : NULL;
+        float *y = output + (size_t)r * (size_t)hidden_dim;
+        float x_alias[hidden_dim];
+        if (output == hidden) {
+            memcpy(x_alias, x, (size_t)hidden_dim * sizeof(float));
+            x = x_alias;
+        }
+
+        if (ck_moe_debug_enabled() && r == 0) {
+            fprintf(stderr,
+                    "[CK_DEBUG_MOE] shared_q5q8 rows=%d hidden=%d intermediate=%d up_row_bytes=%zu down_row_bytes=%zu alias=%d\n",
+                    rows,
+                    hidden_dim,
+                    intermediate_dim,
+                    up_row_bytes,
+                    down_row_bytes,
+                    output == hidden);
+            ck_moe_debug_finite("shared.hidden[0]", x, (size_t)hidden_dim);
+            ck_moe_debug_finite("shared.hidden_all", hidden, (size_t)rows * (size_t)hidden_dim);
+            ck_moe_debug_finite("shared.routed[0]", route, (size_t)hidden_dim);
+            if (routed) ck_moe_debug_finite("shared.routed_all", routed, (size_t)rows * (size_t)hidden_dim);
+        }
+
+        for (int i = 0; i < intermediate_dim; ++i) {
+            dequant_q5_1_row(up_base + (size_t)i * up_row_bytes, up_row, (size_t)hidden_dim);
+            float v = 0.0f;
+            for (int h = 0; h < hidden_dim; ++h) v += up_row[h] * x[h];
+            act[i] = (v > 0.0f) ? v * v : 0.0f;
+        }
+
+        for (int h = 0; h < hidden_dim; ++h) {
+            dequant_q8_0_row(down_base + (size_t)h * down_row_bytes, down_row, (size_t)intermediate_dim);
+            float v = route ? route[h] : 0.0f;
+            for (int i = 0; i < intermediate_dim; ++i) v += down_row[i] * act[i];
+            y[h] = v;
+        }
+
+        if (ck_moe_debug_enabled() && r == 0) {
+            ck_moe_debug_finite("shared.output[0]", y, (size_t)hidden_dim);
+            ck_moe_debug_finite("shared.output_all", output, (size_t)rows * (size_t)hidden_dim);
         }
     }
 }

--- a/src/kernels/embedding_kernels.c
+++ b/src/kernels/embedding_kernels.c
@@ -128,6 +128,61 @@ void embedding_forward_q4_k(const int32_t *token_ids,
     }
 }
 
+void embedding_forward_q5_0(const int32_t *token_ids,
+                            int token_count,
+                            int vocab_size,
+                            const void *token_embeddings,
+                            const float *pos_embeddings,
+                            float *output,
+                            int embed_dim,
+                            int aligned_embed_dim,
+                            int context_window,
+                            int add_pos)
+{
+    if (!token_ids || !token_embeddings || !output) {
+        return;
+    }
+
+    int tokens = token_count;
+    if (tokens < 0) {
+        tokens = 0;
+    }
+    if (tokens > context_window) {
+        tokens = context_window;
+    }
+
+    const size_t row_bytes = ck_dtype_row_bytes(CK_DT_Q5_0, (size_t)aligned_embed_dim);
+    const uint8_t *base = (const uint8_t *)token_embeddings;
+
+    for (int t = 0; t < tokens; ++t) {
+        int id = token_ids[t];
+        if (id < 0 || id >= vocab_size) {
+            id = 0;
+        }
+
+        const void *tok = base + (size_t)id * row_bytes;
+        const float *pos = pos_embeddings ? (pos_embeddings + (size_t)t * (size_t)aligned_embed_dim) : NULL;
+        float *out = output + (size_t)t * (size_t)aligned_embed_dim;
+
+        dequant_q5_0_row(tok, out, (size_t)aligned_embed_dim);
+
+        if (add_pos && pos) {
+            for (int d = 0; d < embed_dim; ++d) {
+                out[d] += pos[d];
+            }
+        }
+
+        for (int d = embed_dim; d < aligned_embed_dim; ++d) {
+            out[d] = 0.0f;
+        }
+    }
+
+    for (int t = tokens; t < context_window; ++t) {
+        float *out = output + (size_t)t * (size_t)aligned_embed_dim;
+        memset(out, 0, (size_t)aligned_embed_dim * sizeof(float));
+    }
+}
+
 void embedding_forward_q8_0(const int32_t *token_ids,
                             int token_count,
                             int vocab_size,

--- a/src/kernels/mamba2_kernels.c
+++ b/src/kernels/mamba2_kernels.c
@@ -2,6 +2,40 @@
 
 #include <math.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+static int ck_mamba_debug_enabled(void) {
+    static int cached = -1;
+    if (cached < 0) {
+        const char *v = getenv("CK_DEBUG_MAMBA");
+        cached = (v && v[0] && v[0] != '0') ? 1 : 0;
+    }
+    return cached;
+}
+
+static void ck_mamba_debug_finite(const char *name, const float *x, size_t n) {
+    if (!ck_mamba_debug_enabled() || !x || n == 0) {
+        return;
+    }
+    size_t finite = 0, nan = 0, inf = 0;
+    float min_v = 0.0f, max_v = 0.0f;
+    for (size_t i = 0; i < n; ++i) {
+        const float v = x[i];
+        if (isnan(v)) {
+            ++nan;
+        } else if (!isfinite(v)) {
+            ++inf;
+        } else {
+            if (finite == 0 || v < min_v) min_v = v;
+            if (finite == 0 || v > max_v) max_v = v;
+            ++finite;
+        }
+    }
+    fprintf(stderr, "[CK_DEBUG_MAMBA] %s finite=%zu/%zu nan=%zu inf=%zu min=%g max=%g\n",
+            name, finite, n, nan, inf, finite ? (double)min_v : 0.0, finite ? (double)max_v : 0.0);
+}
 
 static inline float mamba2_sigmoid_f32(float x) {
     if (x >= 0.0f) {
@@ -47,6 +81,7 @@ void mamba2_in_proj_split_f32(const float *projected,
     const int hidden_bc_offset = gate_offset + intermediate_dim;
     const int dt_offset = hidden_bc_offset + conv_dim;
 
+    ck_mamba_debug_finite("split.projected[0]", projected, (size_t)projection_dim);
     for (int row = 0; row < rows; ++row) {
         const float *src = projected + (size_t)row * (size_t)projection_dim;
         memcpy(gate + (size_t)row * (size_t)intermediate_dim,
@@ -59,6 +94,9 @@ void mamba2_in_proj_split_f32(const float *projected,
                src + dt_offset,
                (size_t)num_heads * sizeof(float));
     }
+    ck_mamba_debug_finite("split.gate[0]", gate, (size_t)intermediate_dim);
+    ck_mamba_debug_finite("split.hidden_bc[0]", hidden_bc, (size_t)conv_dim);
+    ck_mamba_debug_finite("split.dt[0]", dt, (size_t)num_heads);
 }
 
 void mamba2_conv1d_decode_f32(const float *state_in,
@@ -75,23 +113,37 @@ void mamba2_conv1d_decode_f32(const float *state_in,
         return;
     }
 
+    ck_mamba_debug_finite("conv.state_in", state_in, (size_t)conv_dim * (size_t)kernel_size);
+    ck_mamba_debug_finite("conv.x[0]", x, (size_t)conv_dim);
+
+    /* State layout is [conv_dim, kernel_size]. Rows are time steps, not
+     * independent batch entries. Keep a local rolling state so prefill scans
+     * the prompt in order and decode (rows=1) is the same contract.
+     */
+    float state_work[(size_t)conv_dim * (size_t)kernel_size];
+    memcpy(state_work, state_in, (size_t)conv_dim * (size_t)kernel_size * sizeof(float));
+
     for (int row = 0; row < rows; ++row) {
         for (int ch = 0; ch < conv_dim; ++ch) {
-            const size_t base = ((size_t)row * (size_t)conv_dim + (size_t)ch) * (size_t)kernel_size;
+            const size_t base = (size_t)ch * (size_t)kernel_size;
             for (int k = 0; k < kernel_size - 1; ++k) {
-                state_out[base + (size_t)k] = state_in[base + (size_t)k + 1u];
+                state_work[base + (size_t)k] = state_work[base + (size_t)k + 1u];
             }
-            state_out[base + (size_t)kernel_size - 1u] =
+            state_work[base + (size_t)kernel_size - 1u] =
                 x[(size_t)row * (size_t)conv_dim + (size_t)ch];
 
             float acc = bias ? bias[ch] : 0.0f;
             for (int k = 0; k < kernel_size; ++k) {
-                acc += state_out[base + (size_t)k] *
+                acc += state_work[base + (size_t)k] *
                        weight[(size_t)ch * (size_t)kernel_size + (size_t)k];
             }
             conv_out[(size_t)row * (size_t)conv_dim + (size_t)ch] = mamba2_silu_f32(acc);
         }
     }
+
+    memcpy(state_out, state_work, (size_t)conv_dim * (size_t)kernel_size * sizeof(float));
+    ck_mamba_debug_finite("conv.out[0]", conv_out, (size_t)conv_dim);
+    ck_mamba_debug_finite("conv.state_out", state_out, (size_t)conv_dim * (size_t)kernel_size);
 }
 
 void mamba2_dt_softplus_f32(const float *dt,
@@ -105,6 +157,8 @@ void mamba2_dt_softplus_f32(const float *dt,
         return;
     }
 
+    ck_mamba_debug_finite("dt.in[0]", dt, (size_t)num_heads);
+    ck_mamba_debug_finite("dt.bias", dt_bias, (size_t)num_heads);
     for (int row = 0; row < rows; ++row) {
         for (int h = 0; h < num_heads; ++h) {
             float v = dt[(size_t)row * (size_t)num_heads + (size_t)h];
@@ -122,6 +176,7 @@ void mamba2_dt_softplus_f32(const float *dt,
             dt_out[(size_t)row * (size_t)num_heads + (size_t)h] = v;
         }
     }
+    ck_mamba_debug_finite("dt.out[0]", dt_out, (size_t)num_heads);
 }
 
 void mamba2_selective_state_update_decode_f32(const float *state_in,
@@ -193,22 +248,41 @@ void mamba2_selective_scan_f32(const float *state_init,
     }
 
     const size_t state_per_batch = (size_t)num_heads * (size_t)head_dim * (size_t)state_dim;
+    ck_mamba_debug_finite("scan.state_init", state_init, state_per_batch);
+    ck_mamba_debug_finite("scan.x[0]", x, (size_t)num_heads * (size_t)head_dim + 2u * (size_t)num_groups * (size_t)state_dim);
+    ck_mamba_debug_finite("scan.dt[0]", dt, (size_t)num_heads);
+    ck_mamba_debug_finite("scan.a", a, (size_t)num_heads);
+    ck_mamba_debug_finite("scan.d", d, (size_t)num_heads);
     memcpy(state_out, state_init, (size_t)batch * state_per_batch * sizeof(float));
 
     for (int bs = 0; bs < batch; ++bs) {
         float *state_batch = state_out + (size_t)bs * state_per_batch;
         for (int t = 0; t < seq_len; ++t) {
             for (int h = 0; h < num_heads; ++h) {
-                const int group = (int)(((long long)h * (long long)num_groups) / (long long)num_heads);
+                /* Nemotron-H no-cache/chunked prefill expands B/C with
+                 * repeat(..., num_heads / num_groups, ...), yielding a
+                 * repeating head->group mapping.  The separate decode state
+                 * update kernel keeps the cache-path contiguous mapping.
+                 */
+                const int group = h % num_groups;
                 const float dt_h = dt[((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_heads + (size_t)h];
                 const float d_a = expf(dt_h * a[h]);
                 const float d_h = d[h];
-                const float *b_row = b + (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
-                const float *c_row = c + (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
+                const int packed_xbc = (x == b && b == c);
+                const size_t inner_dim = (size_t)num_heads * (size_t)head_dim;
+                const size_t bc_dim = (size_t)num_groups * (size_t)state_dim;
+                const size_t packed_stride = inner_dim + 2u * bc_dim;
+                const float *packed_row = x + ((size_t)bs * (size_t)seq_len + (size_t)t) * packed_stride;
+                const float *b_row = packed_xbc
+                    ? (packed_row + inner_dim + (size_t)group * (size_t)state_dim)
+                    : (b + (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_groups + (size_t)group) * (size_t)state_dim);
+                const float *c_row = packed_xbc
+                    ? (packed_row + inner_dim + bc_dim + (size_t)group * (size_t)state_dim)
+                    : (c + (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_groups + (size_t)group) * (size_t)state_dim);
 
                 for (int hd = 0; hd < head_dim; ++hd) {
                     const size_t x_idx = (((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_heads + (size_t)h) * (size_t)head_dim + (size_t)hd;
-                    const float x_val = x[x_idx];
+                    const float x_val = packed_xbc ? packed_row[(size_t)h * (size_t)head_dim + (size_t)hd] : x[x_idx];
                     const size_t state_base = ((size_t)h * (size_t)head_dim + (size_t)hd) * (size_t)state_dim;
                     float acc = 0.0f;
                     for (int st = 0; st < state_dim; ++st) {
@@ -222,6 +296,8 @@ void mamba2_selective_scan_f32(const float *state_init,
             }
         }
     }
+    ck_mamba_debug_finite("scan.state_out", state_out, (size_t)batch * state_per_batch);
+    ck_mamba_debug_finite("scan.y[0]", y, (size_t)num_heads * (size_t)head_dim);
 }
 
 void mamba2_rmsnorm_gate_f32(const float *x,
@@ -236,6 +312,9 @@ void mamba2_rmsnorm_gate_f32(const float *x,
         return;
     }
 
+    ck_mamba_debug_finite("rmsgate.x[0]", x, (size_t)inner_dim);
+    ck_mamba_debug_finite("rmsgate.gate[0]", gate, (size_t)inner_dim);
+    ck_mamba_debug_finite("rmsgate.weight", weight, (size_t)inner_dim);
     for (int row = 0; row < rows; ++row) {
         const float *x_row = x + (size_t)row * (size_t)inner_dim;
         const float *gate_row = gate + (size_t)row * (size_t)inner_dim;
@@ -259,4 +338,5 @@ void mamba2_rmsnorm_gate_f32(const float *x,
             }
         }
     }
+    ck_mamba_debug_finite("rmsgate.out[0]", out, (size_t)inner_dim);
 }

--- a/src/kernels/topk_kernels.c
+++ b/src/kernels/topk_kernels.c
@@ -346,7 +346,7 @@ int argmax_f32(const float *scores, int n)
  * Group-limited MoE router for Nemotron-H/DeepSeek-style routed experts.
  *
  * Contract:
- *   scores          [rows, n_experts] sigmoid router scores
+ *   scores          [rows, n_experts] raw router logits; sigmoid is applied internally
  *   correction_bias [n_experts] optional score correction used only for choice
  *   indices         [rows, top_k]
  *   weights         [rows, top_k]
@@ -356,10 +356,21 @@ int argmax_f32(const float *scores, int n)
  *   group_scores = sum(top2(choice_scores within group))
  *   selected_groups = topk(group_scores, topk_group)
  *   selected_experts = topk(choice_scores masked to selected groups, top_k)
- *   weights = gather(scores, selected_experts)
+ *   weights = gather(sigmoid(scores), selected_experts)
  *   if norm_topk_prob: weights /= sum(weights) + 1e-20
  *   weights *= routed_scaling_factor
  * ============================================================================= */
+
+static inline float ck_router_sigmoid_f32(float x)
+{
+    if (x >= 0.0f) {
+        const float z = expf(-x);
+        return 1.0f / (1.0f + z);
+    }
+    const float z = expf(x);
+    return z / (1.0f + z);
+}
+
 static void ck_topk_insert_desc(int idx, float val, int *indices, float *values, int k)
 {
     for (int pos = 0; pos < k; ++pos) {
@@ -400,7 +411,11 @@ void nemotron_group_limited_topk_router_f32(const float *scores,
     }
 
     for (int r = 0; r < rows; ++r) {
-        const float *row_scores = scores + (size_t)r * (size_t)n_experts;
+        const float *row_logits = scores + (size_t)r * (size_t)n_experts;
+        float row_scores[n_experts];
+        for (int e = 0; e < n_experts; ++e) {
+            row_scores[e] = ck_router_sigmoid_f32(row_logits[e]);
+        }
         int *row_indices = indices + (size_t)r * (size_t)top_k;
         float *row_weights = weights + (size_t)r * (size_t)top_k;
 

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -337,6 +337,8 @@ def test_nemotron_h_safetensors_to_bump_dry_run_maps_hybrid_mamba_attention_moe(
     assert audit["unmapped_source_tensors"] == []
     assert cfg["layer_kinds"] == ["mamba", "attention", "moe", "mlp"]
     assert cfg["layer_state_policy"] == ["mamba2", "none", "none", "none"]
+    assert cfg["ssm_conv_kernel"] == 4
+    assert cfg["ssm_conv_history"] == 4
     assert cfg["layer_moe_policy"] == ["none", "none", "routed_relu2", "none"]
     assert "layer.0.mamba_in_proj" in names
     assert "layer.0.mamba_conv1d" in names
@@ -348,3 +350,148 @@ def test_nemotron_h_safetensors_to_bump_dry_run_maps_hybrid_mamba_attention_moe(
     assert "layer.3.mlp_up" in names
     assert "output.weight" in names
     assert any(row["target"] == "layer.0.mamba_a" and row["transform"] == "neg_exp_a_log" for row in audit["transforms"])
+
+
+def test_nemotron_h_safetensors_to_bump_dry_run_maps_dense_mamba_attention_relu2_without_moe(tmp_path: Path) -> None:
+    torch, st = _require_torch_safetensors()
+    checkpoint = tmp_path / "nemotron_h_dense"
+    out = tmp_path / "out_nemotron_h_dense"
+    checkpoint.mkdir()
+    out.mkdir()
+
+    config = {
+        "architectures": ["NemotronHForCausalLM"],
+        "model_type": "nemotron_h",
+        "num_hidden_layers": 3,
+        "hidden_size": 8,
+        "intermediate_size": 6,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "vocab_size": 32,
+        "max_position_embeddings": 128,
+        "hybrid_override_pattern": "M*-",
+        "mamba_num_heads": 2,
+        "mamba_head_dim": 4,
+        "ssm_state_size": 3,
+        "conv_kernel": 4,
+        "n_groups": 2,
+        "chunk_size": 8,
+        "mlp_hidden_act": "relu2",
+        "tie_word_embeddings": False,
+        "attention_bias": False,
+        "mlp_bias": False,
+        "rope_theta": 10000.0,
+        "layer_norm_epsilon": 1e-5,
+    }
+    (checkpoint / "config.json").write_text(json.dumps(config) + "\n", encoding="utf-8")
+
+    tensors = {
+        "backbone.embeddings.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+        "backbone.norm_f.weight": torch.ones(8, dtype=torch.float32),
+        "lm_head.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+        "backbone.layers.0.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.0.mixer.in_proj.weight": torch.randn(34, 8, dtype=torch.bfloat16),
+        "backbone.layers.0.mixer.conv1d.weight": torch.randn(20, 1, 4, dtype=torch.float32),
+        "backbone.layers.0.mixer.conv1d.bias": torch.randn(20, dtype=torch.float32),
+        "backbone.layers.0.mixer.dt_bias": torch.randn(2, dtype=torch.float32),
+        "backbone.layers.0.mixer.A_log": torch.randn(2, dtype=torch.float32),
+        "backbone.layers.0.mixer.D": torch.randn(2, dtype=torch.float32),
+        "backbone.layers.0.mixer.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.0.mixer.out_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "backbone.layers.1.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.1.mixer.q_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "backbone.layers.1.mixer.k_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+        "backbone.layers.1.mixer.v_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+        "backbone.layers.1.mixer.o_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "backbone.layers.2.norm.weight": torch.ones(8, dtype=torch.float32),
+        "backbone.layers.2.mixer.up_proj.weight": torch.randn(6, 8, dtype=torch.bfloat16),
+        "backbone.layers.2.mixer.down_proj.weight": torch.randn(8, 6, dtype=torch.bfloat16),
+    }
+
+    st.save_file(tensors, checkpoint / "model.safetensors")
+    script = Path("version/v8/scripts/convert_safetensors_to_bump_v8.py")
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(out / "weights.bump"),
+            "--config-out",
+            str(out / "config.json"),
+            "--manifest-out",
+            str(out / "weights_manifest.json"),
+            "--arch",
+            "auto",
+            "--dry-run",
+        ],
+        check=True,
+    )
+
+    manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
+    audit = json.loads((out / "conversion_audit.json").read_text(encoding="utf-8"))
+    cfg = json.loads((out / "config.json").read_text(encoding="utf-8"))
+    names = [entry["name"] for entry in manifest["entries"]]
+    assert manifest["model"] == "nemotron_h"
+    assert audit["verdict"] == "pass"
+    assert audit["unmapped_source_tensors"] == []
+    assert cfg["layer_kinds"] == ["mamba", "attention", "mlp"]
+    assert cfg["layer_state_policy"] == ["mamba2", "none", "none"]
+    assert cfg["layer_moe_policy"] == ["none", "none", "none"]
+    assert cfg["layer_mlp_policy"] == ["none", "none", "relu2"]
+    assert cfg["ssm_conv_kernel"] == 4
+    assert cfg["ssm_conv_history"] == 4
+    assert "layer.0.mamba_in_proj" in names
+    assert "layer.1.attn_q" in names
+    assert "layer.2.mlp_up" in names
+    assert "layer.2.mlp_down" in names
+    assert "output.weight" in names
+    assert not any(".moe_" in name or name.endswith("moe_router") for name in names)
+    assert any(row["target"] == "layer.0.mamba_a" and row["transform"] == "neg_exp_a_log" for row in audit["transforms"])
+
+    build_ir = Path("version/v8/scripts/build_ir_v8.py")
+    lowered = out / "lowered_decode.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(build_ir),
+            "--manifest",
+            str(out / "weights_manifest.json"),
+            "--mode",
+            "decode",
+            "--output",
+            str(out / "ir1_decode.json"),
+            "--layout-output",
+            str(out / "layout_decode.json"),
+            "--lowered-output",
+            str(lowered),
+            "--call-output",
+            str(out / "lowered_decode_call.json"),
+            "--context-len",
+            "8",
+        ],
+        check=True,
+    )
+    layout = json.loads((out / "layout_decode.json").read_text(encoding="utf-8"))
+    conv_state = next(
+        buf for buf in layout["memory"]["activations"]["buffers"] if buf["name"] == "recurrent_conv_state"
+    )
+    assert conv_state["shape"] == "[3, 4, 20]"
+
+    lowered_ops = json.loads(lowered.read_text(encoding="utf-8"))["operations"]
+    by_op = {(op["layer"], op["op"]): op for op in lowered_ops}
+
+    mamba_in = by_op[(0, "mamba_in_proj")]
+    assert mamba_in["kernel"] == "gemv_bf16"
+    assert mamba_in["activations"]["x"]["buffer"] == "layer_input"
+
+    mlp_up = by_op[(2, "mlp_up")]
+    relu2 = by_op[(2, "relu2")]
+    mlp_down = by_op[(2, "mlp_down")]
+    assert mlp_up["kernel"] == "gemv_bf16"
+    assert mlp_up["activations"]["x"]["buffer"] == "layer_input"
+    assert relu2["activations"]["x"]["buffer"] == "mlp_scratch"
+    assert relu2["outputs"]["out"]["buffer"] == "mlp_scratch"
+    assert mlp_down["activations"]["x"]["buffer"] == "mlp_scratch"

--- a/unittest/test_mamba2_reference.py
+++ b/unittest/test_mamba2_reference.py
@@ -67,16 +67,20 @@ class TestMamba2Reference(unittest.TestCase):
     def test_conv1d_decode_matches_torch(self) -> None:
         rows, conv_dim, kernel = 2, 11, 4
         torch.manual_seed(2)
-        state = torch.randn(rows, conv_dim, kernel, dtype=torch.float32) * 0.2
+        state = torch.randn(conv_dim, kernel, dtype=torch.float32) * 0.2
         x = torch.randn(rows, conv_dim, dtype=torch.float32) * 0.2
         weight = torch.randn(conv_dim, kernel, dtype=torch.float32) * 0.3
         bias = torch.randn(conv_dim, dtype=torch.float32) * 0.1
-        state_ref = torch.roll(state, shifts=-1, dims=-1)
-        state_ref[:, :, -1] = x
-        conv_ref = torch.nn.functional.silu((state_ref * weight.unsqueeze(0)).sum(dim=-1) + bias)
+        state_ref = state.clone()
+        conv_rows = []
+        for row in range(rows):
+            state_ref = torch.roll(state_ref, shifts=-1, dims=-1)
+            state_ref[:, -1] = x[row]
+            conv_rows.append(torch.nn.functional.silu((state_ref * weight).sum(dim=-1) + bias))
+        conv_ref = torch.stack(conv_rows, dim=0)
         state_np, x_np, weight_np, bias_np = map(_np, (state, x, weight, bias))
         conv = np.empty((rows, conv_dim), dtype=np.float32)
-        state_out = np.empty((rows, conv_dim, kernel), dtype=np.float32)
+        state_out = np.empty((conv_dim, kernel), dtype=np.float32)
         LIB.mamba2_conv1d_decode_f32(_fptr(state_np), _fptr(x_np), _fptr(weight_np), _fptr(bias_np), _fptr(conv), _fptr(state_out), rows, conv_dim, kernel)
         np.testing.assert_allclose(state_out, _np(state_ref), atol=0.0, rtol=0.0)
         np.testing.assert_allclose(conv, _np(conv_ref), atol=1e-6, rtol=0.0)
@@ -136,7 +140,7 @@ class TestMamba2Reference(unittest.TestCase):
         for bs in range(batch):
             for t in range(seq):
                 for h in range(heads):
-                    g = h * groups // heads
+                    g = h % groups
                     decay = torch.exp(dt[bs, t, h] * a[h])
                     for hd in range(head_dim):
                         new_state = state_ref[bs, h, hd] * decay + dt[bs, t, h] * b[bs, t, g] * x[bs, t, h, hd]
@@ -150,10 +154,14 @@ class TestMamba2Reference(unittest.TestCase):
         np.testing.assert_allclose(state_out, _np(state_ref), atol=1e-6, rtol=0.0)
         np.testing.assert_allclose(y, _np(y_ref), atol=1e-6, rtol=0.0)
 
-    def test_selective_scan_matches_repeated_decode_kernel(self) -> None:
-        batch, seq, heads, head_dim, state_dim, groups = 2, 4, 4, 3, 5, 2
+    def test_selective_scan_prefill_group_mapping_differs_from_decode_cache_mapping(self) -> None:
+        # Nemotron-H no-cache/chunked prefill expands B/C with torch.repeat,
+        # giving h % groups. The cache decode path expands with contiguous group
+        # blocks. Keep this test as a contract guard so the two kernels are not
+        # accidentally forced back to the same mapping.
+        batch, seq, heads, head_dim, state_dim, groups = 1, 1, 8, 2, 3, 2
         rng = np.random.default_rng(77)
-        state0 = np.ascontiguousarray((0.1 * rng.standard_normal((batch, heads, head_dim, state_dim))).astype(np.float32))
+        state0 = np.zeros((batch, heads, head_dim, state_dim), dtype=np.float32)
         x = np.ascontiguousarray((0.2 * rng.standard_normal((batch, seq, heads, head_dim))).astype(np.float32))
         dt = np.ascontiguousarray((0.01 + 0.3 * rng.random((batch, seq, heads))).astype(np.float32))
         a = np.ascontiguousarray((-(0.1 + 0.5 * rng.random(heads))).astype(np.float32))
@@ -164,20 +172,13 @@ class TestMamba2Reference(unittest.TestCase):
         scan_y = np.empty_like(x)
         LIB.mamba2_selective_scan_f32(_fptr(state0), _fptr(x), _fptr(dt), _fptr(a), _fptr(b), _fptr(c), _fptr(d), _fptr(scan_state), _fptr(scan_y), batch, seq, heads, head_dim, state_dim, groups)
 
-        decode_state = state0.copy()
-        decode_y = np.empty_like(x)
-        for t in range(seq):
-            next_state = np.empty_like(decode_state)
-            y_t = np.empty((batch, heads, head_dim), dtype=np.float32)
-            LIB.mamba2_selective_state_update_decode_f32(
-                _fptr(decode_state), _fptr(np.ascontiguousarray(x[:, t])), _fptr(np.ascontiguousarray(dt[:, t])),
-                _fptr(a), _fptr(np.ascontiguousarray(b[:, t])), _fptr(np.ascontiguousarray(c[:, t])), _fptr(d),
-                _fptr(next_state), _fptr(y_t), batch, heads, head_dim, state_dim, groups,
-            )
-            decode_state = next_state
-            decode_y[:, t] = y_t
-        np.testing.assert_allclose(scan_state, decode_state, atol=0.0, rtol=0.0)
-        np.testing.assert_allclose(scan_y, decode_y, atol=1e-7, rtol=0.0)
+        ref = np.empty_like(scan_y)
+        for h in range(heads):
+            g = h % groups
+            for hd in range(head_dim):
+                new_state = dt[0, 0, h] * b[0, 0, g] * x[0, 0, h, hd]
+                ref[0, 0, h, hd] = float(np.dot(new_state, c[0, 0, g]) + d[h] * x[0, 0, h, hd])
+        np.testing.assert_allclose(scan_y, ref, atol=1e-6, rtol=0.0)
 
     def test_rmsnorm_gate_matches_torch_grouped_after_gate(self) -> None:
         rows, inner_dim, group_size = 3, 24, 6

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -3,9 +3,9 @@
     "description": "Kernel registry generated from v8 kernel maps",
     "version": "v8",
     "generated_by": "ck_run_v8.py",
-    "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
+    "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 158,
+      "total": 162,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -15,7 +15,7 @@
         "attn_gate_sigmoid_mul": 1,
         "attn_gate_sigmoid_mul_backward": 1,
         "bias_add": 1,
-        "embedding": 6,
+        "embedding": 7,
         "embedding_backward": 1,
         "feature_concat": 1,
         "feature_slice_copy": 1,
@@ -42,7 +42,7 @@
         "mamba_rmsnorm_gate": 1,
         "mamba_selective_scan": 1,
         "mamba_selective_state_update_decode": 1,
-        "moe_relu2_expert_mlp": 2,
+        "moe_relu2_expert_mlp": 4,
         "optimizer": 4,
         "position_embeddings": 2,
         "position_ids": 1,
@@ -68,6 +68,7 @@
         "rope_backward": 2,
         "rope_init": 2,
         "rowwise_bias_add": 1,
+        "shared_relu2_expert_mlp": 1,
         "softmax": 1,
         "spatial_merge": 2,
         "split_q_gate": 1,
@@ -3935,6 +3936,115 @@
       "notes": "Token embedding lookup with Q4_K quantized weights. Output is FP32 for downstream computation.",
       "name": "embedding_forward_q4_k",
       "_source_file": "embedding_forward_q4_k.json"
+    },
+    {
+      "id": "embedding_forward_q5_0",
+      "op": "embedding",
+      "variant": "q5_0",
+      "quant": {
+        "weight": "q5_0",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "tokens",
+          "dtype": "int32",
+          "shape": [
+            "T"
+          ],
+          "desc": "Input token IDs [tokens]"
+        }
+      ],
+      "weights": [
+        {
+          "name": "weight",
+          "dtype": "q5_0",
+          "shape": [
+            "V",
+            "E"
+          ],
+          "desc": "Embedding weights [vocab_size, embed_dim] (Q5_0 quantized)"
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Embeddings [tokens, embed_dim]"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "T",
+        "E",
+        "V"
+      ],
+      "params": [],
+      "parallelization": {
+        "supported": [
+          "token"
+        ],
+        "preferred": {
+          "prefill": "token",
+          "decode": "token"
+        },
+        "strategies": [
+          {
+            "name": "token",
+            "partition_dim": "T",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            },
+            "notes": "Process tokens in parallel; each thread handles a slice of tokens."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "E": 32
+        },
+        "notes": "Q5_0 requires E multiple of 32 for dequantization."
+      },
+      "impl": {
+        "function": "embedding_forward_q5_0",
+        "c_declaration": "void embedding_forward_q5_0(const int32_t *token_ids, int token_count, int vocab_size, const void *token_embeddings, const float *pos_embeddings, float *output, int embed_dim, int aligned_embed_dim, int context_window, int add_pos);",
+        "sources": [
+          "src/kernels/embedding_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "default",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_embedding.py"
+        ],
+        "bench": [
+          "scripts/bench_embedding.py"
+        ],
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": "python unittest/test_embedding.py --compare-numpy",
+            "tolerance": "1e-5",
+            "notes": "Compare against numpy reference"
+          }
+        ]
+      },
+      "notes": "Token embedding lookup with Q5_0 quantized weights. Output is FP32 for downstream computation.",
+      "name": "embedding_forward_q5_0",
+      "_source_file": "embedding_forward_q5_0.json"
     },
     {
       "id": "embedding_forward_q6_k",
@@ -11788,6 +11898,291 @@
       },
       "name": "moe_relu2_expert_forward_f32",
       "_source_file": "moe_relu2_expert_forward_f32.json"
+    },
+    {
+      "id": "moe_relu2_expert_forward_q5_0_q5_0",
+      "op": "moe_relu2_expert_mlp",
+      "variant": "q5_0_q5_0_scalar_ref",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "q5_0|q5_0",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "expert_up",
+          "dtype": "q5_0",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_down",
+          "dtype": "q5_0",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I",
+        "E",
+        "K"
+      ],
+      "impl": {
+        "function": "moe_relu2_expert_forward_q5_0_q5_0",
+        "c_declaration": "void moe_relu2_expert_forward_q5_0_q5_0(const float *hidden, const int *indices, const float *routing_weights, const void *expert_up, const void *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_relu2_expert.py"
+        ]
+      },
+      "name": "moe_relu2_expert_forward_q5_0_q5_0",
+      "_source_file": "moe_relu2_expert_forward_q5_0_q5_0.json"
+    },
+    {
+      "id": "moe_relu2_expert_forward_q5_0_q8_0",
+      "op": "moe_relu2_expert_mlp",
+      "variant": "q5_0_q8_0_scalar_ref",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "q5_0|q8_0",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "expert_up",
+          "dtype": "q5_0",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_down",
+          "dtype": "q8_0",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I",
+        "E",
+        "K"
+      ],
+      "impl": {
+        "function": "moe_relu2_expert_forward_q5_0_q8_0",
+        "c_declaration": "void moe_relu2_expert_forward_q5_0_q8_0(const float *hidden, const int *indices, const float *routing_weights, const void *expert_up, const void *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_relu2_expert.py"
+        ]
+      },
+      "name": "moe_relu2_expert_forward_q5_0_q8_0",
+      "_source_file": "moe_relu2_expert_forward_q5_0_q8_0.json"
+    },
+    {
+      "id": "moe_relu2_shared_forward_q5_1_q8_0",
+      "op": "shared_relu2_expert_mlp",
+      "variant": "q5_1_q8_0_scalar_ref",
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "quant": {
+        "weight": "q5_1|q8_0",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "routed",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "shared_up",
+          "dtype": "q5_1",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "shared_down",
+          "dtype": "q8_0",
+          "shape": [
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I"
+      ],
+      "impl": {
+        "function": "moe_relu2_shared_forward_q5_1_q8_0",
+        "c_declaration": "void moe_relu2_shared_forward_q5_1_q8_0(const float *hidden, const float *routed, const void *shared_up, const void *shared_down, float *output, int rows, int hidden_dim, int intermediate_dim);",
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_relu2_expert.py"
+        ]
+      },
+      "name": "moe_relu2_shared_forward_q5_1_q8_0",
+      "_source_file": "moe_relu2_shared_forward_q5_1_q8_0.json"
     },
     {
       "id": "mrope_qk_text",

--- a/version/v8/kernel_maps/embedding_forward_q5_0.json
+++ b/version/v8/kernel_maps/embedding_forward_q5_0.json
@@ -1,0 +1,107 @@
+{
+  "id": "embedding_forward_q5_0",
+  "op": "embedding",
+  "variant": "q5_0",
+  "quant": {
+    "weight": "q5_0",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "tokens",
+      "dtype": "int32",
+      "shape": [
+        "T"
+      ],
+      "desc": "Input token IDs [tokens]"
+    }
+  ],
+  "weights": [
+    {
+      "name": "weight",
+      "dtype": "q5_0",
+      "shape": [
+        "V",
+        "E"
+      ],
+      "desc": "Embedding weights [vocab_size, embed_dim] (Q5_0 quantized)"
+    }
+  ],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Embeddings [tokens, embed_dim]"
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "T",
+    "E",
+    "V"
+  ],
+  "params": [],
+  "parallelization": {
+    "supported": [
+      "token"
+    ],
+    "preferred": {
+      "prefill": "token",
+      "decode": "token"
+    },
+    "strategies": [
+      {
+        "name": "token",
+        "partition_dim": "T",
+        "param_style": "range",
+        "range": {
+          "min_chunk": 1
+        },
+        "notes": "Process tokens in parallel; each thread handles a slice of tokens."
+      }
+    ]
+  },
+  "constraints": {
+    "alignment": {
+      "E": 32
+    },
+    "notes": "Q5_0 requires E multiple of 32 for dequantization."
+  },
+  "impl": {
+    "function": "embedding_forward_q5_0",
+    "c_declaration": "void embedding_forward_q5_0(const int32_t *token_ids, int token_count, int vocab_size, const void *token_embeddings, const float *pos_embeddings, float *output, int embed_dim, int aligned_embed_dim, int context_window, int add_pos);",
+    "sources": [
+      "src/kernels/embedding_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "default",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_embedding.py"
+    ],
+    "bench": [
+      "scripts/bench_embedding.py"
+    ],
+    "parity": [
+      {
+        "kind": "numpy",
+        "command": "python unittest/test_embedding.py --compare-numpy",
+        "tolerance": "1e-5",
+        "notes": "Compare against numpy reference"
+      }
+    ]
+  },
+  "notes": "Token embedding lookup with Q5_0 quantized weights. Output is FP32 for downstream computation."
+}

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -1836,6 +1836,509 @@
           "source": "dim:rope_freq_base"
         }
       ]
+    },
+    "embedding_forward_q5_0": {
+      "params": [
+        {
+          "name": "token_ids",
+          "source": "activation:tokens",
+          "cast": "int32_t*"
+        },
+        {
+          "name": "token_count",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "vocab_size",
+          "source": "dim:vocab_size"
+        },
+        {
+          "name": "token_embeddings",
+          "source": "weight:token_emb"
+        },
+        {
+          "name": "pos_embeddings",
+          "source": "null"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "aligned_embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "context_window",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "add_pos",
+          "source": "const:0"
+        }
+      ]
+    },
+    "mamba2_conv1d_decode_f32": {
+      "params": [
+        {
+          "name": "state_in",
+          "source": "activation:state_in",
+          "cast": "const float*"
+        },
+        {
+          "name": "x",
+          "source": "activation:x",
+          "cast": "const float*"
+        },
+        {
+          "name": "weight",
+          "source": "weight:mamba_conv1d",
+          "cast": "const float*"
+        },
+        {
+          "name": "bias",
+          "source": "weight_f:mamba_conv1d_bias",
+          "cast": "const float*"
+        },
+        {
+          "name": "conv_out",
+          "source": "output:conv_out",
+          "cast": "float*"
+        },
+        {
+          "name": "state_out",
+          "source": "output:state_out",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "conv_dim",
+          "source": "dim:mamba_conv_dim"
+        },
+        {
+          "name": "kernel_size",
+          "source": "dim:ssm_conv_kernel"
+        }
+      ]
+    },
+    "mamba2_selective_scan_f32": {
+      "params": [
+        {
+          "name": "state_init",
+          "source": "activation:state_init",
+          "cast": "const float*"
+        },
+        {
+          "name": "x",
+          "source": "activation:x",
+          "cast": "const float*"
+        },
+        {
+          "name": "dt",
+          "source": "activation:dt",
+          "cast": "const float*"
+        },
+        {
+          "name": "a",
+          "source": "weight:mamba_a",
+          "cast": "const float*"
+        },
+        {
+          "name": "b",
+          "source": "activation:B",
+          "cast": "const float*"
+        },
+        {
+          "name": "c",
+          "source": "activation:C",
+          "cast": "const float*"
+        },
+        {
+          "name": "d",
+          "source": "weight:mamba_d",
+          "cast": "const float*"
+        },
+        {
+          "name": "state_out",
+          "source": "output:state_out",
+          "cast": "float*"
+        },
+        {
+          "name": "y",
+          "source": "output:y",
+          "cast": "float*"
+        },
+        {
+          "name": "batch",
+          "source": "const:1"
+        },
+        {
+          "name": "seq_len",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:mamba_num_heads"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:mamba_head_dim"
+        },
+        {
+          "name": "state_dim",
+          "source": "dim:ssm_state_size"
+        },
+        {
+          "name": "num_groups",
+          "source": "dim:ssm_group_count"
+        }
+      ]
+    },
+    "mamba2_rmsnorm_gate_f32": {
+      "params": [
+        {
+          "name": "x",
+          "source": "activation:x",
+          "cast": "const float*"
+        },
+        {
+          "name": "gate",
+          "source": "activation:gate",
+          "cast": "const float*"
+        },
+        {
+          "name": "weight",
+          "source": "weight:mamba_norm",
+          "cast": "const float*"
+        },
+        {
+          "name": "out",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "inner_dim",
+          "source": "dim:ssm_inner_size"
+        },
+        {
+          "name": "group_size",
+          "source": "dim:mamba_norm_group_size"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_norm_eps"
+        }
+      ]
+    },
+    "nemotron_group_limited_topk_router_f32": {
+      "params": [
+        {
+          "name": "scores",
+          "source": "activation:scores",
+          "cast": "const float*"
+        },
+        {
+          "name": "correction_bias",
+          "source": "weight:moe_router_bias",
+          "cast": "const float*"
+        },
+        {
+          "name": "indices",
+          "source": "output:indices",
+          "cast": "int*"
+        },
+        {
+          "name": "weights",
+          "source": "output:weights",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "n_experts",
+          "source": "dim:n_routed_experts"
+        },
+        {
+          "name": "top_k",
+          "source": "dim:num_experts_per_tok"
+        },
+        {
+          "name": "n_group",
+          "source": "dim:router_num_groups"
+        },
+        {
+          "name": "topk_group",
+          "source": "dim:router_topk_group"
+        },
+        {
+          "name": "norm_topk_prob",
+          "source": "dim:router_norm_topk_prob"
+        },
+        {
+          "name": "routed_scaling_factor",
+          "source": "dim:routed_scaling_factor"
+        }
+      ]
+    },
+    "moe_relu2_expert_forward_q5_0_q8_0": {
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "indices",
+          "source": "activation:indices",
+          "cast": "const int*"
+        },
+        {
+          "name": "routing_weights",
+          "source": "activation:routing_weights",
+          "cast": "const float*"
+        },
+        {
+          "name": "expert_up",
+          "source": "weight:moe_expert_up",
+          "cast": "const void*"
+        },
+        {
+          "name": "expert_down",
+          "source": "weight:moe_expert_down",
+          "cast": "const void*"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "hidden_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:moe_intermediate_size"
+        },
+        {
+          "name": "n_experts",
+          "source": "dim:n_routed_experts"
+        },
+        {
+          "name": "top_k",
+          "source": "dim:num_experts_per_tok"
+        }
+      ]
+    },
+    "moe_relu2_shared_forward_q5_1_q8_0": {
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "routed",
+          "source": "activation:routed",
+          "cast": "const float*"
+        },
+        {
+          "name": "shared_up",
+          "source": "weight:moe_shared_up",
+          "cast": "const void*"
+        },
+        {
+          "name": "shared_down",
+          "source": "weight:moe_shared_down",
+          "cast": "const void*"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "hidden_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:moe_shared_expert_intermediate_size"
+        }
+      ]
+    },
+    "mamba2_in_proj_split_f32": {
+      "params": [
+        {
+          "name": "projected",
+          "source": "activation:projected",
+          "cast": "const float*"
+        },
+        {
+          "name": "gate",
+          "source": "output:gate",
+          "cast": "float*"
+        },
+        {
+          "name": "hidden_bc",
+          "source": "output:hidden_bc",
+          "cast": "float*"
+        },
+        {
+          "name": "dt",
+          "source": "output:dt",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "d_mlp",
+          "source": "const:0"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:ssm_inner_size"
+        },
+        {
+          "name": "conv_dim",
+          "source": "dim:mamba_conv_dim"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:mamba_num_heads"
+        }
+      ]
+    },
+    "mamba2_dt_softplus_f32": {
+      "params": [
+        {
+          "name": "dt",
+          "source": "activation:dt",
+          "cast": "const float*"
+        },
+        {
+          "name": "dt_bias",
+          "source": "weight:mamba_dt_bias",
+          "cast": "const float*"
+        },
+        {
+          "name": "dt_out",
+          "source": "output:dt_out",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:mamba_num_heads"
+        },
+        {
+          "name": "dt_min",
+          "source": "dim:mamba_dt_min"
+        },
+        {
+          "name": "dt_max",
+          "source": "dim:mamba_dt_max"
+        }
+      ]
+    },
+    "moe_relu2_expert_forward_q5_0_q5_0": {
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "indices",
+          "source": "activation:indices",
+          "cast": "const int*"
+        },
+        {
+          "name": "routing_weights",
+          "source": "activation:routing_weights",
+          "cast": "const float*"
+        },
+        {
+          "name": "expert_up",
+          "source": "weight:moe_expert_up",
+          "cast": "const void*"
+        },
+        {
+          "name": "expert_down",
+          "source": "weight:moe_expert_down",
+          "cast": "const void*"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "hidden_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:moe_intermediate_size"
+        },
+        {
+          "name": "n_experts",
+          "source": "dim:n_routed_experts"
+        },
+        {
+          "name": "top_k",
+          "source": "dim:num_experts_per_tok"
+        }
+      ]
+    },
+    "relu2_forward": {
+      "params": [
+        {
+          "name": "input",
+          "source": "activation:x",
+          "cast": "const float*"
+        },
+        {
+          "name": "output",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "n",
+          "source": "dim:relu2_elems"
+        }
+      ]
     }
   }
 }

--- a/version/v8/kernel_maps/moe_relu2_expert_forward_q5_0_q5_0.json
+++ b/version/v8/kernel_maps/moe_relu2_expert_forward_q5_0_q5_0.json
@@ -1,0 +1,97 @@
+{
+  "id": "moe_relu2_expert_forward_q5_0_q5_0",
+  "op": "moe_relu2_expert_mlp",
+  "variant": "q5_0_q5_0_scalar_ref",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "q5_0|q5_0",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "indices",
+      "dtype": "i32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "expert_up",
+      "dtype": "q5_0",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_down",
+      "dtype": "q5_0",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "dims": [
+    "R",
+    "H",
+    "I",
+    "E",
+    "K"
+  ],
+  "impl": {
+    "function": "moe_relu2_expert_forward_q5_0_q5_0",
+    "c_declaration": "void moe_relu2_expert_forward_q5_0_q5_0(const float *hidden, const int *indices, const float *routing_weights, const void *expert_up, const void *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_relu2_expert.py"
+    ]
+  }
+}

--- a/version/v8/kernel_maps/moe_relu2_expert_forward_q5_0_q8_0.json
+++ b/version/v8/kernel_maps/moe_relu2_expert_forward_q5_0_q8_0.json
@@ -1,0 +1,97 @@
+{
+  "id": "moe_relu2_expert_forward_q5_0_q8_0",
+  "op": "moe_relu2_expert_mlp",
+  "variant": "q5_0_q8_0_scalar_ref",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "q5_0|q8_0",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "indices",
+      "dtype": "i32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "expert_up",
+      "dtype": "q5_0",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_down",
+      "dtype": "q8_0",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "dims": [
+    "R",
+    "H",
+    "I",
+    "E",
+    "K"
+  ],
+  "impl": {
+    "function": "moe_relu2_expert_forward_q5_0_q8_0",
+    "c_declaration": "void moe_relu2_expert_forward_q5_0_q8_0(const float *hidden, const int *indices, const float *routing_weights, const void *expert_up, const void *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);",
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_relu2_expert.py"
+    ]
+  }
+}

--- a/version/v8/kernel_maps/moe_relu2_shared_forward_q5_1_q8_0.json
+++ b/version/v8/kernel_maps/moe_relu2_shared_forward_q5_1_q8_0.json
@@ -1,0 +1,85 @@
+{
+  "id": "moe_relu2_shared_forward_q5_1_q8_0",
+  "op": "shared_relu2_expert_mlp",
+  "variant": "q5_1_q8_0_scalar_ref",
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "quant": {
+    "weight": "q5_1|q8_0",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "routed",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "shared_up",
+      "dtype": "q5_1",
+      "shape": [
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "shared_down",
+      "dtype": "q8_0",
+      "shape": [
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "dims": [
+    "R",
+    "H",
+    "I"
+  ],
+  "impl": {
+    "function": "moe_relu2_shared_forward_q5_1_q8_0",
+    "c_declaration": "void moe_relu2_shared_forward_q5_1_q8_0(const float *hidden, const float *routed, const void *shared_up, const void *shared_down, float *output, int rows, int hidden_dim, int intermediate_dim);",
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ]
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_relu2_expert.py"
+    ]
+  }
+}

--- a/version/v8/model_maps/gguf_ck_map.json
+++ b/version/v8/model_maps/gguf_ck_map.json
@@ -1,0 +1,91 @@
+{
+  "version": 1,
+  "description": "Declarative GGUF-to-CK model contract map. Keep model file tensor names here; keep kernel_maps focused on CK op-to-C-kernel bindings.",
+  "architectures": {
+    "nemotron_h_moe": {
+      "template": "nemotron_h",
+      "family": "nemotron_h",
+      "layer_kind_config_key": "layer_kinds",
+      "metadata_map": {
+        "block_count": "nemotron_h_moe.block_count",
+        "context_length": "nemotron_h_moe.context_length",
+        "embedding_length": "nemotron_h_moe.embedding_length",
+        "feed_forward_length": "nemotron_h_moe.feed_forward_length",
+        "vocab_size": "nemotron_h_moe.vocab_size",
+        "attention_head_count": "nemotron_h_moe.attention.head_count",
+        "attention_head_count_kv": "nemotron_h_moe.attention.head_count_kv",
+        "attention_key_length": "nemotron_h_moe.attention.key_length",
+        "attention_value_length": "nemotron_h_moe.attention.value_length",
+        "rope_freq_base": "nemotron_h_moe.rope.freq_base",
+        "rope_dimension_count": "nemotron_h_moe.rope.dimension_count",
+        "ssm_conv_kernel": "nemotron_h_moe.ssm.conv_kernel",
+        "ssm_state_size": "nemotron_h_moe.ssm.state_size",
+        "ssm_group_count": "nemotron_h_moe.ssm.group_count",
+        "ssm_inner_size": "nemotron_h_moe.ssm.inner_size",
+        "ssm_time_step_rank": "nemotron_h_moe.ssm.time_step_rank",
+        "expert_count": "nemotron_h_moe.expert_count",
+        "expert_used_count": "nemotron_h_moe.expert_used_count",
+        "expert_feed_forward_length": "nemotron_h_moe.expert_feed_forward_length",
+        "expert_shared_feed_forward_length": "nemotron_h_moe.expert_shared_feed_forward_length"
+      },
+      "layer_kinds": {
+        "mamba": {
+          "required_suffixes": [
+            "attn_norm.weight",
+            "ssm_in.weight",
+            "ssm_conv1d.weight",
+            "ssm_conv1d.bias",
+            "ssm_dt.bias",
+            "ssm_a",
+            "ssm_d",
+            "ssm_norm.weight",
+            "ssm_out.weight"
+          ]
+        },
+        "moe": {
+          "required_suffixes": [
+            "attn_norm.weight",
+            "ffn_gate_inp.weight",
+            "ffn_up_exps.weight",
+            "ffn_down_exps.weight",
+            "ffn_up_shexp.weight",
+            "ffn_down_shexp.weight"
+          ]
+        },
+        "attention": {
+          "required_suffixes": [
+            "attn_norm.weight",
+            "attn_q.weight",
+            "attn_k.weight",
+            "attn_v.weight",
+            "attn_output.weight"
+          ]
+        }
+      },
+      "tensor_map": {
+        "token_embd.weight": "token_emb",
+        "output_norm.weight": "final_ln_weight",
+        "output.weight": "output.weight",
+        "blk.{L}.attn_norm.weight": "layer.{L}.block_norm",
+        "blk.{L}.ssm_in.weight": "layer.{L}.mamba_in_proj",
+        "blk.{L}.ssm_conv1d.weight": "layer.{L}.mamba_conv1d",
+        "blk.{L}.ssm_conv1d.bias": "layer.{L}.mamba_conv1d_bias",
+        "blk.{L}.ssm_dt.bias": "layer.{L}.mamba_dt_bias",
+        "blk.{L}.ssm_a": "layer.{L}.mamba_a",
+        "blk.{L}.ssm_d": "layer.{L}.mamba_d",
+        "blk.{L}.ssm_norm.weight": "layer.{L}.mamba_norm",
+        "blk.{L}.ssm_out.weight": "layer.{L}.mamba_out_proj",
+        "blk.{L}.ffn_gate_inp.weight": "layer.{L}.moe_router",
+        "blk.{L}.exp_probs_b.bias": "layer.{L}.moe_router_bias",
+        "blk.{L}.ffn_up_exps.weight": "layer.{L}.moe_expert_up",
+        "blk.{L}.ffn_down_exps.weight": "layer.{L}.moe_expert_down",
+        "blk.{L}.ffn_up_shexp.weight": "layer.{L}.moe_shared_up",
+        "blk.{L}.ffn_down_shexp.weight": "layer.{L}.moe_shared_down",
+        "blk.{L}.attn_q.weight": "layer.{L}.attn_q",
+        "blk.{L}.attn_k.weight": "layer.{L}.attn_k",
+        "blk.{L}.attn_v.weight": "layer.{L}.attn_v",
+        "blk.{L}.attn_output.weight": "layer.{L}.attn_o"
+      }
+    }
+  }
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -401,6 +401,10 @@ OP_DATAFLOW = {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "block_rmsnorm": {
+        "inputs": {"input": "main_stream"},
+        "outputs": {"output": {"slot": "layer_input", "dtype": "fp32"}},
+    },
     "post_attention_norm": {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
@@ -645,6 +649,84 @@ OP_DATAFLOW = {
         },
         "outputs": {"out": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "moe_router": {
+        "inputs": {"x": "layer_input"},
+        "outputs": {"y": {"slot": "mlp_scratch", "dtype": "fp32"}},
+    },
+    "group_limited_topk_router": {
+        "inputs": {"scores": "mlp_scratch"},
+        "outputs": {
+            "indices": {"slot": "q_scratch", "dtype": "i32"},
+            "weights": {"slot": "k_scratch", "dtype": "fp32"},
+        },
+    },
+    "moe_relu2_expert_mlp": {
+        "inputs": {
+            "hidden": "layer_input",
+            "indices": "q_scratch",
+            "routing_weights": "k_scratch",
+        },
+        "outputs": {"output": {"slot": "mlp_scratch", "dtype": "fp32"}},
+    },
+    "shared_relu2_expert_mlp": {
+        "inputs": {
+            "hidden": "layer_input",
+            "routed": "mlp_scratch",
+        },
+        "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
+    },
+
+    "mamba_in_proj": {
+        "inputs": {"x": "main_stream_q8"},
+        "outputs": {"y": {"slot": "recurrent_packed", "dtype": "fp32"}},
+    },
+    "mamba_in_proj_split": {
+        "inputs": {"projected": "recurrent_packed"},
+        "outputs": {
+            "gate": {"slot": "recurrent_z", "dtype": "fp32"},
+            "hidden_bc": {"slot": "recurrent_conv_qkv", "dtype": "fp32"},
+            "dt": {"slot": "recurrent_g", "dtype": "fp32"},
+        },
+    },
+    "mamba_dt_softplus": {
+        "inputs": {"dt": "recurrent_g"},
+        "outputs": {"dt_out": {"slot": "recurrent_g", "dtype": "fp32"}},
+    },
+    "mamba_conv1d_silu": {
+        "inputs": {
+            "state_in": "recurrent_conv_state",
+            "x": "recurrent_conv_qkv",
+        },
+        "outputs": {
+            "conv_out": {"slot": "recurrent_conv_qkv", "dtype": "fp32"},
+            "state_out": {"slot": "recurrent_conv_state", "dtype": "fp32"},
+        },
+    },
+    "mamba_selective_scan": {
+        "inputs": {
+            "state_init": "recurrent_ssm_state",
+            "x": "recurrent_conv_qkv",
+            "dt": "recurrent_g",
+            "B": "recurrent_conv_qkv",
+            "C": "recurrent_conv_qkv",
+        },
+        "outputs": {
+            "state_out": {"slot": "recurrent_ssm_state", "dtype": "fp32"},
+            "y": {"slot": "recurrent_v", "dtype": "fp32"},
+        },
+    },
+    "mamba_rmsnorm_gate": {
+        "inputs": {"x": "recurrent_v", "gate": "recurrent_z"},
+        "outputs": {"out": {"slot": "recurrent_normed", "dtype": "fp32"}},
+    },
+    "quantize_mamba_out_proj_input": {
+        "inputs": {"input": "recurrent_normed"},
+        "outputs": {"output": {"slot": "main_stream_q8", "dtype": "q8_k"}},
+    },
+    "mamba_out_proj": {
+        "inputs": {"x": "recurrent_normed"},
+        "outputs": {"y": {"slot": "main_stream", "dtype": "fp32"}},
+    },
 
     # MLP block
     "mlp_gate_up": {
@@ -668,6 +750,10 @@ OP_DATAFLOW = {
         "outputs": {"out": {"slot": "mlp_scratch", "dtype": "fp32"}},  # In-place
     },
     "gelu": {
+        "inputs": {"x": "mlp_scratch"},
+        "outputs": {"out": {"slot": "mlp_scratch", "dtype": "fp32"}},  # In-place
+    },
+    "relu2": {
         "inputs": {"x": "mlp_scratch"},
         "outputs": {"out": {"slot": "mlp_scratch", "dtype": "fp32"}},  # In-place
     },
@@ -1750,7 +1836,7 @@ def build_activation_specs(config: Dict[str, Any], mode: str, context_len: int, 
         recurrent_q, recurrent_k, recurrent_v, recurrent_inner,
         recurrent_gate, recurrent_conv_channels, recurrent_state_size,
     )):
-        packed_dim = max(recurrent_q + recurrent_k + recurrent_v, recurrent_inner)
+        packed_dim = max(recurrent_q + recurrent_k + recurrent_v, recurrent_inner, int(config.get("mamba_projection_size", 0) or 0))
         packed_size = seq_len * packed_dim * 4
         recurrent_inner_size = seq_len * recurrent_inner * 4
         gate_size = seq_len * recurrent_gate * 4
@@ -1821,6 +1907,7 @@ TEMPLATE_TO_KERNEL_OP = {
     "rmsnorm": "rmsnorm",
     "layernorm": "layernorm",
     "attn_norm": "rmsnorm",
+    "block_rmsnorm": "rmsnorm",
     "post_attention_norm": "rmsnorm",
     "ffn_norm": "rmsnorm",
     "post_ffn_norm": "rmsnorm",
@@ -1851,6 +1938,17 @@ TEMPLATE_TO_KERNEL_OP = {
     "recurrent_norm_gate": "recurrent_norm_gate",
     "attn_gate_sigmoid_mul": "attn_gate_sigmoid_mul",
     "recurrent_out_proj": "matmul",
+    "mamba_in_proj": "matmul",
+    "mamba_in_proj_split": "mamba_in_proj_split",
+    "mamba_dt_softplus": "mamba_dt_softplus",
+    "mamba_conv1d_silu": "mamba_conv1d_state_update",
+    "mamba_selective_scan": "mamba_selective_scan",
+    "mamba_rmsnorm_gate": "mamba_rmsnorm_gate",
+    "mamba_out_proj": "matmul",
+    "moe_router": "matmul",
+    "group_limited_topk_router": "group_limited_topk_router",
+    "moe_relu2_expert_mlp": "moe_relu2_expert_mlp",
+    "shared_relu2_expert_mlp": "shared_relu2_expert_mlp",
     "rope_qk": "rope",
     "mrope_qk": "rope",
     "kv_cache_store": "kv_cache_store",  # Store K,V to KV cache at pos
@@ -1867,6 +1965,7 @@ TEMPLATE_TO_KERNEL_OP = {
     # Use simple matmul for mlp_gate_up to avoid the mismatch.
     "mlp_gate_up": "matmul",  # gemv (decode) or gemm (prefill) - use unfused MLP
     "mlp_up": "matmul",
+    "relu2": "relu2",
     "silu_mul": "swiglu",
     "geglu": "geglu",
     "gelu": "gelu",
@@ -2006,14 +2105,14 @@ def _dedupe_preserve_order(items: List[str]) -> List[str]:
     return out
 
 
-PRE_NORM_OP_NAMES = {"rmsnorm", "layernorm", "attn_norm", "ffn_norm", "post_attention_norm"}
+PRE_NORM_OP_NAMES = {"rmsnorm", "layernorm", "attn_norm", "ffn_norm", "post_attention_norm", "block_rmsnorm"}
 RESIDUAL_SOURCE_BRANCH_STARTERS = {
     # Attention branches
     "q_proj", "q_gate_proj", "qkv_proj", "qkv_packed_proj",
     "recurrent_qkv_proj", "recurrent_gate_proj",
-    "recurrent_alpha_proj", "recurrent_beta_proj",
-    # Feed-forward branches
-    "mlp_gate_up", "mlp_gate", "mlp_up",
+    "recurrent_alpha_proj", "recurrent_beta_proj", "mamba_in_proj",
+    # Feed-forward / routed expert branches
+    "mlp_gate_up", "mlp_gate", "mlp_up", "moe_router",
 }
 PRE_NORM_Q8_DIRECT_CONSUMERS = RESIDUAL_SOURCE_BRANCH_STARTERS
 
@@ -2616,6 +2715,25 @@ def _apply_layer_quant_aliases(
         if dst not in effective and src in effective:
             effective[dst] = effective[src]
 
+    # Canonical IR weight slots are intentionally older/stable names (w1/w2/w3),
+    # while newer safetensors converters often emit semantic names
+    # (mlp_gate/mlp_down/mlp_up). Keep this fallback in the lowerer so templates
+    # do not need brittle per-source alias variants just to preserve dtype
+    # propagation.
+    canonical_aliases = {
+        "w1": ("ffn_gate", "mlp_gate"),
+        "w2": ("ffn_down", "mlp_down"),
+        "w3": ("ffn_up", "mlp_up"),
+        "wo": ("attn_o", "out_proj"),
+    }
+    for dst, candidates in canonical_aliases.items():
+        if dst in effective:
+            continue
+        for src in candidates:
+            if src in effective:
+                effective[dst] = effective[src]
+                break
+
     return effective
 
 def compute_matmul_dims(op_name: str, config: Dict) -> Tuple[Optional[int], Optional[int]]:
@@ -2660,6 +2778,16 @@ def compute_matmul_dims(op_name: str, config: Dict) -> Tuple[Optional[int], Opti
         return embed, attn_out
     if op_name in ("recurrent_out_proj",):
         return embed, int(config.get("ssm_inner_size", attn_out))
+    if op_name in ("mamba_in_proj",):
+        return int(config.get("mamba_projection_size", 0) or 0) or None, embed
+    if op_name in ("mamba_out_proj",):
+        return embed, int(config.get("ssm_inner_size", config.get("mamba_intermediate_size", attn_out)) or attn_out)
+    if op_name in ("moe_router",):
+        return int(config.get("n_routed_experts", config.get("num_experts", 0)) or 0) or None, embed
+    if op_name in ("moe_relu2_expert_mlp",):
+        return int(config.get("moe_intermediate_size", inter) or inter), embed
+    if op_name in ("shared_relu2_expert_mlp",):
+        return int(config.get("moe_shared_expert_intermediate_size", inter) or inter), embed
     if op_name in ("mlp_gate_up",):
         return inter * 2, embed
     if op_name in ("mlp_up",):
@@ -2700,6 +2828,9 @@ def compute_matmul_dims(op_name: str, config: Dict) -> Tuple[Optional[int], Opti
     if op_name in ("quantize_recurrent_out_proj_input",):
         recurrent_inner = int(config.get("ssm_inner_size", attn_out))
         return recurrent_inner, recurrent_inner
+    if op_name in ("quantize_mamba_out_proj_input",):
+        mamba_inner = int(config.get("mamba_intermediate_size", config.get("ssm_inner_size", attn_out)))
+        return mamba_inner, mamba_inner
     if op_name in ("quantize_mlp_down_input",):
         return inter, inter  # _input_dim = intermediate_size
     return None, None
@@ -2757,6 +2888,49 @@ def apply_layer_attention_dims(op_name: str, params: Dict, layer: int, config: D
             params["n_dims"] = rotary_dim
             params["rope_freq_base"] = rope_freq_base
             params["use_rope_freq_factors"] = 1 if op_name == "rope_qk" else 0
+        return
+    if model_lc == "nemotron_h":
+        embed_dim = int(config.get("embed_dim", 0) or 0)
+        num_heads = int(config.get("num_heads", config.get("num_attention_heads", 1)) or 1)
+        num_kv_heads = int(config.get("num_kv_heads", config.get("num_key_value_heads", num_heads)) or num_heads)
+        head_dim = int(config.get("head_dim", 0) or 0)
+        q_dim = int(config.get("attn_out_dim", num_heads * head_dim) or (num_heads * head_dim))
+        k_dim = int(num_kv_heads * head_dim)
+        v_dim = int(num_kv_heads * head_dim)
+        rotary_dim = int(config.get("rotary_dim", head_dim) or head_dim)
+        rope_freq_base = float(config.get("rope_freq_base", config.get("rope_theta", 10000.0)) or 10000.0)
+        if op_name == "q_proj":
+            params["_output_dim"] = q_dim
+            params["_input_dim"] = embed_dim
+            params["output_dim"] = q_dim
+        elif op_name == "k_proj":
+            params["_output_dim"] = k_dim
+            params["_input_dim"] = embed_dim
+            params["output_dim"] = k_dim
+        elif op_name == "v_proj":
+            params["_output_dim"] = v_dim
+            params["_input_dim"] = embed_dim
+            params["output_dim"] = v_dim
+        elif op_name == "out_proj":
+            params["_output_dim"] = embed_dim
+            params["_input_dim"] = q_dim
+            params["input_dim"] = q_dim
+        elif op_name == "quantize_out_proj_input":
+            params["_output_dim"] = q_dim
+            params["_input_dim"] = q_dim
+            params["input_dim"] = q_dim
+        elif op_name in ("qk_norm", "rope_qk", "kv_cache_store", "attn", "attn_sliding"):
+            params["head_dim"] = head_dim
+            params["q_head_dim"] = head_dim
+            params["k_head_dim"] = head_dim
+            params["v_head_dim"] = head_dim
+            params["q_dim"] = q_dim
+            params["k_dim"] = k_dim
+            params["v_dim"] = v_dim
+            params["rotary_dim"] = rotary_dim
+            params["n_dims"] = rotary_dim
+            params["rope_freq_base"] = rope_freq_base
+            params["use_rope_freq_factors"] = int(config.get("use_rope_freq_factors", 0) or 0)
         return
     if model_lc != "gemma4":
         return
@@ -3008,29 +3182,72 @@ def _normalize_manifest_config(config: Dict) -> Dict:
     if q_gate_proj_dim is not None:
         out["q_gate_proj_dim"] = int(q_gate_proj_dim)
     ssm_state = _pick("ssm_state_size")
-    ssm_groups = _pick("ssm_group_count")
-    ssm_heads = _pick("ssm_time_step_rank")
+    ssm_groups = _pick("ssm_group_count", "n_groups")
+    ssm_heads = _pick("ssm_time_step_rank", "mamba_num_heads")
     ssm_inner = _pick("ssm_inner_size")
-    ssm_conv_kernel = _pick("ssm_conv_kernel")
+    mamba_head_dim_value = _pick("mamba_head_dim")
+    model_kind_for_ssm = str(out.get("model_type") or out.get("arch") or "").lower()
+    if ssm_inner is None and model_kind_for_ssm == "nemotron_h" and ssm_heads is not None and mamba_head_dim_value is not None:
+        ssm_inner = int(ssm_heads) * int(mamba_head_dim_value)
+    ssm_conv_kernel = _pick("ssm_conv_kernel", "conv_kernel")
     if ssm_state is not None:
         out["ssm_state_size"] = int(ssm_state)
     if ssm_groups is not None:
         out["ssm_group_count"] = int(ssm_groups)
     if ssm_heads is not None:
         out["ssm_time_step_rank"] = int(ssm_heads)
+        if model_kind_for_ssm == "nemotron_h":
+            out["mamba_num_heads"] = int(ssm_heads)
+    if mamba_head_dim_value is not None:
+        out["mamba_head_dim"] = int(mamba_head_dim_value)
     if ssm_inner is not None:
         out["ssm_inner_size"] = int(ssm_inner)
     if ssm_conv_kernel is not None:
         out["ssm_conv_kernel"] = int(ssm_conv_kernel)
-        out["ssm_conv_history"] = max(int(ssm_conv_kernel) - 1, 0)
+        out["ssm_conv_history"] = max(int(ssm_conv_kernel), 0) if model_kind_for_ssm == "nemotron_h" else max(int(ssm_conv_kernel) - 1, 0)
     if None not in (ssm_state, ssm_groups, ssm_heads, ssm_inner):
-        q_dim = int(ssm_state) * int(ssm_groups)
-        v_dim = int(ssm_inner)
-        out["q_dim"] = q_dim
-        out["k_dim"] = q_dim
-        out["v_dim"] = v_dim
-        out["gate_dim"] = int(ssm_heads)
-        out["ssm_conv_channels"] = q_dim + q_dim + v_dim
+        model_kind = str(out.get("model_type") or out.get("arch") or "").lower()
+        if model_kind == "nemotron_h":
+            # Runtime dt clamp follows time_step_limit. time_step_min/max are
+            # initialization ranges and must not clamp forward activations.
+            # Use (0, 0) to disable the CK clamp for PyTorch's default (0, inf).
+            limit = out.get("time_step_limit")
+            if isinstance(limit, (list, tuple)) and len(limit) >= 2:
+                dt_lo = float(limit[0] or 0.0)
+                try:
+                    dt_hi = float(limit[1])
+                except Exception:
+                    dt_hi = float("inf")
+                if dt_hi == float("inf"):
+                    dt_lo, dt_hi = 0.0, 0.0
+            else:
+                dt_lo, dt_hi = 0.0, 0.0
+            out["mamba_dt_min"] = dt_lo
+            out["mamba_dt_max"] = dt_hi
+            if int(ssm_groups) > 0:
+                out["mamba_norm_group_size"] = int(ssm_inner) // int(ssm_groups)
+            v_dim = int(ssm_inner)
+            q_dim = int(ssm_state) * int(ssm_groups)
+            conv_dim = v_dim + q_dim + q_dim
+            out["q_dim"] = q_dim
+            out["k_dim"] = q_dim
+            out["v_dim"] = v_dim
+            out["gate_dim"] = v_dim
+            out["mamba_intermediate_size"] = v_dim
+            out["mamba_conv_dim"] = conv_dim
+            out["mamba_projection_size"] = v_dim + conv_dim + int(ssm_heads)
+            out["ssm_conv_channels"] = conv_dim
+            out.setdefault("ssm_conv_history", max(int(out.get("ssm_conv_kernel", 0) or 0), 0))
+            out.setdefault("rope_freq_base", float(out.get("rope_theta", 10000.0) or 10000.0))
+            out.setdefault("use_rope_freq_factors", 0)
+        else:
+            q_dim = int(ssm_state) * int(ssm_groups)
+            v_dim = int(ssm_inner)
+            out["q_dim"] = q_dim
+            out["k_dim"] = q_dim
+            out["v_dim"] = v_dim
+            out["gate_dim"] = int(ssm_heads)
+            out["ssm_conv_channels"] = q_dim + q_dim + v_dim
         out["recurrent_num_heads"] = int(ssm_heads)
         out["recurrent_head_dim"] = int(v_dim // int(ssm_heads)) if int(ssm_heads) else int(ssm_state)
     attn_out = _pick("attn_out_dim", default=(out.get("num_heads", 0) * out.get("head_dim", 0)))
@@ -4191,7 +4408,9 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         if not kernel_id:
             return None
         act = kernel_act_dtype.get(kernel_id, "fp32")
-        if op_type in ("q_proj", "q_gate_proj", "k_proj", "v_proj", "qkv_packed_proj", "mlp_gate_up", "mlp_up", "projector_fc1"):
+        if op_type in ("q_proj", "q_gate_proj", "k_proj", "v_proj", "qkv_packed_proj", "mlp_gate_up", "mlp_up"):
+            return {"x": "layer_input" if act == "fp32" else "main_stream_q8"}
+        if op_type == "projector_fc1":
             return {"x": "main_stream" if act == "fp32" else "main_stream_q8"}
         if op_type == "out_proj":
             return {"x": "attn_scratch" if act == "fp32" else "main_stream_q8"}
@@ -4201,9 +4420,9 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             return {"x": "branch_normed" if act == "fp32" else "branch_normed"}
         if op_type == "branch_fc2":
             return {"x": "branch_mlp" if act == "fp32" else "branch_mlp"}
-        if op_type == "recurrent_gate_proj":
+        if op_type in ("recurrent_qkv_proj", "recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj", "mamba_in_proj"):
             return {"x": "main_stream" if act == "fp32" else "main_stream_q8"}
-        if op_type == "recurrent_out_proj":
+        if op_type in ("recurrent_out_proj", "mamba_out_proj"):
             return {"x": "recurrent_normed" if act == "fp32" else "main_stream_q8"}
         if op_type == "mlp_down":
             return {"x": "mlp_scratch" if act == "fp32" else "main_stream_q8"}
@@ -4270,6 +4489,17 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "recurrent_beta_proj": ["ssm_beta"],
         "recurrent_ssm_conv": ["ssm_conv1d"],
         "recurrent_out_proj": ["ssm_out"],
+    "mamba_in_proj": ["mamba_in_proj"],
+    "mamba_in_proj_split": [],
+    "mamba_dt_softplus": ["mamba_dt_bias"],
+    "mamba_conv1d_silu": ["mamba_conv1d", "mamba_conv1d_bias"],
+    "mamba_selective_scan": ["mamba_a", "mamba_d"],
+    "mamba_rmsnorm_gate": ["mamba_norm"],
+    "mamba_out_proj": ["mamba_out_proj"],
+    "moe_router": ["moe_router"],
+    "group_limited_topk_router": ["moe_router_bias"],
+    "moe_relu2_expert_mlp": ["moe_expert_up", "moe_expert_down"],
+    "shared_relu2_expert_mlp": ["moe_shared_up", "moe_shared_down"],
         "out_proj": ["wo"],
         "mlp_gate_up": ["w1"],
         "mlp_up": ["w3"],
@@ -4285,6 +4515,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "rmsnorm": None,  # gamma is always fp32
         "layernorm": None,  # gamma/beta are fp32
         "attn_norm": None,
+        "block_rmsnorm": None,
         "post_attention_norm": None,
         "ffn_norm": None,
         "post_ffn_norm": None,
@@ -4407,7 +4638,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         # Explicit no-weight math ops. These are real kernels, but they must not
         # flow through the header/footer weighted path below, which would invent
         # a q8_0 weight requirement and fail to bind kernels such as Gemma4 V RMSNorm.
-        if op in {"v_norm"}:
+        if op in {"v_norm", "group_limited_topk_router", "mamba_in_proj_split"}:
             kernel_id = find_kernel(
                 registry,
                 op=kernel_op,
@@ -4438,6 +4669,19 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                 if token_dtype == "bf16":
                     return ["gemma4_per_layer_prepare_bf16_forward"]
                 return ["gemma4_per_layer_prepare_forward"]
+
+            if op == "moe_relu2_expert_mlp":
+                up_dtype = str(layer_quant.get("moe_expert_up", "")).lower()
+                down_dtype = str(layer_quant.get("moe_expert_down", "")).lower()
+                if up_dtype == "q5_0" and down_dtype == "q8_0":
+                    return ["moe_relu2_expert_forward_q5_0_q8_0"]
+                if up_dtype == "q5_0" and down_dtype == "q5_0":
+                    return ["moe_relu2_expert_forward_q5_0_q5_0"]
+            if op == "shared_relu2_expert_mlp":
+                up_dtype = str(layer_quant.get("moe_shared_up", "")).lower()
+                down_dtype = str(layer_quant.get("moe_shared_down", "")).lower()
+                if up_dtype == "q5_1" and down_dtype == "q8_0":
+                    return ["moe_relu2_shared_forward_q5_1_q8_0"]
 
             # Try fused kernel first (e.g., qkv_projection)
             weight_dtype = layer_quant.get(weight_info[0], "fp32")
@@ -4798,7 +5042,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
 
                         # Check if we need to insert quantize op BEFORE out_proj or mlp_down
                         # v7 compatibility: quantize activation output before these projections
-                        if op in ("out_proj", "mlp_down", "recurrent_out_proj") and kernels:
+                        if op in ("out_proj", "mlp_down", "recurrent_out_proj", "mamba_out_proj") and kernels:
                             first_kernel = kernels[0]
                             fk_id = first_kernel[0] if isinstance(first_kernel, tuple) else first_kernel
                             if kernel_needs_q8_activation(registry, fk_id):
@@ -5056,6 +5300,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         ("layernorm", 0): ["ln1_gamma", "ln1_beta"],  # Pre-attention norm
         ("layernorm", 1): ["ln2_gamma", "ln2_beta"],  # Pre-MLP norm
         ("attn_norm", 0): ["ln1_gamma"],    # Pre-attention norm (Gemma)
+        ("block_rmsnorm", 0): ["ln1_gamma"], # Generic pre-block norm
         ("ffn_norm", 0): ["ln2_gamma"],     # Pre-MLP norm (Gemma)
         ("post_attention_norm", 0): ["post_attention_norm"],
         ("post_ffn_norm", 0): ["post_ffn_norm"],
@@ -6157,7 +6402,7 @@ def generate_ir_lower_1(
 # Maps: kernel weight ref → possible manifest entry patterns
 WEIGHT_PATTERNS = {
     # QKV projection weights and biases
-    "wq": ["layer.{L}.wq", "layers.{L}.attention.wq", "layer.{L}.attn_q_gate"],
+    "wq": ["layer.{L}.wq", "layers.{L}.attention.wq", "layer.{L}.attn_q_gate", "layer.{L}.attn_q"],
     "wk": ["layer.{L}.wk", "layers.{L}.attention.wk", "layer.{L}.attn_k"],
     "wv": ["layer.{L}.wv", "layers.{L}.attention.wv", "layer.{L}.attn_v"],
     "bq": ["layer.{L}.bq", "layers.{L}.attention.bq"],
@@ -6179,20 +6424,34 @@ WEIGHT_PATTERNS = {
     "ssm_a": ["layer.{L}.ssm_a"],
     "ssm_norm": ["layer.{L}.ssm_norm"],
     "ssm_out": ["layer.{L}.ssm_out"],
+    "mamba_in_proj": ["layer.{L}.mamba_in_proj"],
+    "mamba_conv1d": ["layer.{L}.mamba_conv1d"],
+    "mamba_conv1d_bias": ["layer.{L}.mamba_conv1d_bias"],
+    "mamba_dt_bias": ["layer.{L}.mamba_dt_bias"],
+    "mamba_a": ["layer.{L}.mamba_a"],
+    "mamba_d": ["layer.{L}.mamba_d"],
+    "mamba_norm": ["layer.{L}.mamba_norm"],
+    "mamba_out_proj": ["layer.{L}.mamba_out_proj"],
+    "moe_router": ["layer.{L}.moe_router"],
+    "moe_router_bias": ["layer.{L}.moe_router_bias"],
+    "moe_expert_up": ["layer.{L}.moe_expert_up", "layer.{L}.moe_expert.{E}.up"],
+    "moe_expert_down": ["layer.{L}.moe_expert_down", "layer.{L}.moe_expert.{E}.down"],
+    "moe_shared_up": ["layer.{L}.moe_shared_up"],
+    "moe_shared_down": ["layer.{L}.moe_shared_down"],
 
     # Output projection
-    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output"],
+    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output", "layer.{L}.attn_o"],
     "bo": ["layer.{L}.bo", "layers.{L}.attention.bo"],
 
     # MLP weights and biases
     "w1": ["layer.{L}.w1", "layers.{L}.feed_forward.w1", "layer.{L}.ffn_gate"],
-    "w2": ["layer.{L}.w2", "layers.{L}.feed_forward.w2", "layer.{L}.ffn_down"],
-    "w3": ["layer.{L}.w3", "layers.{L}.feed_forward.w3", "layer.{L}.ffn_up"],
+    "w2": ["layer.{L}.w2", "layers.{L}.feed_forward.w2", "layer.{L}.ffn_down", "layer.{L}.mlp_down"],
+    "w3": ["layer.{L}.w3", "layers.{L}.feed_forward.w3", "layer.{L}.ffn_up", "layer.{L}.mlp_up"],
     "b1": ["layer.{L}.b1", "layers.{L}.feed_forward.b1", "v.blk.{L}.ffn_up.bias"],
     "b2": ["layer.{L}.b2", "layers.{L}.feed_forward.b2", "v.blk.{L}.ffn_down.bias"],
 
     # Layer norms
-    "ln1_gamma": ["layer.{L}.ln1_gamma", "layers.{L}.attention_norm.weight", "layer.{L}.attn_norm"],
+    "ln1_gamma": ["layer.{L}.ln1_gamma", "layers.{L}.attention_norm.weight", "layer.{L}.attn_norm", "layer.{L}.block_norm"],
     "ln2_gamma": ["layer.{L}.ln2_gamma", "layers.{L}.ffn_norm.weight", "layer.{L}.post_attention_norm"],
     "ln1_beta": ["layer.{L}.ln1_beta", "layers.{L}.attention_norm.bias", "v.blk.{L}.ln1.bias"],
     "ln2_beta": ["layer.{L}.ln2_beta", "layers.{L}.ffn_norm.bias", "v.blk.{L}.ln2.bias"],
@@ -6243,15 +6502,15 @@ WEIGHT_PATTERNS = {
     "mm1_w": ["mm.2.weight"],
     "mm1_b": ["mm.2.bias"],
     "attn_qkv": ["layer.{L}.attn_qkv", "layer.{L}.attn_qkv.weight", "v.blk.{L}.attn_qkv.weight"],
-    "ln1_gamma": ["layer.{L}.ln1_gamma", "layers.{L}.attention_norm.weight", "layer.{L}.attn_norm", "v.blk.{L}.ln1.weight"],
+    "ln1_gamma": ["layer.{L}.ln1_gamma", "layers.{L}.attention_norm.weight", "layer.{L}.attn_norm", "layer.{L}.block_norm", "v.blk.{L}.ln1.weight"],
     "ln2_gamma": ["layer.{L}.ln2_gamma", "layers.{L}.ffn_norm.weight", "layer.{L}.post_attention_norm", "v.blk.{L}.ln2.weight"],
     "ln1_beta": ["layer.{L}.ln1_beta", "layers.{L}.attention_norm.bias", "v.blk.{L}.ln1.bias"],
     "ln2_beta": ["layer.{L}.ln2_beta", "layers.{L}.ffn_norm.bias", "v.blk.{L}.ln2.bias"],
-    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output", "v.blk.{L}.attn_out.weight"],
+    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output", "layer.{L}.attn_o", "v.blk.{L}.attn_out.weight"],
     "bo": ["layer.{L}.bo", "layers.{L}.attention.bo", "v.blk.{L}.attn_out.bias"],
     "w1": ["layer.{L}.w1", "layers.{L}.feed_forward.w1", "layer.{L}.ffn_gate", "v.blk.{L}.ffn_gate.weight"],
-    "w2": ["layer.{L}.w2", "layers.{L}.feed_forward.w2", "layer.{L}.ffn_down", "v.blk.{L}.ffn_down.weight"],
-    "w3": ["layer.{L}.w3", "layers.{L}.feed_forward.w3", "layer.{L}.ffn_up", "v.blk.{L}.ffn_up.weight"],
+    "w2": ["layer.{L}.w2", "layers.{L}.feed_forward.w2", "layer.{L}.ffn_down", "layer.{L}.mlp_down", "v.blk.{L}.ffn_down.weight"],
+    "w3": ["layer.{L}.w3", "layers.{L}.feed_forward.w3", "layer.{L}.ffn_up", "layer.{L}.mlp_up", "v.blk.{L}.ffn_up.weight"],
     "branch_norm_gamma": ["v.deepstack.{L}.norm.weight"],
     "branch_norm_beta": ["v.deepstack.{L}.norm.bias"],
     "branch_fc1_w": ["v.deepstack.{L}.fc1.weight"],
@@ -6283,6 +6542,7 @@ TEMPLATE_OP_WEIGHTS = {
     "rmsnorm": ["ln1_gamma", "ln2_gamma", "final_ln_weight", "final_ln_bias"],
     "layernorm": ["ln1_gamma", "ln1_beta", "ln2_gamma", "ln2_beta", "final_ln_weight", "final_ln_bias"],
     "attn_norm": ["ln1_gamma"],
+    "block_rmsnorm": ["ln1_gamma"],
     "post_attention_norm": ["post_attention_norm"],
     "ffn_norm": ["ln2_gamma"],
     "post_ffn_norm": ["post_ffn_norm"],
@@ -6323,6 +6583,17 @@ TEMPLATE_OP_WEIGHTS = {
     "recurrent_core": [],
     "recurrent_norm_gate": ["ssm_norm"],
     "recurrent_out_proj": ["ssm_out"],
+    "mamba_in_proj": ["mamba_in_proj"],
+    "mamba_in_proj_split": [],
+    "mamba_dt_softplus": ["mamba_dt_bias"],
+    "mamba_conv1d_silu": ["mamba_conv1d", "mamba_conv1d_bias"],
+    "mamba_selective_scan": ["mamba_a", "mamba_d"],
+    "mamba_rmsnorm_gate": ["mamba_norm"],
+    "mamba_out_proj": ["mamba_out_proj"],
+    "moe_router": ["moe_router"],
+    "group_limited_topk_router": ["moe_router_bias"],
+    "moe_relu2_expert_mlp": ["moe_expert_up", "moe_expert_down"],
+    "shared_relu2_expert_mlp": ["moe_shared_up", "moe_shared_down"],
     "qk_norm": ["q_norm", "k_norm"],  # Per-head RMSNorm gamma weights for Q and K
     "rope_qk": [],  # No model weights (uses precomputed tables)
     "mrope_qk": [],  # No model weights (runtime positions + RoPE params)
@@ -6903,7 +7174,7 @@ def generate_memory_layout(
         recurrent_q, recurrent_k, recurrent_v, recurrent_inner,
         recurrent_gate, recurrent_conv_channels, recurrent_state_size,
     )):
-        packed_dim = max(recurrent_q + recurrent_k + recurrent_v, recurrent_inner)
+        packed_dim = max(recurrent_q + recurrent_k + recurrent_v, recurrent_inner, int(config.get("mamba_projection_size", 0) or 0))
         packed_size = seq_len * packed_dim * 4
         recurrent_inner_size = seq_len * recurrent_inner * 4
         gate_size = seq_len * recurrent_gate * 4
@@ -7600,7 +7871,7 @@ def generate_ir_lower_2(
                             "ptr_expr": f"activations + {v_buf['offset'] if v_buf else 0}",
                         }
                         last_output_buffer = "v_scratch"
-        elif op_type in ("q_proj", "q_gate_proj", "k_proj", "v_proj", "recurrent_qkv_proj", "recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj"):
+        elif op_type in ("q_proj", "q_gate_proj", "k_proj", "v_proj", "recurrent_qkv_proj", "recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj", "mamba_in_proj"):
             # ═══════════════════════════════════════════════════════════════
             # USE MEMORY PLANNER for QKV input buffer assignment
             # The memory planner knows the correct buffer (main_stream_q8)
@@ -7614,8 +7885,12 @@ def generate_ir_lower_2(
             op_id = ir_op.get("idx", ir_op.get("op_id", -1))
             kernel_id = ir_op.get("kernel", "")
 
-            # Determine the correct input buffer based on kernel's activation dtype
-            # Default to layer_input (Q8 buffer), but use embedded_input (FP32) for fp32-activation kernels
+            # Determine the correct input buffer based on kernel's activation dtype.
+            # Body projections consume the pre-norm stream. Quantized kernels read
+            # the Q8 view planned for that stream; FP32/BF16 kernels must read the
+            # physical FP32 stream. This matters for Qwen3.5 recurrent_qkv_proj:
+            # gemv_q5_k consumes FP32 activations, while layer_input is also reused
+            # as the Q8 scratch for quantize_input_0 on this layout.
             needs_q8_input = kernel_needs_q8_activation(registry, kernel_id)
             default_buf_name = "layer_input" if needs_q8_input else "embedded_input"
             default_buf = activation_buffers.get(default_buf_name)
@@ -7625,30 +7900,28 @@ def generate_ir_lower_2(
                 if input_name in ir_op.get("weights", {}):
                     continue
 
-                # Buffer selection: kernel activation dtype takes priority
-                # FP32-activation kernels (e.g., gemm_nt_q5_1) MUST read FP32 buffer,
-                # even if the memory planner assigns Q8 buffer (planner is driven by
-                # OP_DATAFLOW which hardcodes main_stream_q8 for QKV inputs).
-                if not needs_q8_input:
-                    # FP32 kernel: always use embedded_input (FP32 buffer)
-                    buf_name = default_buf_name  # "embedded_input"
-                    buf = default_buf
-                else:
-                    # Q8 kernel: use memory planner assignment
+                # Use the planner/declared dataflow slot for both Q8 and FP32/BF16
+                # paths.  Older code forced FP32 kernels back to embedded_input,
+                # bypassing block_rmsnorm for safetensors models.
+                dataflow_name = {"A": "x", "x_q8": "x", "x": "x", "input": "x"}.get(input_name, input_name)
+                planned = get_planned_buffer(op_id, "inputs", dataflow_name)
+                if not planned:
                     planned = get_planned_buffer(op_id, "inputs", input_name)
-                    if planned:
-                        planner_buf = planned.get("buffer", default_buf_name)
-                        declared_slot = _get_declared_dataflow_slot(ir_op, "inputs", input_name, input_name)
-                        buf_name = _resolve_logical_buffer_name(
-                            planner_buf,
-                            declared_slot or input_info.get("slot"),
-                            activation_buffers,
-                            buffer_name_map,
-                        )
-                        buf = activation_buffers.get(buf_name)
-                    else:
-                        buf_name = default_buf_name  # "layer_input"
-                        buf = default_buf
+                if planned:
+                    planner_buf = planned.get("buffer", default_buf_name)
+                    declared_slot = _get_declared_dataflow_slot(ir_op, "inputs", dataflow_name, input_name)
+                    buf_name = _resolve_logical_buffer_name(
+                        planner_buf,
+                        declared_slot or input_info.get("slot"),
+                        activation_buffers,
+                        buffer_name_map,
+                    )
+                    if not needs_q8_input and buf_name in ("layer_input", "main_stream_q8"):
+                        buf_name = "embedded_input"
+                    buf = activation_buffers.get(buf_name)
+                else:
+                    buf_name = default_buf_name
+                    buf = default_buf
 
                 if buf:
                     # Set dtype based on kernel's activation requirement (q8_0 for Q8 kernels, fp32 for FP32 kernels)
@@ -7708,6 +7981,7 @@ def generate_ir_lower_2(
                     "recurrent_gate_proj": "recurrent_z",
                     "recurrent_alpha_proj": "recurrent_g",
                     "recurrent_beta_proj": "recurrent_beta",
+                    "mamba_in_proj": "recurrent_packed",
                 }
                 for output_name, output_info in ir_op.get("outputs", {}).items():
                     dataflow_slot = str(output_info.get("slot", ""))
@@ -8477,7 +8751,7 @@ def generate_ir_lower_2(
             merged_tokens = int(params.get("vision_merged_tokens", 0) or 0)
             hidden_dim = int(params.get("projector_hidden_dim", 0) or 0)
             params.setdefault("gelu_elems", merged_tokens * hidden_dim)
-        if op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2", "quantize_out_proj_input", "quantize_mlp_down_input", "quantize_recurrent_out_proj_input", "quantize_final_output"):
+        if op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2", "quantize_out_proj_input", "quantize_mlp_down_input", "quantize_recurrent_out_proj_input", "quantize_mamba_out_proj_input", "quantize_final_output"):
             default_quant_rows = int(params.get("_m", params.get("seq_len", 1)) or 1)
             params.setdefault("rows", default_quant_rows)
         if op_type == "quantize_final_output":
@@ -8590,7 +8864,7 @@ def generate_ir_lower_2(
             op_type == "rope_qk" and ir_op.get("kernel", "") == "mrope_qk_vision"
         ):
             params["_m"] = int(params.get("vision_num_patches", params.get("_m", 1)) or 1)
-        if op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2", "quantize_out_proj_input", "quantize_mlp_down_input", "quantize_recurrent_out_proj_input", "quantize_final_output"):
+        if op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2", "quantize_out_proj_input", "quantize_mlp_down_input", "quantize_recurrent_out_proj_input", "quantize_mamba_out_proj_input", "quantize_final_output"):
             inferred_quant_rows = int(params.get("_m", params.get("seq_len", params.get("rows", 1))) or 1)
             if int(params.get("rows", 0) or 0) <= 1 and inferred_quant_rows > 1:
                 params["rows"] = inferred_quant_rows
@@ -8601,6 +8875,11 @@ def generate_ir_lower_2(
             )
         if op_type == "gelu":
             params["gelu_elems"] = (
+                int(params.get("_m", params.get("seq_len", 0)) or 0)
+                * int(params.get("intermediate_size", 0) or 0)
+            )
+        if op_type == "relu2":
+            params["relu2_elems"] = (
                 int(params.get("_m", params.get("seq_len", 0)) or 0)
                 * int(params.get("intermediate_size", 0) or 0)
             )
@@ -8674,10 +8953,108 @@ def validate_buffer_assignments(lowered_ir: Dict) -> None:
     """
     ops = lowered_ir.get("operations", [])
     registry = load_kernel_registry()
+    kernel_quant = {
+        k.get("id"): k.get("quant", {})
+        for k in registry.get("kernels", [])
+        if k.get("id")
+    }
+
+    body_projection_ops = {
+        "q_proj",
+        "q_gate_proj",
+        "k_proj",
+        "v_proj",
+        "qkv_packed_proj",
+        "mlp_gate_up",
+        "mlp_up",
+        "mamba_in_proj",
+        "recurrent_gate_proj",
+    }
 
     for op in ops:
         op_name = op.get("op", op.get("kernel", "unknown"))
         layer = op.get("layer", -1)
+        kernel_id = op.get("kernel", "")
+
+        # ===== WEIGHT/KERNEL DTYPE CONTRACT =====
+        # Safetensors/BUMP BF16 weights must not silently fall through to FP32
+        # matmul kernels. That produces finite output but corrupts the graph by
+        # interpreting BF16 payload bytes as FP32 values.
+        if kernel_id:
+            kernel_weight_dtype = str(kernel_quant.get(kernel_id, {}).get("weight", "")).lower()
+            for weight_name, weight_info in op.get("weights", {}).items():
+                weight_dtype = str(weight_info.get("dtype", "")).lower()
+                if weight_dtype == "bf16" and kernel_weight_dtype != "bf16":
+                    raise RuntimeError(
+                        f"\n❌ HARD FAULT: Weight/kernel dtype mismatch\n"
+                        f"   op={op_name} layer={layer} kernel={kernel_id}\n"
+                        f"   weight={weight_name} dtype=bf16\n"
+                        f"   kernel weight dtype: {kernel_weight_dtype or '<missing>'}\n"
+                        f"   Fix: ensure quant_summary aliases select BF16 kernels for safetensors/BUMP weights\n"
+                    )
+
+        # ===== BODY PROJECTION INPUT STREAM =====
+        # Projections inside a transformer/recurrent block consume the normalized
+        # layer stream. They must not read the raw token embedding stream.
+        if op_name in body_projection_ops and str(op.get("expects_layer_input", "")).lower() in ("1", "true", "yes"):
+            activations = op.get("activations", {})
+            x_in = (
+                activations.get("x")
+                or activations.get("A")
+                or activations.get("x_q8")
+                or activations.get("input")
+            )
+            if x_in:
+                x_buf = x_in.get("buffer", "")
+                if x_buf != "layer_input":
+                    raise RuntimeError(
+                        f"\n❌ HARD FAULT: Invalid body projection input\n"
+                        f"   op={op_name} layer={layer} kernel={kernel_id}\n"
+                        f"   expected input: layer_input (post-norm stream)\n"
+                        f"   got: {x_buf}\n"
+                        f"   Fix: projection dataflow/lowering must preserve block norm output\n"
+                    )
+
+        # ===== MLP ACTIVATION SCRATCH CONTRACT =====
+        if op_name in ("relu2", "silu_mul", "geglu", "gelu"):
+            activations = op.get("activations", {})
+            outputs = op.get("outputs", {})
+            x_in = activations.get("x") or activations.get("input") or activations.get("a")
+            out = outputs.get("out") or outputs.get("y")
+            if x_in and x_in.get("buffer", "") != "mlp_scratch":
+                raise RuntimeError(
+                    f"\n❌ HARD FAULT: Invalid MLP activation input\n"
+                    f"   op={op_name} layer={layer}\n"
+                    f"   expected input: mlp_scratch\n"
+                    f"   got: {x_in.get('buffer', '')}\n"
+                )
+            if out and out.get("buffer", "") != "mlp_scratch":
+                raise RuntimeError(
+                    f"\n❌ HARD FAULT: Invalid MLP activation output\n"
+                    f"   op={op_name} layer={layer}\n"
+                    f"   expected output: mlp_scratch\n"
+                    f"   got: {out.get('buffer', '')}\n"
+                )
+
+        # Only enforce the scratch contract on lowered MLP-down kernels that
+        # are explicitly part of the activation/MoE scratch path. Existing
+        # transformer decode families can lower quantized mlp_down directly
+        # from the layer stream, and the v8 family regression suite relies on
+        # that contract for Qwen/Gemma/Nanbeige.
+        if op_name == "mlp_down" and (
+            "relu2" in str(kernel_id).lower()
+            or "moe" in str(kernel_id).lower()
+            or str(op.get("expects_mlp_scratch", "")).lower() in ("1", "true", "yes")
+        ):
+            activations = op.get("activations", {})
+            x_in = activations.get("x") or activations.get("A") or activations.get("x_q8")
+            if x_in and x_in.get("buffer", "") != "mlp_scratch":
+                raise RuntimeError(
+                    f"\n❌ HARD FAULT: Invalid MLP down input\n"
+                    f"   op={op_name} layer={layer} kernel={kernel_id}\n"
+                    f"   expected input: mlp_scratch\n"
+                    f"   got: {x_in.get('buffer', '')}\n"
+                )
 
         # ===== ATTENTION OPERATIONS =====
         if op_name in ("attn", "attention", "attn_sliding"):

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -1297,7 +1297,7 @@ def emit_op(
                 f"{1 if force_mlp_gate_up_q8_contract else 0});"
             )
             lines.append(f"    if ({q8_contract_name} && ck_debug_mlp_gate_up_fp32_input != NULL) {{")
-            lines.append(f"    quantize_row_q8_k(ck_debug_mlp_gate_up_fp32_input, {x_expr}, {k_expr});")
+            lines.append(f"    quantize_row_q8_k(ck_debug_mlp_gate_up_fp32_input, (void*)({x_expr}), {k_expr});")
             lines.append(f"    {function}(")
             lines.append(f"        {gate_y_expr},")
             lines.append(f"        {gate_w_expr},")
@@ -1562,6 +1562,26 @@ def emit_op(
         if out_expr:
             lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_down", (const float*){out_expr}, EMBED_DIM);')
             _emit_hidden_export_last_row(out_expr, "mlp_down", "EMBED_DIM")
+    elif op_name == "mamba_in_proj":
+        _emit_hidden_export(
+            _hidden_arg("output", "out", "c", "y"),
+            "mamba_in_proj",
+            _hidden_count("m", "M", "rows", "out_dim", default="0"),
+        )
+    elif op_name == "mamba_in_proj_split":
+        _emit_hidden_export(_hidden_arg("gate", "z"), "mamba_gate", _hidden_count("intermediate_dim", "inner_dim", default="INTERMEDIATE_SIZE"))
+        _emit_hidden_export(_hidden_arg("hidden_bc", "conv_qkv", "x"), "mamba_hidden_bc", _hidden_count("conv_dim", default="0"))
+        _emit_hidden_export(_hidden_arg("dt"), "mamba_dt_raw", _hidden_count("num_heads", default="0"))
+    elif op_name == "mamba_conv1d_silu":
+        _emit_hidden_export(_hidden_arg("conv_out", "out", "y"), "mamba_conv", _hidden_count("conv_dim", default="0"))
+    elif op_name == "mamba_dt_softplus":
+        _emit_hidden_export(_hidden_arg("dt_out", "out", "y"), "mamba_dt", _hidden_count("num_heads", default="0"))
+    elif op_name == "mamba_selective_scan":
+        _emit_hidden_export(_hidden_arg("y", "out"), "mamba_scan_y", _mul_expr(_hidden_arg("num_heads") or "0", _hidden_arg("head_dim") or "0"))
+    elif op_name == "mamba_rmsnorm_gate":
+        _emit_hidden_export(_hidden_arg("out", "y"), "mamba_normed", _hidden_count("inner_dim", "intermediate_dim", default="INTERMEDIATE_SIZE"))
+    elif op_name == "mamba_out_proj":
+        _emit_hidden_export(_hidden_arg("output", "out", "c", "y"), "mamba_out_proj", "EMBED_DIM")
     elif op_name == "gemma4_per_layer_prepare":
         out_expr = _hidden_raw(_hidden_arg("output", "out", "per_layer_input", "y"))
         if out_expr:

--- a/version/v8/scripts/compare_nemotron_torch_ck_v8.py
+++ b/version/v8/scripts/compare_nemotron_torch_ck_v8.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Nemotron-H safetensors PyTorch-vs-CK first-token guardrail.
+
+This is the correctness workflow entry point after compiler/lowering guardrails:
+
+1. Tokenize a prompt, or accept explicit token ids.
+2. Run the safetensors model in PyTorch with the local CPU Nemotron shims.
+3. Run the converted CK/BUMP runtime on the same token ids.
+4. Compare final-token logits and top-k ranking.
+5. Optionally dump PyTorch hidden states for the next layer-by-layer pass.
+
+The script intentionally exits nonzero when requested semantic thresholds fail.
+That makes it useful for nightly/local guardrails while still producing a JSON
+artifact with enough evidence for the next debugging step.
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from version.v8.scripts.compare_first_token_logits_v8 import compare_logits, discover_ck_model_dir, load_ck_logits
+from version.v8.scripts.export_ck_hidden_v8 import export_ck_hidden
+from version.v8.scripts.export_nemotron_torch_hidden_v8 import (
+    _install_nemotron_cpu_shims,
+    _parse_hidden_indices,
+    _parse_tokens,
+    _tensor_stats,
+)
+
+
+def _finite_stats(x: np.ndarray) -> dict[str, Any]:
+    finite = np.isfinite(x)
+    return {
+        "size": int(x.size),
+        "finite": int(finite.sum()),
+        "nan": int(np.isnan(x).sum()),
+        "inf": int(np.isinf(x).sum()),
+        "min": float(np.min(x[finite])) if finite.any() else None,
+        "max": float(np.max(x[finite])) if finite.any() else None,
+    }
+
+
+def _top_texts(tokenizer: Any, ids: list[int]) -> list[str]:
+    out: list[str] = []
+    for tok in ids:
+        try:
+            out.append(str(tokenizer.decode([int(tok)])))
+        except Exception:
+            out.append("")
+    return out
+
+
+def _top_values(logits: np.ndarray, ids: list[int]) -> list[float]:
+    return [float(logits[int(i)]) for i in ids]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--safetensors", required=True, type=Path, help="Nemotron-H safetensors directory")
+    ap.add_argument("--ck-model-dir", required=True, type=Path, help="CK run dir containing libmodel.so/weights.bump")
+    ap.add_argument("--prompt", default="Hello", help="Prompt text; ignored when --tokens is set")
+    ap.add_argument("--tokens", help="Comma-separated token ids; overrides --prompt")
+    ap.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
+    ap.add_argument("--top-k", type=int, default=16)
+    ap.add_argument("--ck-prefill-mode", default="auto", choices=("auto", "batched", "sequential", "hybrid"))
+    ap.add_argument("--require-top1-match", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--min-topk-overlap", type=float, default=0.50)
+    ap.add_argument("--max-abs-threshold", type=float, default=1.0e9)
+    ap.add_argument("--hidden-indices", default="0,1,2,5,10,20,30,40,-1")
+    ap.add_argument("--dump-dir", type=Path, help="Optional directory for PyTorch .npy dumps and CK hidden snapshots")
+    ap.add_argument("--ck-hidden-mode", choices=("decode", "prefill"), default="decode")
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+
+    _install_nemotron_cpu_shims()
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    safetensors_dir = args.safetensors.expanduser().resolve()
+    ck_model_dir = discover_ck_model_dir(args.ck_model_dir)
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
+
+    load_t0 = time.time()
+    tokenizer = AutoTokenizer.from_pretrained(safetensors_dir, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        safetensors_dir,
+        trust_remote_code=True,
+        dtype=dtype,
+        device_map=None,
+        low_cpu_mem_usage=True,
+    )
+    model.eval()
+    load_seconds = time.time() - load_t0
+
+    token_ids = _parse_tokens(args.tokens)
+    if token_ids is None:
+        encoded = tokenizer(args.prompt, return_tensors="pt")
+        input_ids = encoded["input_ids"]
+        prompt_text = args.prompt
+        token_ids = [int(x) for x in input_ids[0].tolist()]
+    else:
+        input_ids = torch.tensor([token_ids], dtype=torch.long)
+        prompt_text = tokenizer.decode(token_ids)
+
+    fwd_t0 = time.time()
+    with torch.inference_mode():
+        torch_out = model(input_ids=input_ids, use_cache=False, output_hidden_states=True, return_dict=True)
+    torch_seconds = time.time() - fwd_t0
+
+    torch_logits = torch_out.logits[0, -1].float().contiguous().cpu().numpy().astype(np.float32, copy=False)
+    ck = load_ck_logits(ck_model_dir, token_ids, ck_prefill_mode=args.ck_prefill_mode)
+    ck_logits = ck["logits"].astype(np.float32, copy=False)
+    cmp = compare_logits(ck_logits, torch_logits, int(args.top_k))
+
+    ck_ids = cmp["ck_topk_ids"]
+    torch_ids = cmp["llama_topk_ids"]
+    cmp["ck_topk_texts"] = _top_texts(tokenizer, ck_ids)
+    cmp["torch_topk_texts"] = _top_texts(tokenizer, torch_ids)
+    cmp["ck_topk_values"] = _top_values(ck_logits, ck_ids)
+    cmp["torch_topk_values"] = _top_values(torch_logits, torch_ids)
+
+    hidden_count = len(torch_out.hidden_states)
+    hidden_indices = _parse_hidden_indices(args.hidden_indices, hidden_count)
+    hidden_report: dict[str, Any] = {}
+
+    ck_hidden_dir = None
+    ck_hidden_files: list[str] = []
+    if args.dump_dir:
+        args.dump_dir.mkdir(parents=True, exist_ok=True)
+        np.save(args.dump_dir / "input_ids.npy", input_ids.cpu().numpy().astype(np.int64, copy=False))
+        np.save(args.dump_dir / "torch_logits_last.npy", torch_logits)
+        np.save(args.dump_dir / "ck_logits_last.npy", ck_logits)
+        ck_hidden_dir = args.dump_dir / "ck_hidden"
+        export_ck_hidden(
+            model_dir=ck_model_dir,
+            tokens=token_ids,
+            out_dir=ck_hidden_dir,
+            mode=args.ck_hidden_mode,
+        )
+        ck_hidden_files = [p.name for p in sorted(ck_hidden_dir.glob("*.f32"))]
+
+    for idx in hidden_indices:
+        h_last = torch_out.hidden_states[idx][0, -1].float().contiguous()
+        hidden_report[str(idx)] = _tensor_stats(h_last)
+        if args.dump_dir:
+            np.save(args.dump_dir / f"torch_hidden_{idx:03d}_last.npy", h_last.cpu().numpy().astype(np.float32, copy=False))
+
+    overlap_ok = cmp["topk_overlap_ratio"] >= float(args.min_topk_overlap)
+    top1_threshold_ok = (not bool(args.require_top1_match)) or bool(cmp["top1_match"])
+    max_abs_ok = cmp["max_abs_diff"] <= float(args.max_abs_threshold)
+    ck_finite = _finite_stats(ck_logits)
+    torch_finite = _finite_stats(torch_logits)
+    finite_ok = ck_finite["finite"] == int(ck_logits.size) and torch_finite["finite"] == int(torch_logits.size)
+    semantic_top1_match = bool(cmp["top1_match"])
+    semantic_topk_overlap_ok = cmp["topk_overlap_ratio"] >= 0.50
+    passed = bool(top1_threshold_ok and overlap_ok and max_abs_ok and finite_ok)
+    next_step = (
+        "top logits match; proceed to longer prompts"
+        if semantic_top1_match and semantic_topk_overlap_ok
+        else "run layer/op hidden parity around the first mismatching boundary"
+    )
+
+    report: dict[str, Any] = {
+        "status": "pass" if passed else "fail",
+        "pass": passed,
+        "safetensors": str(safetensors_dir),
+        "ck_model_dir": str(ck_model_dir),
+        "dtype": args.dtype,
+        "prompt": prompt_text,
+        "input_ids": [int(x) for x in token_ids],
+        "timing": {
+            "torch_load_seconds": load_seconds,
+            "torch_forward_seconds": torch_seconds,
+        },
+        "thresholds": {
+            "require_top1_match": bool(args.require_top1_match),
+            "min_topk_overlap": float(args.min_topk_overlap),
+            "max_abs_threshold": float(args.max_abs_threshold),
+        },
+        "ck": {
+            "vocab": int(ck["vocab"]),
+            "active_tokens": int(ck["active_tokens"]),
+            "logits_stride": int(ck["stride"]),
+            "prefill_policy": str(ck.get("prefill_policy", "")),
+            "contract_prefill_policy": str(ck.get("contract_prefill_policy", "")),
+            "finite": ck_finite,
+        },
+        "torch": {
+            "logits_shape": [int(x) for x in torch_out.logits.shape],
+            "hidden_count": int(hidden_count),
+            "finite": torch_finite,
+        },
+        "compare": cmp,
+        "semantic": {
+            "top1_match": semantic_top1_match,
+            "topk_overlap_ok": semantic_topk_overlap_ok,
+            "topk_overlap_ratio": float(cmp["topk_overlap_ratio"]),
+        },
+        "threshold_result": {
+            "top1_threshold_ok": bool(top1_threshold_ok),
+            "overlap_threshold_ok": bool(overlap_ok),
+            "max_abs_threshold_ok": bool(max_abs_ok),
+            "finite_ok": bool(finite_ok),
+        },
+        "torch_hidden": hidden_report,
+        "dump_artifacts": {
+            "dump_dir": str(args.dump_dir) if args.dump_dir else None,
+            "ck_hidden_dir": str(ck_hidden_dir) if ck_hidden_dir else None,
+            "ck_hidden_file_count": int(len(ck_hidden_files)),
+            "ck_hidden_files_sample": ck_hidden_files[:20],
+        },
+        "next_step": next_step,
+    }
+
+    text = json.dumps(report, indent=2, sort_keys=True)
+    print(text)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text + "\n", encoding="utf-8")
+    return 0 if passed else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -124,6 +124,7 @@ EXT_METADATA_SIZE = 24                               # Extended metadata block (
 DATA_START = HEADER_SIZE + EXT_METADATA_SIZE         # = 152, where dtype_table begins
 
 CACHE_ALIGN = 64
+GGUF_CK_MAP_PATH = SCRIPT_DIR.parent / "model_maps" / "gguf_ck_map.json"
 
 # BUMP format versions
 BUMP_VERSION_V4 = 4
@@ -145,6 +146,62 @@ CK_DT_Q8_K = 10
 CK_DT_Q5_0 = 11
 CK_DT_Q5_1 = 12
 CK_DT_Q5_K = 13
+
+_GGUF_CK_MAP_CACHE: Optional[Dict[str, Any]] = None
+
+
+def load_gguf_ck_map() -> Dict[str, Any]:
+    """Load declarative GGUF model-name to CK-contract mappings.
+
+    This map is intentionally separate from kernel_maps: kernel_maps bind CK ops
+    to C functions, while this file binds external model artifact names to CK
+    logical tensor/config names.
+    """
+    global _GGUF_CK_MAP_CACHE
+    if _GGUF_CK_MAP_CACHE is not None:
+        return _GGUF_CK_MAP_CACHE
+    if not GGUF_CK_MAP_PATH.exists():
+        _GGUF_CK_MAP_CACHE = {"version": 0, "architectures": {}}
+        return _GGUF_CK_MAP_CACHE
+    with open(GGUF_CK_MAP_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise GGUFError(f"{GGUF_CK_MAP_PATH}: expected JSON object")
+    arch_map = data.get("architectures")
+    if arch_map is None:
+        data["architectures"] = {}
+    elif not isinstance(arch_map, dict):
+        raise GGUFError(f"{GGUF_CK_MAP_PATH}: 'architectures' must be an object")
+    _GGUF_CK_MAP_CACHE = data
+    return data
+
+
+def gguf_ck_arch_contract(arch: str) -> Dict[str, Any]:
+    arch_name = str(arch or "").lower()
+    contracts = load_gguf_ck_map().get("architectures") or {}
+    contract = contracts.get(arch_name, {})
+    return contract if isinstance(contract, dict) else {}
+
+
+def gguf_ck_template_arch(arch: str) -> str:
+    contract = gguf_ck_arch_contract(arch)
+    template = contract.get("template")
+    return str(template).lower() if template else str(arch).lower()
+
+
+def gguf_ck_layer_kind_from_map(arch: Optional[str], suffixes: set[str]) -> Optional[str]:
+    if not arch:
+        return None
+    layer_kinds = gguf_ck_arch_contract(arch).get("layer_kinds") or {}
+    if not isinstance(layer_kinds, dict):
+        return None
+    for kind, spec in layer_kinds.items():
+        if not isinstance(spec, dict):
+            continue
+        required = spec.get("required_suffixes") or []
+        if required and set(str(s) for s in required).issubset(suffixes):
+            return str(kind)
+    return None
 
 
 def align_up(n: int, a: int) -> int:
@@ -286,7 +343,7 @@ def _inject_runtime_config_defaults(config: dict, arch: str) -> dict:
         config.setdefault("prefer_q8_0_contract", True)
         _merge_activation_defaults(
             {
-                "recurrent_gate_proj": "fp32",
+                "recurrent_gate_proj": "q8_k",
                 "recurrent_alpha_proj": "q8_0",
                 "recurrent_beta_proj": "q8_0",
             }
@@ -306,10 +363,10 @@ def _inject_runtime_config_defaults(config: dict, arch: str) -> dict:
 
 
 def load_template_for_arch(arch: str) -> dict:
-    # Intentional contract: template selection is strict (arch -> templates/<arch>.json).
-    # We do not alias or guess here; supported models are explicit via templates.
-    # By design: unknown arch MUST fail so new families get their own templates.
-    template_name = str(arch).lower()
+    # Intentional contract: template selection is explicit. Most architectures use
+    # templates/<arch>.json directly; GGUF aliases must be declared in
+    # model_maps/gguf_ck_map.json rather than guessed in Python conditionals.
+    template_name = gguf_ck_template_arch(arch)
     base_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "templates"))
     template_path = os.path.join(base_dir, f"{template_name}.json")
     if not os.path.exists(template_path):
@@ -881,10 +938,14 @@ def _layer_tensor_suffixes(tensors: Dict[str, "TensorInfo"], layer: int) -> set[
     }
 
 
-def classify_layer_contract(tensors: Dict[str, "TensorInfo"], layer: int) -> str:
+def classify_layer_contract(tensors: Dict[str, "TensorInfo"], layer: int, arch: Optional[str] = None) -> str:
     names = _layer_tensor_suffixes(tensors, layer)
     if not names:
         return "missing"
+
+    mapped_kind = gguf_ck_layer_kind_from_map(arch, names)
+    if mapped_kind:
+        return f"mapped_{mapped_kind}"
 
     recurrent_qwen35 = {
         "attn_qkv.weight",
@@ -946,9 +1007,16 @@ def classify_layer_contract(tensors: Dict[str, "TensorInfo"], layer: int) -> str
 
 def describe_layer_contract(tensors: Dict[str, "TensorInfo"], layer: int, arch: Optional[str] = None) -> Optional[str]:
     names = _layer_tensor_suffixes(tensors, layer)
-    kind = classify_layer_contract(tensors, layer)
+    kind = classify_layer_contract(tensors, layer, arch=arch)
     arch_name = (arch or "").lower()
 
+    if kind.startswith("mapped_"):
+        mapped = kind[len("mapped_"):]
+        return (
+            f"Layer {layer}: GGUF map classifies this layer as '{mapped}' for arch '{arch_name}'. "
+            "The model contract is recognized, but converter/IR lowering for this mapped layer kind "
+            "is not fully implemented yet."
+        )
     if kind == "qwen35_recurrent_hybrid":
         return (
             f"Layer {layer}: found a qwen35 recurrent hybrid block "
@@ -2195,6 +2263,34 @@ def main() -> None:
         "qwen35.ssm.time_step_rank",
         "qwen35.ssm.inner_size",
         "qwen35.full_attention_interval",
+        # Nemotron-H MoE/Mamba hybrid keys
+        "nemotron_h_moe.block_count",
+        "nemotron_h_moe.context_length",
+        "nemotron_h_moe.embedding_length",
+        "nemotron_h_moe.feed_forward_length",
+        "nemotron_h_moe.vocab_size",
+        "nemotron_h_moe.attention.head_count",
+        "nemotron_h_moe.attention.head_count_kv",
+        "nemotron_h_moe.attention.key_length",
+        "nemotron_h_moe.attention.value_length",
+        "nemotron_h_moe.attention.layer_norm_rms_epsilon",
+        "nemotron_h_moe.attention.layer_norm_epsilon",
+        "nemotron_h_moe.rope.freq_base",
+        "nemotron_h_moe.rope.dimension_count",
+        "nemotron_h_moe.ssm.conv_kernel",
+        "nemotron_h_moe.ssm.state_size",
+        "nemotron_h_moe.ssm.group_count",
+        "nemotron_h_moe.ssm.inner_size",
+        "nemotron_h_moe.ssm.time_step_rank",
+        "nemotron_h_moe.expert_count",
+        "nemotron_h_moe.expert_used_count",
+        "nemotron_h_moe.expert_group_count",
+        "nemotron_h_moe.expert_group_used_count",
+        "nemotron_h_moe.expert_feed_forward_length",
+        "nemotron_h_moe.expert_shared_feed_forward_length",
+        "nemotron_h_moe.expert_shared_count",
+        "nemotron_h_moe.expert_weights_norm",
+        "nemotron_h_moe.expert_weights_scale",
         # Gemma3-style keys
         "gemma3.block_count",
         "gemma3.context_length",
@@ -2248,6 +2344,7 @@ def main() -> None:
         "qwen2.tie_word_embeddings",
         "qwen3.tie_word_embeddings",
         "qwen3vl.tie_word_embeddings",
+        "nemotron_h_moe.tie_word_embeddings",
         "gemma3.tie_word_embeddings",
         "mistral.tie_word_embeddings",
         "mistral3.tie_word_embeddings",
@@ -2258,6 +2355,7 @@ def main() -> None:
         "qwen2.embedding_weight_tying",
         "qwen3.embedding_weight_tying",
         "qwen3vl.embedding_weight_tying",
+        "nemotron_h_moe.embedding_weight_tying",
         "gemma3.embedding_weight_tying",
         "gemma4.tie_word_embeddings",
         "gemma4.embedding_weight_tying",
@@ -2488,6 +2586,19 @@ def main() -> None:
                         return int(v)
                     if isinstance(v, (int, np.integer)):
                         return int(v)
+            return None
+
+        def meta_int_or_list(*keys: str):
+            """Get integer or integer list from metadata, trying multiple keys in order."""
+            for key in keys:
+                v = meta.get(key)
+                if v is not None:
+                    if isinstance(v, bool):
+                        return int(v)
+                    if isinstance(v, (int, np.integer)):
+                        return int(v)
+                    if isinstance(v, list):
+                        return [int(x) for x in v]
             return None
 
         def meta_float(*keys: str) -> Optional[float]:
@@ -3082,7 +3193,7 @@ def main() -> None:
 
         num_layers = meta_int(
             "deepseek2.block_count", "mistral3.block_count", "mistral.block_count",
-            "llama.block_count", "qwen35.block_count", "qwen3vl.block_count", "qwen3.block_count", "qwen2.block_count",
+            "llama.block_count", "qwen35.block_count", "nemotron_h_moe.block_count", "qwen3vl.block_count", "qwen3.block_count", "qwen2.block_count",
             "gemma3.block_count", "gemma4.block_count"
         )
         if num_layers is None:
@@ -3098,11 +3209,14 @@ def main() -> None:
                 raise GGUFError("Could not infer num_layers (missing block_count and no blk.* tensors found)")
             num_layers = max(layer_ids) + 1
 
-        intermediate = meta_int(
+        intermediate = meta_int_or_list(
             "deepseek2.feed_forward_length", "mistral3.feed_forward_length", "mistral.feed_forward_length",
-            "llama.feed_forward_length", "qwen35.feed_forward_length", "qwen3vl.feed_forward_length", "qwen3.feed_forward_length", "qwen2.feed_forward_length",
+            "llama.feed_forward_length", "qwen35.feed_forward_length", "nemotron_h_moe.feed_forward_length", "qwen3vl.feed_forward_length", "qwen3.feed_forward_length", "qwen2.feed_forward_length",
             "gemma3.feed_forward_length", "gemma4.feed_forward_length"
         )
+        if isinstance(intermediate, list):
+            nz_intermediate = [int(x) for x in intermediate if int(x) > 0]
+            intermediate = max(nz_intermediate) if nz_intermediate else None
         if intermediate is None:
             gate0 = tensors.get("blk.0.ffn_gate.weight")
             if gate0 and len(gate0.dims) == 2:
@@ -3112,20 +3226,21 @@ def main() -> None:
 
         num_heads = meta_int(
             "deepseek2.attention.head_count", "mistral3.attention.head_count", "mistral.attention.head_count",
-            "llama.attention.head_count", "qwen35.attention.head_count", "qwen3vl.attention.head_count", "qwen3.attention.head_count", "qwen2.attention.head_count",
+            "llama.attention.head_count", "qwen35.attention.head_count", "nemotron_h_moe.attention.head_count", "qwen3vl.attention.head_count", "qwen3.attention.head_count", "qwen2.attention.head_count",
             "gemma3.attention.head_count", "gemma4.attention.head_count"
         )
         if num_heads is None:
             raise GGUFError("Missing attention.head_count (num_heads)")
-        num_kv_heads = meta_int(
+        num_kv_heads_meta = meta_int(
             "deepseek2.attention.head_count_kv", "mistral3.attention.head_count_kv", "mistral.attention.head_count_kv",
-            "llama.attention.head_count_kv", "qwen35.attention.head_count_kv", "qwen3vl.attention.head_count_kv", "qwen3.attention.head_count_kv", "qwen2.attention.head_count_kv",
+            "llama.attention.head_count_kv", "qwen35.attention.head_count_kv", "nemotron_h_moe.attention.head_count_kv", "qwen3vl.attention.head_count_kv", "qwen3.attention.head_count_kv", "qwen2.attention.head_count_kv",
             "gemma3.attention.head_count_kv", "gemma4.attention.head_count_kv"
-        ) or num_heads
+        )
+        num_kv_heads = num_kv_heads_meta if num_kv_heads_meta and num_kv_heads_meta > 0 else 0
 
         context_len = meta_int(
             "deepseek2.context_length", "mistral3.context_length", "mistral.context_length",
-            "llama.context_length", "qwen35.context_length", "qwen3vl.context_length", "qwen3.context_length", "qwen2.context_length",
+            "llama.context_length", "qwen35.context_length", "nemotron_h_moe.context_length", "qwen3vl.context_length", "qwen3.context_length", "qwen2.context_length",
             "gemma3.context_length", "gemma4.context_length"
         ) or 0
         if args.context is not None:
@@ -3152,6 +3267,7 @@ def main() -> None:
         # Q/K/V head dimensions (some models report explicit key/value lengths)
         key_length_meta = meta_int(
             "qwen35.attention.key_length",
+            "nemotron_h_moe.attention.key_length",
             "qwen3vl.attention.key_length",
             "qwen3.attention.key_length",
             "gemma3.attention.key_length",
@@ -3160,6 +3276,7 @@ def main() -> None:
         )
         value_length_meta = meta_int(
             "qwen35.attention.value_length",
+            "nemotron_h_moe.attention.value_length",
             "qwen3vl.attention.value_length",
             "qwen3.attention.value_length",
             "gemma3.attention.value_length",
@@ -3171,6 +3288,7 @@ def main() -> None:
         # Resolve after head_dim is known.
         rotary_dim_meta = meta_int(
             "qwen35.rope.dimension_count",
+            "nemotron_h_moe.rope.dimension_count",
             "llama.rope.dim",
             "attention.rotary_dim",
             "qwen2.rotary_dim",
@@ -3346,35 +3464,45 @@ def main() -> None:
             print(f"Warning: rotary_dim {rotary_dim} is odd, decrementing to make even")
             rotary_dim -= 1
 
-        # Infer correct dimensions from actual tensors if metadata doesn't match
-        # This handles non-standard architectures like Qwen3/Devstral
-        wq0 = tensors.get("blk.0.attn_q.weight")
-        wk0 = tensors.get("blk.0.attn_k.weight")
-        wo0 = tensors.get("blk.0.attn_output.weight")
-        if wq0 and wk0 and wo0:
-            # Check if actual dimensions match expected
-            q_dim1 = wq0.ne1
-            k_dim1 = wk0.ne1
-            o_dim0 = wo0.ne0
+        # Infer correct dimensions from the first actual attention tensors if metadata
+        # is missing or inconsistent. Hybrid models such as Nemotron can start with
+        # Mamba layers, so blk.0 is not necessarily an attention block.
+        wq0 = wk0 = wv0 = wo0 = None
+        for _layer in range(num_layers):
+            wq0 = tensors.get(f"blk.{_layer}.attn_q.weight")
+            wk0 = tensors.get(f"blk.{_layer}.attn_k.weight")
+            wv0 = tensors.get(f"blk.{_layer}.attn_v.weight")
+            wo0 = tensors.get(f"blk.{_layer}.attn_output.weight")
+            if wq0 and wk0 and wv0 and wo0:
+                break
+        else:
+            wq0 = wk0 = wv0 = wo0 = None
 
-            if q_dim1 != embed_dim or k_dim1 != embed_kv:
-                # Infer from actual tensor shapes
-                # Infer head dimensions
-                inferred_q_head_dim = q_dim1 // num_heads if q_dim1 % num_heads == 0 else q_dim1
-                # Update for consistency with actual tensors
-                embed_kv = k_dim1
+        embed_kv = int(num_kv_heads or 0) * int(head_dim)
+        if wq0 and wk0 and wo0:
+            q_dim1 = int(wq0.ne1)
+            k_dim1 = int(wk0.ne1)
+            if key_length_meta is None and q_dim1 > 0 and q_dim1 % int(num_heads) == 0:
+                inferred_q_head_dim = q_dim1 // int(num_heads)
                 head_dim = inferred_q_head_dim
-                # If rotary_dim was not explicitly provided, recompute from updated head_dim
                 if rotary_dim_meta is None:
                     rotary_dim = head_dim
+            if (not num_kv_heads or int(num_kv_heads) <= 0) and k_dim1 > 0 and int(head_dim) > 0:
+                if k_dim1 % int(head_dim) == 0:
+                    num_kv_heads = max(1, k_dim1 // int(head_dim))
+            embed_kv = int(num_kv_heads or 0) * int(head_dim)
+
+        if not num_kv_heads or int(num_kv_heads) <= 0:
+            num_kv_heads = num_heads
+            embed_kv = int(num_kv_heads) * int(head_dim)
 
         # Attention output dim (attn_out). For most models this == embed_dim,
-        # but some (e.g., Qwen3) use num_heads * head_dim.
-        attn_out_dim = num_heads * head_dim
+        # but grouped/packed attention models use num_heads * head_dim.
+        attn_out_dim = int(num_heads) * int(head_dim)
         if wq0 and len(wq0.dims) == 2:
-            attn_out_dim = wq0.ne1
+            attn_out_dim = int(wq0.ne1)
         elif wo0 and len(wo0.dims) == 2:
-            attn_out_dim = wo0.ne0
+            attn_out_dim = int(wo0.ne0)
 
 
         aligned_embed_dim = embed_dim
@@ -3665,6 +3793,7 @@ def main() -> None:
                 qwen35_config["ssm_time_step_rank"] = int(ssm_time_step_rank)
             if ssm_inner_size is not None:
                 qwen35_config["ssm_inner_size"] = int(ssm_inner_size)
+            qwen35_config = _inject_runtime_config_defaults(qwen35_config, arch)
 
             qwen35_quant_summary: Dict[str, Any] = {
                 "token_emb": next(entry["dtype"] for entry in qwen35_plan if entry["name"] == "token_emb"),
@@ -4064,6 +4193,380 @@ def main() -> None:
                 f"materialized_shared_kv={gemma4_materialized_shared_kv}, "
                 f"extra_projection_tensors={extra_tensors}."
             )
+
+        if arch == "nemotron_h_moe":
+            contract = gguf_ck_arch_contract(arch)
+            tensor_map = contract.get("tensor_map") or {}
+            if not isinstance(tensor_map, dict):
+                raise GGUFError(f"{GGUF_CK_MAP_PATH}: nemotron_h_moe tensor_map must be an object")
+
+            def _mapped_shape(info: TensorInfo) -> list[int]:
+                if len(info.dims) <= 1:
+                    return [int(info.ne0)]
+                return [int(d) for d in reversed(info.dims)]
+
+            def _mapped_entry(dst_name: str, info: TensorInfo, *, layer_kind: Optional[str] = None) -> Dict[str, Any]:
+                dt = weight_dtype(info, dst_name)
+                if info.ggml_type == GGML_TYPE_F16 and dst_name != "token_emb":
+                    raise GGUFError(
+                        f"{info.name}: FP16 nemotron_h_moe tensors are not supported yet outside token embeddings."
+                    )
+                entry = {
+                    "name": dst_name,
+                    "dtype": ck_dtype_name(dt).lower(),
+                    "shape": _mapped_shape(info),
+                    "source_dtype": ggml_type_name(info.ggml_type),
+                    "source_name": info.name,
+                    "_info": info,
+                    "_dtype_id": dt,
+                    "_size": int(np.prod(info.dims)) * 4 if info.ggml_type == GGML_TYPE_F16 else ggml_tensor_bytes(info),
+                }
+                if len(info.dims) > 1:
+                    entry["gguf_dims"] = [int(d) for d in info.dims]
+                if layer_kind:
+                    entry["layer_kind"] = layer_kind
+                return entry
+
+            def _add_mapped_entry(plan: list[Dict[str, Any]], consumed: set[str], dst_name: str, src_name: str, *, layer_kind: Optional[str] = None) -> TensorInfo:
+                info = tensors.get(src_name)
+                if info is None:
+                    raise GGUFError(f"nemotron_h_moe conversion missing required tensor: {src_name}")
+                plan.append(_mapped_entry(dst_name, info, layer_kind=layer_kind))
+                consumed.add(src_name)
+                return info
+
+            nemotron_plan: list[Dict[str, Any]] = []
+            consumed_sources: set[str] = set()
+            layer_kinds: list[str] = []
+            layer_quant_summary: dict[str, dict[str, str]] = {}
+
+            _add_mapped_entry(nemotron_plan, consumed_sources, "token_emb", "token_embd.weight")
+            if out_weight is not None:
+                _add_mapped_entry(nemotron_plan, consumed_sources, "output.weight", "output.weight")
+
+            mamba_projection_size = 0
+            mamba_intermediate_size = 0
+            mamba_conv_dim = int(meta_int("nemotron_h_moe.ssm.inner_size") or 0) + 2 * int(meta_int("nemotron_h_moe.ssm.group_count") or 0) * int(meta_int("nemotron_h_moe.ssm.state_size") or 0)
+            mamba_num_heads = int(meta_int("nemotron_h_moe.ssm.time_step_rank") or 0)
+            mamba_head_dim = 0
+            moe_intermediate_size = int(meta_int("nemotron_h_moe.expert_feed_forward_length") or intermediate)
+            moe_shared_intermediate_size = int(meta_int("nemotron_h_moe.expert_shared_feed_forward_length") or 0)
+            n_routed_experts = int(meta_int("nemotron_h_moe.expert_count") or 0)
+            experts_per_tok = int(meta_int("nemotron_h_moe.expert_used_count") or 0)
+
+            for layer in range(num_layers):
+                kind = classify_layer_contract(tensors, layer, arch=arch)
+                if not kind.startswith("mapped_"):
+                    detail = describe_layer_contract(tensors, layer, arch=arch)
+                    if detail:
+                        raise GGUFError(detail)
+                    raise GGUFError(f"Layer {layer}: unsupported nemotron_h_moe layer contract ({kind})")
+                layer_kind = kind[len("mapped_"):]
+                layer_kinds.append(layer_kind)
+                layer_key = f"layer.{layer}"
+                layer_quant_summary[layer_key] = {}
+
+                for src_pattern, dst_pattern in tensor_map.items():
+                    if "{L}" not in src_pattern:
+                        continue
+                    src_name = src_pattern.replace("{L}", str(layer))
+                    if src_name not in tensors:
+                        continue
+                    dst_name = str(dst_pattern).replace("{L}", str(layer))
+                    info = _add_mapped_entry(nemotron_plan, consumed_sources, dst_name, src_name, layer_kind=layer_kind)
+                    layer_quant_summary[layer_key][dst_name.split(".")[-1]] = ck_dtype_name(weight_dtype(info, dst_name)).lower()
+
+                if layer_kind == "mamba":
+                    in_proj = tensors.get(f"blk.{layer}.ssm_in.weight")
+                    out_proj = tensors.get(f"blk.{layer}.ssm_out.weight")
+                    conv_bias = tensors.get(f"blk.{layer}.ssm_conv1d.bias")
+                    if in_proj is None or out_proj is None or conv_bias is None:
+                        raise GGUFError(f"Layer {layer}: mamba layer missing ssm_in/ssm_out/conv bias")
+                    mamba_projection_size = max(mamba_projection_size, int(in_proj.ne1))
+                    inner = int(out_proj.ne0)
+                    if mamba_num_heads > 0:
+                        mamba_head_dim = max(mamba_head_dim, inner // mamba_num_heads)
+                    conv_dim = int(conv_bias.ne0)
+                    mamba_conv_dim = max(mamba_conv_dim, conv_dim)
+                    # Nemotron-H Mamba projects [gate/inner, conv_xbc, dt].
+                    # It does not use the optional d_mlp prefix handled by the
+                    # generic split helper, so the gate/intermediate width is
+                    # the SSM inner width, not a half-residual candidate.
+                    mamba_intermediate_size = max(mamba_intermediate_size, int(meta_int("nemotron_h_moe.ssm.inner_size") or inner))
+
+            _add_mapped_entry(nemotron_plan, consumed_sources, "final_ln_weight", "output_norm.weight")
+            nemotron_plan.append({
+                "name": "final_ln_bias",
+                "dtype": "fp32",
+                "shape": [int(embed_dim)],
+                "source_dtype": "synthetic",
+                "source_name": "synthetic:zeros_fp32",
+                "_info": None,
+                "_dtype_id": CK_DT_FP32,
+                "_size": int(embed_dim) * 4,
+                "synthetic": "zeros_fp32",
+            })
+
+            unconsumed_sources = sorted(set(tensors.keys()) - consumed_sources)
+            if unconsumed_sources:
+                raise GGUFError(
+                    f"nemotron_h_moe conversion plan left {len(unconsumed_sources)} source tensors unconsumed: "
+                    f"{unconsumed_sources[:16]}"
+                )
+            source_coverage = {
+                "arch": arch,
+                "total_source_tensors": len(tensors),
+                "consumed_source_tensors": len(consumed_sources),
+                "unconsumed_source_tensors": unconsumed_sources,
+                "pass": not unconsumed_sources,
+                "map_path": str(GGUF_CK_MAP_PATH),
+            }
+
+            if mamba_head_dim <= 0 and mamba_num_heads > 0:
+                mamba_head_dim = int((meta_int("nemotron_h_moe.ssm.inner_size") or 0) // mamba_num_heads)
+            if mamba_intermediate_size <= 0:
+                mamba_intermediate_size = int(meta_int("nemotron_h_moe.ssm.inner_size") or intermediate)
+            if mamba_projection_size <= 0:
+                mamba_projection_size = int(mamba_intermediate_size + mamba_conv_dim + mamba_num_heads)
+
+            nemotron_config = _inject_runtime_config_defaults({
+                "model": "nemotron_h",
+                "arch": "nemotron_h",
+                "source_arch": arch,
+                "model_type": "nemotron_h",
+                "embed_dim": int(embed_dim),
+                "attn_out_dim": int(num_heads * head_dim),
+                "num_layers": int(num_layers),
+                "num_heads": int(num_heads),
+                "num_kv_heads": int(num_kv_heads),
+                "head_dim": int(head_dim),
+                "intermediate_dim": int(intermediate),
+                "intermediate_size": int(intermediate),
+                "mamba_intermediate_size": int(mamba_intermediate_size),
+                "moe_intermediate_size": int(moe_intermediate_size),
+                "moe_shared_expert_intermediate_size": int(moe_shared_intermediate_size),
+                "n_routed_experts": int(n_routed_experts),
+                "experts_per_tok": int(experts_per_tok),
+                "num_experts_per_tok": int(experts_per_tok),
+                "router_num_groups": int(meta_int("nemotron_h_moe.expert_group_count") or meta_int("nemotron_h_moe.router_num_groups") or 8),
+                "router_topk_group": int(meta_int("nemotron_h_moe.expert_topk_group") or meta_int("nemotron_h_moe.router_topk_group") or 4),
+                "router_norm_topk_prob": int(meta_int("nemotron_h_moe.norm_topk_prob") or meta_int("nemotron_h_moe.router_norm_topk_prob") or 1),
+                "routed_scaling_factor": float(meta_float("nemotron_h_moe.routed_scaling_factor") or meta_float("nemotron_h_moe.expert_routed_scaling_factor") or 1.0),
+                "vocab_size": int(vocab_size),
+                "max_seq_len": int(context_len),
+                "context_length": int(context_len),
+                "rope_theta": float(rope_theta),
+                "rotary_dim": int(rotary_dim),
+                "rope_scaling_type": rope_scaling_type,
+                "rope_scaling_factor": float(rope_scaling_factor),
+                "rope_original_context_length": int(rope_original_context_length),
+                "rope_beta_fast": float(rope_beta_fast),
+                "rope_beta_slow": float(rope_beta_slow),
+                "rope_attn_factor": float(rope_attn_factor),
+                "rms_eps": float(rms_eps) if rms_eps else 1e-5,
+                "rms_norm_eps": float(rms_eps) if rms_eps else 1e-5,
+                "tie_word_embeddings": bool(tie_word_embeddings),
+                "layer_kinds": layer_kinds,
+                "hybrid_block_pattern": layer_kinds[:],
+                "layer_state_policy": ["mamba2" if k == "mamba" else "none" for k in layer_kinds],
+                "layer_attention_policy": ["full_attention" if k == "attention" else "none" for k in layer_kinds],
+                "layer_recurrent_policy": ["mamba2" if k == "mamba" else "none" for k in layer_kinds],
+                "layer_moe_policy": ["routed_relu2" if k == "moe" else "none" for k in layer_kinds],
+                "layer_mlp_policy": ["relu2" if k == "mlp" else "none" for k in layer_kinds],
+                "layer_kv_policy": ["attention_kv_cache" if k == "attention" else "none" for k in layer_kinds],
+                "mamba_num_heads": int(mamba_num_heads),
+                "mamba_head_dim": int(mamba_head_dim),
+                "ssm_state_size": int(meta_int("nemotron_h_moe.ssm.state_size") or 0),
+                "ssm_conv_kernel": int(meta_int("nemotron_h_moe.ssm.conv_kernel") or 0),
+                "ssm_group_count": int(meta_int("nemotron_h_moe.ssm.group_count") or 0),
+                "ssm_inner_size": int(meta_int("nemotron_h_moe.ssm.inner_size") or 0),
+                "ssm_time_step_rank": int(mamba_num_heads),
+                "ssm_conv_history": max(int(meta_int("nemotron_h_moe.ssm.conv_kernel") or 0), 0),
+                "ssm_conv_channels": int(mamba_conv_dim),
+                "mamba_conv_dim": int(mamba_conv_dim),
+                "mamba_projection_size": int(mamba_projection_size),
+                "gate_dim": int(mamba_intermediate_size),
+                "recurrent_num_heads": int(mamba_num_heads),
+                "recurrent_head_dim": int(mamba_head_dim),
+                "has_qk_norm": False,
+                "has_attention_biases": False,
+            }, "nemotron_h")
+            if tokenizer_contract:
+                nemotron_config["tokenizer_contract"] = tokenizer_contract
+            chat_template = meta.get("tokenizer.chat_template")
+            if isinstance(chat_template, str) and chat_template.strip():
+                nemotron_config["chat_template"] = chat_template
+            if template_data is None:
+                template_data = load_template_for_arch(arch)
+            template_data = apply_model_contract_overrides(template_data, tie_word_embeddings=bool(tie_word_embeddings), has_untied_output_weight=out_weight is not None)
+            if tokenizer_contract:
+                template_data = _apply_tokenizer_contract_overrides(template_data, str(tokenizer_contract.get("tokenizer_type") or "").strip().lower())
+            chat_contract = _extract_chat_contract(template_data, meta)
+            if chat_contract:
+                nemotron_config["chat_contract"] = chat_contract
+            special_tokens = _apply_special_tokenizer_overrides(_extract_special_tokens_from_meta(meta), tokenizer_contract)
+            quant_summary: dict[str, Any] = {
+                "source": "gguf",
+                "token_emb": get_quant_type_name(tok.ggml_type),
+                "lm_head": get_quant_type_name(out_weight.ggml_type) if out_weight is not None else get_quant_type_name(tok.ggml_type),
+            }
+            quant_summary.update(layer_quant_summary)
+            dtype_table = [int(entry["_dtype_id"]) for entry in nemotron_plan]
+            dtype_table_bytes = bytes(dtype_table)
+
+            os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+            manifest_entries: list[dict[str, Any]] = []
+            current_offset = DATA_START
+
+            def _record_mapped_entry(entry: Dict[str, Any], size: int, source_name: str) -> None:
+                nonlocal current_offset
+                out_entry = {
+                    "name": entry["name"],
+                    "dtype": entry["dtype"],
+                    "file_offset": current_offset,
+                    "size": int(size),
+                    "source_name": source_name,
+                    "shape": entry.get("shape") or [],
+                }
+                if entry.get("layer_kind"):
+                    out_entry["layer_kind"] = entry["layer_kind"]
+                if entry.get("gguf_dims"):
+                    out_entry["gguf_dims"] = entry["gguf_dims"]
+                manifest_entries.append(out_entry)
+                current_offset += int(size)
+
+            with open(args.output, "w+b") as out_f:
+                out_f.write(b"\x00" * HEADER_SIZE)
+                out_f.write(b"\x00" * EXT_METADATA_SIZE)
+                w = HashingWriter(out_f)
+                current_offset += 4 + len(dtype_table_bytes)
+                w.write(struct.pack("<I", len(dtype_table_bytes)))
+                w.write(dtype_table_bytes)
+                for entry in nemotron_plan:
+                    if entry.get("synthetic") == "zeros_fp32":
+                        size = int(entry["_size"])
+                        _record_mapped_entry(entry, size, str(entry.get("source_name") or "synthetic:zeros_fp32"))
+                        write_f32_zeros(w, size // 4)
+                        continue
+                    info = entry.get("_info")
+                    if info is None:
+                        raise GGUFError(f"Mapped entry {entry['name']} has no source tensor")
+                    if info.ggml_type == GGML_TYPE_F16:
+                        elems = int(np.prod(info.dims))
+                        size = elems * 4
+                        _record_mapped_entry(entry, size, info.name)
+                        copy_f16_to_f32_stream(f, data_start + info.offset, elems, w)
+                    else:
+                        size = int(entry["_size"])
+                        _record_mapped_entry(entry, size, info.name)
+                        copy_bytes_stream(f, data_start + info.offset, size, w)
+
+                if vocab_offsets is not None and vocab_strings is not None:
+                    offsets_bytes = struct.pack(f"<{len(vocab_offsets)}i", *vocab_offsets)
+                    tok_entry = {"name": "vocab_offsets", "dtype": "i32", "shape": [len(vocab_offsets)]}
+                    _record_mapped_entry(tok_entry, len(offsets_bytes), "gguf_tokenizer_metadata")
+                    w.write(offsets_bytes)
+                    tok_entry = {"name": "vocab_strings", "dtype": "u8", "shape": [len(vocab_strings)]}
+                    _record_mapped_entry(tok_entry, len(vocab_strings), "gguf_tokenizer_metadata")
+                    w.write(vocab_strings)
+                    if vocab_scores is not None:
+                        scores_bytes = struct.pack(f"<{len(vocab_scores)}f", *vocab_scores)
+                        tok_entry = {"name": "vocab_scores", "dtype": "f32", "shape": [len(vocab_scores)]}
+                        _record_mapped_entry(tok_entry, len(scores_bytes), "gguf_tokenizer_metadata")
+                        w.write(scores_bytes)
+                    if vocab_types is not None:
+                        types_bytes = struct.pack(f"<{len(vocab_types)}B", *vocab_types)
+                        tok_entry = {"name": "vocab_types", "dtype": "u8", "shape": [len(vocab_types)]}
+                        _record_mapped_entry(tok_entry, len(types_bytes), "gguf_tokenizer_metadata")
+                        w.write(types_bytes)
+                    merges_bytes = b""
+                    if vocab_merges:
+                        merges_bytes = struct.pack(f"<{len(vocab_merges)}i", *vocab_merges)
+                    tok_entry = {"name": "vocab_merges", "dtype": "i32", "shape": [len(vocab_merges or [])]}
+                    _record_mapped_entry(tok_entry, len(merges_bytes), "gguf_tokenizer_metadata")
+                    if merges_bytes:
+                        w.write(merges_bytes)
+
+                checksum = w.digest()
+                out_f.flush()
+                out_f.seek(0, os.SEEK_SET)
+                out_f.write(b"BUMPWGT5")
+                out_f.write(struct.pack("<I", BUMP_VERSION_V5))
+                out_f.write(struct.pack("<I", 1))
+                out_f.write(struct.pack("<I", int(num_layers)))
+                out_f.write(struct.pack("<I", int(vocab_size)))
+                out_f.write(struct.pack("<I", int(embed_dim)))
+                out_f.write(struct.pack("<I", int(intermediate)))
+                out_f.write(struct.pack("<I", int(context_len)))
+                out_f.write(struct.pack("<I", int(num_heads)))
+                out_f.write(struct.pack("<I", int(num_kv_heads)))
+                out_f.write(struct.pack("<I", int(head_dim)))
+                out_f.write(struct.pack("<Q", int(aligned_embed_dim)))
+                out_f.write(struct.pack("<Q", int(aligned_head_dim)))
+                out_f.write(struct.pack("<Q", int(aligned_intermediate)))
+                out_f.write(struct.pack("<Q", int(aligned_context)))
+                out_f.write(struct.pack("<I", int(num_merges)))
+                out_f.write(struct.pack("<I", int(total_vocab_bytes)))
+                out_f.write(checksum)
+
+                manifest_dict = {
+                    "version": 5,
+                    "model": "nemotron_h",
+                    "source_arch": arch,
+                    "source_format": "gguf",
+                    "bump_layout": {"header_size": HEADER_SIZE, "ext_metadata_size": EXT_METADATA_SIZE, "data_start": DATA_START},
+                    "config": nemotron_config,
+                    "template": template_data,
+                    "quant_summary": quant_summary,
+                    "special_tokens": special_tokens if special_tokens else None,
+                    "tokenizer_contract": tokenizer_contract if tokenizer_contract else None,
+                    "chat_contract": chat_contract if chat_contract else None,
+                    "source_tensor_coverage": source_coverage,
+                    "num_layers": num_layers,
+                    "embed_dim": embed_dim,
+                    "num_heads": num_heads,
+                    "num_kv_heads": num_kv_heads,
+                    "head_dim": head_dim,
+                    "intermediate_size": intermediate,
+                    "vocab_size": vocab_size,
+                    "context_length": context_len,
+                    "has_attention_biases": False,
+                    "has_qk_norm": False,
+                    "num_merges": num_merges,
+                    "total_vocab_bytes": total_vocab_bytes,
+                    "entries": manifest_entries,
+                }
+                manifest_hash = calculate_manifest_hash(manifest_dict)
+                metadata = build_bumpv5_metadata(template_data, nemotron_config, quant_summary, manifest_hash, "convert_gguf_to_bump_v8.py")
+                metadata["template_hash"] = calculate_template_hash(template_data)
+                metadata_bytes = _canonical_json_bytes(metadata)
+                meta_hash = calculate_metadata_hash(metadata)
+                out_f.seek(0, os.SEEK_END)
+                meta_offset = out_f.tell()
+                out_f.write(metadata_bytes)
+                write_bumpv5_footer(out_f, len(metadata_bytes), meta_hash)
+                print(f"[bumpv5] Metadata: {len(metadata_bytes)} bytes @ offset {meta_offset}")
+                print(f"[bumpv5] Template: {template_data.get('name', 'nemotron_h')}, mapped entries: {len(manifest_entries)}")
+
+            if args.config_out:
+                os.makedirs(os.path.dirname(args.config_out) or ".", exist_ok=True)
+                with open(args.config_out, "w", encoding="utf-8") as cf:
+                    json.dump(nemotron_config, cf, indent=2)
+                    cf.write("\n")
+            if args.manifest_out:
+                os.makedirs(os.path.dirname(args.manifest_out) or ".", exist_ok=True)
+                with open(args.manifest_out, "w", encoding="utf-8") as mf:
+                    json.dump(manifest_dict, mf, indent=2)
+                    mf.write("\n")
+                print(f"[manifest] Written: {args.manifest_out} ({len(manifest_entries)} entries)")
+
+            print(
+                f"[gguf->bump] version={args.bump_version} arch={arch}->nemotron_h layers={num_layers} "
+                f"hidden={embed_dim} heads={num_heads}/{num_kv_heads} ff={intermediate} "
+                f"mamba_proj={mamba_projection_size} entries={len(manifest_entries)} -> {args.output}"
+            )
+            print_generic_conversion_report(arch="nemotron_h", manifest_entries=manifest_entries, coverage_report=source_coverage)
+            return
 
         layer_infos = []
         dtype_table = [token_dtype]
@@ -4883,6 +5386,7 @@ def main() -> None:
             cfg["chat_contract"] = chat_contract
         if tokenizer_contract:
             cfg["tokenizer_contract"] = tokenizer_contract
+        cfg = _inject_runtime_config_defaults(cfg, arch)
         with open(args.config_out, "w", encoding="utf-8") as cf:
             json.dump(cfg, cf, indent=2)
             cf.write("\n")

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -13,6 +13,7 @@ import argparse
 import hashlib
 import json
 import os
+import shutil
 import struct
 import sys
 from dataclasses import dataclass
@@ -328,6 +329,27 @@ def _parse_nemotron_h_pattern(pattern: str, num_layers: int) -> list[str]:
         raise SystemExit(f"Unsupported Nemotron-H layer pattern character: {exc.args[0]!r}") from exc
 
 
+
+
+def _nemotron_dt_limit(config: dict[str, Any]) -> tuple[float, float]:
+    """Return CK runtime dt clamp bounds for Nemotron-H.
+
+    Nemotron-H uses time_step_min/max for initialization only. Runtime forward
+    clamps softplus(dt + bias) with time_step_limit; the common (0, inf) limit
+    is represented as (0, 0) so the CK kernel disables clamping.
+    """
+    limit = config.get("time_step_limit")
+    if isinstance(limit, (list, tuple)) and len(limit) >= 2:
+        lo = float(limit[0] or 0.0)
+        try:
+            hi = float(limit[1])
+        except Exception:
+            hi = float("inf")
+        if hi == float("inf"):
+            return 0.0, 0.0
+        return lo, hi
+    return 0.0, 0.0
+
 def _nemotron_h_text_refs(config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef]:
     text = config.get("text_config") if isinstance(config.get("text_config"), dict) else config
     num_layers = int(text.get("num_hidden_layers") or config.get("num_layers") or 0)
@@ -570,6 +592,14 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
     cfg.setdefault("tie_word_embeddings", bool(text.get("tie_word_embeddings", True)))
     if arch == "nemotron_h":
         layer_kinds = _parse_nemotron_h_pattern(str(text.get("hybrid_override_pattern") or ""), int(cfg.get("num_layers") or 0))
+        mamba_num_heads = int(text.get("mamba_num_heads") or 0)
+        mamba_head_dim = int(text.get("mamba_head_dim") or 0)
+        ssm_state_size = int(text.get("ssm_state_size") or 0)
+        ssm_group_count = int(text.get("n_groups") or 0)
+        ssm_conv_kernel = int(text.get("conv_kernel") or 0)
+        ssm_inner_size = mamba_num_heads * mamba_head_dim
+        mamba_conv_dim = ssm_inner_size + 2 * ssm_group_count * ssm_state_size
+        mamba_projection_size = ssm_inner_size + mamba_conv_dim + mamba_num_heads
         cfg.update({
             "model": "nemotron_h",
             "arch": "nemotron_h",
@@ -583,14 +613,20 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "layer_mlp_policy": ["relu2" if k == "mlp" else "none" for k in layer_kinds],
             "layer_kv_policy": ["attention_kv_cache" if k == "attention" else "none" for k in layer_kinds],
             "intermediate_dim": int(text.get("intermediate_size") or 0),
-            "mamba_num_heads": int(text.get("mamba_num_heads") or 0),
-            "mamba_head_dim": int(text.get("mamba_head_dim") or 0),
-            "ssm_state_size": int(text.get("ssm_state_size") or 0),
-            "ssm_conv_kernel": int(text.get("conv_kernel") or 0),
-            "ssm_group_count": int(text.get("n_groups") or 0),
+            "mamba_num_heads": mamba_num_heads,
+            "mamba_head_dim": mamba_head_dim,
+            "ssm_state_size": ssm_state_size,
+            "ssm_conv_kernel": ssm_conv_kernel,
+            "ssm_group_count": ssm_group_count,
+            "mamba_norm_group_size": int(ssm_inner_size // ssm_group_count) if ssm_group_count else int(mamba_head_dim),
             "chunk_size": int(text.get("chunk_size") or 0),
-            "mamba_conv_dim": int((text.get("mamba_num_heads") or 0) * (text.get("mamba_head_dim") or 0) + 2 * (text.get("n_groups") or 0) * (text.get("ssm_state_size") or 0)),
-            "mamba_projection_size": int(2 * (text.get("intermediate_size") or 0) + (text.get("mamba_num_heads") or 0) * (text.get("mamba_head_dim") or 0) + ((text.get("mamba_num_heads") or 0) * (text.get("mamba_head_dim") or 0) + 2 * (text.get("n_groups") or 0) * (text.get("ssm_state_size") or 0)) + (text.get("mamba_num_heads") or 0)),
+            "mamba_dt_min": _nemotron_dt_limit(text)[0],
+            "mamba_dt_max": _nemotron_dt_limit(text)[1],
+            "ssm_inner_size": ssm_inner_size,
+            "ssm_conv_channels": mamba_conv_dim,
+            "ssm_conv_history": max(ssm_conv_kernel, 0),
+            "mamba_conv_dim": mamba_conv_dim,
+            "mamba_projection_size": mamba_projection_size,
             "moe_intermediate_size": int(text.get("moe_intermediate_size") or 0),
             "moe_shared_expert_intermediate_size": int(text.get("moe_shared_expert_intermediate_size") or 0),
             "n_routed_experts": int(text.get("n_routed_experts") or 0),
@@ -601,6 +637,8 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "routed_scaling_factor": float(text.get("routed_scaling_factor") or 1.0),
             "rope_layout": "split",
             "rope_theta": float(text.get("rope_theta") or 10000.0),
+            "rope_freq_base": float(text.get("rope_theta") or 10000.0),
+            "use_rope_freq_factors": 0,
             "has_attention_biases": bool(text.get("attention_bias", False)),
             "has_qk_norm": False,
             "prefill_policy": "batched",
@@ -818,10 +856,53 @@ def _copy_tokenizer_sidecars(model_dir: Path, out_dir: Path) -> None:
                 dst.write_bytes(src.read_bytes())
 
 
+def _resolve_output_path(output: Path | None, *, ram_output: bool, ram_dir: Path, checkpoint: Path) -> Path:
+    if not ram_output:
+        if output is None:
+            raise SystemExit("--output is required unless --ram-output is used")
+        return output
+
+    ram_root = ram_dir.resolve()
+    if output is not None and output.is_absolute() and str(output.resolve()).startswith(str(ram_root)):
+        return output
+
+    name = checkpoint.resolve().name or "model"
+    base = ram_root / "ck-engine-v8" / name
+    if output is None:
+        return base / "weights.bump"
+    return base / output.name
+
+
+
+
+def _is_proc_fd_path(path: Path) -> bool:
+    text = str(path)
+    return text.startswith("/proc/self/fd/") or (text.startswith("/proc/") and "/fd/" in text)
+
+def _check_output_capacity(path: Path, estimated_bytes: int, *, ram_output: bool) -> None:
+    if _is_proc_fd_path(path):
+        return
+    probe = path.parent
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    usage = shutil.disk_usage(probe)
+    reserve = max(256 * 1024 * 1024, int(estimated_bytes * 0.02))
+    required = int(estimated_bytes) + reserve
+    if usage.free < required:
+        kind = "RAM/tmpfs" if ram_output else "filesystem"
+        raise SystemExit(
+            f"Not enough free space in {kind} for BUMP output: need about "
+            f"{required / 1024 / 1024 / 1024:.2f} GiB including reserve, "
+            f"free {usage.free / 1024 / 1024 / 1024:.2f} GiB at {path.parent}"
+        )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Convert HF safetensors language weights to v8 BUMPWGT5")
     ap.add_argument("--checkpoint", required=True, type=Path, help="HF safetensors model directory")
-    ap.add_argument("--output", required=True, type=Path, help="output weights.bump")
+    ap.add_argument("--output", type=Path, help="output weights.bump")
+    ap.add_argument("--ram-output", action="store_true", help="write weights.bump under a RAM-backed tmpfs path instead of the checkpoint/output directory")
+    ap.add_argument("--ram-dir", type=Path, default=Path("/dev/shm"), help="tmpfs directory for --ram-output; default: /dev/shm")
     ap.add_argument("--config-out", required=True, type=Path)
     ap.add_argument("--manifest-out", required=True, type=Path)
     ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h"])
@@ -833,6 +914,7 @@ def main() -> int:
     args = ap.parse_args()
 
     model_dir = args.checkpoint.resolve()
+    args.output = _resolve_output_path(args.output, ram_output=bool(args.ram_output), ram_dir=args.ram_dir, checkpoint=model_dir)
     headers = _load_safetensors_headers(model_dir)
     hf = _hf_config(model_dir)
     arch = args.arch
@@ -920,18 +1002,24 @@ def main() -> int:
         "entries": entries_preview,
     }
 
+    print(f"[safetensors->bump] arch={arch} tensors={len(refs)} entries={len(entries_preview)} dry_run={args.dry_run}")
+    estimated_bytes = int(offset - DATA_START)
+    print(f"[safetensors->bump] output={args.output}")
+    if args.ram_output:
+        print(f"[safetensors->bump] ram_output=True ram_dir={args.ram_dir}")
+    print(f"[safetensors->bump] estimated weights payload={(offset - (DATA_START + 4 + len(refs))) / 1024 / 1024:.1f} MiB")
+
     args.config_out.parent.mkdir(parents=True, exist_ok=True)
     args.manifest_out.parent.mkdir(parents=True, exist_ok=True)
     args.config_out.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     args.manifest_out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    _copy_tokenizer_sidecars(model_dir, args.output.parent)
-
-    print(f"[safetensors->bump] arch={arch} tensors={len(refs)} entries={len(entries_preview)} dry_run={args.dry_run}")
-    print(f"[safetensors->bump] estimated weights payload={(offset - (DATA_START + 4 + len(refs))) / 1024 / 1024:.1f} MiB")
     if args.dry_run:
         return 0
 
-    args.output.parent.mkdir(parents=True, exist_ok=True)
+    _check_output_capacity(args.output, estimated_bytes, ram_output=bool(args.ram_output))
+    if not _is_proc_fd_path(args.output):
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        _copy_tokenizer_sidecars(model_dir, args.output.parent)
     with args.output.open("w+b") as f:
         f.write(b"\x00" * HEADER_SIZE)
         f.write(b"\x00" * EXT_METADATA_SIZE)

--- a/version/v8/scripts/export_nemotron_torch_hidden_v8.py
+++ b/version/v8/scripts/export_nemotron_torch_hidden_v8.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Export PyTorch hidden/logit baselines for Nemotron-H safetensors.
+
+The NVIDIA Nemotron-H remote model requires ``mamba-ssm`` at import time even
+when running the pure PyTorch CPU Mamba2 path.  For CK parity bring-up we need a
+CPU reference that can run on the same Xeon notebook without Triton/CUDA.  This
+script installs a narrow CPU ``rmsnorm_fn`` shim, runs one forward pass, and
+exports hidden/logit summaries or tensors for later CK comparison.
+"""
+
+import argparse
+import contextlib
+import json
+import sys
+import time
+import types
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+
+def _install_nemotron_cpu_shims() -> None:
+    def rmsnorm_fn(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        z: torch.Tensor | None = None,
+        eps: float = 1e-5,
+        group_size: int | None = None,
+        norm_before_gate: bool = False,
+        **_: Any,
+    ) -> torch.Tensor:
+        y = x.float()
+        if z is not None and not norm_before_gate:
+            y = y * torch.nn.functional.silu(z.float())
+
+        if group_size is None or group_size <= 0 or group_size == y.shape[-1]:
+            y = y * torch.rsqrt(y.square().mean(dim=-1, keepdim=True) + eps)
+        else:
+            chunks = []
+            for chunk in torch.split(y, int(group_size), dim=-1):
+                chunks.append(chunk * torch.rsqrt(chunk.square().mean(dim=-1, keepdim=True) + eps))
+            y = torch.cat(chunks, dim=-1)
+
+        y = y * weight.float()
+        if bias is not None:
+            y = y + bias.float()
+        if z is not None and norm_before_gate:
+            y = y * torch.nn.functional.silu(z.float())
+        return y.to(x.dtype)
+
+    for name in (
+        "mamba_ssm",
+        "mamba_ssm.ops",
+        "mamba_ssm.ops.triton",
+        "mamba_ssm.ops.triton.layernorm_gated",
+    ):
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules["mamba_ssm.ops.triton.layernorm_gated"].rmsnorm_fn = rmsnorm_fn
+
+    class _NoStream(contextlib.AbstractContextManager):
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+    # NemotronHBlock wraps all block work in torch.cuda.stream(...).  On CPU this
+    # should be a no-op for parity export.
+    torch.cuda.stream = lambda _stream=None: _NoStream()  # type: ignore[assignment]
+    torch.cuda.default_stream = lambda _device=None: None  # type: ignore[assignment]
+
+
+def _parse_tokens(text: str | None) -> list[int] | None:
+    if not text:
+        return None
+    return [int(x.strip()) for x in text.split(",") if x.strip()]
+
+
+def _parse_hidden_indices(text: str, count: int) -> list[int]:
+    if text == "all":
+        return list(range(count))
+    out = []
+    for item in text.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        idx = int(item)
+        if idx < 0:
+            idx += count
+        if idx < 0 or idx >= count:
+            raise SystemExit(f"hidden index {item} out of range for {count} hidden states")
+        out.append(idx)
+    return out
+
+
+def _tensor_stats(t: torch.Tensor) -> dict[str, Any]:
+    x = t.float()
+    return {
+        "shape": [int(v) for v in t.shape],
+        "mean": float(x.mean()),
+        "rms": float(torch.sqrt(torch.mean(x * x))),
+        "maxabs": float(x.abs().max()),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("model", type=Path, help="Nemotron-H safetensors directory")
+    ap.add_argument("--prompt", default="Hello world.", help="Prompt text for tokenizer input")
+    ap.add_argument("--tokens", help="Comma-separated token ids; overrides --prompt")
+    ap.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
+    ap.add_argument("--top-k", type=int, default=8)
+    ap.add_argument("--hidden-indices", default="0,1,2,5,10,20,30,40,-1")
+    ap.add_argument("--dump-dir", type=Path, help="Optional directory for .npy hidden/logit dumps")
+    ap.add_argument("--json-out", type=Path, help="Optional JSON output path")
+    args = ap.parse_args()
+
+    _install_nemotron_cpu_shims()
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
+    load_t0 = time.time()
+    tok = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        trust_remote_code=True,
+        dtype=dtype,
+        device_map=None,
+        low_cpu_mem_usage=True,
+    )
+    model.eval()
+    load_seconds = time.time() - load_t0
+
+    token_ids = _parse_tokens(args.tokens)
+    if token_ids is None:
+        encoded = tok(args.prompt, return_tensors="pt")
+        input_ids = encoded["input_ids"]
+        prompt_text = args.prompt
+    else:
+        input_ids = torch.tensor([token_ids], dtype=torch.long)
+        prompt_text = tok.decode(token_ids)
+
+    fwd_t0 = time.time()
+    with torch.inference_mode():
+        out = model(input_ids=input_ids, use_cache=False, output_hidden_states=True, return_dict=True)
+    forward_seconds = time.time() - fwd_t0
+
+    logits_last = out.logits[0, -1].float().contiguous()
+    top = torch.topk(logits_last, int(args.top_k))
+    hidden_count = len(out.hidden_states)
+    hidden_indices = _parse_hidden_indices(args.hidden_indices, hidden_count)
+
+    report: dict[str, Any] = {
+        "model": str(args.model),
+        "dtype": args.dtype,
+        "prompt": prompt_text,
+        "input_ids": [int(x) for x in input_ids[0].tolist()],
+        "load_seconds": load_seconds,
+        "forward_seconds": forward_seconds,
+        "logits_shape": [int(v) for v in out.logits.shape],
+        "hidden_count": hidden_count,
+        "top_logits": {
+            "tokens": [int(x) for x in top.indices.tolist()],
+            "values": [float(x) for x in top.values.tolist()],
+            "texts": [tok.decode([int(x)]) for x in top.indices.tolist()],
+        },
+        "hidden": {},
+    }
+
+    if args.dump_dir:
+        args.dump_dir.mkdir(parents=True, exist_ok=True)
+        np.save(args.dump_dir / "input_ids.npy", input_ids.cpu().numpy().astype(np.int64, copy=False))
+        np.save(args.dump_dir / "logits_last.npy", logits_last.cpu().numpy().astype(np.float32, copy=False))
+
+    for idx in hidden_indices:
+        h_last = out.hidden_states[idx][0, -1].float().contiguous()
+        report["hidden"][str(idx)] = _tensor_stats(h_last)
+        if args.dump_dir:
+            np.save(args.dump_dir / f"hidden_{idx:03d}_last.npy", h_last.cpu().numpy().astype(np.float32, copy=False))
+
+    text = json.dumps(report, indent=2, sort_keys=True)
+    print(text)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/run_safetensors_memfd_bump_v8.py
+++ b/version/v8/scripts/run_safetensors_memfd_bump_v8.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Convert safetensors to a RAM-only memfd BUMP and optionally run a command.
+
+This is for very large safetensors checkpoints where there is enough RAM but not
+enough disk or /dev/shm capacity to materialize weights.bump.  The script creates
+an anonymous Linux memfd, invokes the v8 safetensors converter with the inherited
+fd path, then keeps that fd alive while running a child command.  Use the literal
+``{weights}`` in the child command; it is replaced with ``/proc/self/fd/<fd>``.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CONVERTER = SCRIPT_DIR / "convert_safetensors_to_bump_v8.py"
+
+
+def _memfd_create(name: str) -> int:
+    if not hasattr(os, "memfd_create"):
+        raise SystemExit("os.memfd_create is not available on this Python/Linux build")
+    fd = os.memfd_create(name, flags=0)
+    os.set_inheritable(fd, True)
+    return fd
+
+
+def _run(cmd: list[str], *, pass_fd: int) -> int:
+    proc = subprocess.run(cmd, pass_fds=(pass_fd,), check=False)
+    return int(proc.returncode)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--checkpoint", required=True, type=Path)
+    ap.add_argument("--config-out", required=True, type=Path)
+    ap.add_argument("--manifest-out", required=True, type=Path)
+    ap.add_argument("--audit-out", type=Path)
+    ap.add_argument("--arch", default="auto")
+    ap.add_argument("--dtype", default="preserve", choices=("preserve", "bf16", "fp32"))
+    ap.add_argument("--config-template", type=Path)
+    ap.add_argument("--dry-run", action="store_true", help="run converter dry-run without creating a memfd")
+    ap.add_argument("--keep-open", action="store_true", help="after conversion, print fd path and wait for Enter; useful for manual inspection")
+    ap.add_argument("command", nargs=argparse.REMAINDER, help="optional command after --; replace {weights} with the memfd path")
+    args = ap.parse_args()
+
+    if args.dry_run:
+        cmd = [
+            sys.executable,
+            str(CONVERTER),
+            "--checkpoint", str(args.checkpoint),
+            "--output", "weights.bump",
+            "--config-out", str(args.config_out),
+            "--manifest-out", str(args.manifest_out),
+            "--arch", str(args.arch),
+            "--dtype", str(args.dtype),
+            "--dry-run",
+        ]
+        if args.audit_out:
+            cmd.extend(["--audit-out", str(args.audit_out)])
+        if args.config_template:
+            cmd.extend(["--config-template", str(args.config_template)])
+        return subprocess.run(cmd, check=False).returncode
+
+    fd = _memfd_create("ck-v8-weights.bump")
+    fd_path = f"/proc/self/fd/{fd}"
+    try:
+        convert_cmd = [
+            sys.executable,
+            str(CONVERTER),
+            "--checkpoint", str(args.checkpoint),
+            "--output", fd_path,
+            "--config-out", str(args.config_out),
+            "--manifest-out", str(args.manifest_out),
+            "--arch", str(args.arch),
+            "--dtype", str(args.dtype),
+        ]
+        if args.audit_out:
+            convert_cmd.extend(["--audit-out", str(args.audit_out)])
+        if args.config_template:
+            convert_cmd.extend(["--config-template", str(args.config_template)])
+
+        print(f"[memfd-bump] converting into anonymous RAM fd {fd_path}")
+        rc = _run(convert_cmd, pass_fd=fd)
+        if rc != 0:
+            return rc
+        size = os.lseek(fd, 0, os.SEEK_END)
+        os.lseek(fd, 0, os.SEEK_SET)
+        print(f"[memfd-bump] ready path={fd_path} size={size / 1024 / 1024 / 1024:.2f} GiB")
+
+        command = list(args.command)
+        if command and command[0] == "--":
+            command = command[1:]
+        if command:
+            child_cmd = [fd_path if item == "{weights}" else item for item in command]
+            print("[memfd-bump] running:", " ".join(child_cmd))
+            return _run(child_cmd, pass_fd=fd)
+        if args.keep_open:
+            print(f"[memfd-bump] fd is open at {fd_path}; press Enter to close and release RAM")
+            try:
+                input()
+            except EOFError:
+                pass
+        else:
+            print("[memfd-bump] no command provided; closing fd now releases the RAM BUMP")
+        return 0
+    finally:
+        os.close(fd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/templates/nemotron_h.json
+++ b/version/v8/templates/nemotron_h.json
@@ -101,7 +101,9 @@
           "mamba": [
             "block_rmsnorm",
             "mamba_in_proj",
+            "mamba_in_proj_split",
             "mamba_conv1d_silu",
+            "mamba_dt_softplus",
             "mamba_selective_scan",
             "mamba_rmsnorm_gate",
             "mamba_out_proj",
@@ -132,6 +134,20 @@
             "shared_relu2_expert_mlp",
             "residual_add"
           ]
+        },
+        "quant_aliases_common": {
+          "ln1_gamma": "block_norm",
+          "w1": "ffn_gate",
+          "w3": "ffn_up",
+          "w2": "ffn_down"
+        },
+        "quant_aliases_by_kind": {
+          "attention": {
+            "wq": "attn_q",
+            "wk": "attn_k",
+            "wv": "attn_v",
+            "wo": "attn_o"
+          }
         }
       },
       "footer": [


### PR DESCRIPTION
## Summary
- Add Nemotron-H/Mamba2 conversion, kernel-map, and runtime guardrails.
- Add GGUF model map support plus Nemotron diagnostic scripts.
- Preserve existing Qwen/Gemma/Nanbeige v8 contracts; fixed Qwen3.5 head-dimension inference so explicit GGUF metadata wins over tensor-shape inference.

## Validation
- .venv/bin/python -m py_compile for changed v8 scripts
- .venv/bin/python unittest/test_mamba2_reference.py: passed 7/7
- make build/libckernel_engine.so: passed
- make v8-kernel-map-contracts: passed
- targeted Qwen3.5 v8 smoke: coherent
- make v8-regression-fast: overall PASS
- pre-commit staged v7-regression-fast and v8-regression-fast: passed
- pre-push build, kernel parity, v8 E2E smoke, v7 inference, v7/v8 fast regression, and training-kernel parity: passed

## Note
- pytest subset for tests/test_v8_safetensors_to_bump.py -k nemotron_h was not run locally because pytest is not installed in this venv.