### PR TITLE
docs(test-report): label fast regression as v8 inference

### DIFF
--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -257,9 +257,9 @@
     </div>
 
     <div class="regression-section">
-      <h2>v7 Fast Regression</h2>
+      <h2>v8 Inference Regression</h2>
       <p class="regression-meta" id="regression-fast-meta">
-        `make regression-fast` status is not available in this report yet.
+        `make regression-fast` / `make v8-regression-fast` status is not available in this report yet.
       </p>
 
       <div class="summary-cards" style="margin: 0 0 1rem 0;">
@@ -545,8 +545,8 @@
       (<code>make visualizer</code>, <code>make visualizer-full</code>)</li>
     <li><strong>v7 Visualizer Health Gate</strong>: Contract-driven static analysis (160 checks) + JS unit tests (100 test vectors) for IR visualizer, dataset viewer, and IR hub
       (<code>make v7-visualizer-health</code>)</li>
-    <li><strong>v7 Fast Regression</strong>: Family bring-up gate for Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige with build/smoke/contract/first-token checks
-      (<code>make regression-fast</code>)</li>
+    <li><strong>v8 Inference Regression</strong>: Family bring-up gate for Gemma3, Qwen2, Qwen3, Qwen3.5, Qwen3-VL, and Nanbeige with build/smoke/coherence/contract checks
+      (<code>make regression-fast</code>, aliasing the promoted <code>make v8-regression-fast</code> lane)</li>
     <li><strong>v7 Regression Ledger</strong>: Canonical root-cause log for fixed and monitored bugs, consumed by operators in the visualizer
       (<code>version/v7/reports/REGRESSION_LEDGER.md</code>, <code>version/v7/reports/REGRESSION_LEDGER.json</code>)</li>
     <li><strong>llama.cpp Parity</strong>: CK vs llama.cpp kernel parity flow

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1197,9 +1197,9 @@
     </div>
 
     <div class="regression-section">
-      <h2>v7 Fast Regression</h2>
+      <h2>v8 Inference Regression</h2>
       <p class="regression-meta" id="regression-fast-meta">
-        `make regression-fast` status is not available in this report yet.
+        `make regression-fast` / `make v8-regression-fast` status is not available in this report yet.
       </p>
 
       <div class="summary-cards" style="margin: 0 0 1rem 0;">
@@ -1485,8 +1485,8 @@
       (<code>make visualizer</code>, <code>make visualizer-full</code>)</li>
     <li><strong>v7 Visualizer Health Gate</strong>: Contract-driven static analysis (160 checks) + JS unit tests (100 test vectors) for IR visualizer, dataset viewer, and IR hub
       (<code>make v7-visualizer-health</code>)</li>
-    <li><strong>v7 Fast Regression</strong>: Family bring-up gate for Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige with build/smoke/contract/first-token checks
-      (<code>make regression-fast</code>)</li>
+    <li><strong>v8 Inference Regression</strong>: Family bring-up gate for Gemma3, Qwen2, Qwen3, Qwen3.5, Qwen3-VL, and Nanbeige with build/smoke/coherence/contract checks
+      (<code>make regression-fast</code>, aliasing the promoted <code>make v8-regression-fast</code> lane)</li>
     <li><strong>v7 Regression Ledger</strong>: Canonical root-cause log for fixed and monitored bugs, consumed by operators in the visualizer
       (<code>version/v7/reports/REGRESSION_LEDGER.md</code>, <code>version/v7/reports/REGRESSION_LEDGER.json</code>)</li>
     <li><strong>llama.cpp Parity</strong>: CK vs llama.cpp kernel parity flow
@@ -2337,7 +2337,7 @@ document.addEventListener('DOMContentLoaded', loadResults);
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-20</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
- Rename the test report fast regression card from v7 to v8 inference
- Clarify that make regression-fast aliases the promoted make v8-regression-fast lane
- Regenerate docs/site/test-report.html

## Validation
- docs/site/build.sh
- pre-push validation passed on push, including v8 inference contracts and v7 training checks