### PR TITLE
feat(v8): add GLM4 template and conversion guardrails

### DIFF
--- a/docs/site/_pages/model-kernel-matrix.html
+++ b/docs/site/_pages/model-kernel-matrix.html
@@ -344,6 +344,31 @@
       </div>
     </div>
 
+    <!-- GLM4 -->
+    <div class="model-card mc-qwen">
+      <span class="model-badge">template: glm4.json</span>
+      <div class="model-title">GLM4</div>
+      <div class="model-arch">RMSNorm · partial RoPE · GQA · SwiGLU<br>BPE tokenizer · attention bias · GGUF + safetensors conversion lane</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 template — GLM4 chat contract and partial-RoPE metadata</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Conversion/parity harness — GGUF fixes, safetensors declarative map, PyTorch-vs-CK comparator</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up scope: GLM4 support is currently a low-memory conversion and template lane. The patch adds a declarative safetensors source map, GGUF metadata handling, synthetic safetensors conversion coverage, and a PyTorch-vs-CK parity harness. Full real-model runtime smoke should run on a higher-memory machine.
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">declarative safetensors map</span>
+        <span class="tag learned">partial_rope contract</span>
+        <span class="tag fixed">synthetic conversion tested</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip">BF16 safetensors</span>
+        <span class="mq-chip">GGUF</span>
+        <span class="mq-chip">Q4_K</span>
+        <span class="mq-chip">Q8_0</span>
+      </div>
+    </div>
+
     <!-- Gemma4 -->
     <div class="model-card mc-gemma4">
       <span class="model-badge">template: gemma4.json</span>
@@ -693,6 +718,7 @@
       <div class="test-item">mradermacher--Nanbeige4.1-3B-GGUF</div>
       <div class="test-item">Qwen--Qwen3.5-0.8B-GGUF</div>
       <div class="test-item">bartowski--nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF / Q4_K_M</div>
+      <div class="test-item">GLM4 synthetic safetensors + GGUF conversion/parity harness</div>
     </div>
     <p class="source-note" style="margin-top: 0.75rem;">
       Bring-up note: if a Llama-family/Nanbeige first reply starts with <code>&lt;think&gt;</code> or echoes
@@ -719,6 +745,9 @@
       <div class="test-item">
         <strong>Nemotron Nano 9B v2:</strong> the first real failure was stitching, not tokenizer or final head: Mamba2 state shape and no-RoPE KV placement had to be explicit in IR. Native BPE encode is now default-on so <code>ck_run_v8.py</code> raw prompts work end-to-end; token-id-only fallback remains available with <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code>.
       </div>
+      <div class="test-item">
+        <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK parity harness. This is a conversion/parity lane until full real-model smoke is run on a higher-memory host.
+      </div>
     </div>
   </div>
 
@@ -741,9 +770,9 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
   </div>
 
   <div class="roadmap">
-    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4, Nemotron-H, plus the Llama/Nanbeige bring-up lane.
+    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4, Nemotron-H, GLM4 conversion/parity scaffolding, plus the Llama/Nanbeige bring-up lane.
     Qwen3.5 adds hybrid recurrent-attention coverage with Gated DeltaNet kernels (forward + backward), compatible with the 0.8B dense variant.
-    Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
+    Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, GLM4 adds partial-RoPE/BPE conversion contracts, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
     v7 still targets full training expansion: backward kernels, optimizer state, gradient reduction, and IR‑driven training schedules.
     This page will keep evolving into a single matrix that shows inference + training coverage per model family.
   </div>

--- a/docs/site/_pages/v8-runbook.html
+++ b/docs/site/_pages/v8-runbook.html
@@ -202,6 +202,20 @@ python -m pip install -r requirements-v8.txt</pre>
     </div>
     <p class="mini-note">Use this as the current Nemotron-H / Mamba2 GGUF smoke. Native BPE text encode is enabled by default for generated BPE runtimes; set <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code> only when you intentionally want token-id prompts plus lightweight token display. A healthy run should produce normal instructional text, not token-zero collapse or repeated punctuation.</p>
 
+    <h3>GLM4</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre># Low-memory validation lane: template + conversion + comparator syntax
+.venv/bin/python -m unittest tests.test_v8_glm4_template
+.venv/bin/python -m py_compile \
+  version/v8/scripts/compare_glm4_torch_ck_v8.py \
+  version/v8/scripts/convert_gguf_to_bump_v8.py \
+  version/v8/scripts/convert_safetensors_to_bump_v8.py \
+  tests/test_v8_glm4_template.py \
+  tests/test_v8_safetensors_to_bump.py</pre>
+    </div>
+    <p class="mini-note">GLM4 is currently tracked as a v8 template/conversion/parity-harness lane. The patch adds GLM4 GGUF metadata handling, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK comparator. Run full real-model GLM4 smoke on a higher-memory host before promoting it to the high-memory runtime lane.</p>
+
     <h3>Qwen2 0.5B Instruct</h3>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
@@ -274,6 +288,7 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
         <li><strong>Gemma 3:</strong> use <code>--chat-template auto</code> for normal instruction/chat runs. <code>--chat-template none</code> is raw continuation mode now and needs <code>--allow-raw-prompt</code> if you intentionally want it.</li>
         <li><strong>Gemma 4:</strong> use <code>--chat-template gemma4</code>. The template uses explicit per-layer/direct split-half RoPE metadata; do not replace it with the older global split-half RoPE path when debugging.</li>
         <li><strong>Nemotron Nano 9B v2:</strong> use <code>--chat-template auto</code>. The BPE runtime should encode raw prompts by default; set <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code> only for token-id fallback/debug runs.</li>
+        <li><strong>GLM4:</strong> start with the template and safetensors/GGUF conversion tests. It has partial-RoPE and BPE contract coverage, but should stay in the conversion/parity lane until real-model smoke runs on a higher-memory host.</li>
         <li><strong>Qwen2 / Qwen3 / Qwen3.5:</strong> the <code>v8</code> runner now reproduces the same public command shapes as <code>v7</code> and clean short prompt smokes succeed on the promoted examples.</li>
         <li><strong>NaanBeige / llama-family symptom:</strong> if the first reply echoes <code>&lt;|im_start|&gt;assistant</code> or starts with <code>&lt;think&gt;</code>, keep <code>--chat-template auto</code>, do not force <code>none</code>, and treat it as a prompt-wrapper/chat-contract symptom rather than the expected reply.</li>
     </ul>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -1283,6 +1283,31 @@
       </div>
     </div>
 
+    <!-- GLM4 -->
+    <div class="model-card mc-qwen">
+      <span class="model-badge">template: glm4.json</span>
+      <div class="model-title">GLM4</div>
+      <div class="model-arch">RMSNorm · partial RoPE · GQA · SwiGLU<br>BPE tokenizer · attention bias · GGUF + safetensors conversion lane</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 template — GLM4 chat contract and partial-RoPE metadata</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Conversion/parity harness — GGUF fixes, safetensors declarative map, PyTorch-vs-CK comparator</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up scope: GLM4 support is currently a low-memory conversion and template lane. The patch adds a declarative safetensors source map, GGUF metadata handling, synthetic safetensors conversion coverage, and a PyTorch-vs-CK parity harness. Full real-model runtime smoke should run on a higher-memory machine.
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">declarative safetensors map</span>
+        <span class="tag learned">partial_rope contract</span>
+        <span class="tag fixed">synthetic conversion tested</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip">BF16 safetensors</span>
+        <span class="mq-chip">GGUF</span>
+        <span class="mq-chip">Q4_K</span>
+        <span class="mq-chip">Q8_0</span>
+      </div>
+    </div>
+
     <!-- Gemma4 -->
     <div class="model-card mc-gemma4">
       <span class="model-badge">template: gemma4.json</span>
@@ -1305,6 +1330,31 @@
         <span class="mq-chip">BF16 safetensors</span>
         <span class="mq-chip">Q4_K</span>
         <span class="mq-chip">Q6_K</span>
+      </div>
+    </div>
+
+    <!-- Nemotron -->
+    <div class="model-card mc-llama">
+      <span class="model-badge">template: nemotron_h.json</span>
+      <div class="model-title">Nemotron Nano 9B v2</div>
+      <div class="model-arch">Nemotron-H · Mamba2 recurrent blocks · sparse attention layers<br>ReLU2 MLP · Q5_0/Q4_K/Q8_0 GGUF · BPE tokenizer</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF Q4_K_M coherent C-code smoke</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Safetensors/PyTorch parity lane — Mamba2 stitching and state-shape guardrails</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up fix: Nemotron-H uses Mamba2 state shaped as <code>[heads, head_dim, state_dim]</code>, not a square DeltaNet-style recurrent matrix. The template/lowering path now carries that contract explicitly, stores no-RoPE attention KV after <code>v_proj</code>, and generated BPE runtimes can encode raw prompts end-to-end by default.
+      </div>
+      <div class="model-tags">
+        <span class="tag fixed">Mamba2 state shape explicit</span>
+        <span class="tag fixed">native BPE encode default-on</span>
+        <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip preferred">Q4_K_M ★</span>
+        <span class="mq-chip">Q5_0</span>
+        <span class="mq-chip">Q8_0</span>
+        <span class="mq-chip">BF16 safetensors</span>
       </div>
     </div>
 
@@ -1606,6 +1656,8 @@
       <div class="test-item">unsloth--gemma-4-E4B-it-GGUF / local Q4_K_M BUMP</div>
       <div class="test-item">mradermacher--Nanbeige4.1-3B-GGUF</div>
       <div class="test-item">Qwen--Qwen3.5-0.8B-GGUF</div>
+      <div class="test-item">bartowski--nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF / Q4_K_M</div>
+      <div class="test-item">GLM4 synthetic safetensors + GGUF conversion/parity harness</div>
     </div>
     <p class="source-note" style="margin-top: 0.75rem;">
       Bring-up note: if a Llama-family/Nanbeige first reply starts with <code>&lt;think&gt;</code> or echoes
@@ -1629,6 +1681,12 @@
       <div class="test-item">
         <strong>Llama / Nanbeige:</strong> SentencePiece + ChatML bring-up stabilized with untied <code>output.weight</code> preserved. Nanbeige remains an active inference lane; long coherent think traces are treated as model style, not as evidence of kernel breakage.
       </div>
+      <div class="test-item">
+        <strong>Nemotron Nano 9B v2:</strong> the first real failure was stitching, not tokenizer or final head: Mamba2 state shape and no-RoPE KV placement had to be explicit in IR. Native BPE encode is now default-on so <code>ck_run_v8.py</code> raw prompts work end-to-end; token-id-only fallback remains available with <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code>.
+      </div>
+      <div class="test-item">
+        <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK parity harness. This is a conversion/parity lane until full real-model smoke is run on a higher-memory host.
+      </div>
     </div>
   </div>
 
@@ -1651,9 +1709,9 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
   </div>
 
   <div class="roadmap">
-    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4 plus the Llama/Nanbeige bring-up lane.
+    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4, Nemotron-H, GLM4 conversion/parity scaffolding, plus the Llama/Nanbeige bring-up lane.
     Qwen3.5 adds hybrid recurrent-attention coverage with Gated DeltaNet kernels (forward + backward), compatible with the 0.8B dense variant.
-    Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
+    Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, GLM4 adds partial-RoPE/BPE conversion contracts, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
     v7 still targets full training expansion: backward kernels, optimizer state, gradient reduction, and IR‑driven training schedules.
     This page will keep evolving into a single matrix that shows inference + training coverage per model family.
   </div>
@@ -1893,8 +1951,8 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-19</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-22</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -1127,6 +1127,34 @@ python -m pip install -r requirements-v8.txt</pre>
     </div>
     <p class="mini-note">Use this as the current Gemma4 GGUF coherence smoke. A healthy run should produce a normal long answer and stop by EOS or <code>--max-tokens</code>, not by prompt-marker echo or language corruption. The tested local Q4_K_M run generated 1024 coherent C-code tokens; performance work remains separate.</p>
 
+    <h3>Nemotron Nano 9B v2</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://bartowski/nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF/nvidia_NVIDIA-Nemotron-Nano-9B-v2-Q4_K_M.gguf \
+  --context-len 2048 \
+  --force-convert --force-compile \
+  --prompt 'Give me a concise example of C code.' \
+  --chat-template auto \
+  --max-tokens 256 \
+  --temperature 0.0</pre>
+    </div>
+    <p class="mini-note">Use this as the current Nemotron-H / Mamba2 GGUF smoke. Native BPE text encode is enabled by default for generated BPE runtimes; set <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code> only when you intentionally want token-id prompts plus lightweight token display. A healthy run should produce normal instructional text, not token-zero collapse or repeated punctuation.</p>
+
+    <h3>GLM4</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre># Low-memory validation lane: template + conversion + comparator syntax
+.venv/bin/python -m unittest tests.test_v8_glm4_template
+.venv/bin/python -m py_compile \
+  version/v8/scripts/compare_glm4_torch_ck_v8.py \
+  version/v8/scripts/convert_gguf_to_bump_v8.py \
+  version/v8/scripts/convert_safetensors_to_bump_v8.py \
+  tests/test_v8_glm4_template.py \
+  tests/test_v8_safetensors_to_bump.py</pre>
+    </div>
+    <p class="mini-note">GLM4 is currently tracked as a v8 template/conversion/parity-harness lane. The patch adds GLM4 GGUF metadata handling, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK comparator. Run full real-model GLM4 smoke on a higher-memory host before promoting it to the high-memory runtime lane.</p>
+
     <h3>Qwen2 0.5B Instruct</h3>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
@@ -1178,11 +1206,28 @@ python -m pip install -r requirements-v8.txt</pre>
     <p class="mini-note">Current scope: these are the validated <code>v8</code> text-family operator surfaces. The multimodal Qwen3-VL path is separate and remains the only promoted vision family today.</p>
 </div>
 
+<div class="card card-yellow">
+    <h3 style="margin-top: 0;">High-Memory v8 Smoke Targets</h3>
+    <p>Gemma4 and Nemotron Nano 9B v2 are intentionally tracked as high-memory smoke lanes. They should appear in nightly/test reports, but skip cleanly on smaller runners instead of pretending the model family is untested.</p>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>make test-v8-gemma4-highmem
+make test-v8-nemotron9-highmem
+
+# Lower the threshold only when you intentionally want to run locally:
+V8_GEMMA4_MIN_MEM_GB=24 make test-v8-gemma4-highmem
+V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
+    </div>
+    <p class="mini-note">These tests are coherence/runtime smokes, not performance gates. They validate that the v8 conversion, compile, tokenizer/chat-template path, and first generated tokens remain sane for large model families.</p>
+</div>
+
 <div class="card">
     <h3 style="margin-top: 0;">Text-Family Notes</h3>
     <ul>
         <li><strong>Gemma 3:</strong> use <code>--chat-template auto</code> for normal instruction/chat runs. <code>--chat-template none</code> is raw continuation mode now and needs <code>--allow-raw-prompt</code> if you intentionally want it.</li>
         <li><strong>Gemma 4:</strong> use <code>--chat-template gemma4</code>. The template uses explicit per-layer/direct split-half RoPE metadata; do not replace it with the older global split-half RoPE path when debugging.</li>
+        <li><strong>Nemotron Nano 9B v2:</strong> use <code>--chat-template auto</code>. The BPE runtime should encode raw prompts by default; set <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code> only for token-id fallback/debug runs.</li>
+        <li><strong>GLM4:</strong> start with the template and safetensors/GGUF conversion tests. It has partial-RoPE and BPE contract coverage, but should stay in the conversion/parity lane until real-model smoke runs on a higher-memory host.</li>
         <li><strong>Qwen2 / Qwen3 / Qwen3.5:</strong> the <code>v8</code> runner now reproduces the same public command shapes as <code>v7</code> and clean short prompt smokes succeed on the promoted examples.</li>
         <li><strong>NaanBeige / llama-family symptom:</strong> if the first reply echoes <code>&lt;|im_start|&gt;assistant</code> or starts with <code>&lt;think&gt;</code>, keep <code>--chat-template auto</code>, do not force <code>none</code>, and treat it as a prompt-wrapper/chat-contract symptom rather than the expected reply.</li>
     </ul>
@@ -1553,8 +1598,8 @@ python -m pip install -r requirements-v8.txt</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-19</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-22</p>
             </div>
         </div>
     </footer>

--- a/tests/test_v8_glm4_template.py
+++ b/tests/test_v8_glm4_template.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+V8_BUILD_PATH = ROOT / "version" / "v8" / "scripts" / "build_ir_v8.py"
+
+
+def _load_module(name: str, path: Path):
+    if str(path.parent) not in sys.path:
+        sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+build_ir_v8 = _load_module("build_ir_v8_glm4_tests", V8_BUILD_PATH)
+
+
+class V8GLM4TemplateTests(unittest.TestCase):
+    def test_builtin_template_declares_glm4_contract(self) -> None:
+        doc = build_ir_v8._load_builtin_template_doc("glm4")
+        self.assertEqual(doc["name"], "glm4")
+        self.assertEqual(doc["flags"]["tokenizer"], "bpe")
+        self.assertEqual(doc["contract"]["attention_contract"]["rope_layout"], "split")
+        self.assertTrue(doc["contract"]["attention_contract"]["partial_rotary"])
+        self.assertTrue(doc["contract"]["block_contract"]["qkv_bias"])
+        self.assertEqual(doc["contract"]["chat_contract"]["force_bos_text_if_tokenizer_add_bos_false"], "[gMASK]")
+        self.assertEqual(
+            doc["block_types"]["decoder"]["body"]["ops"],
+            [
+                "rmsnorm",
+                "qkv_proj",
+                "rope_qk",
+                "attn",
+                "out_proj",
+                "post_attention_norm",
+                "residual_add",
+                "rmsnorm",
+                "mlp_gate_up",
+                "silu_mul",
+                "mlp_down",
+                "post_ffn_norm",
+                "residual_add",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -605,3 +605,95 @@ def test_nemotron_h_safetensors_to_bump_dry_run_maps_dense_mamba_attention_relu2
     assert relu2["activations"]["x"]["buffer"] == "mlp_scratch"
     assert relu2["outputs"]["out"]["buffer"] == "mlp_scratch"
     assert mlp_down["activations"]["x"]["buffer"] == "mlp_scratch"
+
+
+def test_glm4_safetensors_to_bump_uses_declarative_source_map(tmp_path: Path) -> None:
+    torch, st = _require_torch_safetensors()
+    checkpoint = tmp_path / "glm4"
+    out = tmp_path / "out_glm4"
+    checkpoint.mkdir()
+    out.mkdir()
+
+    (checkpoint / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Glm4ForCausalLM"],
+                "model_type": "glm4",
+                "num_hidden_layers": 1,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 4,
+                "partial_rotary_factor": 0.5,
+                "vocab_size": 32,
+                "max_position_embeddings": 64,
+                "rope_theta": 10000.0,
+                "rms_norm_eps": 1e-5,
+                "attention_bias": True,
+                "tie_word_embeddings": False,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_tiny_bpe_tokenizer(checkpoint, vocab_size=32)
+
+    tensors = {
+        "model.embed_tokens.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+        "model.layers.0.input_layernorm.weight": torch.ones(8, dtype=torch.float32),
+        "model.layers.0.post_attention_layernorm.weight": torch.ones(8, dtype=torch.float32),
+        "model.layers.0.self_attn.q_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "model.layers.0.self_attn.q_proj.bias": torch.randn(8, dtype=torch.float32),
+        "model.layers.0.self_attn.k_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+        "model.layers.0.self_attn.k_proj.bias": torch.randn(4, dtype=torch.float32),
+        "model.layers.0.self_attn.v_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+        "model.layers.0.self_attn.v_proj.bias": torch.randn(4, dtype=torch.float32),
+        "model.layers.0.self_attn.o_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "model.layers.0.self_attn.o_proj.bias": torch.randn(8, dtype=torch.float32),
+        "model.layers.0.mlp.gate_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+        "model.layers.0.mlp.up_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+        "model.layers.0.mlp.down_proj.weight": torch.randn(8, 16, dtype=torch.bfloat16),
+        "model.norm.weight": torch.ones(8, dtype=torch.float32),
+        "lm_head.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+    }
+    st.save_file(tensors, checkpoint / "model.safetensors")
+
+    script = Path("version/v8/scripts/convert_safetensors_to_bump_v8.py")
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(out / "weights.bump"),
+            "--config-out",
+            str(out / "config.json"),
+            "--manifest-out",
+            str(out / "weights_manifest.json"),
+            "--arch",
+            "auto",
+        ],
+        check=True,
+    )
+
+    manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
+    audit = json.loads((out / "conversion_audit.json").read_text(encoding="utf-8"))
+    names = [entry["name"] for entry in manifest["entries"]]
+    entries = {entry["name"]: entry for entry in manifest["entries"]}
+
+    assert manifest["model"] == "glm4"
+    assert manifest["template"]["name"] == "glm4"
+    assert manifest["template"]["contract"]["chat_contract"]["force_bos_text_if_tokenizer_add_bos_false"] == "[gMASK]"
+    assert manifest["has_attention_biases"] is True
+    assert manifest["has_qk_norm"] is False
+    assert manifest["config"]["rotary_dim"] == 2
+    assert manifest["config"]["partial_rotary_factor"] == 0.5
+    assert audit["verdict"] == "pass"
+    assert audit["unmapped_source_tensors"] == []
+    assert "layer.0.bq" in names and "layer.0.bo" in names
+    assert entries["layer.0.w1"]["source_name"].endswith("gate_proj.weight+model.layers.0.mlp.up_proj.weight")
+    assert entries["layer.0.w1"]["shape"] == [16, 8]
+    assert entries["layer.0.b1"]["shape"] == [32]
+    assert "output.weight" in names

--- a/version/v8/model_maps/safetensors_ck_map.json
+++ b/version/v8/model_maps/safetensors_ck_map.json
@@ -1,0 +1,169 @@
+{
+  "version": 1,
+  "description": "Declarative safetensors-to-CK source tensor mapping. Source formats are not first-class CK runtime artifacts; they map into BUMP manifest names consumed by templates.",
+  "architectures": {
+    "glm4": {
+      "template": "glm4",
+      "family": "glm",
+      "aliases": [
+        "glm4",
+        "Glm4ForCausalLM"
+      ],
+      "config": {
+        "model": "glm4",
+        "arch": "glm4",
+        "model_type": "glm4",
+        "rope_layout": "split",
+        "rope_param_mode": "precomputed",
+        "has_qk_norm": false,
+        "has_attention_biases": true,
+        "prefill_policy": "batched",
+        "partial_rotary_factor_key": "partial_rotary_factor"
+      },
+      "tensor_refs": [
+        {
+          "target": "token_emb",
+          "sources": [
+            "model.embed_tokens.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.ln1_gamma",
+          "sources": [
+            "model.layers.{L}.input_layernorm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "layer.{L}.ln2_gamma",
+          "sources": [
+            "model.layers.{L}.post_attention_layernorm.weight",
+            "model.layers.{L}.pre_feedforward_layernorm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "layer.{L}.wq",
+          "sources": [
+            "model.layers.{L}.self_attn.q_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.bq",
+          "sources": [
+            "model.layers.{L}.self_attn.q_proj.bias"
+          ],
+          "dtype": "fp32",
+          "fallback_synth": "zeros_fp32",
+          "shape": [
+            "q_dim"
+          ]
+        },
+        {
+          "target": "layer.{L}.wk",
+          "sources": [
+            "model.layers.{L}.self_attn.k_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.bk",
+          "sources": [
+            "model.layers.{L}.self_attn.k_proj.bias"
+          ],
+          "dtype": "fp32",
+          "fallback_synth": "zeros_fp32",
+          "shape": [
+            "kv_dim"
+          ]
+        },
+        {
+          "target": "layer.{L}.wv",
+          "sources": [
+            "model.layers.{L}.self_attn.v_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.bv",
+          "sources": [
+            "model.layers.{L}.self_attn.v_proj.bias"
+          ],
+          "dtype": "fp32",
+          "fallback_synth": "zeros_fp32",
+          "shape": [
+            "kv_dim"
+          ]
+        },
+        {
+          "target": "layer.{L}.wo",
+          "sources": [
+            "model.layers.{L}.self_attn.o_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.bo",
+          "sources": [
+            "model.layers.{L}.self_attn.o_proj.bias"
+          ],
+          "dtype": "fp32",
+          "fallback_synth": "zeros_fp32",
+          "shape": [
+            "embed_dim"
+          ]
+        },
+        {
+          "target": "layer.{L}.w1",
+          "sources": [
+            "model.layers.{L}.mlp.gate_proj.weight",
+            "model.layers.{L}.mlp.up_proj.weight"
+          ],
+          "combine": "concat"
+        },
+        {
+          "target": "layer.{L}.b1",
+          "synth": "zeros_fp32",
+          "dtype": "fp32",
+          "shape": [
+            "2*intermediate_size"
+          ]
+        },
+        {
+          "target": "layer.{L}.w2",
+          "sources": [
+            "model.layers.{L}.mlp.down_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.b2",
+          "synth": "zeros_fp32",
+          "dtype": "fp32",
+          "shape": [
+            "embed_dim"
+          ]
+        },
+        {
+          "target": "final_ln_weight",
+          "sources": [
+            "model.norm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "final_ln_bias",
+          "synth": "zeros_fp32",
+          "dtype": "fp32",
+          "shape": [
+            "embed_dim"
+          ]
+        },
+        {
+          "target": "output.weight",
+          "sources": [
+            "lm_head.weight",
+            "model.lm_head.weight"
+          ],
+          "optional": true
+        }
+      ]
+    }
+  }
+}

--- a/version/v8/scripts/compare_glm4_torch_ck_v8.py
+++ b/version/v8/scripts/compare_glm4_torch_ck_v8.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""GLM4 safetensors PyTorch-vs-CK logit parity guardrail.
+
+This script compares next-token logits for the same teacher-forced prefixes:
+
+1. Load the official GLM4 safetensors model with Transformers/PyTorch.
+2. Tokenize either --prompt or explicit --tokens.
+3. Run one causal PyTorch forward over the full prefix.
+4. Replay selected prefixes through an already-built CK v8 runtime.
+5. Compare final-token logits, top-k overlap, and tie-aware top-1 ranking.
+
+Use this for CK safetensors-to-BUMP parity first. It can also be pointed at a
+GGUF-converted CK runtime, but that compares quantized CK weights against
+unquantized PyTorch weights and should be interpreted as a smoke/diagnostic,
+not exact numerical parity.
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from version.v8.scripts.compare_first_token_logits_v8 import (  # noqa: E402
+    compare_logits,
+    discover_ck_model_dir,
+    load_ck_logits,
+    parse_tokens_csv,
+)
+
+
+def _torch_dtype(name: str) -> torch.dtype:
+    n = str(name).strip().lower()
+    if n in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if n in {"fp32", "float32"}:
+        return torch.float32
+    if n in {"fp16", "float16"}:
+        return torch.float16
+    raise ValueError(f"unsupported dtype: {name}")
+
+
+def _top_texts(tokenizer: Any, ids: list[int]) -> list[str]:
+    out: list[str] = []
+    for tok in ids:
+        try:
+            out.append(str(tokenizer.decode([int(tok)])))
+        except Exception:
+            out.append("")
+    return out
+
+
+def _top_values(logits: np.ndarray, ids: list[int]) -> list[float]:
+    return [float(logits[int(i)]) for i in ids]
+
+
+def _finite_stats(x: np.ndarray) -> dict[str, Any]:
+    finite = np.isfinite(x)
+    return {
+        "size": int(x.size),
+        "finite": int(finite.sum()),
+        "nan": int(np.isnan(x).sum()),
+        "inf": int(np.isinf(x).sum()),
+        "min": float(np.min(x[finite])) if finite.any() else None,
+        "max": float(np.max(x[finite])) if finite.any() else None,
+    }
+
+
+def _prefixes(spec: str, token_count: int) -> list[int]:
+    if token_count <= 0:
+        return []
+    text = str(spec or "auto").strip().lower()
+    if text in {"all", "every"}:
+        return list(range(1, token_count + 1))
+    if text in {"auto", ""}:
+        vals = [1, 2, 3, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+        vals = [v for v in vals if v <= token_count]
+        if token_count not in vals:
+            vals.append(token_count)
+        return vals
+    vals: list[int] = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        v = int(part)
+        if v < 0:
+            v = token_count + v + 1
+        if 1 <= v <= token_count:
+            vals.append(v)
+    return sorted(set(vals))
+
+
+def _parse_tokens_or_prompt(args: argparse.Namespace, tokenizer: Any) -> tuple[list[int], str]:
+    if args.tokens:
+        ids = parse_tokens_csv(args.tokens)
+        return ids, tokenizer.decode(ids)
+    enc = tokenizer(
+        args.prompt,
+        add_special_tokens=not bool(args.no_special_tokens),
+        return_tensors="pt",
+    )
+    ids = [int(x) for x in enc["input_ids"][0].tolist()]
+    if args.max_input_tokens and len(ids) > int(args.max_input_tokens):
+        ids = ids[: int(args.max_input_tokens)]
+    return ids, args.prompt
+
+
+def _row_report(
+    *,
+    tokenizer: Any,
+    prefix_len: int,
+    ck_logits: np.ndarray,
+    torch_logits: np.ndarray,
+    top_k: int,
+    require_top1: bool,
+    min_topk_overlap: float,
+    max_abs_threshold: float,
+    tie_margin: float,
+) -> dict[str, Any]:
+    cmp = compare_logits(ck_logits.astype(np.float32, copy=False), torch_logits.astype(np.float32, copy=False), top_k)
+    ck_ids = [int(x) for x in cmp["ck_topk_ids"]]
+    torch_ids = [int(x) for x in cmp["llama_topk_ids"]]
+    cmp["ck_topk_texts"] = _top_texts(tokenizer, ck_ids)
+    cmp["torch_topk_texts"] = _top_texts(tokenizer, torch_ids)
+    cmp["ck_topk_values"] = _top_values(ck_logits, ck_ids)
+    cmp["torch_topk_values"] = _top_values(torch_logits, torch_ids)
+
+    torch_top1_margin = float(cmp.get("llama_top1_margin", 0.0))
+    top1_match = bool(cmp["top1_match"])
+    tie_aware_top1 = top1_match or (torch_top1_margin <= float(tie_margin) and int(cmp["top1_ck"]) in torch_ids)
+    finite = _finite_stats(ck_logits)
+    torch_finite = _finite_stats(torch_logits)
+    finite_ok = finite["finite"] == int(ck_logits.size) and torch_finite["finite"] == int(torch_logits.size)
+    top1_ok = (not bool(require_top1)) or tie_aware_top1
+    overlap_ok = float(cmp["topk_overlap_ratio"]) >= float(min_topk_overlap)
+    max_abs_ok = float(cmp["max_abs_diff"]) <= float(max_abs_threshold)
+    passed = bool(finite_ok and top1_ok and overlap_ok and max_abs_ok)
+    return {
+        "prefix_len": int(prefix_len),
+        "status": "pass" if passed else "fail",
+        "pass": passed,
+        "finite_ok": bool(finite_ok),
+        "top1_match": top1_match,
+        "tie_aware_top1_ok": bool(tie_aware_top1),
+        "overlap_ok": bool(overlap_ok),
+        "max_abs_ok": bool(max_abs_ok),
+        "ck_finite": finite,
+        "torch_finite": torch_finite,
+        "compare": cmp,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--safetensors", required=True, type=Path, help="Official GLM4 HF safetensors directory")
+    ap.add_argument("--ck-model-dir", required=True, type=Path, help="CK v8 run dir containing libmodel.so/weights.bump")
+    ap.add_argument("--prompt", default="Give me a detailed example of C code.")
+    ap.add_argument("--tokens", help="Comma-separated token ids; overrides --prompt")
+    ap.add_argument("--prefixes", default="auto", help="auto, all, or comma-separated prefix lengths")
+    ap.add_argument("--max-input-tokens", type=int, default=0)
+    ap.add_argument("--no-special-tokens", action="store_true")
+    ap.add_argument("--dtype", choices=("bf16", "fp32", "fp16"), default="bf16")
+    ap.add_argument("--trust-remote-code", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--low-cpu-mem-usage", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--top-k", type=int, default=16)
+    ap.add_argument("--ck-prefill-mode", default="auto", choices=("auto", "batched", "sequential", "hybrid"))
+    ap.add_argument("--require-top1-match", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--tie-margin", type=float, default=0.05)
+    ap.add_argument("--min-topk-overlap", type=float, default=0.50)
+    ap.add_argument("--max-abs-threshold", type=float, default=1.0e9)
+    ap.add_argument("--dump-dir", type=Path, help="Optional directory for logits .npy dumps")
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    safetensors_dir = args.safetensors.expanduser().resolve()
+    ck_model_dir = discover_ck_model_dir(args.ck_model_dir)
+    dtype = _torch_dtype(args.dtype)
+
+    load_t0 = time.time()
+    tokenizer = AutoTokenizer.from_pretrained(safetensors_dir, trust_remote_code=bool(args.trust_remote_code))
+    model = AutoModelForCausalLM.from_pretrained(
+        safetensors_dir,
+        trust_remote_code=bool(args.trust_remote_code),
+        torch_dtype=dtype,
+        device_map=None,
+        low_cpu_mem_usage=bool(args.low_cpu_mem_usage),
+    )
+    model.eval()
+    load_seconds = time.time() - load_t0
+
+    token_ids, prompt_text = _parse_tokens_or_prompt(args, tokenizer)
+    if not token_ids:
+        raise SystemExit("empty token sequence")
+    input_ids = torch.tensor([token_ids], dtype=torch.long)
+    wanted_prefixes = _prefixes(args.prefixes, len(token_ids))
+    if not wanted_prefixes:
+        raise SystemExit("no valid prefixes selected")
+
+    fwd_t0 = time.time()
+    with torch.inference_mode():
+        out = model(input_ids=input_ids, use_cache=False, return_dict=True)
+    torch_seconds = time.time() - fwd_t0
+    torch_logits_all = out.logits[0].float().contiguous().cpu().numpy().astype(np.float32, copy=False)
+
+    if args.dump_dir:
+        args.dump_dir.mkdir(parents=True, exist_ok=True)
+        np.save(args.dump_dir / "input_ids.npy", input_ids.cpu().numpy().astype(np.int64, copy=False))
+
+    rows: list[dict[str, Any]] = []
+    ck_seconds_total = 0.0
+    for prefix_len in wanted_prefixes:
+        torch_logits = torch_logits_all[int(prefix_len) - 1]
+        ck_t0 = time.time()
+        ck = load_ck_logits(ck_model_dir, token_ids[: int(prefix_len)], ck_prefill_mode=args.ck_prefill_mode)
+        ck_seconds = time.time() - ck_t0
+        ck_seconds_total += ck_seconds
+        row = _row_report(
+            tokenizer=tokenizer,
+            prefix_len=int(prefix_len),
+            ck_logits=ck["logits"],
+            torch_logits=torch_logits,
+            top_k=int(args.top_k),
+            require_top1=bool(args.require_top1_match),
+            min_topk_overlap=float(args.min_topk_overlap),
+            max_abs_threshold=float(args.max_abs_threshold),
+            tie_margin=float(args.tie_margin),
+        )
+        row["ck_seconds"] = ck_seconds
+        row["ck_active_tokens"] = int(ck.get("active_tokens", 0))
+        row["ck_prefill_policy"] = str(ck.get("prefill_policy", ""))
+        rows.append(row)
+        if args.dump_dir:
+            np.save(args.dump_dir / f"torch_logits_prefix_{int(prefix_len):04d}.npy", torch_logits)
+            np.save(args.dump_dir / f"ck_logits_prefix_{int(prefix_len):04d}.npy", ck["logits"].astype(np.float32, copy=False))
+
+    passed = all(bool(r["pass"]) for r in rows)
+    first_fail = next((r for r in rows if not bool(r["pass"])), None)
+    report: dict[str, Any] = {
+        "status": "pass" if passed else "fail",
+        "pass": bool(passed),
+        "safetensors": str(safetensors_dir),
+        "ck_model_dir": str(ck_model_dir),
+        "dtype": args.dtype,
+        "prompt": prompt_text,
+        "input_ids": [int(x) for x in token_ids],
+        "prefixes": [int(x) for x in wanted_prefixes],
+        "thresholds": {
+            "require_top1_match": bool(args.require_top1_match),
+            "tie_margin": float(args.tie_margin),
+            "min_topk_overlap": float(args.min_topk_overlap),
+            "max_abs_threshold": float(args.max_abs_threshold),
+        },
+        "timing": {
+            "torch_load_seconds": float(load_seconds),
+            "torch_forward_seconds": float(torch_seconds),
+            "ck_total_seconds": float(ck_seconds_total),
+        },
+        "rows": rows,
+        "first_failure": first_fail,
+        "next_step": "GLM4 CK-vs-PyTorch logits pass for selected prefixes" if passed else "dump layer boundaries around the first failing prefix",
+    }
+
+    text = json.dumps(report, indent=2, sort_keys=True)
+    print(text)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text + "\n", encoding="utf-8")
+    return 0 if passed else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -2309,6 +2309,21 @@ def main() -> None:
         "nemotron_h_moe.expert_shared_count",
         "nemotron_h_moe.expert_weights_norm",
         "nemotron_h_moe.expert_weights_scale",
+        # GLM4-style keys
+        "glm4.block_count",
+        "glm4.context_length",
+        "glm4.embedding_length",
+        "glm4.feed_forward_length",
+        "glm4.vocab_size",
+        "glm4.attention.head_count",
+        "glm4.attention.head_count_kv",
+        "glm4.attention.key_length",
+        "glm4.attention.value_length",
+        "glm4.attention.layer_norm_rms_epsilon",
+        "glm4.rope.freq_base",
+        "glm4.rope.dimension_count",
+        "glm4.tie_word_embeddings",
+        "glm4.embedding_weight_tying",
         # Gemma3-style keys
         "gemma3.block_count",
         "gemma3.context_length",
@@ -2378,7 +2393,9 @@ def main() -> None:
         "nemotron_h_moe.embedding_weight_tying",
         "gemma3.embedding_weight_tying",
         "gemma4.tie_word_embeddings",
+        "glm4.tie_word_embeddings",
         "gemma4.embedding_weight_tying",
+        "glm4.embedding_weight_tying",
         "mistral.embedding_weight_tying",
         "mistral3.embedding_weight_tying",
         "deepseek2.embedding_weight_tying",
@@ -3159,7 +3176,7 @@ def main() -> None:
         embed_dim = meta_int(
             "deepseek2.embedding_length", "mistral3.embedding_length", "mistral.embedding_length",
             "llama.embedding_length", "nemotron_h.embedding_length", "nemotron_h_moe.embedding_length", "qwen3vl.embedding_length", "qwen3.embedding_length", "qwen2.embedding_length",
-            "gemma3.embedding_length", "gemma4.embedding_length"
+            "gemma3.embedding_length", "gemma4.embedding_length", "glm4.embedding_length"
         ) or tok.ne0
         vocab_size = tok.ne1
 
@@ -3214,7 +3231,7 @@ def main() -> None:
         num_layers = meta_int(
             "deepseek2.block_count", "mistral3.block_count", "mistral.block_count",
             "llama.block_count", "qwen35.block_count", "nemotron_h.block_count", "nemotron_h_moe.block_count", "qwen3vl.block_count", "qwen3.block_count", "qwen2.block_count",
-            "gemma3.block_count", "gemma4.block_count"
+            "gemma3.block_count", "gemma4.block_count", "glm4.block_count"
         )
         if num_layers is None:
             # Infer from present blocks.
@@ -3232,7 +3249,7 @@ def main() -> None:
         intermediate = meta_int_or_list(
             "deepseek2.feed_forward_length", "mistral3.feed_forward_length", "mistral.feed_forward_length",
             "llama.feed_forward_length", "qwen35.feed_forward_length", "nemotron_h.feed_forward_length", "nemotron_h_moe.feed_forward_length", "qwen3vl.feed_forward_length", "qwen3.feed_forward_length", "qwen2.feed_forward_length",
-            "gemma3.feed_forward_length", "gemma4.feed_forward_length"
+            "gemma3.feed_forward_length", "gemma4.feed_forward_length", "glm4.feed_forward_length"
         )
         if isinstance(intermediate, list):
             nz_intermediate = [int(x) for x in intermediate if int(x) > 0]
@@ -3247,14 +3264,14 @@ def main() -> None:
         num_heads = meta_int(
             "deepseek2.attention.head_count", "mistral3.attention.head_count", "mistral.attention.head_count",
             "llama.attention.head_count", "qwen35.attention.head_count", "nemotron_h.attention.head_count", "nemotron_h_moe.attention.head_count", "qwen3vl.attention.head_count", "qwen3.attention.head_count", "qwen2.attention.head_count",
-            "gemma3.attention.head_count", "gemma4.attention.head_count"
+            "gemma3.attention.head_count", "gemma4.attention.head_count", "glm4.attention.head_count"
         )
         if num_heads is None:
             raise GGUFError("Missing attention.head_count (num_heads)")
         num_kv_heads_meta = meta_int_or_list(
             "deepseek2.attention.head_count_kv", "mistral3.attention.head_count_kv", "mistral.attention.head_count_kv",
             "llama.attention.head_count_kv", "qwen35.attention.head_count_kv", "nemotron_h.attention.head_count_kv", "nemotron_h_moe.attention.head_count_kv", "qwen3vl.attention.head_count_kv", "qwen3.attention.head_count_kv", "qwen2.attention.head_count_kv",
-            "gemma3.attention.head_count_kv", "gemma4.attention.head_count_kv"
+            "gemma3.attention.head_count_kv", "gemma4.attention.head_count_kv", "glm4.attention.head_count_kv"
         )
         if isinstance(num_kv_heads_meta, list):
             nz_kv_heads = [int(x) for x in num_kv_heads_meta if int(x) > 0]
@@ -3264,7 +3281,7 @@ def main() -> None:
         context_len = meta_int(
             "deepseek2.context_length", "mistral3.context_length", "mistral.context_length",
             "llama.context_length", "qwen35.context_length", "nemotron_h.context_length", "nemotron_h_moe.context_length", "qwen3vl.context_length", "qwen3.context_length", "qwen2.context_length",
-            "gemma3.context_length", "gemma4.context_length"
+            "gemma3.context_length", "gemma4.context_length", "glm4.context_length"
         ) or 0
         if args.context is not None:
             context_len = int(args.context)
@@ -3284,7 +3301,7 @@ def main() -> None:
         rope_theta = meta_float(
             "deepseek2.rope.freq_base", "mistral3.rope.freq_base", "mistral.rope.freq_base",
             "llama.rope.freq_base", "qwen35.rope.freq_base", "nemotron_h.rope.freq_base", "nemotron_h_moe.rope.freq_base", "qwen3vl.rope.freq_base", "qwen3.rope.freq_base", "qwen2.rope.freq_base",
-            "gemma3.rope.freq_base", "gemma4.rope.freq_base"
+            "gemma3.rope.freq_base", "gemma4.rope.freq_base", "glm4.rope.freq_base"
         ) or 10000.0
 
         # Q/K/V head dimensions (some models report explicit key/value lengths)
@@ -3296,6 +3313,7 @@ def main() -> None:
             "qwen3.attention.key_length",
             "gemma3.attention.key_length",
             "gemma4.attention.key_length",
+            "glm4.attention.key_length",
             "llama.attention.key_length",
         )
         value_length_meta = meta_int(
@@ -3306,6 +3324,7 @@ def main() -> None:
             "qwen3.attention.value_length",
             "gemma3.attention.value_length",
             "gemma4.attention.value_length",
+            "glm4.attention.value_length",
             "llama.attention.value_length",
         )
 
@@ -3323,6 +3342,7 @@ def main() -> None:
             "gemma.attention.key_length",
             "gemma3.attention.key_length",
             "gemma4.rope.dimension_count",
+            "glm4.rope.dimension_count",
         )
 
         # RoPE scaling (supports scalar and structured GGUF metadata)
@@ -3412,7 +3432,7 @@ def main() -> None:
             "mistral.attention.layer_norm_rms_epsilon", "llama.norm_rms_eps",
             "nemotron_h.attention.layer_norm_rms_epsilon", "nemotron_h_moe.attention.layer_norm_rms_epsilon",
             "qwen35.attention.layer_norm_rms_epsilon", "qwen3vl.attention.layer_norm_rms_epsilon", "qwen3.attention.layer_norm_rms_epsilon", "qwen2.attention.layer_norm_rms_epsilon",
-            "gemma3.attention.layer_norm_rms_epsilon", "gemma4.attention.layer_norm_rms_epsilon"
+            "gemma3.attention.layer_norm_rms_epsilon", "gemma4.attention.layer_norm_rms_epsilon", "glm4.attention.layer_norm_rms_epsilon"
         ) or 1e-5
 
         if embed_dim != tok.ne0:
@@ -4645,6 +4665,14 @@ def main() -> None:
             gate = tensors.get(f"blk.{layer}.ffn_gate.weight")
             up = tensors.get(f"blk.{layer}.ffn_up.weight")
             down = tensors.get(f"blk.{layer}.ffn_down.weight")
+            fused_gate_up = False
+            if arch == "glm4" and gate is None and up is not None:
+                # GLM4 GGUF stores the SwiGLU gate/up projection as a single
+                # concatenated ffn_up tensor. CK's runtime contract is already
+                # w1 = gate || up, so preserve the tensor verbatim.
+                if up.ne0 == embed_dim and up.ne1 == 2 * intermediate:
+                    gate = up
+                    fused_gate_up = True
             # Attention biases (optional - Qwen2 has them, LLaMA/Qwen3 don't)
             bq = tensors.get(f"blk.{layer}.attn_q.bias")
             bk = tensors.get(f"blk.{layer}.attn_k.bias")
@@ -4720,11 +4748,17 @@ def main() -> None:
             if wo.ne0 != wq.ne1:
                 raise GGUFError(f"{wo.name}: ne0 mismatch with Q ne1: expected {wq.ne1}, got {wo.ne0}")
 
-            for tensor, label in ((gate, "gate"), (up, "up")):
-                if tensor.ne0 != embed_dim or tensor.ne1 != intermediate:
+            if fused_gate_up:
+                if up.ne0 != embed_dim or up.ne1 != 2 * intermediate:
                     raise GGUFError(
-                        f"{tensor.name}: expected dims [ne0={embed_dim}, ne1={intermediate}] for {label}, got {tensor.dims}"
+                        f"{up.name}: expected fused dims [ne0={embed_dim}, ne1={2 * intermediate}] for gate||up, got {up.dims}"
                     )
+            else:
+                for tensor, label in ((gate, "gate"), (up, "up")):
+                    if tensor.ne0 != embed_dim or tensor.ne1 != intermediate:
+                        raise GGUFError(
+                            f"{tensor.name}: expected dims [ne0={embed_dim}, ne1={intermediate}] for {label}, got {tensor.dims}"
+                        )
             if down.ne0 != intermediate or down.ne1 != embed_dim:
                 raise GGUFError(
                     f"{down.name}: expected dims [ne0={intermediate}, ne1={embed_dim}] for down, got {down.dims}"
@@ -4798,6 +4832,7 @@ def main() -> None:
                 "gate": gate,
                 "up": up,
                 "down": down,
+                "fused_gate_up": fused_gate_up,
                 "bq": bq,  # Optional bias tensors (None if not present)
                 "bk": bk,
                 "bv": bv,
@@ -5069,12 +5104,19 @@ def main() -> None:
                 record_entry(f"layer.{layer}.bo", "fp32", bo_size)
                 write_f32_zeros(w, aligned_embed_dim)  # bo
 
-                # W1 (gate + up)
-                gate_size = ggml_tensor_bytes(info["gate"])
-                up_size = ggml_tensor_bytes(info["up"])
-                record_entry(f"layer.{layer}.w1", get_quant_type_name(info["gate"].ggml_type), gate_size + up_size)
-                copy_bytes_stream(f, data_start + info["gate"].offset, gate_size, w)
-                copy_bytes_stream(f, data_start + info["up"].offset, up_size, w)
+                # W1 (gate + up). Some GGUF writers already store this as
+                # one fused gate||up tensor (notably GLM4), while most store
+                # gate and up separately. CK consumes the concatenated layout.
+                if info.get("fused_gate_up"):
+                    up_size = ggml_tensor_bytes(info["up"])
+                    record_entry(f"layer.{layer}.w1", get_quant_type_name(info["up"].ggml_type), up_size)
+                    copy_bytes_stream(f, data_start + info["up"].offset, up_size, w)
+                else:
+                    gate_size = ggml_tensor_bytes(info["gate"])
+                    up_size = ggml_tensor_bytes(info["up"])
+                    record_entry(f"layer.{layer}.w1", get_quant_type_name(info["gate"].ggml_type), gate_size + up_size)
+                    copy_bytes_stream(f, data_start + info["gate"].offset, gate_size, w)
+                    copy_bytes_stream(f, data_start + info["up"].offset, up_size, w)
                 b1_size = 2 * intermediate * 4
                 record_entry(f"layer.{layer}.b1", "fp32", b1_size)
                 write_f32_zeros(w, 2 * intermediate)  # b1

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -61,6 +61,9 @@ DTYPE_TO_CK = {
     "float16": ("fp16", CK_DT_FP16, 2),
 }
 
+SAFETENSORS_CK_MAP_PATH = SCRIPT_DIR.parent / "model_maps" / "safetensors_ck_map.json"
+_SAFETENSORS_CK_MAP_CACHE: dict[str, Any] | None = None
+
 
 def align_up(n: int, a: int = CACHE_ALIGN) -> int:
     return ((int(n) + int(a) - 1) // int(a)) * int(a)
@@ -197,6 +200,137 @@ def _load_runtime_config_template(path: Path | None) -> dict[str, Any]:
         return dict(data["config"])
     return dict(data)
 
+
+
+def _load_safetensors_ck_map() -> dict[str, Any]:
+    global _SAFETENSORS_CK_MAP_CACHE
+    if _SAFETENSORS_CK_MAP_CACHE is not None:
+        return _SAFETENSORS_CK_MAP_CACHE
+    if not SAFETENSORS_CK_MAP_PATH.exists():
+        _SAFETENSORS_CK_MAP_CACHE = {"version": 0, "architectures": {}}
+        return _SAFETENSORS_CK_MAP_CACHE
+    data = json.loads(SAFETENSORS_CK_MAP_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"{SAFETENSORS_CK_MAP_PATH}: expected JSON object")
+    archs = data.get("architectures")
+    if archs is None:
+        data["architectures"] = {}
+    elif not isinstance(archs, dict):
+        raise SystemExit(f"{SAFETENSORS_CK_MAP_PATH}: architectures must be an object")
+    _SAFETENSORS_CK_MAP_CACHE = data
+    return data
+
+
+def _safetensors_arch_contract(arch: str) -> dict[str, Any]:
+    contracts = _load_safetensors_ck_map().get("architectures") or {}
+    row = contracts.get(str(arch or "").lower())
+    return row if isinstance(row, dict) else {}
+
+
+def _shape_symbol_value(name: str, config: dict[str, Any]) -> int:
+    key = str(name)
+    if key == "embed_dim":
+        return int(config.get("embed_dim") or config.get("hidden_size") or 0)
+    if key == "intermediate_size":
+        return int(config.get("intermediate_size") or 0)
+    if key == "q_dim":
+        return int(config.get("num_heads") or config.get("num_attention_heads") or 0) * int(config.get("head_dim") or 0)
+    if key == "kv_dim":
+        return int(config.get("num_kv_heads") or config.get("num_key_value_heads") or config.get("num_heads") or 0) * int(config.get("head_dim") or 0)
+    if key.isdigit():
+        return int(key)
+    raise SystemExit(f"Unsupported safetensors map shape symbol: {key}")
+
+
+def _shape_from_spec(spec: Any, config: dict[str, Any]) -> tuple[int, ...]:
+    if spec is None:
+        return ()
+    if not isinstance(spec, list):
+        raise SystemExit(f"safetensors map shape must be a list, got {type(spec).__name__}")
+    dims: list[int] = []
+    for item in spec:
+        if isinstance(item, int):
+            dims.append(int(item))
+            continue
+        text = str(item).strip()
+        if "*" in text:
+            total = 1
+            for part in text.split("*"):
+                total *= _shape_symbol_value(part.strip(), config)
+            dims.append(total)
+        else:
+            dims.append(_shape_symbol_value(text, config))
+    return tuple(dims)
+
+
+def _first_existing_from_patterns(headers: dict[str, HeaderTensor], patterns: Iterable[str], layer: int | None = None) -> str | None:
+    for pattern in patterns:
+        name = str(pattern)
+        if layer is not None:
+            name = name.replace("{L}", str(layer))
+        if name in headers:
+            return name
+    return None
+
+
+def _refs_from_safetensors_contract(arch: str, config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef] | None:
+    contract = _safetensors_arch_contract(arch)
+    refs_spec = contract.get("tensor_refs") if isinstance(contract, dict) else None
+    if not isinstance(refs_spec, list):
+        return None
+    num_layers = int(config.get("num_layers") or config.get("num_hidden_layers") or 0)
+    refs: list[TensorRef] = []
+    for spec in refs_spec:
+        if not isinstance(spec, dict):
+            raise SystemExit(f"{SAFETENSORS_CK_MAP_PATH}: tensor_refs entries must be objects")
+        target = str(spec.get("target") or "")
+        if not target:
+            raise SystemExit(f"{SAFETENSORS_CK_MAP_PATH}: tensor_refs entry missing target")
+        layers: list[int | None]
+        if "{L}" in target:
+            layers = list(range(num_layers))
+        else:
+            layers = [None]
+        for layer in layers:
+            ck_name = target.replace("{L}", str(layer)) if layer is not None else target
+            dtype = spec.get("dtype")
+            dtype = str(dtype) if dtype is not None else None
+            synth = spec.get("synth")
+            synth = str(synth) if synth is not None else None
+            shape = _shape_from_spec(spec.get("shape"), config) if (synth or spec.get("fallback_synth")) else None
+            sources_raw = spec.get("sources") or []
+            if isinstance(sources_raw, str):
+                sources_raw = [sources_raw]
+            if not isinstance(sources_raw, list):
+                raise SystemExit(f"{SAFETENSORS_CK_MAP_PATH}: sources for {ck_name} must be a list")
+            if synth:
+                refs.append(TensorRef(ck_name, (), dtype=dtype, synth=synth, shape=shape))
+                continue
+            if str(spec.get("combine") or "").strip().lower() == "concat":
+                resolved: list[str] = []
+                missing: list[str] = []
+                for src in sources_raw:
+                    name = str(src).replace("{L}", str(layer)) if layer is not None else str(src)
+                    if name not in headers:
+                        missing.append(name)
+                    else:
+                        resolved.append(name)
+                if missing:
+                    raise SystemExit(f"Missing required safetensors tensor for {ck_name}: tried {missing}")
+                refs.append(TensorRef(ck_name, tuple(resolved), dtype=dtype))
+                continue
+            found = _first_existing_from_patterns(headers, (str(x) for x in sources_raw), layer)
+            if found is not None:
+                refs.append(TensorRef(ck_name, (found,), dtype=dtype))
+                continue
+            fallback = spec.get("fallback_synth")
+            if fallback:
+                refs.append(TensorRef(ck_name, (), dtype=dtype, synth=str(fallback), shape=shape))
+                continue
+            if bool(spec.get("optional", False)):
+                continue
+            raise SystemExit(f"Missing required safetensors tensor for {ck_name}: tried {sources_raw}")
+    return refs
 
 def _gemma4_text_refs(config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef]:
     num_layers = int(config.get("num_layers") or config.get("num_hidden_layers") or 0)
@@ -529,6 +663,14 @@ def _llama_family_text_refs(config: dict[str, Any], headers: dict[str, HeaderTen
 def _infer_arch(hf: dict[str, Any]) -> str:
     text = hf.get("text_config") if isinstance(hf.get("text_config"), dict) else hf
     mt = str(text.get("model_type") or hf.get("model_type") or "").lower()
+    arch_names = [str(x).lower() for x in (text.get("architectures") or hf.get("architectures") or []) if isinstance(x, str)]
+    contracts = (_load_safetensors_ck_map().get("architectures") or {})
+    for ck_arch, contract in contracts.items():
+        aliases = [str(ck_arch).lower()]
+        if isinstance(contract, dict):
+            aliases.extend(str(x).lower() for x in contract.get("aliases", []) if isinstance(x, str))
+        if mt in aliases or any(name in aliases for name in arch_names):
+            return str(ck_arch).lower()
     if "gemma" in mt and "4" in mt:
         return "gemma4"
     if "gemma" in mt and "3" in mt:
@@ -539,6 +681,8 @@ def _infer_arch(hf: dict[str, Any]) -> str:
         return "qwen3"
     if "qwen2" in mt or mt == "qwen":
         return "qwen2"
+    if "glm" in mt:
+        return "glm4"
     if "llama" in mt:
         return "llama"
     if "nemotron_h" in mt or "nemotron-h" in mt:
@@ -547,6 +691,9 @@ def _infer_arch(hf: dict[str, Any]) -> str:
 
 
 def _refs_for_arch(arch: str, config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef]:
+    mapped_refs = _refs_from_safetensors_contract(arch, config, headers)
+    if mapped_refs is not None:
+        return mapped_refs
     if arch == "gemma4":
         return _gemma4_text_refs(config, headers)
     if arch == "qwen35":
@@ -648,6 +795,34 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "rope_freq_base": float(text.get("rope_theta") or 10000.0),
             "use_rope_freq_factors": 0,
             "has_attention_biases": bool(text.get("attention_bias", False)),
+            "has_qk_norm": False,
+            "prefill_policy": "batched",
+        })
+
+    if arch == "glm4":
+        partial_key = "partial_rotary_factor"
+        contract = _safetensors_arch_contract("glm4")
+        contract_cfg = contract.get("config") if isinstance(contract.get("config"), dict) else {}
+        if isinstance(contract_cfg.get("partial_rotary_factor_key"), str):
+            partial_key = str(contract_cfg["partial_rotary_factor_key"])
+        partial = float(text.get(partial_key, text.get("partial_rotary_factor", 1.0)) or 1.0)
+        head_dim_value = int(cfg.get("head_dim") or 0)
+        rotary_dim = int(head_dim_value * partial) if head_dim_value > 0 else int(cfg.get("rotary_dim") or 0)
+        cfg.update({k: v for k, v in contract_cfg.items() if k != "partial_rotary_factor_key"})
+        cfg.update({
+            "model": "glm4",
+            "arch": "glm4",
+            "model_type": "glm4",
+            "intermediate_dim": int(cfg.get("intermediate_size") or 0),
+            "attn_out_dim": int(cfg.get("num_heads") or 0) * head_dim_value,
+            "rotary_dim": rotary_dim,
+            "partial_rotary_factor": partial,
+            "max_seq_len": int(cfg.get("context_length") or 0),
+            "rms_eps": float(text.get("rms_norm_eps", cfg.get("rms_eps", 1e-5)) or 1e-5),
+            "rms_norm_eps": float(text.get("rms_norm_eps", cfg.get("rms_eps", 1e-5)) or 1e-5),
+            "rope_theta": float(text.get("rope_theta", cfg.get("rope_theta", 10000.0)) or 10000.0),
+            "rope_freq_base": float(text.get("rope_theta", cfg.get("rope_theta", 10000.0)) or 10000.0),
+            "has_attention_biases": bool(text.get("attention_bias", True)),
             "has_qk_norm": False,
             "prefill_policy": "batched",
         })
@@ -980,7 +1155,7 @@ def main() -> int:
     ap.add_argument("--ram-dir", type=Path, default=Path("/dev/shm"), help="tmpfs directory for --ram-output; default: /dev/shm")
     ap.add_argument("--config-out", required=True, type=Path)
     ap.add_argument("--manifest-out", required=True, type=Path)
-    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h"])
+    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h", "glm4"])
     ap.add_argument("--config-template", type=Path, help="existing v8 config/manifest to reuse explicit runtime policy")
     ap.add_argument("--dtype", default="preserve", choices=["preserve", "bf16", "fp32"])
     ap.add_argument("--dry-run", action="store_true", help="validate mapping and write JSON reports only; do not write BUMP")
@@ -1092,8 +1267,8 @@ def main() -> int:
         "intermediate_size": _int_or_zero(config.get("intermediate_size")),
         "vocab_size": _int_or_zero(config.get("vocab_size")),
         "context_length": _int_or_zero(config.get("context_length")),
-        "has_attention_biases": False,
-        "has_qk_norm": True,
+        "has_attention_biases": bool(config.get("has_attention_biases", False)),
+        "has_qk_norm": bool(config.get("has_qk_norm", False)),
         "source_audit": audit,
         "special_tokens": special_tokens,
         "tokenizer_contract": tokenizer_contract if tokenizer_contract else None,

--- a/version/v8/templates/glm4.json
+++ b/version/v8/templates/glm4.json
@@ -1,0 +1,137 @@
+{
+  "version": 2,
+  "name": "glm4",
+  "family": "glm",
+  "flags": {
+    "use_qkv_bias": true,
+    "activation": "swiglu",
+    "rope": "rope",
+    "tokenizer": "bpe",
+    "post_attention_norm": true,
+    "post_ffn_norm": true
+  },
+  "contract": {
+    "tokenizer_contract": {
+      "tokenizer_type": "bpe",
+      "bos_policy": "model_defined",
+      "eos_policy": "model_defined",
+      "special_tokens": {
+        "source": "manifest_or_gguf"
+      }
+    },
+    "chat_contract": {
+      "version": 1,
+      "name": "glm4",
+      "raw_prompt_allowed": false,
+      "turn_prefix": "<|{role}|>\n",
+      "turn_suffix": "\n",
+      "assistant_generation_prefix": "<|assistant|>\n",
+      "role_labels": {
+        "system": "system",
+        "user": "user",
+        "assistant": "assistant"
+      },
+      "system_prompt_mode": "dedicated_turn",
+      "system_prompt_separator": "\n\n",
+      "default_system_prompt": "",
+      "inject_default_system_prompt": false,
+      "force_bos_text_if_tokenizer_add_bos_false": "[gMASK]",
+      "last_user_prefix": "",
+      "last_user_prefix_suppression_markers": [],
+      "stop_text_markers": [
+        "<|user|>",
+        "<|observation|>",
+        "<|assistant|>"
+      ],
+      "token_stop_markers": [
+        "<|user|>",
+        "<|observation|>"
+      ],
+      "template_markers": [
+        "[gMASK]",
+        "<|system|>",
+        "<|user|>",
+        "<|assistant|>",
+        "<|observation|>"
+      ],
+      "min_response_tokens": 8
+    },
+    "attention_contract": {
+      "rope_layout": "split",
+      "rope_type": "rope",
+      "qk_norm": false,
+      "kv_layout": "layer_major_kv_cache",
+      "attn_variant": "dense",
+      "partial_rotary": true
+    },
+    "block_contract": {
+      "norm_type": "rmsnorm",
+      "mlp_formula": "gate_up -> silu_mul -> down",
+      "activation": "swiglu",
+      "qkv_bias": true
+    },
+    "logits_contract": {
+      "final_norm": "rmsnorm",
+      "lm_head": "weight_tying",
+      "logits_layout": "auto"
+    },
+    "quant_contract": {
+      "kernel_select": "weight_dtype_registry",
+      "activation_dtype": "fp32_or_q8_path",
+      "per_tensor_mixed_quant": true
+    },
+    "runtime_invariants": {
+      "required_call_args": {
+        "kv_cache_batch_copy": [
+          "activation:k_src",
+          "activation:v_src",
+          "output:k_dst",
+          "output:v_dst",
+          "dim:_kv_copy_bytes"
+        ]
+      }
+    }
+  },
+  "kernels": {
+    "rope_qk": "rope_forward_qk"
+  },
+  "sequence": [
+    "decoder"
+  ],
+  "block_types": {
+    "decoder": {
+      "sequence": [
+        "header",
+        "body",
+        "footer"
+      ],
+      "header": [
+        "bpe_tokenizer",
+        "dense_embedding_lookup"
+      ],
+      "body": {
+        "type": "dense",
+        "ops": [
+          "rmsnorm",
+          "qkv_proj",
+          "rope_qk",
+          "attn",
+          "out_proj",
+          "post_attention_norm",
+          "residual_add",
+          "rmsnorm",
+          "mlp_gate_up",
+          "silu_mul",
+          "mlp_down",
+          "post_ffn_norm",
+          "residual_add"
+        ]
+      },
+      "footer": [
+        "rmsnorm",
+        "weight_tying",
+        "logits"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Why: add GLM4 as a v8 template/conversion/parity-harness lane with GGUF metadata handling and declarative safetensors mapping, without claiming full local runtime smoke on this low-memory machine.

Test: py_compile changed v8 scripts and tests; python -m unittest tests.test_v8_glm4_template; make build/libckernel_engine.so; git diff --cached --check. Pytest GLM safetensors smoke was not run because pytest is not installed in this venv.