### PR TITLE
Harden v8 Nemotron and Q4_K runtime guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,6 +590,8 @@ PY_TESTS := unittest/test_layernorm.py \
             unittest/test_rmsnorm.py \
             unittest/test_qk_norm.py \
             tests/test_deltanet.py \
+            unittest/test_recurrent_conv_state_update.py \
+            unittest/test_mamba2_reference.py \
             unittest/test_deepseek_reference_kernels.py \
             unittest/test_swiglu.py \
             unittest/test_fused_swiglu_decode.py \
@@ -2460,6 +2462,11 @@ test-v8-decoder-matrix-quick: ck-cli-v8
 		--repeats $${CK_V8_DECODER_REPEATS:-1} \
 		--json-out build/v8_decoder_matrix_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_DECODER_PROMPT:-128}_n$${CK_V8_DECODER_DECODE:-32}.json
 
+test-v8-template-circuit-audit:
+	@echo "Running v8 template circuit artifact audit tests..."
+	@$(PYTHON) -m py_compile version/v8/scripts/audit_template_circuit_v8.py
+	@$(PYTHON) -m unittest tests.test_v8_template_circuit_audit -v
+
 test-v8-gemma4-highmem:
 	@avail_kb=$$(awk '/MemAvailable:/ {print $$2}' /proc/meminfo 2>/dev/null || echo 0); \
 	threshold_kb=$$(( $(V8_GEMMA4_MIN_MEM_GB) * 1024 * 1024 )); \
@@ -2503,7 +2510,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-gemma4-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-gemma4-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,11 @@ V8_GEMMA4_MIN_MEM_GB ?= 50
 V8_GEMMA4_CONTEXT ?= 2048
 V8_GEMMA4_MAX_TOKENS ?= 64
 V8_GEMMA4_PROMPT ?= Give me a short example of C code.
+V8_NEMOTRON9_MODEL ?= hf://bartowski/nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF/nvidia_NVIDIA-Nemotron-Nano-9B-v2-Q4_K_M.gguf
+V8_NEMOTRON9_MIN_MEM_GB ?= 70
+V8_NEMOTRON9_CONTEXT ?= 2048
+V8_NEMOTRON9_MAX_TOKENS ?= 64
+V8_NEMOTRON9_PROMPT ?= Give me a concise example of C code.
 
 # =============================================================================
 # Intel oneAPI Integration (MKL / oneDNN)
@@ -2485,6 +2490,24 @@ test-v8-gemma4-highmem:
 			--temperature 0.0; \
 	fi
 
+test-v8-nemotron9-highmem:
+	@avail_kb=$$(awk '/MemAvailable:/ {print $$2}' /proc/meminfo 2>/dev/null || echo 0); \
+	threshold_kb=$$(( $(V8_NEMOTRON9_MIN_MEM_GB) * 1024 * 1024 )); \
+	if [ "$$avail_kb" -lt "$$threshold_kb" ]; then \
+		avail_gb=$$(( $$avail_kb / 1024 / 1024 )); \
+		echo "SKIP: Nemotron Nano 9B v2 v8 smoke needs >=$(V8_NEMOTRON9_MIN_MEM_GB) GiB MemAvailable; found $${avail_gb} GiB"; \
+	else \
+		echo "Running v8 Nemotron Nano 9B v2 high-memory smoke..."; \
+		CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+			$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/ck_run_v8.py run "$(V8_NEMOTRON9_MODEL)" \
+			--context-len $(V8_NEMOTRON9_CONTEXT) \
+			--force-convert --force-compile \
+			--prompt "$(V8_NEMOTRON9_PROMPT)" \
+			--chat-template auto \
+			--max-tokens $(V8_NEMOTRON9_MAX_TOKENS) \
+			--temperature 0.0; \
+	fi
+
 profile-v8-prefill-ops: ck-cli-v8
 	@echo "Profiling v8 prefill operator costs..."
 	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
@@ -2510,7 +2533,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-gemma4-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/docs/site/_pages/concepts.html
+++ b/docs/site/_pages/concepts.html
@@ -27,6 +27,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
+    <li><a href="#nemotron-h-hybrid">Nemotron-H Hybrid Circuit</a></li>
     <li><a href="#mamba2-reference">Mamba2 Reference Kernels</a></li>
     <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
@@ -576,6 +577,45 @@ y = gamma * x / (rms + eps)
     <h3 style="margin-top: 0;">Why Remove Mean Centering?</h3>
     <p>Research found that the re-centering (subtracting mean) in LayerNorm isn't necessary for good performance. RMSNorm keeps just the scaling, which is what matters for gradient flow.</p>
     <p><strong>Used in:</strong> Llama, Mistral, Qwen, Gemma (most modern LLMs)</p>
+</div>
+
+<hr>
+
+<h2 id="nemotron-h-hybrid">Nemotron-H Hybrid Circuit: Attention + Mamba2 + MoE</h2>
+
+<p>Nemotron-H is important for CK because it is not just another dense transformer stack. A single model family can mix attention layers, Mamba2-style state-space layers, routed MoE blocks, ReLU2 experts, tokenizer guardrails, and model-specific template rules. CK needs to represent that as an auditable circuit of named kernels before it becomes a high-performance runtime.</p>
+
+<div class="img-container svg-viewer" data-title="Nemotron-H Hybrid Circuit">
+    <img src="assets/concept-nemotron-h-hybrid-circuit.svg" alt="Nemotron-H hybrid attention, Mamba2, and MoE circuit">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">What CK Has to Preserve</h3>
+        <p>The hard part is not only implementing the math once. The runtime has to preserve state ownership and layout contracts across different layer types:</p>
+        <ul>
+            <li><strong>Attention:</strong> Q/K/V projection, RoPE or no-RoPE policy, KV-cache placement, and output projection.</li>
+            <li><strong>Mamba2 / SSM:</strong> input projection split, convolution state, <code>dt</code> softplus, recurrent selective state update, and gated normalization.</li>
+            <li><strong>MoE:</strong> group-limited routing, top-k expert selection, ReLU2 expert execution, and weighted accumulation.</li>
+        </ul>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why Profiling Comes Before Fusion</h3>
+        <p>VTune and Advisor are exactly the right tools here. They tell us whether a slow path is memory bandwidth, cache misses, branch pressure, vector under-utilization, bad thread placement, or true arithmetic cost. Only then should CK promote a fused kernel.</p>
+        <p>Good fusion candidates are real, but they should be gated:</p>
+        <ul>
+            <li>Q/K/V projection plus quantization or layout packing for prefill.</li>
+            <li>Mamba2 in-proj split plus conv-state update plus <code>dt</code> preparation.</li>
+            <li>Selective scan chunks once scalar sequence parity is locked.</li>
+            <li>Router plus expert dispatch when sparse row ownership is stable.</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <p>The current Nemotron path is deliberately reference-first. <code>make test-mamba2-reference</code> validates Mamba2 decode and sequence-scan behavior. <code>make test-nemotron-router</code> validates group-limited routing. <code>make test-moe-relu2-expert</code> validates routed ReLU2 expert math. The v8 guardrail tests cover tokenizer capability codegen, template-circuit audit rules, and high-memory Nemotron smoke coverage behind <code>make test-v8-nemotron9-highmem</code>.</p>
+    <p>This is the right foundation for the next optimization phase: use profiling to decide which references become packed, tiled, SIMD, chunked, or fused kernels, without losing the ability to explain exactly which kernel changed.</p>
 </div>
 
 <hr>

--- a/docs/site/_pages/model-kernel-matrix.html
+++ b/docs/site/_pages/model-kernel-matrix.html
@@ -369,6 +369,31 @@
       </div>
     </div>
 
+    <!-- Nemotron -->
+    <div class="model-card mc-llama">
+      <span class="model-badge">template: nemotron_h.json</span>
+      <div class="model-title">Nemotron Nano 9B v2</div>
+      <div class="model-arch">Nemotron-H · Mamba2 recurrent blocks · sparse attention layers<br>ReLU2 MLP · Q5_0/Q4_K/Q8_0 GGUF · BPE tokenizer</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF Q4_K_M coherent C-code smoke</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Safetensors/PyTorch parity lane — Mamba2 stitching and state-shape guardrails</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up fix: Nemotron-H uses Mamba2 state shaped as <code>[heads, head_dim, state_dim]</code>, not a square DeltaNet-style recurrent matrix. The template/lowering path now carries that contract explicitly, stores no-RoPE attention KV after <code>v_proj</code>, and generated BPE runtimes can encode raw prompts end-to-end by default.
+      </div>
+      <div class="model-tags">
+        <span class="tag fixed">Mamba2 state shape explicit</span>
+        <span class="tag fixed">native BPE encode default-on</span>
+        <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip preferred">Q4_K_M ★</span>
+        <span class="mq-chip">Q5_0</span>
+        <span class="mq-chip">Q8_0</span>
+        <span class="mq-chip">BF16 safetensors</span>
+      </div>
+    </div>
+
     <!-- Llama / Nanbeige -->
     <div class="model-card mc-llama">
       <span class="model-badge">template: llama.json</span>
@@ -667,6 +692,7 @@
       <div class="test-item">unsloth--gemma-4-E4B-it-GGUF / local Q4_K_M BUMP</div>
       <div class="test-item">mradermacher--Nanbeige4.1-3B-GGUF</div>
       <div class="test-item">Qwen--Qwen3.5-0.8B-GGUF</div>
+      <div class="test-item">bartowski--nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF / Q4_K_M</div>
     </div>
     <p class="source-note" style="margin-top: 0.75rem;">
       Bring-up note: if a Llama-family/Nanbeige first reply starts with <code>&lt;think&gt;</code> or echoes
@@ -690,6 +716,9 @@
       <div class="test-item">
         <strong>Llama / Nanbeige:</strong> SentencePiece + ChatML bring-up stabilized with untied <code>output.weight</code> preserved. Nanbeige remains an active inference lane; long coherent think traces are treated as model style, not as evidence of kernel breakage.
       </div>
+      <div class="test-item">
+        <strong>Nemotron Nano 9B v2:</strong> the first real failure was stitching, not tokenizer or final head: Mamba2 state shape and no-RoPE KV placement had to be explicit in IR. Native BPE encode is now default-on so <code>ck_run_v8.py</code> raw prompts work end-to-end; token-id-only fallback remains available with <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code>.
+      </div>
     </div>
   </div>
 
@@ -712,9 +741,9 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
   </div>
 
   <div class="roadmap">
-    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4 plus the Llama/Nanbeige bring-up lane.
+    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4, Nemotron-H, plus the Llama/Nanbeige bring-up lane.
     Qwen3.5 adds hybrid recurrent-attention coverage with Gated DeltaNet kernels (forward + backward), compatible with the 0.8B dense variant.
-    Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
+    Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
     v7 still targets full training expansion: backward kernels, optimizer state, gradient reduction, and IR‑driven training schedules.
     This page will keep evolving into a single matrix that shows inference + training coverage per model family.
   </div>

--- a/docs/site/_pages/v8-runbook.html
+++ b/docs/site/_pages/v8-runbook.html
@@ -253,11 +253,27 @@ python -m pip install -r requirements-v8.txt</pre>
     <p class="mini-note">Current scope: these are the validated <code>v8</code> text-family operator surfaces. The multimodal Qwen3-VL path is separate and remains the only promoted vision family today.</p>
 </div>
 
+<div class="card card-yellow">
+    <h3 style="margin-top: 0;">High-Memory v8 Smoke Targets</h3>
+    <p>Gemma4 and Nemotron Nano 9B v2 are intentionally tracked as high-memory smoke lanes. They should appear in nightly/test reports, but skip cleanly on smaller runners instead of pretending the model family is untested.</p>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>make test-v8-gemma4-highmem
+make test-v8-nemotron9-highmem
+
+# Lower the threshold only when you intentionally want to run locally:
+V8_GEMMA4_MIN_MEM_GB=24 make test-v8-gemma4-highmem
+V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
+    </div>
+    <p class="mini-note">These tests are coherence/runtime smokes, not performance gates. They validate that the v8 conversion, compile, tokenizer/chat-template path, and first generated tokens remain sane for large model families.</p>
+</div>
+
 <div class="card">
     <h3 style="margin-top: 0;">Text-Family Notes</h3>
     <ul>
         <li><strong>Gemma 3:</strong> use <code>--chat-template auto</code> for normal instruction/chat runs. <code>--chat-template none</code> is raw continuation mode now and needs <code>--allow-raw-prompt</code> if you intentionally want it.</li>
         <li><strong>Gemma 4:</strong> use <code>--chat-template gemma4</code>. The template uses explicit per-layer/direct split-half RoPE metadata; do not replace it with the older global split-half RoPE path when debugging.</li>
+        <li><strong>Nemotron Nano 9B v2:</strong> use <code>--chat-template auto</code>. The BPE runtime should encode raw prompts by default; set <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code> only for token-id fallback/debug runs.</li>
         <li><strong>Qwen2 / Qwen3 / Qwen3.5:</strong> the <code>v8</code> runner now reproduces the same public command shapes as <code>v7</code> and clean short prompt smokes succeed on the promoted examples.</li>
         <li><strong>NaanBeige / llama-family symptom:</strong> if the first reply echoes <code>&lt;|im_start|&gt;assistant</code> or starts with <code>&lt;think&gt;</code>, keep <code>--chat-template auto</code>, do not force <code>none</code>, and treat it as a prompt-wrapper/chat-contract symptom rather than the expected reply.</li>
     </ul>

--- a/docs/site/_pages/v8-runbook.html
+++ b/docs/site/_pages/v8-runbook.html
@@ -188,6 +188,20 @@ python -m pip install -r requirements-v8.txt</pre>
     </div>
     <p class="mini-note">Use this as the current Gemma4 GGUF coherence smoke. A healthy run should produce a normal long answer and stop by EOS or <code>--max-tokens</code>, not by prompt-marker echo or language corruption. The tested local Q4_K_M run generated 1024 coherent C-code tokens; performance work remains separate.</p>
 
+    <h3>Nemotron Nano 9B v2</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://bartowski/nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF/nvidia_NVIDIA-Nemotron-Nano-9B-v2-Q4_K_M.gguf \
+  --context-len 2048 \
+  --force-convert --force-compile \
+  --prompt 'Give me a concise example of C code.' \
+  --chat-template auto \
+  --max-tokens 256 \
+  --temperature 0.0</pre>
+    </div>
+    <p class="mini-note">Use this as the current Nemotron-H / Mamba2 GGUF smoke. Native BPE text encode is enabled by default for generated BPE runtimes; set <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code> only when you intentionally want token-id prompts plus lightweight token display. A healthy run should produce normal instructional text, not token-zero collapse or repeated punctuation.</p>
+
     <h3>Qwen2 0.5B Instruct</h3>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>

--- a/docs/site/assets/concept-nemotron-h-hybrid-circuit.svg
+++ b/docs/site/assets/concept-nemotron-h-hybrid-circuit.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="760" viewBox="0 0 1180 760" role="img" aria-labelledby="title desc">
+  <title id="title">Nemotron-H hybrid circuit in C-Kernel-Engine</title>
+  <desc id="desc">Diagram showing how CK maps a Nemotron-H block into attention, Mamba2 state-space, and MoE/ReLU2 kernel families with parity and profiling gates.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.52" stop-color="#171717"/>
+      <stop offset="1" stop-color="#0b1220"/>
+    </linearGradient>
+    <linearGradient id="attention" x1="0" x2="1">
+      <stop offset="0" stop-color="#0ea5e9"/>
+      <stop offset="1" stop-color="#38bdf8"/>
+    </linearGradient>
+    <linearGradient id="mamba" x1="0" x2="1">
+      <stop offset="0" stop-color="#22c55e"/>
+      <stop offset="1" stop-color="#84cc16"/>
+    </linearGradient>
+    <linearGradient id="moe" x1="0" x2="1">
+      <stop offset="0" stop-color="#f59e0b"/>
+      <stop offset="1" stop-color="#fb7185"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="12" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#cbd5e1"/>
+    </marker>
+    <style>
+      .title { fill: #f8fafc; font: 800 30px Inter, system-ui, sans-serif; }
+      .subtitle { fill: #cbd5e1; font: 500 16px Inter, system-ui, sans-serif; }
+      .label { fill: #f8fafc; font: 700 16px Inter, system-ui, sans-serif; }
+      .small { fill: #d1d5db; font: 500 12px Inter, system-ui, sans-serif; }
+      .code { fill: #e5e7eb; font: 600 12px "JetBrains Mono", "SFMono-Regular", monospace; }
+      .box { fill: #1f2937; stroke: #374151; stroke-width: 1.4; rx: 10; filter: url(#shadow); }
+      .inner { fill: #111827; stroke: #475569; stroke-width: 1; rx: 8; }
+      .wire { stroke: #cbd5e1; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .softwire { stroke: #64748b; stroke-width: 1.6; fill: none; stroke-dasharray: 6 6; marker-end: url(#arrow); }
+      .pill { rx: 15; }
+    </style>
+  </defs>
+
+  <rect width="1180" height="760" fill="url(#bg)"/>
+  <circle cx="1010" cy="95" r="150" fill="#0ea5e9" opacity="0.07"/>
+  <circle cx="155" cy="680" r="180" fill="#22c55e" opacity="0.07"/>
+
+  <text x="48" y="58" class="title">Nemotron-H in CK: hybrid blocks become named C kernels</text>
+  <text x="48" y="86" class="subtitle">Attention, Mamba2 state-space, and MoE/ReLU2 are separate math circuits. CK keeps them explicit before optimizing layout, fusion, or distributed placement.</text>
+
+  <rect x="48" y="128" width="170" height="80" class="box"/>
+  <text x="74" y="160" class="label">Token rows</text>
+  <text x="74" y="184" class="code">[M, hidden]</text>
+
+  <path d="M 218 168 L 282 168" class="wire"/>
+  <rect x="282" y="128" width="180" height="80" class="box"/>
+  <text x="312" y="160" class="label">Block contract</text>
+  <text x="312" y="184" class="code">norm + template map</text>
+
+  <path d="M 462 168 C 520 168 520 168 576 168" class="wire"/>
+  <rect x="576" y="110" width="250" height="118" class="box"/>
+  <rect x="600" y="136" width="202" height="26" class="pill" fill="url(#attention)" opacity="0.92"/>
+  <text x="616" y="155" class="code" fill="#04111d">attention path</text>
+  <text x="600" y="186" class="small">Q/K/V projection, RoPE policy, KV cache</text>
+  <text x="600" y="208" class="code">gemm -> rope -> attn -> out</text>
+
+  <path d="M 462 168 C 520 168 520 340 576 340" class="wire"/>
+  <rect x="576" y="270" width="250" height="150" class="box"/>
+  <rect x="600" y="296" width="202" height="26" class="pill" fill="url(#mamba)" opacity="0.92"/>
+  <text x="616" y="315" class="code" fill="#062512">mamba2 / ssm path</text>
+  <text x="600" y="348" class="small">in-proj split, conv state, dt softplus</text>
+  <text x="600" y="370" class="small">selective state update, RMSNorm gate</text>
+  <text x="600" y="394" class="code">state[t] = decay * state[t-1] + input</text>
+
+  <path d="M 462 168 C 520 168 520 542 576 542" class="wire"/>
+  <rect x="576" y="474" width="250" height="136" class="box"/>
+  <rect x="600" y="500" width="202" height="26" class="pill" fill="url(#moe)" opacity="0.94"/>
+  <text x="616" y="519" class="code" fill="#241205">moe + relu2 path</text>
+  <text x="600" y="552" class="small">group-limited router selects experts</text>
+  <text x="600" y="574" class="small">ReLU2 experts run only active rows</text>
+  <text x="600" y="596" class="code">out += weight[e] * expert[e](x)</text>
+
+  <path d="M 826 168 L 900 168" class="wire"/>
+  <path d="M 826 340 L 900 340" class="wire"/>
+  <path d="M 826 542 L 900 542" class="wire"/>
+  <rect x="900" y="118" width="232" height="512" class="box"/>
+  <text x="928" y="154" class="label">CK guardrails</text>
+
+  <rect x="926" y="182" width="180" height="70" class="inner"/>
+  <text x="946" y="208" class="code">parity first</text>
+  <text x="946" y="230" class="small">PyTorch vs scalar C</text>
+
+  <rect x="926" y="276" width="180" height="88" class="inner"/>
+  <text x="946" y="302" class="code">state ownership</text>
+  <text x="946" y="324" class="small">KV cache, conv state,</text>
+  <text x="946" y="344" class="small">SSM recurrent state</text>
+
+  <rect x="926" y="388" width="180" height="88" class="inner"/>
+  <text x="946" y="414" class="code">layout proof</text>
+  <text x="946" y="436" class="small">VTune / Advisor:</text>
+  <text x="946" y="456" class="small">cache, bandwidth, stalls</text>
+
+  <rect x="926" y="500" width="180" height="94" class="inner"/>
+  <text x="946" y="526" class="code">promote only when</text>
+  <text x="946" y="548" class="small">shape sweeps pass and</text>
+  <text x="946" y="568" class="small">fused/packed kernels keep</text>
+  <text x="946" y="588" class="small">numerical parity</text>
+
+  <path d="M 694 228 C 694 250 694 252 694 270" class="softwire"/>
+  <path d="M 694 420 C 694 450 694 452 694 474" class="softwire"/>
+  <text x="110" y="286" class="label">Why this matters</text>
+  <rect x="48" y="314" width="420" height="252" class="box"/>
+  <text x="76" y="350" class="small">Nemotron-style models are not a single transformer loop.</text>
+  <text x="76" y="378" class="small">The runtime must know which path owns which state,</text>
+  <text x="76" y="406" class="small">which kernels are decode-only, and where future packed</text>
+  <text x="76" y="434" class="small">or fused kernels can replace references safely.</text>
+  <text x="76" y="480" class="code">tests: mamba2_reference, router, relu2</text>
+  <text x="76" y="506" class="code">audit: template circuit + tokenizer guardrails</text>
+  <text x="76" y="532" class="code">smoke: v8_nemotron9_highmem</text>
+
+  <rect x="48" y="624" width="1084" height="72" rx="12" fill="#0f172a" stroke="#334155"/>
+  <text x="78" y="654" class="label">Optimization rule</text>
+  <text x="78" y="678" class="small">Do not fuse first. Measure the explicit circuit, prove the bottleneck, then promote packed or fused kernels through hardware and shape gates.</text>
+</svg>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -966,6 +966,7 @@
     <li><a href="#sliding-window">Sliding-Window Attention</a></li>
     <li><a href="#gqa">Grouped Query Attention (GQA)</a></li>
     <li><a href="#normalization">Normalization: RMSNorm vs LayerNorm</a></li>
+    <li><a href="#nemotron-h-hybrid">Nemotron-H Hybrid Circuit</a></li>
     <li><a href="#mamba2-reference">Mamba2 Reference Kernels</a></li>
     <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
@@ -1515,6 +1516,45 @@ y = gamma * x / (rms + eps)
     <h3 style="margin-top: 0;">Why Remove Mean Centering?</h3>
     <p>Research found that the re-centering (subtracting mean) in LayerNorm isn't necessary for good performance. RMSNorm keeps just the scaling, which is what matters for gradient flow.</p>
     <p><strong>Used in:</strong> Llama, Mistral, Qwen, Gemma (most modern LLMs)</p>
+</div>
+
+<hr>
+
+<h2 id="nemotron-h-hybrid">Nemotron-H Hybrid Circuit: Attention + Mamba2 + MoE</h2>
+
+<p>Nemotron-H is important for CK because it is not just another dense transformer stack. A single model family can mix attention layers, Mamba2-style state-space layers, routed MoE blocks, ReLU2 experts, tokenizer guardrails, and model-specific template rules. CK needs to represent that as an auditable circuit of named kernels before it becomes a high-performance runtime.</p>
+
+<div class="img-container svg-viewer" data-title="Nemotron-H Hybrid Circuit">
+    <img src="assets/concept-nemotron-h-hybrid-circuit.svg" alt="Nemotron-H hybrid attention, Mamba2, and MoE circuit">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">What CK Has to Preserve</h3>
+        <p>The hard part is not only implementing the math once. The runtime has to preserve state ownership and layout contracts across different layer types:</p>
+        <ul>
+            <li><strong>Attention:</strong> Q/K/V projection, RoPE or no-RoPE policy, KV-cache placement, and output projection.</li>
+            <li><strong>Mamba2 / SSM:</strong> input projection split, convolution state, <code>dt</code> softplus, recurrent selective state update, and gated normalization.</li>
+            <li><strong>MoE:</strong> group-limited routing, top-k expert selection, ReLU2 expert execution, and weighted accumulation.</li>
+        </ul>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why Profiling Comes Before Fusion</h3>
+        <p>VTune and Advisor are exactly the right tools here. They tell us whether a slow path is memory bandwidth, cache misses, branch pressure, vector under-utilization, bad thread placement, or true arithmetic cost. Only then should CK promote a fused kernel.</p>
+        <p>Good fusion candidates are real, but they should be gated:</p>
+        <ul>
+            <li>Q/K/V projection plus quantization or layout packing for prefill.</li>
+            <li>Mamba2 in-proj split plus conv-state update plus <code>dt</code> preparation.</li>
+            <li>Selective scan chunks once scalar sequence parity is locked.</li>
+            <li>Router plus expert dispatch when sparse row ownership is stable.</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <p>The current Nemotron path is deliberately reference-first. <code>make test-mamba2-reference</code> validates Mamba2 decode and sequence-scan behavior. <code>make test-nemotron-router</code> validates group-limited routing. <code>make test-moe-relu2-expert</code> validates routed ReLU2 expert math. The v8 guardrail tests cover tokenizer capability codegen, template-circuit audit rules, and high-memory Nemotron smoke coverage behind <code>make test-v8-nemotron9-highmem</code>.</p>
+    <p>This is the right foundation for the next optimization phase: use profiling to decide which references become packed, tiled, SIMD, chunked, or fused kernels, without losing the ability to explain exactly which kernel changed.</p>
 </div>
 
 <hr>

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -440,6 +440,12 @@ MAKE_TARGETS = {
         "target": "test-v8-gemma4-highmem",
         "timeout_sec": 5400,
     },
+    "v8_nemotron9_highmem": {
+        "name": "v8 Nemotron Nano 9B High-Memory Smoke",
+        "category": "inference",
+        "target": "test-v8-nemotron9-highmem",
+        "timeout_sec": 7200,
+    },
 }
 
 # Benchmark targets with perf extraction

--- a/src/kernels/mamba2_kernels.c
+++ b/src/kernels/mamba2_kernels.c
@@ -198,18 +198,30 @@ void mamba2_selective_state_update_decode_f32(const float *state_in,
         return;
     }
 
+    const int packed_xbc = (x == b && b == c);
+    const size_t inner_dim = (size_t)num_heads * (size_t)head_dim;
+    const size_t bc_dim = (size_t)num_groups * (size_t)state_dim;
+    const size_t packed_stride = inner_dim + 2u * bc_dim;
+
     for (int row = 0; row < rows; ++row) {
+        const float *packed_row = packed_xbc ? x + (size_t)row * packed_stride : NULL;
         for (int h = 0; h < num_heads; ++h) {
-            const int group = (int)(((long long)h * (long long)num_groups) / (long long)num_heads);
+            const int heads_per_group = (num_heads + num_groups - 1) / num_groups;
+            int group = h / heads_per_group;
+            if (group >= num_groups) group = num_groups - 1;
             const float dt_h = dt[(size_t)row * (size_t)num_heads + (size_t)h];
             const float d_a = expf(dt_h * a[h]);
             const float d_h = d[h];
-            const float *b_row = b + ((size_t)row * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
-            const float *c_row = c + ((size_t)row * (size_t)num_groups + (size_t)group) * (size_t)state_dim;
+            const float *b_row = packed_xbc
+                ? (packed_row + inner_dim + (size_t)group * (size_t)state_dim)
+                : (b + ((size_t)row * (size_t)num_groups + (size_t)group) * (size_t)state_dim);
+            const float *c_row = packed_xbc
+                ? (packed_row + inner_dim + bc_dim + (size_t)group * (size_t)state_dim)
+                : (c + ((size_t)row * (size_t)num_groups + (size_t)group) * (size_t)state_dim);
 
             for (int hd = 0; hd < head_dim; ++hd) {
                 const size_t x_idx = ((size_t)row * (size_t)num_heads + (size_t)h) * (size_t)head_dim + (size_t)hd;
-                const float x_val = x[x_idx];
+                const float x_val = packed_xbc ? packed_row[(size_t)h * (size_t)head_dim + (size_t)hd] : x[x_idx];
                 const size_t state_base =
                     (((size_t)row * (size_t)num_heads + (size_t)h) * (size_t)head_dim + (size_t)hd) *
                     (size_t)state_dim;
@@ -259,12 +271,14 @@ void mamba2_selective_scan_f32(const float *state_init,
         float *state_batch = state_out + (size_t)bs * state_per_batch;
         for (int t = 0; t < seq_len; ++t) {
             for (int h = 0; h < num_heads; ++h) {
-                /* Nemotron-H no-cache/chunked prefill expands B/C with
-                 * repeat(..., num_heads / num_groups, ...), yielding a
-                 * repeating head->group mapping.  The separate decode state
-                 * update kernel keeps the cache-path contiguous mapping.
+                /* Nemotron-H prefill and decode both use the repeating
+                 * B/C group map from repeat_interleave semantics.  Keeping
+                 * this in sync is required for full-prefix and incremental
+                 * decode equivalence.
                  */
-                const int group = h % num_groups;
+                const int heads_per_group = (num_heads + num_groups - 1) / num_groups;
+                int group = h / heads_per_group;
+                if (group >= num_groups) group = num_groups - 1;
                 const float dt_h = dt[((size_t)bs * (size_t)seq_len + (size_t)t) * (size_t)num_heads + (size_t)h];
                 const float d_a = expf(dt_h * a[h]);
                 const float d_h = d[h];

--- a/tests/test_deltanet.py
+++ b/tests/test_deltanet.py
@@ -214,6 +214,61 @@ class TestDeltaNetParity(unittest.TestCase):
     def test_wider_case(self) -> None:
         self._run_case(num_heads=3, state_dim=24, seed=19)
 
+    def test_sequence_rollout_matches_repeated_autoregressive_updates(self) -> None:
+        num_heads, state_dim, seq_len = 3, 12, 5
+        rng = np.random.default_rng(41)
+        q = (0.25 * rng.standard_normal((seq_len, num_heads, state_dim))).astype(np.float32)
+        k = (0.25 * rng.standard_normal((seq_len, num_heads, state_dim))).astype(np.float32)
+        v = (0.25 * rng.standard_normal((seq_len, num_heads, state_dim))).astype(np.float32)
+        g = (0.10 * rng.standard_normal((seq_len, num_heads))).astype(np.float32)
+        beta = (0.50 * rng.standard_normal((seq_len, num_heads))).astype(np.float32)
+        state = (0.20 * rng.standard_normal((num_heads, state_dim, state_dim))).astype(np.float32)
+
+        q /= np.linalg.norm(q, axis=-1, keepdims=True) + self.norm_eps
+        k /= np.linalg.norm(k, axis=-1, keepdims=True) + self.norm_eps
+
+        ck_state = state.copy()
+        ck_outs = []
+        ck_states = []
+        for t in range(seq_len):
+            next_state = np.zeros_like(ck_state)
+            out = np.zeros((num_heads, state_dim), dtype=np.float32)
+            LIB.gated_deltanet_autoregressive_forward(
+                _as_ptr(np.ascontiguousarray(q[t])),
+                _as_ptr(np.ascontiguousarray(k[t])),
+                _as_ptr(np.ascontiguousarray(v[t])),
+                _as_ptr(np.ascontiguousarray(g[t])),
+                _as_ptr(np.ascontiguousarray(beta[t])),
+                _as_ptr(ck_state),
+                _as_ptr(next_state),
+                _as_ptr(out),
+                num_heads,
+                state_dim,
+                ctypes.c_float(self.norm_eps),
+            )
+            ck_outs.append(out.copy())
+            ck_states.append(next_state.copy())
+            ck_state = next_state
+
+        torch_state = torch.tensor(state, dtype=torch.float32)
+        torch_outs = []
+        torch_states = []
+        for t in range(seq_len):
+            torch_state, torch_out = torch_deltanet(
+                torch.tensor(q[t], dtype=torch.float32),
+                torch.tensor(k[t], dtype=torch.float32),
+                torch.tensor(v[t], dtype=torch.float32),
+                torch.tensor(g[t], dtype=torch.float32),
+                torch.tensor(beta[t], dtype=torch.float32),
+                torch_state,
+                self.norm_eps,
+            )
+            torch_outs.append(torch_out.detach().numpy())
+            torch_states.append(torch_state.detach().numpy())
+
+        np.testing.assert_allclose(np.stack(ck_outs), np.stack(torch_outs), atol=self.atol_forward, rtol=0.0)
+        np.testing.assert_allclose(np.stack(ck_states), np.stack(torch_states), atol=self.atol_forward, rtol=0.0)
+
     def test_strict_parity_dispatches_ref(self) -> None:
         LIB.ck_set_strict_parity(1)
         try:

--- a/tests/test_v8_nemotron_state_shape.py
+++ b/tests/test_v8_nemotron_state_shape.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "version/v8/scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+BUILD_IR = SCRIPTS / "build_ir_v8.py"
+
+
+def _load_build_ir():
+    spec = importlib.util.spec_from_file_location("build_ir_v8", BUILD_IR)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class NemotronStateShapeTests(unittest.TestCase):
+    def test_nemotron_h_mamba2_state_shape_uses_state_dim_not_square_head_dim(self) -> None:
+        build_ir = _load_build_ir()
+        cfg = build_ir._normalize_manifest_config(
+            {
+                "model_type": "nemotron_h",
+                "arch": "nemotron_h",
+                "num_layers": 8,
+                "embed_dim": 4480,
+                "ssm_state_size": 128,
+                "ssm_group_count": 8,
+                "ssm_time_step_rank": 128,
+                "ssm_inner_size": 10240,
+                "mamba_head_dim": 80,
+                "ssm_conv_kernel": 4,
+            }
+        )
+
+        self.assertEqual(cfg["recurrent_num_heads"], 128)
+        self.assertEqual(cfg["recurrent_head_dim"], 80)
+        self.assertEqual(cfg["recurrent_state_heads"], 128)
+        self.assertEqual(cfg["recurrent_state_rows"], 80)
+        self.assertEqual(cfg["recurrent_state_cols"], 128)
+        self.assertEqual(build_ir._recurrent_state_stride_bytes(cfg, "ssm"), 128 * 80 * 128 * 4)
+
+        specs = build_ir.build_activation_specs(cfg, mode="decode", context_len=64)
+        self.assertEqual(specs["recurrent_ssm_state"]["shape"], "[8, 128, 80, 128]")
+        self.assertEqual(specs["recurrent_ssm_state"]["size"], 8 * 128 * 80 * 128 * 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -14,6 +14,64 @@ def _require_torch_safetensors() -> tuple[object, object]:
     return torch, st
 
 
+
+
+def _write_tiny_bpe_tokenizer(checkpoint: Path, vocab_size: int) -> None:
+    vocab: dict[str, int] = {
+        "<unk>": 0,
+        "<s>": 1,
+        "</s>": 2,
+        "Hello": 3,
+        "world": 4,
+        "!": 5,
+        "Ġtest": 6,
+        "Ġcode": 7,
+        "Helloworld": 8,
+        "ĠtestĠcode": 9,
+    }
+    for idx in range(len(vocab), vocab_size):
+        vocab[f"<tok_{idx}>"] = idx
+
+    (checkpoint / "tokenizer.json").write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "model": {
+                    "type": "BPE",
+                    "unk_token": "<unk>",
+                    "vocab": vocab,
+                    "merges": ["Hello world", "Ġtest Ġcode"],
+                },
+                "added_tokens": [
+                    {"id": 0, "content": "<unk>"},
+                    {"id": 1, "content": "<s>"},
+                    {"id": 2, "content": "</s>"},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (checkpoint / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "tokenizer_class": "PreTrainedTokenizerFast",
+                "bos_token": {"content": "<s>"},
+                "eos_token": {"content": "</s>"},
+                "unk_token": {"content": "<unk>"},
+                "add_bos_token": True,
+                "add_eos_token": False,
+                "added_tokens_decoder": {
+                    "0": {"content": "<unk>"},
+                    "1": {"content": "<s>"},
+                    "2": {"content": "</s>"},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
 def test_qwen3_safetensors_to_bump_smoke(tmp_path: Path) -> None:
     torch, st = _require_torch_safetensors()
     checkpoint = tmp_path / "qwen3"
@@ -41,6 +99,7 @@ def test_qwen3_safetensors_to_bump_smoke(tmp_path: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
+    _write_tiny_bpe_tokenizer(checkpoint, vocab_size=32)
 
     tensors = {
         "model.embed_tokens.weight": torch.randn(32, 8, dtype=torch.bfloat16),
@@ -88,7 +147,27 @@ def test_qwen3_safetensors_to_bump_smoke(tmp_path: Path) -> None:
     assert names[0] == "token_emb"
     assert "layer.0.q_norm" in names
     assert "layer.0.k_norm" in names
-    assert names[-1] == "output.weight"
+    assert "output.weight" in names
+    assert {"vocab_offsets", "vocab_strings", "vocab_merges"}.issubset(set(names))
+    assert names[-3:] == ["vocab_offsets", "vocab_strings", "vocab_merges"]
+    entries = {entry["name"]: entry for entry in manifest["entries"]}
+    assert entries["vocab_offsets"]["dtype"] == "i32"
+    assert entries["vocab_strings"]["dtype"] == "u8"
+    assert entries["vocab_merges"]["dtype"] == "i32"
+    assert entries["vocab_offsets"]["shape"] == [32]
+    assert entries["vocab_strings"]["size"] > 0
+    assert entries["vocab_merges"]["shape"] == [6]
+    assert entries["vocab_merges"]["size"] == 24
+    assert manifest["tokenizer_contract"]["tokenizer_type"] == "bpe"
+    assert manifest["config"]["tokenizer_contract"]["tokenizer_type"] == "bpe"
+    assert manifest["special_tokens"]["bos_token"] == "<s>"
+    assert manifest["special_tokens"]["bos_token_id"] == 1
+    assert manifest["special_tokens"]["eos_token"] == "</s>"
+    assert manifest["special_tokens"]["eos_token_id"] == 2
+    assert manifest["special_tokens"]["unk_token"] == "<unk>"
+    assert manifest["special_tokens"]["unk_token_id"] == 0
+    assert manifest["template"]["flags"]["tokenizer"] == "bpe"
+    assert manifest["template"]["contract"]["tokenizer_contract"]["tokenizer_type"] == "bpe"
     assert (out / "weights.bump").stat().st_size > 0
 
 
@@ -441,8 +520,18 @@ def test_nemotron_h_safetensors_to_bump_dry_run_maps_dense_mamba_attention_relu2
     assert cfg["layer_state_policy"] == ["mamba2", "none", "none"]
     assert cfg["layer_moe_policy"] == ["none", "none", "none"]
     assert cfg["layer_mlp_policy"] == ["none", "none", "relu2"]
+    attention_ops = manifest["template"]["block_types"]["decoder"]["body"]["ops_by_kind"]["attention"]
+    assert "rope_qk" not in attention_ops
     assert cfg["ssm_conv_kernel"] == 4
     assert cfg["ssm_conv_history"] == 4
+    assert cfg["recurrent_num_heads"] == 2
+    assert cfg["recurrent_head_dim"] == 4
+    assert cfg["recurrent_state_heads"] == 2
+    assert cfg["recurrent_state_rows"] == 4
+    assert cfg["recurrent_state_cols"] == 3
+    assert manifest["config"]["recurrent_state_heads"] == 2
+    assert manifest["config"]["recurrent_state_rows"] == 4
+    assert manifest["config"]["recurrent_state_cols"] == 3
     assert "layer.0.mamba_in_proj" in names
     assert "layer.1.attn_q" in names
     assert "layer.2.mlp_up" in names
@@ -478,10 +567,31 @@ def test_nemotron_h_safetensors_to_bump_dry_run_maps_dense_mamba_attention_relu2
     conv_state = next(
         buf for buf in layout["memory"]["activations"]["buffers"] if buf["name"] == "recurrent_conv_state"
     )
+    ssm_state = next(
+        buf for buf in layout["memory"]["activations"]["buffers"] if buf["name"] == "recurrent_ssm_state"
+    )
     assert conv_state["shape"] == "[3, 4, 20]"
+    assert ssm_state["shape"] == "[3, 2, 4, 3]"
+
+    ir1_ops = json.loads((out / "ir1_decode.json").read_text(encoding="utf-8"))["ops"]
+    ir1_by_op = {(op["layer"], op["op"]): op for op in ir1_ops if "layer" in op}
+    ir1_mamba_in = ir1_by_op[(0, "mamba_in_proj")]
+    assert ir1_mamba_in["dataflow"]["inputs"]["x"]["slot"] == "layer_input"
+    assert ir1_mamba_in["dataflow"]["inputs"]["x"]["from_op"] == ir1_by_op[(0, "block_rmsnorm")]["op_id"]
 
     lowered_ops = json.loads(lowered.read_text(encoding="utf-8"))["operations"]
     by_op = {(op["layer"], op["op"]): op for op in lowered_ops}
+
+    attention_layer_ops = [op["op"] for op in lowered_ops if op.get("layer") == 1]
+    assert "rope_qk" not in attention_layer_ops
+    assert "kv_cache_store" in attention_layer_ops
+    assert attention_layer_ops.index("v_proj") < attention_layer_ops.index("kv_cache_store") < attention_layer_ops.index("attn")
+    attn = by_op[(1, "attn")]
+    assert attn["kernel"] == "attention_forward_decode_head_major_gqa_flash"
+    assert attn["_kv_cache_read_layer"] == 1
+    attn_inputs = attn.get("inputs") or attn.get("activations") or {}
+    assert attn_inputs["k_cache"]["buffer"] == "kv_cache"
+    assert attn_inputs["v_cache"]["buffer"] == "kv_cache"
 
     mamba_in = by_op[(0, "mamba_in_proj")]
     assert mamba_in["kernel"] == "gemv_bf16"

--- a/tests/test_v8_template_circuit_audit.py
+++ b/tests/test_v8_template_circuit_audit.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "version/v8/scripts/audit_template_circuit_v8.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("audit_template_circuit_v8", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _op(op_id: int, layer: int, op: str, inputs: dict, outputs: dict) -> dict:
+    return {
+        "op_id": op_id,
+        "layer": layer,
+        "op": op,
+        "kernel": op,
+        "dataflow": {"inputs": inputs, "outputs": outputs},
+    }
+
+
+class TemplateCircuitAuditTests(unittest.TestCase):
+    def test_mamba_in_proj_must_consume_block_rmsnorm_output(self) -> None:
+        audit = _load_module()
+        ir = {
+            "ops": [
+                _op(0, -1, "dense_embedding_lookup", {}, {"out": {"slot": "main_stream", "dtype": "fp32"}}),
+                _op(1, 0, "residual_save", {"src": {"from_op": 0, "slot": "main_stream"}}, {"dst": {"slot": "residual", "dtype": "fp32"}}),
+                _op(2, 0, "block_rmsnorm", {"input": {"from_op": 0, "slot": "main_stream"}}, {"output": {"slot": "layer_input", "dtype": "fp32"}}),
+                _op(3, 0, "mamba_in_proj", {"x": {"from_op": 0, "slot": "main_stream"}}, {"y": {"slot": "recurrent_packed", "dtype": "fp32"}}),
+            ]
+        }
+        errors = audit.audit_ir1(ir)
+        self.assertTrue(any("mamba_in_proj.x" in e and "expected block_rmsnorm" in e for e in errors), errors)
+
+    def test_fixed_mamba_circuit_and_lowered_buffers_pass(self) -> None:
+        audit = _load_module()
+        ir = {
+            "ops": [
+                _op(0, -1, "dense_embedding_lookup", {}, {"out": {"slot": "main_stream", "dtype": "fp32"}}),
+                _op(1, 0, "residual_save", {"src": {"from_op": 0, "slot": "main_stream"}}, {"dst": {"slot": "residual", "dtype": "fp32"}}),
+                _op(2, 0, "block_rmsnorm", {"input": {"from_op": 0, "slot": "main_stream"}}, {"output": {"slot": "layer_input", "dtype": "fp32"}}),
+                _op(3, 0, "mamba_in_proj", {"x": {"from_op": 2, "slot": "layer_input"}}, {"y": {"slot": "recurrent_packed", "dtype": "fp32"}}),
+                _op(4, 0, "mamba_in_proj_split", {"projected": {"from_op": 3, "slot": "recurrent_packed"}}, {"gate": {"slot": "recurrent_z"}, "hidden_bc": {"slot": "recurrent_conv_qkv"}, "dt": {"slot": "recurrent_g"}}),
+            ]
+        }
+        lowered = {
+            "operations": [
+                {"idx": 2, "layer": 0, "op": "block_rmsnorm", "activations": {"input": {"buffer": "embedded_input"}}, "outputs": {"output": {"buffer": "layer_input"}}},
+                {"idx": 3, "layer": 0, "op": "mamba_in_proj", "activations": {"x": {"buffer": "layer_input"}}, "outputs": {"y": {"buffer": "recurrent_packed"}}},
+                {"idx": 4, "layer": 0, "op": "mamba_in_proj_split", "activations": {"projected": {"buffer": "recurrent_packed"}}, "outputs": {}},
+            ]
+        }
+        self.assertEqual(audit.audit_ir1(ir), [])
+        self.assertEqual(audit.audit_lowered(lowered), [])
+
+    def test_cli_reports_generated_c_mamba_input_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            c_path = Path(td) / "model_v8.c"
+            c_path.write_text(
+                """
+    /* Op 3: gemv_bf16 (mamba_in_proj) layer=0 section=body */
+    gemv_bf16(
+        (float*)(model->bump + A_RECURRENT_PACKED),
+        (const void*)(model->bump + W_LAYER_0_MAMBA_IN_PROJ),
+        (const float*)(model->bump + A_EMBEDDED_INPUT),
+        22656,
+        4480
+    );
+""",
+                encoding="utf-8",
+            )
+            audit = _load_module()
+            errors = audit.audit_c_source(c_path)
+            self.assertEqual(len(errors), 1)
+            self.assertIn("expected=A_LAYER_INPUT", errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v8_tokenizer_capability_codegen.py
+++ b/tests/test_v8_tokenizer_capability_codegen.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "version" / "v8" / "scripts") not in sys.path:
+    sys.path.insert(0, str(ROOT / "version" / "v8" / "scripts"))
+
+import build_ir_v8  # type: ignore
+
+
+class TestV8TokenizerCapabilityCodegen(unittest.TestCase):
+    def test_bpe_distinguishes_decode_tables_from_text_encode(self) -> None:
+        generated = build_ir_v8._generate_tokenizer_c_code(
+            "bpe",
+            vocab_size=256,
+            num_merges=0,
+            special_tokens={"bos_token_id": 1, "eos_token_id": 2},
+            model_type="nemotron_h",
+        )
+        self.assertIsNotNone(generated)
+        c_code = str(generated["api_functions"])
+        self.assertIn("CK_EXPORT int ck_model_has_tokenizer(void)", c_code)
+        self.assertIn("#ifdef W_VOCAB_OFFSETS", c_code)
+        self.assertIn("CK_DISABLE_FULL_BPE_TOKENIZER", c_code)
+        self.assertNotIn("CK_ENABLE_FULL_BPE_TOKENIZER", c_code)
+        self.assertIn("CK_EXPORT int ck_model_can_encode_text(void)", c_code)
+        self.assertIn("return (g_model && g_model->tokenizer) ? 1 : 0;", c_code)
+
+    def test_sentencepiece_exports_text_encode_capability(self) -> None:
+        generated = build_ir_v8._generate_tokenizer_c_code(
+            "sentencepiece",
+            vocab_size=256,
+            num_merges=0,
+            special_tokens={"bos_token_id": 1, "eos_token_id": 2},
+            model_type="gemma3",
+        )
+        self.assertIsNotNone(generated)
+        c_code = str(generated["api_functions"])
+        self.assertIn("CK_EXPORT int ck_model_has_tokenizer(void)", c_code)
+        self.assertIn("CK_EXPORT int ck_model_can_encode_text(void)", c_code)
+        self.assertIn("return (g_model && g_model->tokenizer) ? 1 : 0;", c_code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittest/test_mamba2_reference.py
+++ b/unittest/test_mamba2_reference.py
@@ -110,7 +110,7 @@ class TestMamba2Reference(unittest.TestCase):
         y_ref = torch.empty_like(x)
         for r in range(rows):
             for h in range(heads):
-                g = h * groups // heads
+                g = min(h // ((heads + groups - 1) // groups), groups - 1)
                 decay = torch.exp(dt[r, h] * a[h])
                 for hd in range(head_dim):
                     new_state = state[r, h, hd] * decay + dt[r, h] * b[r, g] * x[r, h, hd]
@@ -120,6 +120,41 @@ class TestMamba2Reference(unittest.TestCase):
         state_out = np.empty((rows, heads, head_dim, state_dim), dtype=np.float32)
         y = np.empty((rows, heads, head_dim), dtype=np.float32)
         LIB.mamba2_selective_state_update_decode_f32(*map(_fptr, arrays), _fptr(state_out), _fptr(y), rows, heads, head_dim, state_dim, groups)
+        np.testing.assert_allclose(state_out, _np(state_ref), atol=1e-6, rtol=0.0)
+        np.testing.assert_allclose(y, _np(y_ref), atol=1e-6, rtol=0.0)
+
+
+    def test_selective_state_update_decode_accepts_packed_xbc(self) -> None:
+        rows, heads, head_dim, state_dim, groups = 2, 8, 3, 5, 2
+        torch.manual_seed(44)
+        state = torch.randn(rows, heads, head_dim, state_dim, dtype=torch.float32) * 0.1
+        hidden = torch.randn(rows, heads, head_dim, dtype=torch.float32) * 0.2
+        b = torch.randn(rows, groups, state_dim, dtype=torch.float32) * 0.2
+        c = torch.randn(rows, groups, state_dim, dtype=torch.float32) * 0.2
+        dt = torch.rand(rows, heads, dtype=torch.float32) * 0.3 + 0.01
+        a = -(torch.rand(heads, dtype=torch.float32) * 0.5 + 0.1)
+        d = torch.randn(heads, dtype=torch.float32) * 0.05
+        packed = torch.cat([hidden.reshape(rows, -1), b.reshape(rows, -1), c.reshape(rows, -1)], dim=-1)
+
+        state_ref = torch.empty_like(state)
+        y_ref = torch.empty_like(hidden)
+        for r in range(rows):
+            for h in range(heads):
+                g = min(h // ((heads + groups - 1) // groups), groups - 1)
+                decay = torch.exp(dt[r, h] * a[h])
+                for hd in range(head_dim):
+                    new_state = state[r, h, hd] * decay + dt[r, h] * b[r, g] * hidden[r, h, hd]
+                    state_ref[r, h, hd] = new_state
+                    y_ref[r, h, hd] = (new_state * c[r, g]).sum() + d[h] * hidden[r, h, hd]
+
+        state_np, packed_np, dt_np, a_np, d_np = map(_np, (state, packed, dt, a, d))
+        state_out = np.empty((rows, heads, head_dim, state_dim), dtype=np.float32)
+        y = np.empty((rows, heads, head_dim), dtype=np.float32)
+        LIB.mamba2_selective_state_update_decode_f32(
+            _fptr(state_np), _fptr(packed_np), _fptr(dt_np), _fptr(a_np),
+            _fptr(packed_np), _fptr(packed_np), _fptr(d_np),
+            _fptr(state_out), _fptr(y), rows, heads, head_dim, state_dim, groups,
+        )
         np.testing.assert_allclose(state_out, _np(state_ref), atol=1e-6, rtol=0.0)
         np.testing.assert_allclose(y, _np(y_ref), atol=1e-6, rtol=0.0)
 
@@ -140,7 +175,7 @@ class TestMamba2Reference(unittest.TestCase):
         for bs in range(batch):
             for t in range(seq):
                 for h in range(heads):
-                    g = h % groups
+                    g = min(h // ((heads + groups - 1) // groups), groups - 1)
                     decay = torch.exp(dt[bs, t, h] * a[h])
                     for hd in range(head_dim):
                         new_state = state_ref[bs, h, hd] * decay + dt[bs, t, h] * b[bs, t, g] * x[bs, t, h, hd]
@@ -154,11 +189,10 @@ class TestMamba2Reference(unittest.TestCase):
         np.testing.assert_allclose(state_out, _np(state_ref), atol=1e-6, rtol=0.0)
         np.testing.assert_allclose(y, _np(y_ref), atol=1e-6, rtol=0.0)
 
-    def test_selective_scan_prefill_group_mapping_differs_from_decode_cache_mapping(self) -> None:
-        # Nemotron-H no-cache/chunked prefill expands B/C with torch.repeat,
-        # giving h % groups. The cache decode path expands with contiguous group
-        # blocks. Keep this test as a contract guard so the two kernels are not
-        # accidentally forced back to the same mapping.
+    def test_selective_state_update_decode_matches_single_token_scan_mapping(self) -> None:
+        # Nemotron-H prefill and decode must use the same repeating B/C
+        # group map so full-prefix prefill and incremental decode are equivalent
+        # for the same state, x, dt, A, B, C, and D inputs.
         batch, seq, heads, head_dim, state_dim, groups = 1, 1, 8, 2, 3, 2
         rng = np.random.default_rng(77)
         state0 = np.zeros((batch, heads, head_dim, state_dim), dtype=np.float32)
@@ -172,13 +206,30 @@ class TestMamba2Reference(unittest.TestCase):
         scan_y = np.empty_like(x)
         LIB.mamba2_selective_scan_f32(_fptr(state0), _fptr(x), _fptr(dt), _fptr(a), _fptr(b), _fptr(c), _fptr(d), _fptr(scan_state), _fptr(scan_y), batch, seq, heads, head_dim, state_dim, groups)
 
+        decode_state = np.empty((seq, heads, head_dim, state_dim), dtype=np.float32)
+        decode_y = np.empty((seq, heads, head_dim), dtype=np.float32)
+        LIB.mamba2_selective_state_update_decode_f32(
+            _fptr(state0.reshape(heads, head_dim, state_dim)),
+            _fptr(x.reshape(seq, heads, head_dim)),
+            _fptr(dt.reshape(seq, heads)),
+            _fptr(a),
+            _fptr(b.reshape(seq, groups, state_dim)),
+            _fptr(c.reshape(seq, groups, state_dim)),
+            _fptr(d),
+            _fptr(decode_state),
+            _fptr(decode_y),
+            seq, heads, head_dim, state_dim, groups,
+        )
+
         ref = np.empty_like(scan_y)
         for h in range(heads):
-            g = h % groups
+            g = min(h // ((heads + groups - 1) // groups), groups - 1)
             for hd in range(head_dim):
                 new_state = dt[0, 0, h] * b[0, 0, g] * x[0, 0, h, hd]
                 ref[0, 0, h, hd] = float(np.dot(new_state, c[0, 0, g]) + d[h] * x[0, 0, h, hd])
         np.testing.assert_allclose(scan_y, ref, atol=1e-6, rtol=0.0)
+        np.testing.assert_allclose(decode_y.reshape(batch, seq, heads, head_dim), scan_y, atol=1e-6, rtol=0.0)
+        np.testing.assert_allclose(decode_state.reshape(batch, heads, head_dim, state_dim), scan_state, atol=1e-6, rtol=0.0)
 
     def test_rmsnorm_gate_matches_torch_grouped_after_gate(self) -> None:
         rows, inner_dim, group_size = 3, 24, 6

--- a/unittest/test_recurrent_conv_state_update.py
+++ b/unittest/test_recurrent_conv_state_update.py
@@ -148,6 +148,44 @@ class TestRecurrentConvStateUpdate(unittest.TestCase):
     def test_qwen35_like_case(self) -> None:
         self._run_case(3, 1, 5, 128 * 16, 128 * 16, 2048, 13)
 
+    def test_multi_token_forward_matches_repeated_single_token_updates(self) -> None:
+        history_len, num_seqs, num_tokens = 3, 2, 5
+        q_dim, k_dim, v_dim = 7, 5, 6
+        channels = q_dim + k_dim + v_dim
+        rng = np.random.default_rng(31)
+        state_in = (0.20 * rng.standard_normal((num_seqs, channels, history_len))).astype(np.float32)
+        q = (0.25 * rng.standard_normal((num_seqs * num_tokens, q_dim))).astype(np.float32)
+        k = (0.25 * rng.standard_normal((num_seqs * num_tokens, k_dim))).astype(np.float32)
+        v = (0.25 * rng.standard_normal((num_seqs * num_tokens, v_dim))).astype(np.float32)
+
+        batch_conv = np.zeros((num_seqs, channels, history_len + num_tokens), dtype=np.float32)
+        batch_state = np.zeros((num_seqs, channels, history_len), dtype=np.float32)
+        LIB.recurrent_conv_state_update_forward(
+            _as_ptr(state_in), _as_ptr(q), _as_ptr(k), _as_ptr(v),
+            _as_ptr(batch_conv), _as_ptr(batch_state),
+            history_len, num_seqs, num_tokens, q_dim, k_dim, v_dim,
+        )
+
+        step_state = state_in.copy()
+        step_rows = []
+        for tok in range(num_tokens):
+            q_step = np.ascontiguousarray(q[tok::num_tokens])
+            k_step = np.ascontiguousarray(k[tok::num_tokens])
+            v_step = np.ascontiguousarray(v[tok::num_tokens])
+            step_conv = np.zeros((num_seqs, channels, history_len + 1), dtype=np.float32)
+            next_state = np.zeros_like(step_state)
+            LIB.recurrent_conv_state_update_forward(
+                _as_ptr(step_state), _as_ptr(q_step), _as_ptr(k_step), _as_ptr(v_step),
+                _as_ptr(step_conv), _as_ptr(next_state),
+                history_len, num_seqs, 1, q_dim, k_dim, v_dim,
+            )
+            step_rows.append(step_conv[:, :, -1:])
+            step_state = next_state
+
+        step_tail = np.concatenate(step_rows, axis=2)
+        np.testing.assert_allclose(step_tail, batch_conv[:, :, history_len:], atol=self.atol, rtol=0.0)
+        np.testing.assert_allclose(step_state, batch_state, atol=self.atol, rtol=0.0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/version/v8/model_maps/gguf_ck_map.json
+++ b/version/v8/model_maps/gguf_ck_map.json
@@ -2,6 +2,80 @@
   "version": 1,
   "description": "Declarative GGUF-to-CK model contract map. Keep model file tensor names here; keep kernel_maps focused on CK op-to-C-kernel bindings.",
   "architectures": {
+    "nemotron_h": {
+      "template": "nemotron_h",
+      "family": "nemotron_h",
+      "layer_kind_config_key": "layer_kinds",
+      "metadata_map": {
+        "block_count": "nemotron_h.block_count",
+        "context_length": "nemotron_h.context_length",
+        "embedding_length": "nemotron_h.embedding_length",
+        "feed_forward_length": "nemotron_h.feed_forward_length",
+        "vocab_size": "nemotron_h.vocab_size",
+        "attention_head_count": "nemotron_h.attention.head_count",
+        "attention_head_count_kv": "nemotron_h.attention.head_count_kv",
+        "attention_key_length": "nemotron_h.attention.key_length",
+        "attention_value_length": "nemotron_h.attention.value_length",
+        "rope_freq_base": "nemotron_h.rope.freq_base",
+        "rope_dimension_count": "nemotron_h.rope.dimension_count",
+        "ssm_conv_kernel": "nemotron_h.ssm.conv_kernel",
+        "ssm_state_size": "nemotron_h.ssm.state_size",
+        "ssm_group_count": "nemotron_h.ssm.group_count",
+        "ssm_inner_size": "nemotron_h.ssm.inner_size",
+        "ssm_time_step_rank": "nemotron_h.ssm.time_step_rank"
+      },
+      "layer_kinds": {
+        "mamba": {
+          "required_suffixes": [
+            "attn_norm.weight",
+            "ssm_in.weight",
+            "ssm_conv1d.weight",
+            "ssm_conv1d.bias",
+            "ssm_dt.bias",
+            "ssm_a",
+            "ssm_d",
+            "ssm_norm.weight",
+            "ssm_out.weight"
+          ]
+        },
+        "mlp": {
+          "required_suffixes": [
+            "attn_norm.weight",
+            "ffn_up.weight",
+            "ffn_down.weight"
+          ]
+        },
+        "attention": {
+          "required_suffixes": [
+            "attn_norm.weight",
+            "attn_q.weight",
+            "attn_k.weight",
+            "attn_v.weight",
+            "attn_output.weight"
+          ]
+        }
+      },
+      "tensor_map": {
+        "token_embd.weight": "token_emb",
+        "output_norm.weight": "final_ln_weight",
+        "output.weight": "output.weight",
+        "blk.{L}.attn_norm.weight": "layer.{L}.block_norm",
+        "blk.{L}.ssm_in.weight": "layer.{L}.mamba_in_proj",
+        "blk.{L}.ssm_conv1d.weight": "layer.{L}.mamba_conv1d",
+        "blk.{L}.ssm_conv1d.bias": "layer.{L}.mamba_conv1d_bias",
+        "blk.{L}.ssm_dt.bias": "layer.{L}.mamba_dt_bias",
+        "blk.{L}.ssm_a": "layer.{L}.mamba_a",
+        "blk.{L}.ssm_d": "layer.{L}.mamba_d",
+        "blk.{L}.ssm_norm.weight": "layer.{L}.mamba_norm",
+        "blk.{L}.ssm_out.weight": "layer.{L}.mamba_out_proj",
+        "blk.{L}.ffn_up.weight": "layer.{L}.mlp_up",
+        "blk.{L}.ffn_down.weight": "layer.{L}.mlp_down",
+        "blk.{L}.attn_q.weight": "layer.{L}.attn_q",
+        "blk.{L}.attn_k.weight": "layer.{L}.attn_k",
+        "blk.{L}.attn_v.weight": "layer.{L}.attn_v",
+        "blk.{L}.attn_output.weight": "layer.{L}.attn_o"
+      }
+    },
     "nemotron_h_moe": {
       "template": "nemotron_h",
       "family": "nemotron_h",

--- a/version/v8/scripts/audit_template_circuit_v8.py
+++ b/version/v8/scripts/audit_template_circuit_v8.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Audit v8 generated circuit artifacts for template/dataflow consistency.
+
+This validates the graph after IR generation and lowering. It is intentionally
+artifact-first: if ir1/lowered JSON is wrong, generated C will be wrong too.
+The optional C audit is only a final codegen-preservation check.
+"""
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ops(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    ops = doc.get("ops") or doc.get("operations") or []
+    return ops if isinstance(ops, list) else []
+
+
+def _op_id(op: dict[str, Any]) -> int:
+    return int(op.get("op_id", op.get("idx", -1)))
+
+
+def _layer(op: dict[str, Any]) -> int | None:
+    if "layer" not in op or op.get("layer") is None:
+        return None
+    try:
+        return int(op.get("layer"))
+    except Exception:
+        return None
+
+
+def _input_ref(op: dict[str, Any], name: str) -> dict[str, Any]:
+    return (((op.get("dataflow") or {}).get("inputs") or {}).get(name) or {})
+
+
+def _lookup_tensor(mapping: dict[str, Any], names: tuple[str, ...]) -> dict[str, Any]:
+    for name in names:
+        item = mapping.get(name)
+        if isinstance(item, dict):
+            return item
+    return {}
+
+
+def _input_buffer(op: dict[str, Any], name: str) -> str:
+    aliases = {
+        "x": ("x", "input", "A"),
+        "projected": ("projected", "x", "A"),
+        "dt": ("dt", "x", "A"),
+        "gate": ("gate", "z"),
+    }
+    names = aliases.get(name, (name,))
+    return str((_lookup_tensor(op.get("activations") or {}, names).get("buffer") or ""))
+
+
+def _output_buffer(op: dict[str, Any], name: str) -> str:
+    aliases = {"y": ("y", "out", "C", "output"), "out": ("out", "y", "C", "output")}
+    names = aliases.get(name, (name,))
+    return str((_lookup_tensor(op.get("outputs") or {}, names).get("buffer") or ""))
+
+
+def _by_layer_name(ops: list[dict[str, Any]]) -> dict[tuple[int, str], dict[str, Any]]:
+    out: dict[tuple[int, str], dict[str, Any]] = {}
+    for op in ops:
+        layer = _layer(op)
+        name = str(op.get("op") or "")
+        if layer is None or layer < 0 or not name:
+            continue
+        out.setdefault((layer, name), op)
+    return out
+
+
+def _same_producer(errors: list[str], consumer: dict[str, Any], input_name: str, producer: dict[str, Any], label: str) -> None:
+    ref = _input_ref(consumer, input_name)
+    if int(ref.get("from_op", -999999)) != _op_id(producer):
+        errors.append(
+            f"{label}: {consumer.get('op')}.{input_name} comes from op {ref.get('from_op')} "
+            f"but expected {producer.get('op')} op {_op_id(producer)}"
+        )
+
+
+def _slot(errors: list[str], op: dict[str, Any], input_name: str, expected: str, label: str) -> None:
+    ref = _input_ref(op, input_name)
+    if str(ref.get("slot") or "") != expected:
+        errors.append(f"{label}: {op.get('op')}.{input_name} slot={ref.get('slot')} expected={expected}")
+
+
+def audit_ir1(ir1: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    ops = _ops(ir1)
+    by = _by_layer_name(ops)
+    layers = sorted({layer for layer, _ in by})
+    for layer in layers:
+        norm = by.get((layer, "block_rmsnorm"))
+        residual_save = by.get((layer, "residual_save"))
+        residual_add = by.get((layer, "residual_add"))
+        if norm is None:
+            continue
+        label = f"layer {layer}"
+        for proj_name in ("mamba_in_proj", "q_proj", "q_gate_proj", "k_proj", "v_proj", "mlp_up", "mlp_gate_up", "moe_router"):
+            proj = by.get((layer, proj_name))
+            if proj is not None:
+                _same_producer(errors, proj, "x", norm, f"{label} pre-norm projection")
+                _slot(errors, proj, "x", "layer_input", f"{label} pre-norm projection")
+        split = by.get((layer, "mamba_in_proj_split"))
+        mamba_in = by.get((layer, "mamba_in_proj"))
+        if split is not None and mamba_in is not None:
+            _same_producer(errors, split, "projected", mamba_in, f"{label} mamba split")
+        conv = by.get((layer, "mamba_conv1d_silu"))
+        if conv is not None and split is not None:
+            _same_producer(errors, conv, "x", split, f"{label} mamba conv")
+        dt = by.get((layer, "mamba_dt_softplus"))
+        if dt is not None and split is not None:
+            _same_producer(errors, dt, "dt", split, f"{label} mamba dt")
+        scan = by.get((layer, "mamba_selective_scan"))
+        if scan is not None:
+            if conv is not None:
+                for input_name in ("x", "B", "C"):
+                    _same_producer(errors, scan, input_name, conv, f"{label} mamba scan")
+            if dt is not None:
+                _same_producer(errors, scan, "dt", dt, f"{label} mamba scan")
+        gate_norm = by.get((layer, "mamba_rmsnorm_gate"))
+        if gate_norm is not None:
+            if scan is not None:
+                _same_producer(errors, gate_norm, "x", scan, f"{label} mamba gated norm")
+            if split is not None:
+                _same_producer(errors, gate_norm, "gate", split, f"{label} mamba gated norm")
+        mamba_out = by.get((layer, "mamba_out_proj"))
+        if mamba_out is not None and gate_norm is not None:
+            _same_producer(errors, mamba_out, "x", gate_norm, f"{label} mamba out")
+        relu2 = by.get((layer, "relu2"))
+        mlp_up = by.get((layer, "mlp_up"))
+        if relu2 is not None and mlp_up is not None:
+            _same_producer(errors, relu2, "x", mlp_up, f"{label} mlp relu2")
+        mlp_down = by.get((layer, "mlp_down"))
+        if mlp_down is not None and relu2 is not None:
+            _same_producer(errors, mlp_down, "x", relu2, f"{label} mlp down")
+        q = by.get((layer, "q_proj")); k = by.get((layer, "k_proj")); v = by.get((layer, "v_proj"))
+        rope = by.get((layer, "rope_qk"))
+        if rope is not None:
+            if q is not None:
+                _same_producer(errors, rope, "q", q, f"{label} rope")
+            if k is not None:
+                _same_producer(errors, rope, "k", k, f"{label} rope")
+        attn = by.get((layer, "attn")) or by.get((layer, "attn_sliding"))
+        if attn is not None:
+            if rope is not None:
+                _same_producer(errors, attn, "q", rope, f"{label} attention")
+                k_ref = _input_ref(attn, "k")
+                if k_ref.get("slot") == "kv_cache":
+                    pass  # decode path reads K from the explicit KV cache stream inserted during lowering
+                else:
+                    _same_producer(errors, attn, "k", rope, f"{label} attention")
+            if v is not None:
+                v_ref = _input_ref(attn, "v")
+                if v_ref.get("slot") == "kv_cache":
+                    pass  # decode path reads V from the explicit KV cache stream inserted during lowering
+                else:
+                    _same_producer(errors, attn, "v", v, f"{label} attention")
+        out_proj = by.get((layer, "out_proj"))
+        if out_proj is not None and attn is not None:
+            _same_producer(errors, out_proj, "x", attn, f"{label} attention out")
+        if residual_add is not None and residual_save is not None:
+            residual_ref = _input_ref(residual_add, "residual")
+            if residual_ref and int(residual_ref.get("from_op", -999999)) != _op_id(residual_save):
+                errors.append(f"{label} residual_add.residual does not consume residual_save")
+    return errors
+
+
+def audit_lowered(lowered: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    ops = _ops(lowered)
+    by = _by_layer_name(ops)
+    layers = sorted({layer for layer, _ in by})
+    for layer in layers:
+        label = f"layer {layer}"
+        for proj_name in ("mamba_in_proj", "q_proj", "q_gate_proj", "k_proj", "v_proj", "mlp_up", "mlp_gate_up", "moe_router"):
+            proj = by.get((layer, proj_name))
+            if proj is not None:
+                buf = _input_buffer(proj, "x")
+                if buf != "layer_input":
+                    errors.append(f"{label}: lowered {proj_name}.x buffer={buf} expected=layer_input")
+        checks = [
+            ("mamba_in_proj_split", "projected", "recurrent_packed"),
+            ("mamba_conv1d_silu", "x", "recurrent_conv_qkv"),
+            ("mamba_dt_softplus", "dt", "recurrent_g"),
+            ("mamba_selective_scan", "x", "recurrent_conv_qkv"),
+            ("mamba_selective_scan", "dt", "recurrent_g"),
+            ("mamba_rmsnorm_gate", "x", "recurrent_v"),
+            ("mamba_rmsnorm_gate", "gate", "recurrent_z"),
+            ("mamba_out_proj", "x", "recurrent_normed"),
+            ("relu2", "x", "mlp_scratch"),
+            ("mlp_down", "x", "mlp_scratch"),
+        ]
+        for op_name, input_name, expected in checks:
+            op = by.get((layer, op_name))
+            if op is not None:
+                buf = _input_buffer(op, input_name)
+                if buf != expected:
+                    errors.append(f"{label}: lowered {op_name}.{input_name} buffer={buf} expected={expected}")
+    return errors
+
+
+def audit_c_source(c_path: Path) -> list[str]:
+    if not c_path:
+        return []
+    text = c_path.read_text(encoding="utf-8", errors="replace")
+    errors: list[str] = []
+    pattern = re.compile(
+        r"/\* Op \d+: gemv_bf16 \(mamba_in_proj\) layer=(\d+).*?gemv_bf16\(.*?W_LAYER_\1_MAMBA_IN_PROJ\),\s*\n\s*\(const float\*\)\(model->bump \+ ([^)]+)\),",
+        re.S,
+    )
+    for layer, arg in pattern.findall(text):
+        if arg.strip() != "A_LAYER_INPUT":
+            errors.append(f"generated C layer {layer}: mamba_in_proj input={arg.strip()} expected=A_LAYER_INPUT")
+    return errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ir1", type=Path, help="ir1_*.json artifact")
+    ap.add_argument("--lowered", type=Path, help="lowered_*.json artifact")
+    ap.add_argument("--c-source", type=Path, help="generated model_v8.c artifact")
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+    errors: list[str] = []
+    checks: dict[str, Any] = {}
+    if args.ir1:
+        e = audit_ir1(_load_json(args.ir1)); errors.extend(e); checks["ir1_errors"] = e
+    if args.lowered:
+        e = audit_lowered(_load_json(args.lowered)); errors.extend(e); checks["lowered_errors"] = e
+    if args.c_source:
+        e = audit_c_source(args.c_source); errors.extend(e); checks["c_errors"] = e
+    report = {"status": "pass" if not errors else "fail", "error_count": len(errors), "errors": errors, "checks": checks}
+    text = json.dumps(report, indent=2, sort_keys=True)
+    print(text)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text + "\n", encoding="utf-8")
+    return 0 if not errors else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -950,34 +950,40 @@ def _generate_tokenizer_c_code(tokenizer_type: str, vocab_size: int, num_merges:
             "include": '#include "tokenizer/true_bpe.h"',
             "struct_field": "CKTrueBPE *tokenizer;    /* BPE tokenizer */",
             "init": f"""
-    /* Initialize BPE tokenizer from bump data */
-    g_model->tokenizer = ck_true_bpe_create();
-    if (g_model->tokenizer) {{
-        ck_true_bpe_load_binary(
-            g_model->tokenizer,
-            {vocab_size},
-            (const int32_t*)(g_model->bump + W_VOCAB_OFFSETS),
-            (const char*)(g_model->bump + W_VOCAB_STRINGS),
-            {num_merges},
-            (const int32_t*)(g_model->bump + W_VOCAB_MERGES)
-        );
+    /* Full BPE encode-side tokenizer initialization is enabled by default so
+     * generated runtimes work end-to-end with raw text prompts. Large
+     * vocabularies can still run in token-id/display-only mode by setting
+     * CK_DISABLE_FULL_BPE_TOKENIZER=1 to skip encode-side merge/rank tables. */
+    const char *ck_disable_full_bpe = getenv("CK_DISABLE_FULL_BPE_TOKENIZER");
+    if (!ck_disable_full_bpe || strcmp(ck_disable_full_bpe, "0") == 0) {{
+        g_model->tokenizer = ck_true_bpe_create();
+        if (g_model->tokenizer) {{
+            ck_true_bpe_load_binary(
+                g_model->tokenizer,
+                {vocab_size},
+                (const int32_t*)(g_model->bump + W_VOCAB_OFFSETS),
+                (const char*)(g_model->bump + W_VOCAB_STRINGS),
+                {num_merges},
+                (const int32_t*)(g_model->bump + W_VOCAB_MERGES)
+            );
 {bpe_contract_block}
 
-        /* Register special tokens for pre-BPE matching.
-         * Without this, <|im_end|> gets broken into characters by BPE.
-         */
-        static const char *special_tokens[] = {{
+            /* Register special tokens for pre-BPE matching.
+             * Without this, <|im_end|> gets broken into characters by BPE.
+             */
+            static const char *special_tokens[] = {{
 {special_token_lines}
-            NULL
-        }};
-        for (int i = 0; special_tokens[i] != NULL; i++) {{
-            int32_t id = ck_true_bpe_lookup(g_model->tokenizer, special_tokens[i]);
-            const char *check = ck_true_bpe_id_to_token(g_model->tokenizer, id);
-            if (check && strcmp(check, special_tokens[i]) == 0) {{
-                ck_true_bpe_add_special_token(g_model->tokenizer, special_tokens[i], id);
-                #ifdef CK_DEBUG_TOKENIZER
-                printf("[Tokenizer] Registered special: %s -> %d\\n", special_tokens[i], id);
-                #endif
+                NULL
+            }};
+            for (int i = 0; special_tokens[i] != NULL; i++) {{
+                int32_t id = ck_true_bpe_lookup(g_model->tokenizer, special_tokens[i]);
+                const char *check = ck_true_bpe_id_to_token(g_model->tokenizer, id);
+                if (check && strcmp(check, special_tokens[i]) == 0) {{
+                    ck_true_bpe_add_special_token(g_model->tokenizer, special_tokens[i], id);
+                    #ifdef CK_DEBUG_TOKENIZER
+                    printf("[Tokenizer] Registered special: %s -> %d\n", special_tokens[i], id);
+                    #endif
+                }}
             }}
         }}
     }}""",
@@ -990,38 +996,86 @@ def _generate_tokenizer_c_code(tokenizer_type: str, vocab_size: int, num_merges:
 /* ============================================================================
  * TOKENIZER API - Encode text to tokens using C tokenizer
  * ============================================================================
- * Returns: number of tokens written to internal buffer
- * The tokens are written to the same buffer that prefill() reads from.
- * After encoding, call ck_model_prefill() with the returned count.
+ * Full native text encoding is enabled by default for end-to-end raw prompts.
+ * Token-id prompts and generated-token display can still use the lightweight
+ * BUMP vocab tables if CK_DISABLE_FULL_BPE_TOKENIZER=1 is set.
  */
 CK_EXPORT int ck_model_encode_text(const char *text, int text_len) {
     if (!g_model || !g_model->tokenizer || !text) return 0;
     if (text_len < 0) text_len = (int)strlen(text);
     if (text_len == 0) return 0;
 
-    /* Encode directly into the token_ids buffer that prefill uses */
     int32_t *token_buf = (int32_t*)(g_model->bump + A_TOKEN_IDS);
     int max_tokens = MAX_SEQ_LEN;
+    return ck_true_bpe_encode(g_model->tokenizer, text, text_len, token_buf, max_tokens);
+}
 
-    int num_tokens = ck_true_bpe_encode(
-        g_model->tokenizer,
-        text,
-        text_len,
-        token_buf,
-        max_tokens
-    );
+static const char *ck_model_vocab_piece(int32_t id, int *len_out) {
+#ifndef W_VOCAB_OFFSETS
+    (void)id; (void)len_out;
+    return NULL;
+#else
+    if (!g_model || id < 0 || id >= VOCAB_SIZE || !len_out) return NULL;
+    const int32_t *offsets = (const int32_t*)(g_model->bump + W_VOCAB_OFFSETS);
+    const char *strings = (const char*)(g_model->bump + W_VOCAB_STRINGS);
+    int start = offsets[id];
+    int end = (id + 1 < VOCAB_SIZE) ? offsets[id + 1] : VOCAB_STRINGS_SIZE;
+    if (start < 0 || end < start || end > VOCAB_STRINGS_SIZE) return NULL;
+    *len_out = end - start;
+    return strings + start;
+#endif
+}
 
-    return num_tokens;
+static int ck_model_append_vocab_piece(int32_t id, char *text, int pos, int max_len) {
+    int len = 0;
+    const unsigned char *piece = (const unsigned char*)ck_model_vocab_piece(id, &len);
+    if (!piece || max_len <= 0) return pos;
+    for (int i = 0; i < len && pos < max_len - 1; ) {
+        if (i + 1 < len && piece[i] == 0xC4 && piece[i + 1] == 0xA0) {
+            text[pos++] = ' ';
+            i += 2;
+        } else if (i + 1 < len && piece[i] == 0xC4 && piece[i + 1] == 0x8A) {
+            text[pos++] = '\\n';
+            i += 2;
+        } else if (i + 2 < len && piece[i] == 0xE2 && piece[i + 1] == 0x96 && piece[i + 2] == 0x81) {
+            text[pos++] = ' ';
+            i += 3;
+        } else {
+            text[pos++] = (char)piece[i++];
+        }
+    }
+    text[pos] = '\\0';
+    return pos;
 }
 
 /* Decode tokens back to text */
 CK_EXPORT int ck_model_decode_tokens(const int32_t *ids, int num_ids, char *text, int max_len) {
-    if (!g_model || !g_model->tokenizer || !ids || !text || max_len <= 0) return 0;
-    return ck_true_bpe_decode(g_model->tokenizer, ids, num_ids, text, max_len);
+    if (!g_model || !ids || !text || max_len <= 0) return 0;
+    if (g_model->tokenizer) {
+        return ck_true_bpe_decode(g_model->tokenizer, ids, num_ids, text, max_len);
+    }
+    int pos = 0;
+    text[0] = '\\0';
+    for (int i = 0; i < num_ids; i++) {
+        pos = ck_model_append_vocab_piece(ids[i], text, pos, max_len);
+    }
+    return pos;
 }
 
-/* Check if tokenizer is available */
+/* Check if tokenizer data is available */
 CK_EXPORT int ck_model_has_tokenizer(void) {
+#ifdef W_VOCAB_OFFSETS
+    return g_model ? 1 : 0;
+#else
+    return (g_model && g_model->tokenizer) ? 1 : 0;
+#endif
+}
+
+/* Check if raw text encoding is available.
+ * BPE models can decode from compact vocab tables without constructing the
+ * full tokenizer, but text encoding needs the tokenizer merge/rank state.
+ */
+CK_EXPORT int ck_model_can_encode_text(void) {
     return (g_model && g_model->tokenizer) ? 1 : 0;
 }
 
@@ -1030,22 +1084,23 @@ CK_EXPORT const int32_t* ck_model_get_token_buffer(void) {
     return g_model ? (const int32_t*)(g_model->bump + A_TOKEN_IDS) : NULL;
 }
 
-/* Lookup single token by text (returns token ID or -1 if not found)
- * Uses DIRECT vocabulary lookup, not encoding.
- * This is important for special tokens like <|im_end|> which should NOT
- * be encoded through BPE (which would break them into characters).
- */
+/* Lookup single token by text (returns token ID or -1 if not found) */
 CK_EXPORT int32_t ck_model_lookup_token(const char *text) {
-    if (!g_model || !g_model->tokenizer || !text) return -1;
-    /* Direct vocabulary lookup - returns token ID or unk_id if not found */
-    int32_t id = ck_true_bpe_lookup(g_model->tokenizer, text);
-    /* unk_id is 0 by default, but we want to return -1 for "not found" */
-    /* Check if the token is actually in vocab by verifying round-trip */
-    const char *token_str = ck_true_bpe_id_to_token(g_model->tokenizer, id);
-    if (token_str && strcmp(token_str, text) == 0) {
-        return id;  /* Found exact match */
+    if (!g_model || !text) return -1;
+    if (g_model->tokenizer) {
+        int32_t id = ck_true_bpe_lookup(g_model->tokenizer, text);
+        const char *token_str = ck_true_bpe_id_to_token(g_model->tokenizer, id);
+        return (token_str && strcmp(token_str, text) == 0) ? id : -1;
     }
-    return -1;  /* Not found or matched to different token */
+#ifdef W_VOCAB_OFFSETS
+    int text_len = (int)strlen(text);
+    for (int32_t id = 0; id < VOCAB_SIZE; id++) {
+        int piece_len = 0;
+        const char *piece = ck_model_vocab_piece(id, &piece_len);
+        if (piece && piece_len == text_len && memcmp(piece, text, (size_t)text_len) == 0) return id;
+    }
+#endif
+    return -1;
 }
 """
         }
@@ -1253,6 +1308,11 @@ CK_EXPORT int ck_model_decode_tokens(const int32_t *ids, int num_ids, char *text
 
 /* Check if tokenizer is available */
 CK_EXPORT int ck_model_has_tokenizer(void) {
+    return (g_model && g_model->tokenizer) ? 1 : 0;
+}
+
+/* Check if raw text encoding is available. */
+CK_EXPORT int ck_model_can_encode_text(void) {
     return (g_model && g_model->tokenizer) ? 1 : 0;
 }
 
@@ -3250,6 +3310,10 @@ def _normalize_manifest_config(config: Dict) -> Dict:
             out["ssm_conv_channels"] = q_dim + q_dim + v_dim
         out["recurrent_num_heads"] = int(ssm_heads)
         out["recurrent_head_dim"] = int(v_dim // int(ssm_heads)) if int(ssm_heads) else int(ssm_state)
+        if model_kind == "nemotron_h":
+            out["recurrent_state_heads"] = int(ssm_heads)
+            out["recurrent_state_rows"] = int(out["recurrent_head_dim"])
+            out["recurrent_state_cols"] = int(ssm_state)
     attn_out = _pick("attn_out_dim", default=(out.get("num_heads", 0) * out.get("head_dim", 0)))
     if attn_out is not None:
         out["attn_out_dim"] = int(attn_out)
@@ -3635,6 +3699,8 @@ def _recurrent_state_shape(config: Dict[str, Any]) -> Tuple[int, int, int]:
     The recurrent_core op contract owns this shape. Templates or inspectors may
     declare explicit recurrent_state_{heads,rows,cols} keys; otherwise we fall
     back to the common DeltaNet/KDA layout [num_heads, head_dim, head_dim].
+    Mamba2-style states must set cols explicitly because their state shape is
+    [num_heads, head_dim, state_dim], not square.
     """
     heads = int(
         config.get(
@@ -4420,7 +4486,9 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             return {"x": "branch_normed" if act == "fp32" else "branch_normed"}
         if op_type == "branch_fc2":
             return {"x": "branch_mlp" if act == "fp32" else "branch_mlp"}
-        if op_type in ("recurrent_qkv_proj", "recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj", "mamba_in_proj"):
+        if op_type == "mamba_in_proj":
+            return {"x": "layer_input" if act == "fp32" else "main_stream_q8"}
+        if op_type in ("recurrent_qkv_proj", "recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj"):
             return {"x": "main_stream" if act == "fp32" else "main_stream_q8"}
         if op_type in ("recurrent_out_proj", "mamba_out_proj"):
             return {"x": "recurrent_normed" if act == "fp32" else "main_stream_q8"}
@@ -5132,7 +5200,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                                             if quantize_kernel:
                                                 quant_op_name = f"quantize_input_{norm_instance}"
                                                 quant_op_info = get_op_info(quant_op_name, "body", layer_idx)
-                                                arranged_kernels.append({
+                                                quant_arranged = {
                                                     "op_id": quant_op_info["op_id"],
                                                     "kernel": quantize_kernel,
                                                     "op": quant_op_name,
@@ -5140,7 +5208,10 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                                                     "section": "body",
                                                     "layer": layer_idx,
                                                     "instance": norm_instance,
-                                                })
+                                                }
+                                                if op == "block_rmsnorm":
+                                                    quant_arranged["graph_slots"] = {"inputs": {"input": "layer_input"}}
+                                                arranged_kernels.append(quant_arranged)
                                                 print(f"      [{quant_op_info['op_id']:3d}] {quant_op_name:20s} → {quantize_kernel}  (inst: {norm_instance}) [AUTO-INSERTED]")
                                             break
                                     break
@@ -6137,7 +6208,9 @@ def generate_ir_lower_1(
     # ═══════════════════════════════════════════════════════════════════════════
     # AUTOMATIC KV CACHE INSERTION (decode only)
     # ═══════════════════════════════════════════════════════════════════════════
-    # Insert kv_cache_store ops after rope_qk to store K,V for use in subsequent decode.
+    # Insert kv_cache_store ops after the last K/V-transforming op to store K,V
+    # for subsequent decode. RoPE attention stores after rope_qk; no-RoPE
+    # attention (for example Nemotron-H) stores after v_proj.
     # For decode, also update attention to use the decode kernel with KV cache.
     print(f"\n  [{mode.capitalize()} mode] Inserting KV cache operations...")
     final_ops = []
@@ -6147,6 +6220,16 @@ def generate_ir_lower_1(
     decode_kv_cache_dtype = str(config.get("decode_kv_cache_dtype", "fp32") or "fp32").strip().lower()
     decode_uses_fp16_kv = decode_kv_cache_dtype in {"fp16", "f16"}
     layer_kv_source_cfg = config.get("layer_kv_source") if isinstance(config.get("layer_kv_source"), list) else []
+    decode_attention_layers = {
+        int(op.get("layer", 0))
+        for op in lowered_ops
+        if str(op.get("op", "")) in {"attn", "attn_sliding"}
+    }
+    decode_rope_layers = {
+        int(op.get("layer", 0))
+        for op in lowered_ops
+        if str(op.get("op", "")) in {"rope_qk", "mrope_qk"}
+    }
 
     def _kv_read_layer_for(layer: int) -> int:
         try:
@@ -6156,34 +6239,43 @@ def generate_ir_lower_1(
             pass
         return int(layer)
 
+    def _make_decode_kv_store_op(anchor_op: Dict[str, Any]) -> Dict[str, Any]:
+        layer = int(anchor_op["layer"])
+        return {
+            "idx": len(final_ops),  # Will be renumbered
+            "kernel": "kv_cache_store_f16" if decode_uses_fp16_kv else "kv_cache_store",
+            "op": "kv_cache_store",
+            "layer": layer,
+            "section": anchor_op["section"],
+            "function": "kv_cache_store_f16" if decode_uses_fp16_kv else "kv_cache_store",
+            "weights": {},
+            "inputs": {
+                "k": {"type": "scratch", "source": "k_scratch"},
+                "v": {"type": "scratch", "source": "v_scratch"},
+            },
+            "outputs": {
+                "kv_cache_k": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
+                "kv_cache_v": {"type": "kv_cache", "buffer": f"kv_cache_v_L{layer}"},
+            },
+            "params": copy.deepcopy(anchor_op.get("params", {})),
+            "scratch": [],
+            "_auto_inserted": True,
+        }
+
     for i, op in enumerate(lowered_ops):
         final_ops.append(op)
 
         if mode == "decode" and uses_kv_cache:
-            # After rope_qk, insert kv_cache_store
-            if op["op"] == "rope_qk":
-                layer = op["layer"]
-                kv_store_op = {
-                    "idx": len(final_ops),  # Will be renumbered
-                    "kernel": "kv_cache_store_f16" if decode_uses_fp16_kv else "kv_cache_store",
-                    "op": "kv_cache_store",
-                    "layer": layer,
-                    "section": op["section"],
-                    "function": "kv_cache_store_f16" if decode_uses_fp16_kv else "kv_cache_store",
-                    "weights": {},
-                    "inputs": {
-                        "k": {"type": "scratch", "source": "k_scratch"},
-                        "v": {"type": "scratch", "source": "v_scratch"},
-                    },
-                    "outputs": {
-                        "kv_cache_k": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
-                        "kv_cache_v": {"type": "kv_cache", "buffer": f"kv_cache_v_L{layer}"},
-                    },
-                    "params": copy.deepcopy(op.get("params", {})),
-                    "scratch": [],
-                    "_auto_inserted": True,
-                }
-                final_ops.append(kv_store_op)
+            layer = int(op.get("layer", 0))
+            op_name = str(op.get("op", ""))
+            should_store_after_rope = op_name in {"rope_qk", "mrope_qk"}
+            should_store_after_v = (
+                op_name == "v_proj"
+                and layer in decode_attention_layers
+                and layer not in decode_rope_layers
+            )
+            if should_store_after_rope or should_store_after_v:
+                final_ops.append(_make_decode_kv_store_op(op))
                 kv_store_count += 1
 
             # For decode mode, update attention ops to use decode kernel
@@ -7916,7 +8008,7 @@ def generate_ir_lower_2(
                         activation_buffers,
                         buffer_name_map,
                     )
-                    if not needs_q8_input and buf_name in ("layer_input", "main_stream_q8"):
+                    if not needs_q8_input and buf_name == "main_stream_q8":
                         buf_name = "embedded_input"
                     buf = activation_buffers.get(buf_name)
                 else:

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -369,7 +369,7 @@ def emit_memory_layout(layout: Dict, config: Dict) -> str:
     lines.append("};")
     lines.append("")
     if vocab_merges_size:
-        lines.append(f"#define VOCAB_MERGES_COUNT {vocab_merges_size // 4}")
+        lines.append(f"#define VOCAB_MERGES_COUNT {vocab_merges_size // (3 * 4)}")
     else:
         lines.append("#define VOCAB_MERGES_COUNT 0")
     if vocab_strings_size:
@@ -1416,6 +1416,37 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
+    if op_name == "mamba_selective_scan" and function == "mamba2_selective_scan_f32":
+        by_name = {str(arg.get("name", "")).lower(): str(arg.get("expr", "0")) for arg in args}
+        update_args = [
+            by_name.get("state_init", "0"),
+            by_name.get("x", "0"),
+            by_name.get("dt", "0"),
+            by_name.get("a", "0"),
+            by_name.get("b", "0"),
+            by_name.get("c", "0"),
+            by_name.get("d", "0"),
+            by_name.get("state_out", "0"),
+            by_name.get("y", "0"),
+            "1",
+            by_name.get("num_heads", "0"),
+            by_name.get("head_dim", "0"),
+            by_name.get("state_dim", "0"),
+            by_name.get("num_groups", "0"),
+        ]
+        if profile:
+            lines.append(f"    CK_PROFILE_BEGIN();")
+        lines.append("    mamba2_selective_state_update_decode_f32(")
+        for i, expr in enumerate(update_args):
+            comma = "," if i < len(update_args) - 1 else ""
+            lines.append(f"        {expr}{comma}")
+        lines.append("    );")
+        if profile:
+            lines.append(f'    CK_PROFILE_END("decode", "mamba2_selective_state_update_decode_f32", "{op_name}", {layer});')
+        if seq_idx is not None:
+            lines.append(f"    if (stop_seq == {seq_idx}) return;")
+        return "\n".join(lines)
+
     if profile:
         lines.append(f"    CK_PROFILE_BEGIN();")
     if not args:
@@ -1557,6 +1588,18 @@ def emit_op(
             count_expr = _hidden_count("dim", "n", "intermediate_dim", default="INTERMEDIATE_DIM")
             lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_geglu", (const float*){out_expr}, {count_expr});')
             _emit_hidden_export_last_row(out_expr, "mlp_geglu", count_expr)
+    elif op_name == "mlp_up":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
+        if out_expr:
+            count_expr = _hidden_count("m", "M", "rows", "out_dim", default="INTERMEDIATE_DIM")
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "mlp_up", (const float*){out_expr}, {count_expr});')
+            _emit_hidden_export_last_row(out_expr, "mlp_up", count_expr)
+    elif op_name == "relu2":
+        out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y"))
+        if out_expr:
+            count_expr = _hidden_count("n", "dim", "intermediate_dim", default="INTERMEDIATE_DIM")
+            lines.append(f'    ck_debug_export_hidden(model, {layer}, "relu2", (const float*){out_expr}, {count_expr});')
+            _emit_hidden_export_last_row(out_expr, "relu2", count_expr)
     elif op_name == "mlp_down":
         out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
         if out_expr:

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -415,8 +415,10 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         name = arg.get("name", "")
         name_lc = str(name).lower()
 
-        # Substitute num_tokens for token count parameters
-        if source == "const:1":
+        # Substitute num_tokens for token count parameters. Mamba selective
+        # scan is single-batch prompt prefill: batch stays 1, seq_len is the
+        # runtime token count.
+        if source == "const:1" and not (op_type == "mamba_selective_scan" and name_lc == "batch"):
             expr = "num_tokens"
         elif source == "dim:seq_len":
             expr = "num_tokens"
@@ -587,6 +589,63 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             )
             return "\n".join(lines)
 
+    if op_type == "mamba_in_proj" and func == "gemm_nt_q5_0_q8_0":
+        a_expr = arg_expr_by_name.get("a")
+        b_expr = arg_expr_by_name.get("b")
+        bias_expr = arg_expr_by_name.get("bias", "NULL")
+        c_expr = arg_expr_by_name.get("c")
+        m_expr = arg_expr_by_name.get("m", "num_tokens")
+        n_expr = arg_expr_by_name.get("n")
+        k_expr = arg_expr_by_name.get("k")
+        if a_expr and b_expr and c_expr and n_expr and k_expr:
+            lines.append("    if (debug_prefill_mamba_in_proj_row_gemv) {")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.extend([
+                f"        const int _ck_m = (int)({m_expr});",
+                f"        const int _ck_n = (int)({n_expr});",
+                f"        const int _ck_k = (int)({k_expr});",
+                "        const size_t _ck_a_row_bytes = (size_t)(_ck_k / QK8_0) * sizeof(block_q8_0);",
+                f"        const uint8_t *_ck_a_base = (const uint8_t*)({a_expr});",
+                f"        const uint8_t *_ck_w_base = (const uint8_t*)({b_expr});",
+                f"        const float *_ck_bias = (const float*)({bias_expr});",
+                f"        float *_ck_c_base = (float*)({c_expr});",
+                "        for (int _ck_t = 0; _ck_t < _ck_m; ++_ck_t) {",
+                "            const void *_ck_xq8 = (const void*)(_ck_a_base + (size_t)_ck_t * _ck_a_row_bytes);",
+                "            float *_ck_y = _ck_c_base + (size_t)_ck_t * (size_t)_ck_n;",
+                "            gemv_q5_0_q8_0(_ck_y, (const void*)_ck_w_base, _ck_xq8, _ck_n, _ck_k);",
+                "            if (_ck_bias != NULL) {",
+                "                for (int _ck_i = 0; _ck_i < _ck_n; ++_ck_i) _ck_y[_ck_i] += _ck_bias[_ck_i];",
+                "            }",
+                "        }",
+            ])
+            if profile:
+                lines.append(f'        CK_PROFILE_END("prefill", "gemv_q5_0_q8_0", "{op_type}_row_gemv", {layer});')
+            lines.append("    } else {")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.extend([
+                f"        {func}(",
+                f"            {a_expr},",
+                f"            {b_expr},",
+                f"            {bias_expr},",
+                f"            {c_expr},",
+                f"            {m_expr},",
+                f"            {n_expr},",
+                f"            {k_expr}",
+                "        );",
+            ])
+            if profile:
+                lines.append(f'        CK_PROFILE_END("prefill", "{func}", "{op_type}", {layer});')
+            lines.append("    }")
+            raw_expr = c_expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append(
+                f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "mamba_in_proj_last", '
+                f'(const float*)(((const float*){raw_expr}) + (((size_t)num_tokens - 1u) * (size_t)({n_expr}))), '
+                f'(int)({n_expr}));'
+            )
+            return "\n".join(lines)
+
     # Format the function call / quantization loop
     if batch_quant_kind and len(args) >= 3:
         x_expr = args[0]
@@ -709,6 +768,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         _emit_head_major_last(_hidden_arg("k"), "rope_k", _hidden_arg("num_kv_heads") or "NUM_KV_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
     elif op_type == "out_proj":
         _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "out_proj", "EMBED_DIM")
+    elif op_type == "block_rmsnorm":
+        _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "block_rmsnorm", "EMBED_DIM")
     elif op_type == "post_attention_norm":
         _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "post_attn_norm", "EMBED_DIM")
     elif op_type == "ffn_norm":
@@ -736,8 +797,36 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             )
     elif op_type == "geglu":
         _emit_hidden_last(_hidden_arg("output", "out", "x", "y", "data"), "mlp_geglu", _hidden_arg("dim") or "INTERMEDIATE_DIM")
+    elif op_type == "mlp_up":
+        _emit_hidden_last(
+            _hidden_arg("output", "out", "c", "y"),
+            "mlp_up",
+            _hidden_arg("n", "out_dim") or "INTERMEDIATE_SIZE",
+        )
+    elif op_type == "relu2":
+        _emit_hidden_last(
+            _hidden_arg("output", "out", "x", "y", "data"),
+            "relu2",
+            _hidden_arg("dim", "intermediate_dim") or "INTERMEDIATE_SIZE",
+        )
     elif op_type == "mlp_down":
         _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "mlp_down", "EMBED_DIM")
+    elif op_type == "mamba_in_proj":
+        _emit_hidden_last(_hidden_arg("output", "out", "c", "y", "C"), "mamba_in_proj", _hidden_arg("N") or _hidden_arg("m", "M", "rows", "out_dim") or "0")
+    elif op_type == "mamba_in_proj_split":
+        _emit_hidden_last(_hidden_arg("gate", "z"), "mamba_gate", _hidden_arg("intermediate_dim", "inner_dim") or "INTERMEDIATE_SIZE")
+        _emit_hidden_last(_hidden_arg("hidden_bc", "conv_qkv", "x"), "mamba_hidden_bc", _hidden_arg("conv_dim") or "0")
+        _emit_hidden_last(_hidden_arg("dt"), "mamba_dt_raw", _hidden_arg("num_heads") or "0")
+    elif op_type == "mamba_conv1d_silu":
+        _emit_hidden_last(_hidden_arg("conv_out", "out", "y"), "mamba_conv", _hidden_arg("conv_dim") or "0")
+    elif op_type == "mamba_dt_softplus":
+        _emit_hidden_last(_hidden_arg("dt_out", "out", "y"), "mamba_dt", _hidden_arg("num_heads") or "0")
+    elif op_type == "mamba_selective_scan":
+        _emit_hidden_last(_hidden_arg("y", "out"), "mamba_scan_y", f"(({_hidden_arg('num_heads') or '0'}) * ({_hidden_arg('head_dim') or '0'}))")
+    elif op_type == "mamba_rmsnorm_gate":
+        _emit_hidden_last(_hidden_arg("out", "y"), "mamba_normed", _hidden_arg("inner_dim", "intermediate_dim") or "INTERMEDIATE_SIZE")
+    elif op_type == "mamba_out_proj":
+        _emit_hidden_last(_hidden_arg("output", "out", "c", "y", "C"), "mamba_out_proj", "EMBED_DIM")
     elif op_type == "gemma4_per_layer_embed":
         _emit_hidden_last(_hidden_arg("hidden", "output", "out", "x", "y"), "gemma4_per_layer_embed", "EMBED_DIM")
     elif op_type == "final_rmsnorm":
@@ -867,6 +956,8 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv = debug_prefill_mlp_gate_up_row_gemv_env ? (atoi(debug_prefill_mlp_gate_up_row_gemv_env) != 0) : 0;
     const char *debug_prefill_mlp_gate_up_row_gemv_layer_env = getenv("CK_V8_DEBUG_PREFILL_MLP_GATE_UP_ROW_GEMV_LAYER");
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
+    const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
+    int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
 
     /* Copy input tokens to activation buffer (follow same pattern as decode) */
     memcpy((void*)(model->bump + A_TOKEN_IDS), tokens, (size_t)num_tokens * sizeof(int32_t));
@@ -1290,6 +1381,8 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv = debug_prefill_mlp_gate_up_row_gemv_env ? (atoi(debug_prefill_mlp_gate_up_row_gemv_env) != 0) : 0;
     const char *debug_prefill_mlp_gate_up_row_gemv_layer_env = getenv("CK_V8_DEBUG_PREFILL_MLP_GATE_UP_ROW_GEMV_LAYER");
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
+    const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
+    int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
     const float *ck_debug_mlp_gate_up_fp32_input = NULL;
 """
     prologue = prologue.replace(

--- a/version/v8/scripts/compare_first_token_logits_v8.py
+++ b/version/v8/scripts/compare_first_token_logits_v8.py
@@ -119,6 +119,7 @@ def _run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess
         cmd,
         cwd=str(cwd or ROOT),
         text=True,
+        errors="replace",
         capture_output=True,
         check=False,
     )

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -2263,7 +2263,25 @@ def main() -> None:
         "qwen35.ssm.time_step_rank",
         "qwen35.ssm.inner_size",
         "qwen35.full_attention_interval",
-        # Nemotron-H MoE/Mamba hybrid keys
+        # Nemotron-H Mamba/MLP/attention and MoE/Mamba hybrid keys
+        "nemotron_h.block_count",
+        "nemotron_h.context_length",
+        "nemotron_h.embedding_length",
+        "nemotron_h.feed_forward_length",
+        "nemotron_h.vocab_size",
+        "nemotron_h.attention.head_count",
+        "nemotron_h.attention.head_count_kv",
+        "nemotron_h.attention.key_length",
+        "nemotron_h.attention.value_length",
+        "nemotron_h.attention.layer_norm_rms_epsilon",
+        "nemotron_h.attention.layer_norm_epsilon",
+        "nemotron_h.rope.freq_base",
+        "nemotron_h.rope.dimension_count",
+        "nemotron_h.ssm.conv_kernel",
+        "nemotron_h.ssm.state_size",
+        "nemotron_h.ssm.group_count",
+        "nemotron_h.ssm.inner_size",
+        "nemotron_h.ssm.time_step_rank",
         "nemotron_h_moe.block_count",
         "nemotron_h_moe.context_length",
         "nemotron_h_moe.embedding_length",
@@ -2344,6 +2362,7 @@ def main() -> None:
         "qwen2.tie_word_embeddings",
         "qwen3.tie_word_embeddings",
         "qwen3vl.tie_word_embeddings",
+        "nemotron_h.tie_word_embeddings",
         "nemotron_h_moe.tie_word_embeddings",
         "gemma3.tie_word_embeddings",
         "mistral.tie_word_embeddings",
@@ -2355,6 +2374,7 @@ def main() -> None:
         "qwen2.embedding_weight_tying",
         "qwen3.embedding_weight_tying",
         "qwen3vl.embedding_weight_tying",
+        "nemotron_h.embedding_weight_tying",
         "nemotron_h_moe.embedding_weight_tying",
         "gemma3.embedding_weight_tying",
         "gemma4.tie_word_embeddings",
@@ -3138,7 +3158,7 @@ def main() -> None:
             raise GGUFError(f"{tok_name}: expected 2D, got dims={tok.dims}")
         embed_dim = meta_int(
             "deepseek2.embedding_length", "mistral3.embedding_length", "mistral.embedding_length",
-            "llama.embedding_length", "qwen3vl.embedding_length", "qwen3.embedding_length", "qwen2.embedding_length",
+            "llama.embedding_length", "nemotron_h.embedding_length", "nemotron_h_moe.embedding_length", "qwen3vl.embedding_length", "qwen3.embedding_length", "qwen2.embedding_length",
             "gemma3.embedding_length", "gemma4.embedding_length"
         ) or tok.ne0
         vocab_size = tok.ne1
@@ -3193,7 +3213,7 @@ def main() -> None:
 
         num_layers = meta_int(
             "deepseek2.block_count", "mistral3.block_count", "mistral.block_count",
-            "llama.block_count", "qwen35.block_count", "nemotron_h_moe.block_count", "qwen3vl.block_count", "qwen3.block_count", "qwen2.block_count",
+            "llama.block_count", "qwen35.block_count", "nemotron_h.block_count", "nemotron_h_moe.block_count", "qwen3vl.block_count", "qwen3.block_count", "qwen2.block_count",
             "gemma3.block_count", "gemma4.block_count"
         )
         if num_layers is None:
@@ -3211,7 +3231,7 @@ def main() -> None:
 
         intermediate = meta_int_or_list(
             "deepseek2.feed_forward_length", "mistral3.feed_forward_length", "mistral.feed_forward_length",
-            "llama.feed_forward_length", "qwen35.feed_forward_length", "nemotron_h_moe.feed_forward_length", "qwen3vl.feed_forward_length", "qwen3.feed_forward_length", "qwen2.feed_forward_length",
+            "llama.feed_forward_length", "qwen35.feed_forward_length", "nemotron_h.feed_forward_length", "nemotron_h_moe.feed_forward_length", "qwen3vl.feed_forward_length", "qwen3.feed_forward_length", "qwen2.feed_forward_length",
             "gemma3.feed_forward_length", "gemma4.feed_forward_length"
         )
         if isinstance(intermediate, list):
@@ -3226,21 +3246,24 @@ def main() -> None:
 
         num_heads = meta_int(
             "deepseek2.attention.head_count", "mistral3.attention.head_count", "mistral.attention.head_count",
-            "llama.attention.head_count", "qwen35.attention.head_count", "nemotron_h_moe.attention.head_count", "qwen3vl.attention.head_count", "qwen3.attention.head_count", "qwen2.attention.head_count",
+            "llama.attention.head_count", "qwen35.attention.head_count", "nemotron_h.attention.head_count", "nemotron_h_moe.attention.head_count", "qwen3vl.attention.head_count", "qwen3.attention.head_count", "qwen2.attention.head_count",
             "gemma3.attention.head_count", "gemma4.attention.head_count"
         )
         if num_heads is None:
             raise GGUFError("Missing attention.head_count (num_heads)")
-        num_kv_heads_meta = meta_int(
+        num_kv_heads_meta = meta_int_or_list(
             "deepseek2.attention.head_count_kv", "mistral3.attention.head_count_kv", "mistral.attention.head_count_kv",
-            "llama.attention.head_count_kv", "qwen35.attention.head_count_kv", "nemotron_h_moe.attention.head_count_kv", "qwen3vl.attention.head_count_kv", "qwen3.attention.head_count_kv", "qwen2.attention.head_count_kv",
+            "llama.attention.head_count_kv", "qwen35.attention.head_count_kv", "nemotron_h.attention.head_count_kv", "nemotron_h_moe.attention.head_count_kv", "qwen3vl.attention.head_count_kv", "qwen3.attention.head_count_kv", "qwen2.attention.head_count_kv",
             "gemma3.attention.head_count_kv", "gemma4.attention.head_count_kv"
         )
+        if isinstance(num_kv_heads_meta, list):
+            nz_kv_heads = [int(x) for x in num_kv_heads_meta if int(x) > 0]
+            num_kv_heads_meta = max(nz_kv_heads) if nz_kv_heads else 0
         num_kv_heads = num_kv_heads_meta if num_kv_heads_meta and num_kv_heads_meta > 0 else 0
 
         context_len = meta_int(
             "deepseek2.context_length", "mistral3.context_length", "mistral.context_length",
-            "llama.context_length", "qwen35.context_length", "nemotron_h_moe.context_length", "qwen3vl.context_length", "qwen3.context_length", "qwen2.context_length",
+            "llama.context_length", "qwen35.context_length", "nemotron_h.context_length", "nemotron_h_moe.context_length", "qwen3vl.context_length", "qwen3.context_length", "qwen2.context_length",
             "gemma3.context_length", "gemma4.context_length"
         ) or 0
         if args.context is not None:
@@ -3260,13 +3283,14 @@ def main() -> None:
 
         rope_theta = meta_float(
             "deepseek2.rope.freq_base", "mistral3.rope.freq_base", "mistral.rope.freq_base",
-            "llama.rope.freq_base", "qwen35.rope.freq_base", "qwen3vl.rope.freq_base", "qwen3.rope.freq_base", "qwen2.rope.freq_base",
+            "llama.rope.freq_base", "qwen35.rope.freq_base", "nemotron_h.rope.freq_base", "nemotron_h_moe.rope.freq_base", "qwen3vl.rope.freq_base", "qwen3.rope.freq_base", "qwen2.rope.freq_base",
             "gemma3.rope.freq_base", "gemma4.rope.freq_base"
         ) or 10000.0
 
         # Q/K/V head dimensions (some models report explicit key/value lengths)
         key_length_meta = meta_int(
             "qwen35.attention.key_length",
+            "nemotron_h.attention.key_length",
             "nemotron_h_moe.attention.key_length",
             "qwen3vl.attention.key_length",
             "qwen3.attention.key_length",
@@ -3276,6 +3300,7 @@ def main() -> None:
         )
         value_length_meta = meta_int(
             "qwen35.attention.value_length",
+            "nemotron_h.attention.value_length",
             "nemotron_h_moe.attention.value_length",
             "qwen3vl.attention.value_length",
             "qwen3.attention.value_length",
@@ -3288,6 +3313,7 @@ def main() -> None:
         # Resolve after head_dim is known.
         rotary_dim_meta = meta_int(
             "qwen35.rope.dimension_count",
+            "nemotron_h.rope.dimension_count",
             "nemotron_h_moe.rope.dimension_count",
             "llama.rope.dim",
             "attention.rotary_dim",
@@ -3384,6 +3410,7 @@ def main() -> None:
         rms_eps = meta_float(
             "deepseek2.attention.layer_norm_rms_epsilon", "mistral3.attention.layer_norm_rms_epsilon",
             "mistral.attention.layer_norm_rms_epsilon", "llama.norm_rms_eps",
+            "nemotron_h.attention.layer_norm_rms_epsilon", "nemotron_h_moe.attention.layer_norm_rms_epsilon",
             "qwen35.attention.layer_norm_rms_epsilon", "qwen3vl.attention.layer_norm_rms_epsilon", "qwen3.attention.layer_norm_rms_epsilon", "qwen2.attention.layer_norm_rms_epsilon",
             "gemma3.attention.layer_norm_rms_epsilon", "gemma4.attention.layer_norm_rms_epsilon"
         ) or 1e-5
@@ -3525,6 +3552,8 @@ def main() -> None:
             "qwen2.tie_word_embeddings",
             "qwen3.tie_word_embeddings",
             "qwen3vl.tie_word_embeddings",
+            "nemotron_h.tie_word_embeddings",
+            "nemotron_h_moe.tie_word_embeddings",
             "gemma3.tie_word_embeddings",
             "gemma4.tie_word_embeddings",
             "mistral.tie_word_embeddings",
@@ -3536,6 +3565,8 @@ def main() -> None:
             "qwen2.embedding_weight_tying",
             "qwen3.embedding_weight_tying",
             "qwen3vl.embedding_weight_tying",
+            "nemotron_h.embedding_weight_tying",
+            "nemotron_h_moe.embedding_weight_tying",
             "gemma3.embedding_weight_tying",
             "gemma4.embedding_weight_tying",
             "mistral.embedding_weight_tying",
@@ -4194,7 +4225,10 @@ def main() -> None:
                 f"extra_projection_tensors={extra_tensors}."
             )
 
-        if arch == "nemotron_h_moe":
+        if arch in {"nemotron_h", "nemotron_h_moe"}:
+            nemotron_meta_prefix = "nemotron_h_moe" if arch == "nemotron_h_moe" else "nemotron_h"
+            def nmeta(key: str) -> str:
+                return f"{nemotron_meta_prefix}.{key}"
             contract = gguf_ck_arch_contract(arch)
             tensor_map = contract.get("tensor_map") or {}
             if not isinstance(tensor_map, dict):
@@ -4209,7 +4243,7 @@ def main() -> None:
                 dt = weight_dtype(info, dst_name)
                 if info.ggml_type == GGML_TYPE_F16 and dst_name != "token_emb":
                     raise GGUFError(
-                        f"{info.name}: FP16 nemotron_h_moe tensors are not supported yet outside token embeddings."
+                        f"{info.name}: FP16 nemotron_h tensors are not supported yet outside token embeddings."
                     )
                 entry = {
                     "name": dst_name,
@@ -4230,7 +4264,7 @@ def main() -> None:
             def _add_mapped_entry(plan: list[Dict[str, Any]], consumed: set[str], dst_name: str, src_name: str, *, layer_kind: Optional[str] = None) -> TensorInfo:
                 info = tensors.get(src_name)
                 if info is None:
-                    raise GGUFError(f"nemotron_h_moe conversion missing required tensor: {src_name}")
+                    raise GGUFError(f"nemotron_h conversion missing required tensor: {src_name}")
                 plan.append(_mapped_entry(dst_name, info, layer_kind=layer_kind))
                 consumed.add(src_name)
                 return info
@@ -4246,13 +4280,13 @@ def main() -> None:
 
             mamba_projection_size = 0
             mamba_intermediate_size = 0
-            mamba_conv_dim = int(meta_int("nemotron_h_moe.ssm.inner_size") or 0) + 2 * int(meta_int("nemotron_h_moe.ssm.group_count") or 0) * int(meta_int("nemotron_h_moe.ssm.state_size") or 0)
-            mamba_num_heads = int(meta_int("nemotron_h_moe.ssm.time_step_rank") or 0)
+            mamba_conv_dim = int(meta_int(nmeta("ssm.inner_size")) or 0) + 2 * int(meta_int(nmeta("ssm.group_count")) or 0) * int(meta_int(nmeta("ssm.state_size")) or 0)
+            mamba_num_heads = int(meta_int(nmeta("ssm.time_step_rank")) or 0)
             mamba_head_dim = 0
-            moe_intermediate_size = int(meta_int("nemotron_h_moe.expert_feed_forward_length") or intermediate)
-            moe_shared_intermediate_size = int(meta_int("nemotron_h_moe.expert_shared_feed_forward_length") or 0)
-            n_routed_experts = int(meta_int("nemotron_h_moe.expert_count") or 0)
-            experts_per_tok = int(meta_int("nemotron_h_moe.expert_used_count") or 0)
+            moe_intermediate_size = int(meta_int(nmeta("expert_feed_forward_length")) or intermediate)
+            moe_shared_intermediate_size = int(meta_int(nmeta("expert_shared_feed_forward_length")) or 0)
+            n_routed_experts = int(meta_int(nmeta("expert_count")) or 0)
+            experts_per_tok = int(meta_int(nmeta("expert_used_count")) or 0)
 
             for layer in range(num_layers):
                 kind = classify_layer_contract(tensors, layer, arch=arch)
@@ -4260,7 +4294,7 @@ def main() -> None:
                     detail = describe_layer_contract(tensors, layer, arch=arch)
                     if detail:
                         raise GGUFError(detail)
-                    raise GGUFError(f"Layer {layer}: unsupported nemotron_h_moe layer contract ({kind})")
+                    raise GGUFError(f"Layer {layer}: unsupported nemotron_h layer contract ({kind})")
                 layer_kind = kind[len("mapped_"):]
                 layer_kinds.append(layer_kind)
                 layer_key = f"layer.{layer}"
@@ -4292,7 +4326,7 @@ def main() -> None:
                     # It does not use the optional d_mlp prefix handled by the
                     # generic split helper, so the gate/intermediate width is
                     # the SSM inner width, not a half-residual candidate.
-                    mamba_intermediate_size = max(mamba_intermediate_size, int(meta_int("nemotron_h_moe.ssm.inner_size") or inner))
+                    mamba_intermediate_size = max(mamba_intermediate_size, int(meta_int(nmeta("ssm.inner_size")) or inner))
 
             _add_mapped_entry(nemotron_plan, consumed_sources, "final_ln_weight", "output_norm.weight")
             nemotron_plan.append({
@@ -4310,7 +4344,7 @@ def main() -> None:
             unconsumed_sources = sorted(set(tensors.keys()) - consumed_sources)
             if unconsumed_sources:
                 raise GGUFError(
-                    f"nemotron_h_moe conversion plan left {len(unconsumed_sources)} source tensors unconsumed: "
+                    f"nemotron_h conversion plan left {len(unconsumed_sources)} source tensors unconsumed: "
                     f"{unconsumed_sources[:16]}"
                 )
             source_coverage = {
@@ -4323,9 +4357,9 @@ def main() -> None:
             }
 
             if mamba_head_dim <= 0 and mamba_num_heads > 0:
-                mamba_head_dim = int((meta_int("nemotron_h_moe.ssm.inner_size") or 0) // mamba_num_heads)
+                mamba_head_dim = int((meta_int(nmeta("ssm.inner_size")) or 0) // mamba_num_heads)
             if mamba_intermediate_size <= 0:
-                mamba_intermediate_size = int(meta_int("nemotron_h_moe.ssm.inner_size") or intermediate)
+                mamba_intermediate_size = int(meta_int(nmeta("ssm.inner_size")) or intermediate)
             if mamba_projection_size <= 0:
                 mamba_projection_size = int(mamba_intermediate_size + mamba_conv_dim + mamba_num_heads)
 
@@ -4348,10 +4382,10 @@ def main() -> None:
                 "n_routed_experts": int(n_routed_experts),
                 "experts_per_tok": int(experts_per_tok),
                 "num_experts_per_tok": int(experts_per_tok),
-                "router_num_groups": int(meta_int("nemotron_h_moe.expert_group_count") or meta_int("nemotron_h_moe.router_num_groups") or 8),
-                "router_topk_group": int(meta_int("nemotron_h_moe.expert_topk_group") or meta_int("nemotron_h_moe.router_topk_group") or 4),
-                "router_norm_topk_prob": int(meta_int("nemotron_h_moe.norm_topk_prob") or meta_int("nemotron_h_moe.router_norm_topk_prob") or 1),
-                "routed_scaling_factor": float(meta_float("nemotron_h_moe.routed_scaling_factor") or meta_float("nemotron_h_moe.expert_routed_scaling_factor") or 1.0),
+                "router_num_groups": int(meta_int(nmeta("expert_group_count")) or meta_int(nmeta("router_num_groups")) or 8),
+                "router_topk_group": int(meta_int(nmeta("expert_topk_group")) or meta_int(nmeta("router_topk_group")) or 4),
+                "router_norm_topk_prob": int(meta_int(nmeta("norm_topk_prob")) or meta_int(nmeta("router_norm_topk_prob")) or 1),
+                "routed_scaling_factor": float(meta_float(nmeta("routed_scaling_factor")) or meta_float(nmeta("expert_routed_scaling_factor")) or 1.0),
                 "vocab_size": int(vocab_size),
                 "max_seq_len": int(context_len),
                 "context_length": int(context_len),
@@ -4376,12 +4410,12 @@ def main() -> None:
                 "layer_kv_policy": ["attention_kv_cache" if k == "attention" else "none" for k in layer_kinds],
                 "mamba_num_heads": int(mamba_num_heads),
                 "mamba_head_dim": int(mamba_head_dim),
-                "ssm_state_size": int(meta_int("nemotron_h_moe.ssm.state_size") or 0),
-                "ssm_conv_kernel": int(meta_int("nemotron_h_moe.ssm.conv_kernel") or 0),
-                "ssm_group_count": int(meta_int("nemotron_h_moe.ssm.group_count") or 0),
-                "ssm_inner_size": int(meta_int("nemotron_h_moe.ssm.inner_size") or 0),
+                "ssm_state_size": int(meta_int(nmeta("ssm.state_size")) or 0),
+                "ssm_conv_kernel": int(meta_int(nmeta("ssm.conv_kernel")) or 0),
+                "ssm_group_count": int(meta_int(nmeta("ssm.group_count")) or 0),
+                "ssm_inner_size": int(meta_int(nmeta("ssm.inner_size")) or 0),
                 "ssm_time_step_rank": int(mamba_num_heads),
-                "ssm_conv_history": max(int(meta_int("nemotron_h_moe.ssm.conv_kernel") or 0), 0),
+                "ssm_conv_history": max(int(meta_int(nmeta("ssm.conv_kernel")) or 0), 0),
                 "ssm_conv_channels": int(mamba_conv_dim),
                 "mamba_conv_dim": int(mamba_conv_dim),
                 "mamba_projection_size": int(mamba_projection_size),

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -45,7 +45,10 @@ from convert_gguf_to_bump_v8 import (  # type: ignore
     calculate_manifest_hash,
     calculate_metadata_hash,
     calculate_template_hash,
+    inspect_tokenizer_json,
     load_template_for_arch,
+    load_tokenizer_json,
+    _apply_tokenizer_contract_overrides,
     write_bumpv5_footer,
 )
 
@@ -625,6 +628,11 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "ssm_inner_size": ssm_inner_size,
             "ssm_conv_channels": mamba_conv_dim,
             "ssm_conv_history": max(ssm_conv_kernel, 0),
+            "recurrent_num_heads": mamba_num_heads,
+            "recurrent_head_dim": mamba_head_dim,
+            "recurrent_state_heads": mamba_num_heads,
+            "recurrent_state_rows": mamba_head_dim,
+            "recurrent_state_cols": ssm_state_size,
             "mamba_conv_dim": mamba_conv_dim,
             "mamba_projection_size": mamba_projection_size,
             "moe_intermediate_size": int(text.get("moe_intermediate_size") or 0),
@@ -847,6 +855,73 @@ def _write_ref(w: HashingWriter, model_dir: Path, headers: dict[str, HeaderTenso
     return out_dtype or "fp32", total, out_shape
 
 
+def _tokenizer_payloads_from_json(model_dir: Path, vocab_size: int) -> tuple[list[tuple[str, str, bytes, list[int], str]], dict[str, Any] | None, dict[str, Any]]:
+    tok_path = model_dir / "tokenizer.json"
+    if not tok_path.exists() or vocab_size <= 0:
+        return [], None, {}
+    info = inspect_tokenizer_json(str(tok_path))
+    tok_type = str(info.get("model_type") or "").strip().lower()
+    if tok_type not in {"bpe", "wordpiece"}:
+        return [], None, {}
+    offsets, strings_blob, merges, _scores, _types = load_tokenizer_json(str(tok_path), int(vocab_size))
+    offsets_bytes = struct.pack(f"<{len(offsets)}i", *offsets)
+    merges_bytes = struct.pack(f"<{len(merges)}i", *merges) if merges else b""
+    payloads = [
+        ("vocab_offsets", "i32", offsets_bytes, [len(offsets)], "tokenizer_json"),
+        ("vocab_strings", "u8", strings_blob, [len(strings_blob)], "tokenizer_json"),
+        ("vocab_merges", "i32", merges_bytes, [len(merges)], "tokenizer_json"),
+    ]
+    contract: dict[str, Any] = {
+        "tokenizer_type": tok_type,
+        "source": "tokenizer_json",
+        "path": str(tok_path),
+    }
+    special = _special_tokens_from_tokenizer_config(model_dir, tok_type)
+    return payloads, contract, special
+
+
+def _special_tokens_from_tokenizer_config(model_dir: Path, tokenizer_type: str) -> dict[str, Any]:
+    out: dict[str, Any] = {"tokenizer_model": tokenizer_type}
+    cfg_path = model_dir / "tokenizer_config.json"
+    if not cfg_path.exists():
+        return out
+    try:
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except Exception:
+        return out
+
+    def _content(value: Any) -> str | None:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict) and isinstance(value.get("content"), str):
+            return str(value.get("content"))
+        return None
+
+    added = cfg.get("added_tokens_decoder") if isinstance(cfg.get("added_tokens_decoder"), dict) else {}
+    token_to_id: dict[str, int] = {}
+    for key, row in added.items():
+        if not isinstance(row, dict):
+            continue
+        content = row.get("content")
+        if not isinstance(content, str):
+            continue
+        try:
+            token_to_id[content] = int(key)
+        except Exception:
+            continue
+
+    for name, field in (("bos_token", "bos_token"), ("eos_token", "eos_token"), ("unk_token", "unk_token"), ("pad_token", "pad_token")):
+        tok = _content(cfg.get(field))
+        if tok is not None:
+            out[name] = tok
+            if tok in token_to_id:
+                out[f"{name}_id"] = token_to_id[tok]
+    for key, out_key in (("add_bos_token", "add_bos_token"), ("add_eos_token", "add_eos_token"), ("add_prefix_space", "add_space_prefix")):
+        if key in cfg:
+            out[out_key] = bool(cfg.get(key))
+    return out
+
+
 def _copy_tokenizer_sidecars(model_dir: Path, out_dir: Path) -> None:
     for name in ("tokenizer.json", "tokenizer_config.json", "special_tokens_map.json", "generation_config.json"):
         src = model_dir / name
@@ -952,6 +1027,8 @@ def main() -> int:
         uniq = sorted(set(missing))
         raise SystemExit("Missing required safetensors tensors:\n  " + "\n  ".join(uniq[:80]))
 
+    tokenizer_payloads, tokenizer_contract, special_tokens = _tokenizer_payloads_from_json(model_dir, int(config.get("vocab_size") or 0))
+
     audit = _build_source_audit(arch, headers, refs)
     audit_out = args.audit_out or (args.manifest_out.parent / "conversion_audit.json")
     audit_out.parent.mkdir(parents=True, exist_ok=True)
@@ -965,7 +1042,26 @@ def main() -> int:
         tie_word_embeddings=bool(config.get("tie_word_embeddings", True)),
         has_untied_output_weight=any(e["name"] == "output.weight" for e in entries_preview),
     )
+    if tokenizer_contract:
+        template = _apply_tokenizer_contract_overrides(
+            template,
+            str(tokenizer_contract.get("tokenizer_type") or "").strip().lower(),
+        )
+        config["tokenizer_contract"] = tokenizer_contract
+        config["special_tokens"] = special_tokens
     quant_summary: dict[str, Any] = {"source": "safetensors", "dtype_policy": args.dtype}
+    for name, dt, payload, shape, source in tokenizer_payloads:
+        dtype_table.append(CK_DT_FP32)
+        entries_preview.append({
+            "name": name,
+            "dtype": dt,
+            "file_offset": offset,
+            "size": len(payload),
+            "source_name": source,
+            "shape": shape,
+        })
+        offset += len(payload)
+
     for e in entries_preview:
         if e["name"].startswith("layer."):
             layer_key = ".".join(e["name"].split(".")[:2])
@@ -999,6 +1095,8 @@ def main() -> int:
         "has_attention_biases": False,
         "has_qk_norm": True,
         "source_audit": audit,
+        "special_tokens": special_tokens,
+        "tokenizer_contract": tokenizer_contract if tokenizer_contract else None,
         "entries": entries_preview,
     }
 
@@ -1044,6 +1142,18 @@ def main() -> int:
             if transform:
                 entry["transform"] = transform
             entries.append(entry)
+        for name, dt, payload, shape, source in tokenizer_payloads:
+            start = current_offset
+            w.write(payload)
+            current_offset += len(payload)
+            entries.append({
+                "name": name,
+                "dtype": dt,
+                "file_offset": start,
+                "size": len(payload),
+                "source_name": source,
+                "shape": shape,
+            })
         checksum = w.digest()
         manifest["entries"] = entries
         args.manifest_out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/version/v8/src/ck_cli_v8.c
+++ b/version/v8/src/ck_cli_v8.c
@@ -101,6 +101,7 @@ typedef uintptr_t (*get_named_activation_ptr_t)(const char *name);
 typedef int (*encode_text_t)(const char *text, int text_len);
 typedef int (*decode_tokens_t)(const int32_t *ids, int num_ids, char *text, int max_len);
 typedef int (*has_tokenizer_t)(void);
+typedef int (*can_encode_text_t)(void);
 typedef int32_t (*lookup_token_t)(const char *text);
 typedef const char *(*id_to_token_t)(int32_t id);
 typedef const int32_t *(*get_token_buffer_t)(void);
@@ -141,6 +142,7 @@ typedef struct {
     encode_text_t encode_text;
     decode_tokens_t decode_tokens;
     has_tokenizer_t has_tokenizer;
+    can_encode_text_t can_encode_text;
     lookup_token_t lookup_token;
     id_to_token_t id_to_token;
     get_token_buffer_t get_token_buffer;
@@ -1659,6 +1661,7 @@ static bool load_model_api(const char *lib_path, ModelAPI *api) {
     resolve_symbol(api->handle, "ck_model_encode_text", (void **)&api->encode_text, false);
     resolve_symbol(api->handle, "ck_model_decode_tokens", (void **)&api->decode_tokens, false);
     resolve_symbol(api->handle, "ck_model_has_tokenizer", (void **)&api->has_tokenizer, false);
+    resolve_symbol(api->handle, "ck_model_can_encode_text", (void **)&api->can_encode_text, false);
     resolve_symbol(api->handle, "ck_model_lookup_token", (void **)&api->lookup_token, false);
     resolve_symbol(api->handle, "ck_model_get_token_buffer", (void **)&api->get_token_buffer, false);
 
@@ -2474,7 +2477,9 @@ static int run_prompt(ModelAPI *api, CLIOptions *opt, const char *input) {
 
     /* Tokenize raw user input to get user-only token count */
     int user_tokens = 0;
-    if (api->encode_text) {
+    const bool can_encode = api->encode_text &&
+        ((api->can_encode_text && api->can_encode_text()) || (!api->can_encode_text && api->has_tokenizer && api->has_tokenizer()));
+    if (can_encode) {
         int raw_n = api->encode_text(input, -1);
         if (raw_n > 0) user_tokens = raw_n;
     }
@@ -2500,7 +2505,7 @@ static int run_prompt(ModelAPI *api, CLIOptions *opt, const char *input) {
 
     /* Use model's built-in tokenizer (v7 pattern) */
     int n = -1;
-    if (api->encode_text) {
+    if (can_encode) {
         n = api->encode_text(formatted, -1);
         if (n > 0 && n <= ctx) {
             const int32_t *buf = api->get_token_buffer();
@@ -2510,7 +2515,11 @@ static int run_prompt(ModelAPI *api, CLIOptions *opt, const char *input) {
     free(formatted);
 
     if (n <= 0) {
-        fprintf(stderr, "[Tokenizer] failed to encode prompt\n");
+        if (!can_encode) {
+            fprintf(stderr, "[Tokenizer] raw text encoding is unavailable; unset CK_DISABLE_FULL_BPE_TOKENIZER or use --prompt-tokens\n");
+        } else {
+            fprintf(stderr, "[Tokenizer] failed to encode prompt\n");
+        }
         free(ids);
         return -1;
     }
@@ -4777,18 +4786,19 @@ int main(int argc, char **argv) {
         api.kv_enable(ctx);
     }
 
-    const bool has_tokenizer = api.has_tokenizer && api.has_tokenizer() &&
-                               api.encode_text && api.decode_tokens;
-    if (!has_tokenizer && !opt.prompt_tokens_csv && !opt.bridge_report_path) {
-        fprintf(stderr, "[Tokenizer] Model does not have built-in tokenizer\n");
-        fprintf(stderr, "            Use --prompt-tokens for tokenizer-free generated runtimes\n");
+    const bool has_decode_tokenizer = api.has_tokenizer && api.has_tokenizer() && api.decode_tokens;
+    const bool has_encode_tokenizer = api.encode_text &&
+        ((api.can_encode_text && api.can_encode_text()) || (!api.can_encode_text && has_decode_tokenizer));
+    if (!has_encode_tokenizer && !opt.prompt_tokens_csv && !opt.bridge_report_path) {
+        fprintf(stderr, "[Tokenizer] Model cannot encode raw text with the current tokenizer mode\n");
+        fprintf(stderr, "            Use --prompt-tokens, or unset CK_DISABLE_FULL_BPE_TOKENIZER when native BPE encode is supported\n");
         return 1;
     }
 
     int vocab_size = api.get_vocab_size ? api.get_vocab_size() : 0;
 
     /* Lookup EOS tokens using model's tokenizer */
-    if (has_tokenizer && api.lookup_token) {
+    if (has_decode_tokenizer && api.lookup_token) {
         static const char *eos_tokens[] = {
             "<|im_end|>", "<|endoftext|>", "<|im_start|>",  /* Qwen/ChatML */
             "<|eot_id|>", "<|end_of_text|>",  /* Llama 3 */

--- a/version/v8/templates/nemotron_h.json
+++ b/version/v8/templates/nemotron_h.json
@@ -114,7 +114,6 @@
             "q_proj",
             "k_proj",
             "v_proj",
-            "rope_qk",
             "attn",
             "out_proj",
             "residual_add"


### PR DESCRIPTION
## Summary
- harden v8 Q4_K packed-prefill fallback and keep cks-v8-run pinned to the v8 runner/cache
- add Nemotron-H / Mamba2 bring-up guardrails for BPE tokenizer capability, state shape, no-RoPE KV placement, and template circuit audits
- add Gemma4/Nemotron high-memory v8 smoke lanes so large model-family coverage appears in nightly reports while smaller runners skip cleanly

## Validation
- pre-commit v7-regression-fast passed
- pre-commit v8-regression-fast passed
- pre-push build, kernel parity, v8 E2E, v8 inference contracts, v7 training smoke, v7/v8 fast regressions, and v7 training-kernel parity passed
- make test-mamba2-reference passed
- make test-recurrent-conv-state-update passed
- make test-v8-template-circuit-audit passed
- make bench-q4k-dispatch-matrix-quick passed

## Notes
- High-memory Gemma4 and Nemotron 9B tests skip by default on low-memory runners.
- Pytest-based safetensors tests were not run locally because pytest is not installed in the repo venv.