### PR TITLE
Harden GLM4, Qwen3-VL, and v8 circuit smoke coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,13 @@ BENCH_CXX ?= $(CXX)
 
 BUILD_DIR := build
 BUILD_STAMP := $(BUILD_DIR)/.ck_build_flags
+V8_QWEN3VL_MODEL ?= hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf
 V8_QWEN3VL_MMPROJ ?= $(CURDIR)/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf
+V8_QWEN3VL_CACHE_DIR ?= /opt/app-root/src/.cache/ck-engine-v8/models/Qwen--Qwen3-VL-8B-Instruct-GGUF
+V8_QWEN3VL_CACHED_MODEL ?= $(V8_QWEN3VL_CACHE_DIR)/Qwen3VL-8B-Instruct-Q4_K_M.gguf
+V8_QWEN3VL_CACHED_MMPROJ ?= $(V8_QWEN3VL_CACHE_DIR)/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf
+V8_QWEN3VL_IMAGE ?= version/v8/test_assets/v8_vision_doc_card_72.ppm
+V8_QWEN3VL_MAX_TOKENS ?= 32
 V8_GEMMA4_MODEL ?= hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf
 V8_GEMMA4_MIN_MEM_GB ?= 50
 V8_GEMMA4_CONTEXT ?= 2048
@@ -1191,6 +1197,27 @@ test-head-major-q5-outproj-quick: $(LIB)
 
 test-v8-qwen3vl: $(LIB_VISION)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) tests/test_v8_qwen3vl_template.py
+
+test-v8-qwen3vl-e2e-smoke:
+	@if [ ! -f "$(V8_QWEN3VL_CACHED_MODEL)" ] || [ ! -f "$(V8_QWEN3VL_CACHED_MMPROJ)" ]; then \
+		echo "SKIP: Qwen3-VL cached decoder/mmproj not found under $(V8_QWEN3VL_CACHE_DIR)"; \
+	else \
+		echo "Running cached v8 Qwen3-VL image -> mmproj -> decoder smoke..."; \
+		CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+			$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/ck_run_v8.py run "$(V8_QWEN3VL_MODEL)" \
+			--mmproj "hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf" \
+			--image-path "$(V8_QWEN3VL_IMAGE)" \
+			--prompt "Explain this image." \
+			--context-len 1024 \
+			--force-compile \
+			--thinking-mode suppressed \
+			--max-tokens $(V8_QWEN3VL_MAX_TOKENS) \
+			--temperature 0.0; \
+	fi
+
+test-v8-vision-smoke: test-v8-vision-kernels test-v8-qwen3vl test-v8-qwen3vl-e2e-smoke
+
+test-v8-model-smoke: test-v8-template-circuit-audit v8-regression-fast test-v8-gemma4-highmem test-v8-nemotron9-highmem
 
 parity-v8-qwen3vl-mmproj:
 	@if [ ! -f "$(V8_QWEN3VL_MMPROJ)" ]; then \
@@ -2533,7 +2560,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-qwen3vl-e2e-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -422,6 +422,12 @@ MAKE_TARGETS = {
         "target": "v8-kernel-map-contracts",
         "timeout_sec": 600,
     },
+    "v8_template_circuit_audit": {
+        "name": "v8 Template Circuit/Dataflow Audit",
+        "category": "inference",
+        "target": "test-v8-template-circuit-audit",
+        "timeout_sec": 300,
+    },
     "v8_regression_fast": {
         "name": "v8 Inference Regression (fast)",
         "category": "inference",

--- a/tests/test_v8_template_circuit_audit.py
+++ b/tests/test_v8_template_circuit_audit.py
@@ -96,6 +96,37 @@ class TemplateCircuitAuditTests(unittest.TestCase):
         self.assertEqual(report["missing"], [])
 
 
+    def test_lowered_rejects_quantized_activation_bound_to_fp32_stream(self) -> None:
+        audit = _load_module()
+        lowered = {
+            "operations": [
+                {
+                    "idx": 4,
+                    "layer": 0,
+                    "op": "q_proj",
+                    "activations": {"x": {"dtype": "q8_k", "buffer": "embedded_input"}},
+                    "outputs": {"y": {"buffer": "q_scratch"}},
+                }
+            ]
+        }
+        errors = audit.audit_lowered(lowered)
+        self.assertTrue(any("quantized activation" in e and "embedded_input" in e for e in errors), errors)
+
+    def test_lowered_allows_quantized_activation_bound_to_physical_q8_view(self) -> None:
+        audit = _load_module()
+        lowered = {
+            "operations": [
+                {
+                    "idx": 4,
+                    "layer": 0,
+                    "op": "q_proj",
+                    "activations": {"x": {"dtype": "q8_k", "buffer": "layer_input"}},
+                    "outputs": {"y": {"buffer": "q_scratch"}},
+                }
+            ]
+        }
+        self.assertEqual(audit.audit_lowered(lowered), [])
+
     def test_cli_reports_generated_c_mamba_input_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             c_path = Path(td) / "model_v8.c"

--- a/version/v8/scripts/audit_template_circuit_v8.py
+++ b/version/v8/scripts/audit_template_circuit_v8.py
@@ -141,6 +141,36 @@ def _output_buffer(op: dict[str, Any], name: str) -> str:
     return str((_lookup_tensor(op.get("outputs") or {}, names).get("buffer") or ""))
 
 
+SEMANTIC_FP32_BUFFERS = {
+    "embedded_input",
+    "main_stream",
+    "residual",
+    "layer_output",
+    "attn_scratch",
+    "mlp_scratch",
+    "logits",
+}
+
+
+def _audit_physical_activation_views(ops: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    for op in ops:
+        idx = op.get("idx", op.get("op_id", "?"))
+        op_name = str(op.get("op") or "")
+        layer = op.get("layer", "?")
+        for arg_name, spec in (op.get("activations") or {}).items():
+            if not isinstance(spec, dict):
+                continue
+            dtype = str(spec.get("dtype") or "")
+            buffer = str(spec.get("buffer") or "")
+            if dtype.startswith("q") and buffer in SEMANTIC_FP32_BUFFERS:
+                errors.append(
+                    f"op {idx} layer {layer} {op_name}.{arg_name}: quantized activation dtype={dtype} "
+                    f"is bound to semantic FP32 buffer={buffer}; expected a quantized physical view such as layer_input/main_stream_q8"
+                )
+    return errors
+
+
 def _by_layer_name(ops: list[dict[str, Any]]) -> dict[tuple[int, str], dict[str, Any]]:
     out: dict[tuple[int, str], dict[str, Any]] = {}
     for op in ops:
@@ -252,6 +282,7 @@ def audit_ir1(ir1: dict[str, Any]) -> list[str]:
 def audit_lowered(lowered: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     ops = _ops(lowered)
+    errors.extend(_audit_physical_activation_views(ops))
     by = _by_layer_name(ops)
     layers = sorted({layer for layer, _ in by})
     for layer in layers:


### PR DESCRIPTION
Summary:
- harden GLM4 v8 circuit/dataflow support across chat contract, partial RoPE, GGUF/safetensors conversion, and template audit guardrails
- switch promoted Qwen3-VL doc-card smoke references from PNG to deterministic PPM assets
- add cached Qwen3-VL E2E smoke targets and nightly-visible v8 template/circuit audit coverage
- reject lowered quantized activations bound to semantic FP32 buffers

Validation:
- .venv/bin/python -m py_compile scripts/nightly_runner.py version/v8/scripts/audit_template_circuit_v8.py
- .venv/bin/python -m unittest tests.test_v8_template_circuit_audit
- make --no-print-directory test-v8-template-circuit-audit
- make --no-print-directory test-v8-vision-smoke
- pre-commit v7-regression-fast and v8-regression-fast
- pre-push full gate: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training smoke, v7/v8 fast regression, v7 training-kernel parity