### PR TITLE
Harden GLM4 dataflow and Qwen3-VL smoke assets

### DIFF
--- a/docs/site/_pages/concepts.html
+++ b/docs/site/_pages/concepts.html
@@ -20,6 +20,7 @@
     <li><a href="#architecture">Transformer Architecture Overview</a></li>
     <li><a href="#rope">RoPE: Rotary Position Embedding</a></li>
     <li><a href="#rope-layouts">RoPE Layouts: Pairwise vs Split-Half</a></li>
+    <li><a href="#glm4-rope">GLM-4 RoPE: Pairwise Partial Rotary</a></li>
     <li><a href="#gemma4-rope">Gemma4 RoPE: Per-Layer Direct Split-Half</a></li>
     <li><a href="#attention">Attention Mechanisms</a></li>
     <li><a href="#flash-attention">Flash Attention</a></li>
@@ -190,7 +191,7 @@ Backward:
 <div class="grid grid-2">
     <div class="card card-accent">
         <h3 style="margin-top: 0;">Pairwise / Consecutive RoPE</h3>
-        <p>This is the layout used by <strong>Llama-family checkpoints</strong>, including Nanbeige in our v7 work.</p>
+        <p>This is the layout used by <strong>Llama-family checkpoints</strong>, including Nanbeige in our v7 work, and by <strong>GLM-4</strong> for its rotary slice.</p>
         <pre>(0,1), (2,3), (4,5), ...</pre>
         <p>Each even/odd pair is treated as one 2D rotation plane. That makes the math read exactly like the textbook RoPE formula:</p>
         <pre>x'[2i]   = x[2i] * cos - x[2i+1] * sin
@@ -259,8 +260,30 @@ Split-half:
     </div>
     <div>
         <strong>Implementation note in CK right now</strong><br>
-        The older split-half path already has AVX/AVX-512 SIMD specialization. The pairwise path was added to match Llama-family semantics, and the direct split-half path was added for model families that need per-layer rotary parameters instead of one global cache contract.
+        The older split-half path already has AVX/AVX-512 SIMD specialization. The pairwise path is selected through template/model-map metadata for model families that rotate adjacent even/odd pairs, including Llama-style layouts and GLM-4 partial RoPE. The direct split-half path was added for model families that need per-layer rotary parameters instead of one global cache contract.
     </div>
+</div>
+
+<h3 id="glm4-rope">GLM-4 RoPE: Pairwise Partial Rotary</h3>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">What changed for GLM-4?</h3>
+    <p>GLM-4 uses the pairwise/interleaved RoPE layout, but only on the configured rotary slice of each attention head. For example, with a 128-dimensional head and a 64-dimensional rotary slice, CK rotates adjacent pairs inside the first 64 dimensions and leaves the remaining 64 dimensions unchanged.</p>
+    <pre>Pairwise partial RoPE:
+  rotate:      (x0, x1), (x2, x3), ... within rotary_dim
+  pass-through: dimensions rotary_dim .. head_dim-1
+
+GLM template/model map:
+  rope_layout       = pairwise
+  partial_rotary    = true
+  rope_qk override  = rope_forward_qk_pairwise</pre>
+    <p>This is a model compatibility feature, not a tuning knob. If GLM-4 is lowered with split-half RoPE, the projection kernels can still be correct, but Q/K diverge immediately after RoPE and the attention output drifts from PyTorch.</p>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">How CK controls this</h3>
+    <p>The GLM template declares the circuit-level RoPE policy with <code>rope_layout: "pairwise"</code> and the safetensors model map carries the same architecture contract. Lowering reads that metadata and emits <code>rope_forward_qk_pairwise</code> for the Q/K rotary operation. The kernel itself is generic: it implements pairwise partial rotary math and does not know that the caller is GLM.</p>
+    <p>This keeps the DSL/compiler path deterministic. Templates and model maps describe the semantic contract; kernel maps bind that contract to an implementation; generated C should not infer or guess the rotary convention from tensor shape alone.</p>
 </div>
 
 <h3 id="gemma4-rope">Gemma4 RoPE: Per-Layer Direct Split-Half</h3>

--- a/docs/site/_pages/quickstart.html
+++ b/docs/site/_pages/quickstart.html
@@ -153,7 +153,7 @@ make v7-demo-runtime \
     <pre>version/v8/scripts/cks-v8-run run \
   hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
   --mmproj ./mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
-  --image-path version/v8/test_assets/v8_vision_doc_card_72.png \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
   --prompt "Explain this image." \
   --context-len 1024 \
   --force-convert --force-compile \

--- a/docs/site/_pages/v8-runbook.html
+++ b/docs/site/_pages/v8-runbook.html
@@ -315,7 +315,7 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
 <pre>version/v8/scripts/cks-v8-run run \
   hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
   --mmproj hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
-  --image-path version/v8/test_assets/v8_vision_doc_card_72.png \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
   --prompt "Explain this image." \
   --context-len 1024 \
   --force-convert --force-compile \

--- a/scripts/chat_contract.py
+++ b/scripts/chat_contract.py
@@ -24,6 +24,8 @@ PRESET_ALIASES = {
     "gemma": "gemma3",
     "gemma3": "gemma3",
     "gemma4": "gemma4",
+    "glm4": "glm4",
+    "glm": "glm4",
 }
 
 KNOWN_TEMPLATE_MARKERS = (
@@ -35,6 +37,12 @@ KNOWN_TEMPLATE_MARKERS = (
     "<|im_end|>",
     "<think>",
     "</think>",
+    "[gMASK]",
+    "<sop>",
+    "<|system|>",
+    "<|user|>",
+    "<|assistant|>",
+    "<|observation|>",
 )
 
 
@@ -101,6 +109,9 @@ def looks_like_instruction_chat_model(
         or model_type_lc.startswith("gemma")
         or model_type_lc.startswith("gemma4")
         or model_type_lc.startswith("qwen")
+        or model_type_lc.startswith("glm")
+        or "glm" in model_name_lc
+        or "glm" in template
     )
 
 
@@ -250,6 +261,10 @@ def _infer_explicit_contract_name(
         return "gemma"
     if "<|turn>" in template and "<turn|>" in template:
         return "gemma4"
+    if "[gMASK]" in template and "<sop>" in template and "<|assistant|>" in template:
+        return "glm4"
+    if model_type_lc.startswith("glm") or template_name_lc.startswith("glm"):
+        return "glm4"
     if "<|im_start|>" in template and "<|im_end|>" in template:
         if model_type_lc == "qwen35" or template_name_lc == "qwen35":
             return "qwen35"

--- a/scripts/ck_chat.py
+++ b/scripts/ck_chat.py
@@ -2422,8 +2422,8 @@ def main():
                        help="Stop generation when '<eos>' appears in decoded text")
     parser.add_argument("--stop-on-text", action="append", default=[],
                        help="Stop generation when this decoded text marker appears (repeatable)")
-    parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen3", "qwen35", "gemma", "gemma3", "gemma4"], default="auto",
-                       help="Chat template mode: auto (from GGUF), none, qwen, qwen3, qwen35, or gemma")
+    parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen3", "qwen35", "gemma", "gemma3", "gemma4", "glm4"], default="auto",
+                       help="Chat template mode: auto (from GGUF), none, qwen, qwen3, qwen35, gemma, gemma4, or glm4")
     parser.add_argument("--no-chat-template", action="store_true",
                        help="Disable chat template formatting (same as --chat-template=none)")
     parser.add_argument("--allow-raw-prompt", action="store_true",

--- a/tests/test_run_regression_v8.py
+++ b/tests/test_run_regression_v8.py
@@ -70,7 +70,7 @@ class RegressionHarnessV8Tests(unittest.TestCase):
         self.assertNotIn("--image-path", by_id["qwen3vl"].runtime_args)
         self.assertEqual(by_id["qwen3vl"].smoke_prompts, ["vision_doc_card", "vision_mamba2_card"])
         self.assertIn("--image-path", prompts["vision_doc_card"].runtime_args)
-        self.assertIn("v8_vision_doc_card_72.png", " ".join(prompts["vision_doc_card"].runtime_args))
+        self.assertIn("v8_vision_doc_card_72.ppm", " ".join(prompts["vision_doc_card"].runtime_args))
         self.assertIn("--image-path", prompts["vision_mamba2_card"].runtime_args)
         self.assertIn("v8_vision_mamba2_card_144.png", " ".join(prompts["vision_mamba2_card"].runtime_args))
         self.assertEqual(by_id["qwen3vl"].runtime_expect.get("manifest", {}).get("config.model"), "qwen3vl")
@@ -191,7 +191,7 @@ class RegressionHarnessV8Tests(unittest.TestCase):
             prompt="Explain this image.",
             max_tokens=24,
             heuristics={},
-            runtime_args=["--image-path", "version/v8/test_assets/v8_vision_doc_card_72.png"],
+            runtime_args=["--image-path", "version/v8/test_assets/v8_vision_doc_card_72.ppm"],
         )
 
         with mock.patch.object(
@@ -216,7 +216,7 @@ class RegressionHarnessV8Tests(unittest.TestCase):
         cmd = run_stream.call_args.args[0]
         self.assertIn("--thinking-mode", cmd)
         self.assertIn("--image-path", cmd)
-        self.assertIn("version/v8/test_assets/v8_vision_doc_card_72.png", cmd)
+        self.assertIn("version/v8/test_assets/v8_vision_doc_card_72.ppm", cmd)
 
     def test_run_prompt_prefers_multimodal_bridge_generated_text(self) -> None:
         family = regression.FamilySpec(
@@ -224,7 +224,7 @@ class RegressionHarnessV8Tests(unittest.TestCase):
             label="Qwen3-VL",
             model="hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf",
             context_len=1024,
-            runtime_args=["--image-path", "version/v8/test_assets/v8_vision_doc_card_72.png"],
+            runtime_args=["--image-path", "version/v8/test_assets/v8_vision_doc_card_72.ppm"],
             smoke_prompts=["vision_doc_card"],
             response_contract={"trim_whitespace": True},
             coherence_gate=True,

--- a/tests/test_v8_glm4_template.py
+++ b/tests/test_v8_glm4_template.py
@@ -26,17 +26,118 @@ def _load_module(name: str, path: Path):
 build_ir_v8 = _load_module("build_ir_v8_glm4_tests", V8_BUILD_PATH)
 
 
+def _entry(name: str, dtype: str, shape: list[int], offset: int) -> dict:
+    nbytes_per = {"fp32": 4, "bf16": 2, "fp16": 2, "q8_0": 1, "q5_0": 1, "q6_k": 1, "q4_k": 1}.get(dtype, 4)
+    size = 1
+    for dim in shape:
+        size *= int(dim)
+    return {
+        "name": name,
+        "dtype": dtype,
+        "offset": offset,
+        "shape": shape,
+        "nbytes": size * nbytes_per,
+    }
+
+
+def _make_tiny_glm4_bf16_manifest() -> dict:
+    offset = 0
+    entries = []
+
+    def add(name: str, dtype: str, shape: list[int]) -> None:
+        nonlocal offset
+        item = _entry(name, dtype, shape, offset)
+        entries.append(item)
+        offset += int(item["nbytes"])
+
+    add("token_emb", "bf16", [64, 16])
+    add("layer.0.ln1_gamma", "fp32", [16])
+    add("layer.0.ln2_gamma", "fp32", [16])
+    add("layer.0.post_attention_norm", "fp32", [16])
+    add("layer.0.post_ffn_norm", "fp32", [16])
+    add("layer.0.wq", "bf16", [16, 16])
+    add("layer.0.bq", "fp32", [16])
+    add("layer.0.wk", "bf16", [8, 16])
+    add("layer.0.bk", "fp32", [8])
+    add("layer.0.wv", "bf16", [8, 16])
+    add("layer.0.bv", "fp32", [8])
+    add("layer.0.wo", "bf16", [16, 16])
+    add("layer.0.w1", "bf16", [32, 16])
+    add("layer.0.w2", "bf16", [16, 16])
+    add("final_ln_weight", "fp32", [16])
+
+    return {
+        "config": {
+            "model": "glm4",
+            "arch": "glm4",
+            "num_layers": 1,
+            "embed_dim": 16,
+            "num_heads": 4,
+            "num_kv_heads": 2,
+            "head_dim": 4,
+            "intermediate_size": 16,
+            "context_length": 32,
+            "max_seq_len": 32,
+            "vocab_size": 64,
+            "rope_dim": 4,
+            "rope_partial_rotary_dim": 2,
+        },
+        "quant_summary": {
+            "token_emb": "bf16",
+            "layer.0": {
+                "wq": "bf16",
+                "wk": "bf16",
+                "wv": "bf16",
+                "wo": "bf16",
+                "w1": "bf16",
+                "w2": "bf16",
+            },
+            "final_ln_weight": "fp32",
+        },
+        "entries": entries,
+        "template": build_ir_v8._load_builtin_template_doc("glm4"),
+    }
+
+
+def _make_tiny_glm4_quant_manifest() -> dict:
+    manifest = _make_tiny_glm4_bf16_manifest()
+    for item in manifest["entries"]:
+        name = item["name"]
+        if name == "token_emb":
+            item["dtype"] = "q4_k"
+        elif name.endswith(".wq") or name.endswith(".wk") or name.endswith(".wo") or name.endswith(".w1"):
+            item["dtype"] = "q4_k"
+        elif name.endswith(".wv"):
+            item["dtype"] = "q6_k"
+        elif name.endswith(".w2"):
+            item["dtype"] = "q8_0"
+    manifest["quant_summary"] = {
+        "token_emb": "q4_k",
+        "layer.0": {
+            "wq": "q4_k",
+            "wk": "q4_k",
+            "wv": "q6_k",
+            "wo": "q4_k",
+            "w1": "q4_k",
+            "w2": "q8_0",
+        },
+        "final_ln_weight": "fp32",
+    }
+    return manifest
+
+
 class V8GLM4TemplateTests(unittest.TestCase):
     def test_builtin_template_declares_glm4_contract(self) -> None:
         doc = build_ir_v8._load_builtin_template_doc("glm4")
         self.assertEqual(doc["name"], "glm4")
         self.assertEqual(doc["flags"]["tokenizer"], "bpe")
-        self.assertEqual(doc["contract"]["attention_contract"]["rope_layout"], "split")
+        self.assertEqual(doc["contract"]["attention_contract"]["rope_layout"], "pairwise")
         self.assertTrue(doc["contract"]["attention_contract"]["partial_rotary"])
         self.assertTrue(doc["contract"]["block_contract"]["qkv_bias"])
-        self.assertEqual(doc["contract"]["chat_contract"]["force_bos_text_if_tokenizer_add_bos_false"], "[gMASK]")
+        self.assertEqual(doc["contract"]["chat_contract"]["force_bos_text_if_tokenizer_add_bos_false"], "[gMASK]<sop>\n")
+        body_items = build_ir_v8._normalize_template_op_items(doc["block_types"]["decoder"]["body"]["ops"])
         self.assertEqual(
-            doc["block_types"]["decoder"]["body"]["ops"],
+            [item["op"] for item in body_items],
             [
                 "rmsnorm",
                 "qkv_proj",
@@ -53,6 +154,57 @@ class V8GLM4TemplateTests(unittest.TestCase):
                 "residual_add",
             ],
         )
+        by_op = {item["op"]: item for item in body_items if isinstance(item.get("graph_slots"), dict)}
+        self.assertEqual(by_op["qkv_proj"]["graph_slots"]["inputs"]["x"], "main_stream")
+        self.assertEqual(by_op["out_proj"]["graph_slots"]["inputs"]["x"], "attn_scratch")
+        self.assertEqual(by_op["mlp_gate_up"]["graph_slots"]["inputs"]["x"], "main_stream")
+        self.assertEqual(by_op["mlp_down"]["graph_slots"]["inputs"]["x"], "mlp_scratch")
+        footer_items = build_ir_v8._normalize_template_op_items(doc["block_types"]["decoder"]["footer"])
+        footer_by_op = {item["op"]: item for item in footer_items if isinstance(item.get("graph_slots"), dict)}
+        self.assertEqual(footer_by_op["logits"]["graph_slots"]["inputs"]["x"], "main_stream")
+
+    def test_bf16_dense_projections_read_normed_main_stream(self) -> None:
+        manifest = _make_tiny_glm4_bf16_manifest()
+        ir1_ops = build_ir_v8.build_ir1_direct(
+            manifest,
+            ROOT / "tests" / "glm4_bf16_manifest.synthetic.json",
+            mode="decode",
+        )
+
+        by_op = {}
+        for ir_op in ir1_ops:
+            by_op.setdefault(ir_op["op"], []).append(ir_op)
+
+        for op_name in ("q_proj", "k_proj", "v_proj"):
+            source = by_op[op_name][0]["dataflow"]["inputs"]["x"]
+            self.assertEqual(source["slot"], "main_stream")
+            self.assertEqual(source["from_op"], by_op["rmsnorm"][0]["op_id"])
+
+        mlp_source = by_op["mlp_gate_up"][0]["dataflow"]["inputs"]["x"]
+        self.assertEqual(mlp_source["slot"], "main_stream")
+        self.assertEqual(mlp_source["from_op"], by_op["rmsnorm"][1]["op_id"])
+
+
+    def test_quantized_projections_read_q8_main_stream_view(self) -> None:
+        manifest = _make_tiny_glm4_quant_manifest()
+        ir1_ops = build_ir_v8.build_ir1_direct(
+            manifest,
+            ROOT / "tests" / "glm4_quant_manifest.synthetic.json",
+            mode="decode",
+        )
+
+        by_op = {}
+        for ir_op in ir1_ops:
+            by_op.setdefault(ir_op["op"], []).append(ir_op)
+
+        for op_name in ("q_proj", "k_proj", "v_proj"):
+            source = by_op[op_name][0]["dataflow"]["inputs"]["x"]
+            self.assertEqual(source["slot"], "main_stream_q8")
+            self.assertEqual(source["from_op"], by_op["quantize_input_0"][0]["op_id"])
+
+        mlp_source = by_op["mlp_gate_up"][0]["dataflow"]["inputs"]["x"]
+        self.assertEqual(mlp_source["slot"], "main_stream_q8")
+        self.assertEqual(mlp_source["from_op"], by_op["quantize_input_2"][0]["op_id"])
 
 
 if __name__ == "__main__":

--- a/tests/test_v8_template_circuit_audit.py
+++ b/tests/test_v8_template_circuit_audit.py
@@ -64,6 +64,38 @@ class TemplateCircuitAuditTests(unittest.TestCase):
         self.assertEqual(audit.audit_ir1(ir), [])
         self.assertEqual(audit.audit_lowered(lowered), [])
 
+    def test_template_explicit_edge_audit_reports_missing_and_present_edges(self) -> None:
+        audit = _load_module()
+        template = {
+            "name": "synthetic",
+            "block_types": {
+                "decoder": {
+                    "body": {
+                        "ops": [
+                            "rmsnorm",
+                            {"op": "qkv_proj", "graph_slots": {"inputs": {"x": "main_stream"}}},
+                            "mlp_gate_up",
+                        ]
+                    }
+                }
+            },
+        }
+        report = audit.audit_template_explicit_edges(template)
+        self.assertEqual(report["explicit"], ["decoder.body[1].qkv_proj.x=main_stream"])
+        self.assertEqual(report["missing"], ["decoder.body[2].mlp_gate_up.x"])
+
+    def test_glm4_template_declares_critical_projection_edges(self) -> None:
+        audit = _load_module()
+        template = json.loads((REPO / "version/v8/templates/glm4.json").read_text(encoding="utf-8"))
+        report = audit.audit_template_explicit_edges(template)
+        self.assertIn("decoder.body[1].qkv_proj.x=main_stream", report["explicit"])
+        self.assertIn("decoder.body[4].out_proj.x=attn_scratch", report["explicit"])
+        self.assertIn("decoder.body[8].mlp_gate_up.x=main_stream", report["explicit"])
+        self.assertIn("decoder.body[10].mlp_down.x=mlp_scratch", report["explicit"])
+        self.assertIn("decoder.footer[2].logits.x=main_stream", report["explicit"])
+        self.assertEqual(report["missing"], [])
+
+
     def test_cli_reports_generated_c_mamba_input_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             c_path = Path(td) / "model_v8.c"

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -32,7 +32,7 @@ Notes:
 - `NaanBeige`: if the first reply echoes `<|im_start|>assistant` or starts with `<think>`, keep `--chat-template auto`, do not force `none`, and treat it as a prompt-wrapper/chat-contract symptom rather than a stable expected reply shape.
 
 Canonical vision bring-up example:
-- `version/v8/scripts/cks-v8-run run hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf --mmproj hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf --image-path version/v8/test_assets/v8_vision_doc_card_72.png --prompt "Explain this image."`
+- `version/v8/scripts/cks-v8-run run hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf --mmproj hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm --prompt "Explain this image."`
 
 Notes:
 - For the validated Qwen3-VL 8B path, omitting `--mmproj` now auto-resolves the matching HF companion projector.

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -6142,6 +6142,54 @@
           }
         ]
       },
+      "phase_selection": {
+        "decode": {
+          "op_family": "gemv",
+          "default_kernel": "gemv_q4_k_q8_k",
+          "layout": "canonical_q4_k",
+          "notes": "Single-token decode lowers to GEMV, not GEMM. Keep decode on canonical Q4_K unless a decode-specific packed layout wins its own sweep."
+        },
+        "prefill": {
+          "op_family": "gemm",
+          "default_kernel": "gemm_nt_q4_k_q8_k",
+          "layout": "canonical_q4_k",
+          "candidates": [
+            {
+              "name": "canonical_serial",
+              "function": "gemm_nt_q4_k_q8_k",
+              "layout": "canonical_q4_k",
+              "promotion": "parity_fallback"
+            },
+            {
+              "name": "canonical_threadpool",
+              "function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
+              "layout": "canonical_q4_k",
+              "promotion": "sweep_gated"
+            },
+            {
+              "name": "packed_meta_msplit",
+              "function": "gemm_nt_q4_k_packed_meta_q8_k_threaded",
+              "layout": "q4_k_packed_meta",
+              "promotion": "sweep_gated",
+              "requires": [
+                "packed_weight_layout",
+                "prefill_phase"
+              ]
+            },
+            {
+              "name": "packed_meta_nsplit",
+              "function": "gemm_nt_q4_k_packed_meta_q8_k_threaded_nsplit",
+              "layout": "q4_k_packed_meta",
+              "promotion": "sweep_gated",
+              "requires": [
+                "packed_weight_layout",
+                "prefill_phase"
+              ]
+            }
+          ],
+          "selection_policy": "Use canonical serial as the correctness fallback. Promote packed-meta candidates only when the circuit/template lowering has a packed weight layout available and the hardware sweep policy selects that candidate for the model shape."
+        }
+      },
       "constraints": {
         "alignment": {
           "K": 256
@@ -6191,55 +6239,7 @@
       },
       "notes": "General matrix multiplication with Q4_K weights and Q8_K activations. Used for W2 (down) projection in MLP. High compression ratio.",
       "name": "gemm_nt_q4_k_q8_k",
-      "_source_file": "gemm_nt_q4_k_q8_k.json",
-      "phase_selection": {
-        "decode": {
-          "op_family": "gemv",
-          "default_kernel": "gemv_q4_k_q8_k",
-          "layout": "canonical_q4_k",
-          "notes": "Single-token decode lowers to GEMV, not GEMM. Keep decode on canonical Q4_K unless a decode-specific packed layout wins its own sweep."
-        },
-        "prefill": {
-          "op_family": "gemm",
-          "default_kernel": "gemm_nt_q4_k_q8_k",
-          "layout": "canonical_q4_k",
-          "candidates": [
-            {
-              "name": "canonical_serial",
-              "function": "gemm_nt_q4_k_q8_k",
-              "layout": "canonical_q4_k",
-              "promotion": "parity_fallback"
-            },
-            {
-              "name": "canonical_threadpool",
-              "function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
-              "layout": "canonical_q4_k",
-              "promotion": "sweep_gated"
-            },
-            {
-              "name": "packed_meta_msplit",
-              "function": "gemm_nt_q4_k_packed_meta_q8_k_threaded",
-              "layout": "q4_k_packed_meta",
-              "promotion": "sweep_gated",
-              "requires": [
-                "packed_weight_layout",
-                "prefill_phase"
-              ]
-            },
-            {
-              "name": "packed_meta_nsplit",
-              "function": "gemm_nt_q4_k_packed_meta_q8_k_threaded_nsplit",
-              "layout": "q4_k_packed_meta",
-              "promotion": "sweep_gated",
-              "requires": [
-                "packed_weight_layout",
-                "prefill_phase"
-              ]
-            }
-          ],
-          "selection_policy": "Use canonical serial as the correctness fallback. Promote packed-meta candidates only when the circuit/template lowering has a packed weight layout available and the hardware sweep policy selects that candidate for the model shape."
-        }
-      }
+      "_source_file": "gemm_nt_q4_k_q8_k.json"
     },
     {
       "id": "gemm_nt_q5_0",

--- a/version/v8/model_maps/safetensors_ck_map.json
+++ b/version/v8/model_maps/safetensors_ck_map.json
@@ -13,7 +13,7 @@
         "model": "glm4",
         "arch": "glm4",
         "model_type": "glm4",
-        "rope_layout": "split",
+        "rope_layout": "pairwise",
         "rope_param_mode": "precomputed",
         "has_qk_norm": false,
         "has_attention_biases": true,
@@ -100,6 +100,13 @@
           ]
         },
         {
+          "target": "layer.{L}.post_attention_norm",
+          "sources": [
+            "model.layers.{L}.post_self_attn_layernorm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
           "target": "layer.{L}.bo",
           "sources": [
             "model.layers.{L}.self_attn.o_proj.bias"
@@ -113,10 +120,11 @@
         {
           "target": "layer.{L}.w1",
           "sources": [
+            "model.layers.{L}.mlp.gate_up_proj.weight",
             "model.layers.{L}.mlp.gate_proj.weight",
             "model.layers.{L}.mlp.up_proj.weight"
           ],
-          "combine": "concat"
+          "combine": "concat_or_single"
         },
         {
           "target": "layer.{L}.b1",
@@ -131,6 +139,13 @@
           "sources": [
             "model.layers.{L}.mlp.down_proj.weight"
           ]
+        },
+        {
+          "target": "layer.{L}.post_ffn_norm",
+          "sources": [
+            "model.layers.{L}.post_mlp_layernorm.weight"
+          ],
+          "dtype": "fp32"
         },
         {
           "target": "layer.{L}.b2",

--- a/version/v8/regression/families_arm.json
+++ b/version/v8/regression/families_arm.json
@@ -209,7 +209,7 @@
       "context_len": 100,
       "runtime_args": [
         "--image-path",
-        "version/v8/test_assets/v8_vision_doc_card_72.png",
+        "version/v8/test_assets/v8_vision_doc_card_72.ppm",
         "--thinking-mode",
         "suppressed",
         "--temperature",

--- a/version/v8/regression/prompts.json
+++ b/version/v8/regression/prompts.json
@@ -85,7 +85,7 @@
       "max_tokens": 24,
       "runtime_args": [
         "--image-path",
-        "version/v8/test_assets/v8_vision_doc_card_72.png"
+        "version/v8/test_assets/v8_vision_doc_card_72.ppm"
       ],
       "heuristics": {
         "min_chars": 24,

--- a/version/v8/scripts/audit_template_circuit_v8.py
+++ b/version/v8/scripts/audit_template_circuit_v8.py
@@ -24,6 +24,81 @@ def _ops(doc: dict[str, Any]) -> list[dict[str, Any]]:
     return ops if isinstance(ops, list) else []
 
 
+def _template_op_items(section: Any) -> list[dict[str, Any]]:
+    if not isinstance(section, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in section:
+        if isinstance(item, str):
+            out.append({"op": item})
+        elif isinstance(item, dict) and isinstance(item.get("op"), str):
+            out.append(item)
+    return out
+
+
+CRITICAL_TEMPLATE_INPUTS: dict[str, tuple[str, ...]] = {
+    "qkv_proj": ("x",),
+    "q_proj": ("x",),
+    "q_gate_proj": ("x",),
+    "k_proj": ("x",),
+    "v_proj": ("x",),
+    "mlp_gate_up": ("x",),
+    "mlp_up": ("x",),
+    "mamba_in_proj": ("x",),
+    "recurrent_qkv_proj": ("x",),
+    "recurrent_gate_proj": ("x",),
+    "recurrent_alpha_proj": ("x",),
+    "recurrent_beta_proj": ("x",),
+    "out_proj": ("x",),
+    "mlp_down": ("x",),
+    "mamba_out_proj": ("x",),
+    "recurrent_out_proj": ("x",),
+    "logits": ("x",),
+}
+
+
+def audit_template_explicit_edges(template: dict[str, Any]) -> dict[str, Any]:
+    missing: list[str] = []
+    explicit: list[str] = []
+    ignored: list[str] = []
+    blocks = template.get("block_types") if isinstance(template.get("block_types"), dict) else {}
+    for block_name, block in blocks.items():
+        if not isinstance(block, dict):
+            continue
+        sections: list[tuple[str, Any]] = [("header", block.get("header")), ("footer", block.get("footer"))]
+        body = block.get("body")
+        if isinstance(body, dict):
+            sections.append(("body", body.get("ops")))
+            ops_by_kind = body.get("ops_by_kind")
+            if isinstance(ops_by_kind, dict):
+                for kind, ops in ops_by_kind.items():
+                    sections.append((f"body:{kind}", ops))
+        else:
+            sections.append(("body", body))
+        for section_name, raw_ops in sections:
+            for index, item in enumerate(_template_op_items(raw_ops)):
+                op = str(item.get("op") or "")
+                required = CRITICAL_TEMPLATE_INPUTS.get(op)
+                if not required:
+                    ignored.append(f"{block_name}.{section_name}[{index}].{op}")
+                    continue
+                graph_slots = item.get("graph_slots") if isinstance(item.get("graph_slots"), dict) else {}
+                inputs = graph_slots.get("inputs") if isinstance(graph_slots.get("inputs"), dict) else {}
+                for input_name in required:
+                    label = f"{block_name}.{section_name}[{index}].{op}.{input_name}"
+                    if input_name in inputs:
+                        explicit.append(f"{label}={inputs[input_name]}")
+                    else:
+                        missing.append(label)
+    return {
+        "template": template.get("name"),
+        "explicit_count": len(explicit),
+        "missing_count": len(missing),
+        "explicit": explicit,
+        "missing": missing,
+    }
+
+
 def _op_id(op: dict[str, Any]) -> int:
     return int(op.get("op_id", op.get("idx", -1)))
 
@@ -225,6 +300,8 @@ def audit_c_source(c_path: Path) -> list[str]:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--template", type=Path, help="v8 template JSON to audit for explicit circuit edges")
+    ap.add_argument("--require-explicit-template-edges", action="store_true", help="fail if critical template op inputs rely on implicit defaults")
     ap.add_argument("--ir1", type=Path, help="ir1_*.json artifact")
     ap.add_argument("--lowered", type=Path, help="lowered_*.json artifact")
     ap.add_argument("--c-source", type=Path, help="generated model_v8.c artifact")
@@ -232,6 +309,11 @@ def main() -> int:
     args = ap.parse_args()
     errors: list[str] = []
     checks: dict[str, Any] = {}
+    if args.template:
+        template_report = audit_template_explicit_edges(_load_json(args.template))
+        checks["template_explicit_edges"] = template_report
+        if args.require_explicit_template_edges and template_report["missing_count"]:
+            errors.extend([f"template missing explicit input edge: {item}" for item in template_report["missing"]])
     if args.ir1:
         e = audit_ir1(_load_json(args.ir1)); errors.extend(e); checks["ir1_errors"] = e
     if args.lowered:

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -2154,6 +2154,16 @@ def _extract_template_ops(section: Any, include_inactive: bool = False) -> List[
     return [item["op"] for item in _normalize_template_op_items(section, include_inactive=include_inactive)]
 
 
+def _template_graph_slots(op_item: Dict[str, Any]) -> Dict[str, Any]:
+    graph_slots = op_item.get("graph_slots") if isinstance(op_item.get("graph_slots"), dict) else {}
+    out: Dict[str, Any] = {}
+    for section in ("inputs", "outputs"):
+        value = graph_slots.get(section)
+        if isinstance(value, dict) and value:
+            out[section] = copy.deepcopy(value)
+    return out
+
+
 def _dedupe_preserve_order(items: List[str]) -> List[str]:
     seen = set()
     out: List[str] = []
@@ -4475,7 +4485,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             return None
         act = kernel_act_dtype.get(kernel_id, "fp32")
         if op_type in ("q_proj", "q_gate_proj", "k_proj", "v_proj", "qkv_packed_proj", "mlp_gate_up", "mlp_up"):
-            return {"x": "layer_input" if act == "fp32" else "main_stream_q8"}
+            return {"x": "main_stream" if act == "fp32" else "main_stream_q8"}
         if op_type == "projector_fc1":
             return {"x": "main_stream" if act == "fp32" else "main_stream_q8"}
         if op_type == "out_proj":
@@ -4487,7 +4497,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         if op_type == "branch_fc2":
             return {"x": "branch_mlp" if act == "fp32" else "branch_mlp"}
         if op_type == "mamba_in_proj":
-            return {"x": "layer_input" if act == "fp32" else "main_stream_q8"}
+            return {"x": "main_stream" if act == "fp32" else "main_stream_q8"}
         if op_type in ("recurrent_qkv_proj", "recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj"):
             return {"x": "main_stream" if act == "fp32" else "main_stream_q8"}
         if op_type in ("recurrent_out_proj", "mamba_out_proj"):
@@ -5143,7 +5153,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                             # Get op_id and instance (data flow is handled in IR Lower)
                             op_info = get_op_info(split_op, "body", layer_idx)
 
-                            arranged_kernels.append({
+                            arranged = {
                                 "op_id": op_info["op_id"],
                                 "kernel": kernel_id,
                                 "op": split_op,
@@ -5154,7 +5164,11 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                                 "params": copy.deepcopy(
                                     op_item.get("params") if isinstance(op_item.get("params"), dict) else {}
                                 ),
-                            })
+                            }
+                            graph_slots = _template_graph_slots(op_item)
+                            if graph_slots:
+                                arranged["graph_slots"] = graph_slots
+                            arranged_kernels.append(arranged)
                             print(f"      [{op_info['op_id']:3d}] {split_op:20s} → {kernel_id}  (inst: {op_info['instance']})")
 
                         annotate_branch_taps(emitted_start, "body", layer_idx, op_item)
@@ -5290,7 +5304,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                         # Get op_id and instance (data flow is handled in IR Lower)
                         op_info = get_op_info(split_op, section_name, -1)
 
-                        arranged_kernels.append({
+                        arranged = {
                             "op_id": op_info["op_id"],
                             "kernel": kernel_id,
                             "op": split_op,
@@ -5301,7 +5315,11 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                             "params": copy.deepcopy(
                                 op_item.get("params") if isinstance(op_item.get("params"), dict) else {}
                             ),
-                        })
+                        }
+                        graph_slots = _template_graph_slots(op_item)
+                        if graph_slots:
+                            arranged["graph_slots"] = graph_slots
+                        arranged_kernels.append(arranged)
                         print(f"      [{op_info['op_id']:3d}] {split_op:20s} → {kernel_id}  (inst: {op_info['instance']})")
 
                     annotate_branch_taps(emitted_start, section_name, -1, op_item)
@@ -5339,8 +5357,14 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         graph_slots = ir_op.get("graph_slots", {}) if isinstance(ir_op.get("graph_slots"), dict) else {}
         explicit_input_override = graph_slots.get("inputs") if isinstance(graph_slots.get("inputs"), dict) else {}
         explicit_output_override = graph_slots.get("outputs") if isinstance(graph_slots.get("outputs"), dict) else {}
-        merged_input_override = dict(input_override or {})
-        merged_input_override.update(explicit_input_override)
+        # Template graph_slots describe the semantic producer/consumer edge.
+        # Kernel activation dtype decides the physical view of that edge. For
+        # example GLM4 q_proj semantically consumes main_stream, but a Q4_K x
+        # Q8_K kernel must read main_stream_q8 produced by quantize_input_0.
+        # Keep the kernel ABI override last so explicit circuit slots cannot
+        # accidentally wire a quantized kernel back to the FP32 stream.
+        merged_input_override = dict(explicit_input_override or {})
+        merged_input_override.update(input_override or {})
         dataflow_info = dataflow_tracker.record_op(
             op_id,
             op_type,

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1232,7 +1232,7 @@ Examples:
     run_parser.add_argument("--repeat-last-n", type=int, default=None)
     run_parser.add_argument("--no-repeat-ngram-size", type=int, default=None)
     run_parser.add_argument("--prompt", default=None, help="Single prompt (non-interactive if set)")
-    run_parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen2", "qwen3", "qwen35", "qwen3vl", "gemma", "gemma3", "gemma4", "llama"], default="auto")
+    run_parser.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen2", "qwen3", "qwen35", "qwen3vl", "gemma", "gemma3", "gemma4", "glm4", "llama"], default="auto")
     run_parser.add_argument("--no-chat-template", action="store_true")
     run_parser.add_argument("--allow-raw-prompt", action="store_true")
     run_parser.add_argument("--thinking-mode", choices=["auto", "visible", "suppressed"], default="auto")

--- a/version/v8/scripts/cks-v8-run
+++ b/version/v8/scripts/cks-v8-run
@@ -24,7 +24,7 @@ Raw CLI examples:
 
   version/v8/scripts/cks-v8-run run hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \\
     --mmproj hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \\
-    --image-path version/v8/test_assets/v8_vision_doc_card_72.png \\
+    --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \\
     --prompt "Explain this image."
 
 After a run exists:

--- a/version/v8/scripts/compare_glm4_torch_ck_hidden_v8.py
+++ b/version/v8/scripts/compare_glm4_torch_ck_hidden_v8.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Compare GLM4 PyTorch layer/op tensors against CK hidden dumps.
+
+This is a diagnostic companion to compare_glm4_torch_ck_v8.py.  CK exports
+last-token prefill snapshots through CK_DEBUG_EXPORT_HIDDEN; this script hooks
+the matching Hugging Face GLM4 modules and reports where the hidden stream first
+opens up.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _parse_tokens_csv(text: str) -> list[int]:
+    out: list[int] = []
+    for part in str(text or "").split(","):
+        part = part.strip()
+        if part:
+            out.append(int(part))
+    if not out:
+        raise SystemExit("--tokens did not contain any token IDs")
+    return out
+
+
+def _torch_dtype(name: str):
+    import torch
+
+    n = str(name).lower()
+    if n in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if n in {"fp32", "float32"}:
+        return torch.float32
+    if n in {"fp16", "float16"}:
+        return torch.float16
+    raise ValueError(name)
+
+
+def _to_np(x: Any, token_index: int) -> np.ndarray:
+    import torch
+
+    if isinstance(x, tuple):
+        x = x[0]
+    if not isinstance(x, torch.Tensor):
+        raise TypeError(type(x).__name__)
+    t = x.detach().float().cpu()
+    if t.ndim == 3:
+        t = t[0, token_index, :]
+    elif t.ndim == 2:
+        t = t[token_index, :]
+    elif t.ndim == 4:
+        if t.shape[1] > token_index:
+            t = t[0, token_index, :, :]
+        elif t.shape[2] > token_index:
+            t = t[0, :, token_index, :]
+        else:
+            t = t.reshape(-1)
+    else:
+        t = t.reshape(-1)
+    return t.numpy().astype(np.float32, copy=False).reshape(-1)
+
+
+def _cmp(torch_vec: np.ndarray, ck_vec: np.ndarray) -> dict[str, Any]:
+    a = torch_vec.reshape(-1).astype(np.float64)
+    b = ck_vec.reshape(-1).astype(np.float64)
+    n = min(int(a.size), int(b.size))
+    if n <= 0:
+        return {"compared": 0, "error": "empty"}
+    a = a[:n]
+    b = b[:n]
+    d = a - b
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b))
+    max_idx = int(np.argmax(np.abs(d)))
+    return {
+        "torch_size": int(torch_vec.size),
+        "ck_size": int(ck_vec.size),
+        "compared": int(n),
+        "cosine": float(np.dot(a, b) / denom) if denom else float("nan"),
+        "max_abs": float(np.max(np.abs(d))),
+        "mean_abs": float(np.mean(np.abs(d))),
+        "rmse": float(np.sqrt(np.mean(d * d))),
+        "max_idx": max_idx,
+        "torch_at_max": float(a[max_idx]),
+        "ck_at_max": float(b[max_idx]),
+    }
+
+
+def _ck_file(ck_dir: Path, ck_token_index: int, layer: int, label: str) -> Path:
+    return ck_dir / f"tok_{ck_token_index:04d}_layer_{layer:03d}_{label}.f32"
+
+
+def _load_ck(ck_dir: Path, ck_token_index: int, layer: int, label: str) -> np.ndarray | None:
+    labels = [label]
+    if not label.endswith("_last"):
+        labels.append(f"{label}_last")
+    for lab in labels:
+        path = _ck_file(ck_dir, ck_token_index, layer, lab)
+        if path.exists():
+            return np.fromfile(path, dtype=np.float32)
+    return None
+
+
+def _get_attr(obj: Any, dotted: str) -> Any | None:
+    cur = obj
+    for part in dotted.split("."):
+        if not hasattr(cur, part):
+            return None
+        cur = getattr(cur, part)
+    return cur
+
+
+def _load_input(args: argparse.Namespace, tokenizer: Any) -> tuple[list[int], str]:
+    if args.tokens:
+        ids = _parse_tokens_csv(args.tokens)
+        return ids, tokenizer.decode(ids)
+    enc = tokenizer(args.prompt, add_special_tokens=not args.no_special_tokens, return_tensors="pt")
+    ids = [int(x) for x in enc["input_ids"][0].tolist()]
+    if args.max_input_tokens and len(ids) > int(args.max_input_tokens):
+        ids = ids[: int(args.max_input_tokens)]
+    return ids, args.prompt
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--safetensors", required=True, type=Path)
+    ap.add_argument("--ck-hidden-dir", required=True, type=Path)
+    ap.add_argument("--prompt", default="Give me a detailed example of C, Python, and SQL code.")
+    ap.add_argument("--tokens")
+    ap.add_argument("--max-input-tokens", type=int, default=0)
+    ap.add_argument("--no-special-tokens", action="store_true")
+    ap.add_argument("--dtype", choices=("bf16", "fp32", "fp16"), default="bf16")
+    ap.add_argument("--trust-remote-code", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--token-index", type=int, default=-1, help="PyTorch token row to compare")
+    ap.add_argument("--ck-token-index", type=int, default=0, help="CK hidden dump token prefix, usually 0 for prefill last-row exports")
+    ap.add_argument("--layers", default="all", help="all or comma-separated layer ids")
+    ap.add_argument("--fail-max", type=float, default=2.0)
+    ap.add_argument("--fail-cos", type=float, default=0.995)
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    model_dir = args.safetensors.expanduser().resolve()
+    ck_dir = args.ck_hidden_dir.expanduser().resolve()
+    tok = AutoTokenizer.from_pretrained(model_dir, trust_remote_code=bool(args.trust_remote_code))
+    token_ids, prompt_text = _load_input(args, tok)
+    token_index = int(args.token_index)
+    if token_index < 0:
+        token_index = len(token_ids) + token_index
+    if token_index < 0 or token_index >= len(token_ids):
+        raise SystemExit(f"token index out of range: {args.token_index} for {len(token_ids)} tokens")
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_dir,
+        trust_remote_code=bool(args.trust_remote_code),
+        torch_dtype=_torch_dtype(args.dtype),
+        device_map=None,
+        low_cpu_mem_usage=True,
+    )
+    model.eval()
+    layers = _get_attr(model, "model.layers")
+    if layers is None:
+        raise SystemExit("unable to find model.layers")
+
+    selected_layers: list[int]
+    if str(args.layers).strip().lower() == "all":
+        selected_layers = list(range(len(layers)))
+    else:
+        selected_layers = [int(x.strip()) for x in str(args.layers).split(",") if x.strip()]
+
+    captures: dict[tuple[int, str], np.ndarray] = {}
+    layer_inputs: dict[int, np.ndarray] = {}
+    post_self_norm: dict[int, np.ndarray] = {}
+    after_attn: dict[int, np.ndarray] = {}
+    handles = []
+
+    def save(layer_idx: int, label: str, value: Any) -> None:
+        captures[(layer_idx, label)] = _to_np(value, token_index)
+
+    for layer_idx in selected_layers:
+        layer = layers[layer_idx]
+
+        def make_pre(idx: int):
+            def pre(_module: Any, inputs: tuple[Any, ...]) -> None:
+                if inputs:
+                    layer_inputs[idx] = _to_np(inputs[0], token_index)
+            return pre
+
+        handles.append(layer.register_forward_pre_hook(make_pre(layer_idx)))
+        for attr, label in (
+            ("self_attn.q_proj", "q_proj"),
+            ("self_attn.k_proj", "k_proj"),
+            ("self_attn.v_proj", "v_proj"),
+            ("self_attn.o_proj", "out_proj"),
+            ("post_self_attn_layernorm", "post_attn_norm"),
+            ("mlp.gate_up_proj", "mlp_gate_up"),
+            ("mlp.activation_fn", "mlp_activation"),
+            ("mlp.down_proj", "mlp_down"),
+            ("post_mlp_layernorm", "post_ffn_norm"),
+        ):
+            module = _get_attr(layer, attr)
+            if module is None:
+                continue
+
+            def make_hook(idx: int, lab: str):
+                def hook(_module: Any, _inputs: tuple[Any, ...], output: Any) -> None:
+                    vec = _to_np(output, token_index)
+                    if lab == "mlp_gate_up":
+                        half = vec.size // 2
+                        captures[(idx, "mlp_gate")] = vec[:half].copy()
+                        captures[(idx, "mlp_up")] = vec[half:].copy()
+                    else:
+                        captures[(idx, lab)] = vec
+                        if lab == "post_attn_norm":
+                            post_self_norm[idx] = vec
+                return hook
+
+            handles.append(module.register_forward_hook(make_hook(layer_idx, label)))
+
+        def make_layer_hook(idx: int):
+            def hook(_module: Any, _inputs: tuple[Any, ...], output: Any) -> None:
+                captures[(idx, "layer_out")] = _to_np(output, token_index)
+                if idx in layer_inputs and idx in post_self_norm:
+                    aa = layer_inputs[idx] + post_self_norm[idx]
+                    after_attn[idx] = aa
+                    captures[(idx, "after_attn")] = aa
+                    captures[(idx, "ffn_residual")] = aa
+            return hook
+
+        handles.append(layer.register_forward_hook(make_layer_hook(layer_idx)))
+
+    input_ids = torch.tensor([token_ids], dtype=torch.long)
+    with torch.inference_mode():
+        _ = model(input_ids=input_ids, use_cache=False, return_dict=True)
+    for h in handles:
+        h.remove()
+
+    rows: list[dict[str, Any]] = []
+    first_bad: dict[str, Any] | None = None
+    labels = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "out_proj",
+        "post_attn_norm",
+        "after_attn",
+        "ffn_residual",
+        "mlp_gate",
+        "mlp_up",
+        "mlp_down",
+        "post_ffn_norm",
+        "layer_out",
+    ]
+    for layer_idx in selected_layers:
+        for label in labels:
+            tv = captures.get((layer_idx, label))
+            if tv is None:
+                continue
+            cv = _load_ck(ck_dir, int(args.ck_token_index), layer_idx, label)
+            if cv is None:
+                continue
+            c = _cmp(tv, cv)
+            row = {"layer": layer_idx, "label": label, **c}
+            bad = bool(float(c["max_abs"]) > float(args.fail_max) or float(c["cosine"]) < float(args.fail_cos))
+            row["status"] = "fail" if bad else "pass"
+            rows.append(row)
+            if bad and first_bad is None:
+                first_bad = row
+
+    report = {
+        "status": "pass" if first_bad is None else "fail",
+        "prompt": prompt_text,
+        "input_ids": token_ids,
+        "token_index": int(token_index),
+        "ck_token_index": int(args.ck_token_index),
+        "ck_hidden_dir": str(ck_dir),
+        "thresholds": {"fail_max": float(args.fail_max), "fail_cos": float(args.fail_cos)},
+        "rows": rows,
+        "first_bad": first_bad,
+    }
+    text = json.dumps(report, indent=2, sort_keys=True)
+    print(text)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text + "\n", encoding="utf-8")
+    return 0 if first_bad is None else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -306,18 +306,17 @@ def _refs_from_safetensors_contract(arch: str, config: dict[str, Any], headers: 
             if synth:
                 refs.append(TensorRef(ck_name, (), dtype=dtype, synth=synth, shape=shape))
                 continue
-            if str(spec.get("combine") or "").strip().lower() == "concat":
-                resolved: list[str] = []
-                missing: list[str] = []
-                for src in sources_raw:
-                    name = str(src).replace("{L}", str(layer)) if layer is not None else str(src)
-                    if name not in headers:
-                        missing.append(name)
-                    else:
-                        resolved.append(name)
-                if missing:
-                    raise SystemExit(f"Missing required safetensors tensor for {ck_name}: tried {missing}")
-                refs.append(TensorRef(ck_name, tuple(resolved), dtype=dtype))
+            combine_mode = str(spec.get("combine") or "").strip().lower()
+            if combine_mode in {"concat", "concat_or_single"}:
+                named_sources = [str(src).replace("{L}", str(layer)) if layer is not None else str(src) for src in sources_raw]
+                if combine_mode == "concat_or_single" and named_sources and named_sources[0] in headers:
+                    refs.append(TensorRef(ck_name, (named_sources[0],), dtype=dtype))
+                    continue
+                concat_sources = named_sources[1:] if combine_mode == "concat_or_single" else named_sources
+                missing = [name for name in concat_sources if name not in headers]
+                if missing or not concat_sources:
+                    raise SystemExit(f"Missing required safetensors tensor for {ck_name}: tried {named_sources}")
+                refs.append(TensorRef(ck_name, tuple(concat_sources), dtype=dtype))
                 continue
             found = _first_existing_from_patterns(headers, (str(x) for x in sources_raw), layer)
             if found is not None:
@@ -948,10 +947,10 @@ def _is_qwen35_shifted_norm_ref(ref: TensorRef) -> bool:
     ))
 
 
-def _ref_transform(ref: TensorRef) -> str | None:
+def _ref_transform(arch: str, ref: TensorRef) -> str | None:
     if ref.ck_name.endswith(".ssm_a") or ref.ck_name.endswith(".mamba_a"):
         return "neg_exp_a_log"
-    if _is_qwen35_shifted_norm_ref(ref):
+    if arch == "qwen35" and _is_qwen35_shifted_norm_ref(ref):
         return "qwen35_norm_plus_one"
     return None
 
@@ -971,7 +970,7 @@ def _build_source_audit(arch: str, headers: dict[str, HeaderTensor], refs: list[
     synthetic: list[str] = []
     transforms: list[dict[str, str]] = []
     for ref in refs:
-        transform = _ref_transform(ref)
+        transform = _ref_transform(arch, ref)
         if ref.source_names:
             for src in ref.source_names:
                 consumed.setdefault(src, []).append(ref.ck_name)
@@ -1004,7 +1003,7 @@ def _build_source_audit(arch: str, headers: dict[str, HeaderTensor], refs: list[
     }
 
 
-def _write_ref(w: HashingWriter, model_dir: Path, headers: dict[str, HeaderTensor], ref: TensorRef, dtype_policy: str) -> tuple[str, int, list[int]]:
+def _write_ref(w: HashingWriter, model_dir: Path, headers: dict[str, HeaderTensor], ref: TensorRef, dtype_policy: str, arch: str) -> tuple[str, int, list[int]]:
     if ref.synth:
         data, dt, shape = _synth_bytes(ref.synth, ref.shape or (), dtype_policy)
         w.write(data)
@@ -1014,7 +1013,7 @@ def _write_ref(w: HashingWriter, model_dir: Path, headers: dict[str, HeaderTenso
     out_shape: list[int] = []
     for src in ref.source_names:
         t = _load_tensor(model_dir, headers, src)
-        transform = _ref_transform(ref)
+        transform = _ref_transform(arch, ref)
         if transform == "neg_exp_a_log":
             import torch
             t = -torch.exp(t.to(dtype=torch.float32))
@@ -1193,7 +1192,7 @@ def main() -> int:
             "source_name": "+".join(ref.source_names) if ref.source_names else f"synthetic:{ref.synth}",
             "shape": shape,
         }
-        transform = _ref_transform(ref)
+        transform = _ref_transform(arch, ref)
         if transform:
             preview_entry["transform"] = transform
         entries_preview.append(preview_entry)
@@ -1303,7 +1302,7 @@ def main() -> int:
         current_offset = DATA_START + 4 + len(dtype_table)
         for ref in refs:
             start = current_offset
-            dt, size, shape = _write_ref(w, model_dir, headers, ref, args.dtype)
+            dt, size, shape = _write_ref(w, model_dir, headers, ref, args.dtype, arch)
             current_offset += size
             entry = {
                 "name": ref.ck_name,
@@ -1313,7 +1312,7 @@ def main() -> int:
                 "source_name": "+".join(ref.source_names) if ref.source_names else f"synthetic:{ref.synth}",
                 "shape": shape,
             }
-            transform = _ref_transform(ref)
+            transform = _ref_transform(arch, ref)
             if transform:
                 entry["transform"] = transform
             entries.append(entry)

--- a/version/v8/templates/glm4.json
+++ b/version/v8/templates/glm4.json
@@ -35,7 +35,7 @@
       "system_prompt_separator": "\n\n",
       "default_system_prompt": "",
       "inject_default_system_prompt": false,
-      "force_bos_text_if_tokenizer_add_bos_false": "[gMASK]",
+      "force_bos_text_if_tokenizer_add_bos_false": "[gMASK]<sop>\n",
       "last_user_prefix": "",
       "last_user_prefix_suppression_markers": [],
       "stop_text_markers": [
@@ -57,7 +57,7 @@
       "min_response_tokens": 8
     },
     "attention_contract": {
-      "rope_layout": "split",
+      "rope_layout": "pairwise",
       "rope_type": "rope",
       "qk_norm": false,
       "kv_layout": "layer_major_kv_cache",
@@ -93,7 +93,7 @@
     }
   },
   "kernels": {
-    "rope_qk": "rope_forward_qk"
+    "rope_qk": "rope_forward_qk_pairwise"
   },
   "sequence": [
     "decoder"
@@ -113,16 +113,44 @@
         "type": "dense",
         "ops": [
           "rmsnorm",
-          "qkv_proj",
+          {
+            "op": "qkv_proj",
+            "graph_slots": {
+              "inputs": {
+                "x": "main_stream"
+              }
+            }
+          },
           "rope_qk",
           "attn",
-          "out_proj",
+          {
+            "op": "out_proj",
+            "graph_slots": {
+              "inputs": {
+                "x": "attn_scratch"
+              }
+            }
+          },
           "post_attention_norm",
           "residual_add",
           "rmsnorm",
-          "mlp_gate_up",
+          {
+            "op": "mlp_gate_up",
+            "graph_slots": {
+              "inputs": {
+                "x": "main_stream"
+              }
+            }
+          },
           "silu_mul",
-          "mlp_down",
+          {
+            "op": "mlp_down",
+            "graph_slots": {
+              "inputs": {
+                "x": "mlp_scratch"
+              }
+            }
+          },
           "post_ffn_norm",
           "residual_add"
         ]
@@ -130,7 +158,14 @@
       "footer": [
         "rmsnorm",
         "weight_tying",
-        "logits"
+        {
+          "op": "logits",
+          "graph_slots": {
+            "inputs": {
+              "x": "main_stream"
+            }
+          }
+        }
       ]
     }
   }


### PR DESCRIPTION
Summary:
- harden GLM4 v8 circuit/dataflow support across chat contract, partial RoPE, GGUF/safetensors conversion, and template audit guardrails
- switch promoted Qwen3-VL doc-card smoke references from PNG to deterministic PPM assets
- keep high-memory real GLM/Qwen3-VL smokes out of the laptop path while preserving lightweight regression coverage

Validation:
- .venv/bin/python -m py_compile scripts/chat_contract.py scripts/ck_chat.py version/v8/scripts/ck_run_v8.py version/v8/scripts/build_ir_v8.py version/v8/scripts/convert_safetensors_to_bump_v8.py version/v8/scripts/audit_template_circuit_v8.py version/v8/scripts/compare_glm4_torch_ck_hidden_v8.py
- .venv/bin/python -m unittest tests.test_v8_template_circuit_audit tests.test_v8_glm4_template tests.test_run_regression_v8
- make --no-print-directory test-v8-vision-kernels
- make --no-print-directory test-v8-qwen3vl
- pre-commit v7-regression-fast and v8-regression-fast
- pre-push full gate: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training smoke, v7/v8 fast regression, v7 training-kernel parity