### PR TITLE
Add Gemma4 vision bridge and v8 smoke lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,11 @@ V8_NEMOTRON9_MIN_MEM_GB ?= 70
 V8_NEMOTRON9_CONTEXT ?= 2048
 V8_NEMOTRON9_MAX_TOKENS ?= 64
 V8_NEMOTRON9_PROMPT ?= Give me a concise example of C code.
+V8_GLM4_MODEL ?= hf://unsloth/GLM-4-9B-0414-GGUF/GLM-4-9B-0414-Q4_K_M.gguf
+V8_GLM4_MIN_MEM_GB ?= 70
+V8_GLM4_CONTEXT ?= 1024
+V8_GLM4_MAX_TOKENS ?= 64
+V8_GLM4_PROMPT ?= Give me a concise example of C, Python, and SQL code.
 
 # =============================================================================
 # Intel oneAPI Integration (MKL / oneDNN)
@@ -1217,7 +1222,7 @@ test-v8-qwen3vl-e2e-smoke:
 
 test-v8-vision-smoke: test-v8-vision-kernels test-v8-qwen3vl test-v8-qwen3vl-e2e-smoke
 
-test-v8-model-smoke: test-v8-template-circuit-audit v8-regression-fast test-v8-gemma4-highmem test-v8-nemotron9-highmem
+test-v8-model-smoke: test-v8-template-circuit-audit v8-regression-fast test-v8-gemma4-highmem test-v8-nemotron9-highmem test-v8-glm4-highmem
 
 parity-v8-qwen3vl-mmproj:
 	@if [ ! -f "$(V8_QWEN3VL_MMPROJ)" ]; then \
@@ -2532,6 +2537,24 @@ test-v8-nemotron9-highmem:
 			--prompt "$(V8_NEMOTRON9_PROMPT)" \
 			--chat-template auto \
 			--max-tokens $(V8_NEMOTRON9_MAX_TOKENS) \
+			--temperature 0.0; \
+	fi
+
+test-v8-glm4-highmem:
+	@avail_kb=$$(awk '/MemAvailable:/ {print $$2}' /proc/meminfo 2>/dev/null || echo 0); \
+	threshold_kb=$$(( $(V8_GLM4_MIN_MEM_GB) * 1024 * 1024 )); \
+	if [ "$$avail_kb" -lt "$$threshold_kb" ]; then \
+		avail_gb=$$(( $$avail_kb / 1024 / 1024 )); \
+		echo "SKIP: GLM-4 9B v8 smoke needs >=$(V8_GLM4_MIN_MEM_GB) GiB MemAvailable; found $${avail_gb} GiB"; \
+	else \
+		echo "Running v8 GLM-4 9B high-memory smoke..."; \
+		CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+			$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/ck_run_v8.py run "$(V8_GLM4_MODEL)" \
+			--context-len $(V8_GLM4_CONTEXT) \
+			--force-convert --force-compile \
+			--prompt "$(V8_GLM4_PROMPT)" \
+			--chat-template auto \
+			--max-tokens $(V8_GLM4_MAX_TOKENS) \
 			--temperature 0.0; \
 	fi
 

--- a/docs/site/_pages/model-kernel-matrix.html
+++ b/docs/site/_pages/model-kernel-matrix.html
@@ -32,6 +32,8 @@
     .model-card.mc-qwen2::before  { background: var(--orange); }
     .model-card.mc-qwen3::before  { background: var(--green); }
     .model-card.mc-qwen35::before { background: #1abc9c; }
+    .model-card.mc-qwen3vl::before { background: #00bcd4; }
+    .model-card.mc-qwen::before   { background: #16a085; }
     .model-card.mc-gemma3::before { background: var(--blue); }
     .model-card.mc-gemma4::before { background: #f39c12; }
     .model-card.mc-llama::before  { background: #e74c3c; }
@@ -256,7 +258,64 @@
       font-size: 0.85rem;
       color: var(--text-muted);
     }
+
+    .runner-callout {
+      margin-top: 1.25rem;
+      background: #0f151c;
+      border: 1px solid #263242;
+      border-radius: 12px;
+      padding: 1rem 1.1rem;
+      color: var(--text-secondary);
+      line-height: 1.55;
+    }
+    .runner-callout strong {
+      color: var(--orange);
+    }
+    .model-command {
+      margin: 0.85rem 0 0.75rem;
+      background: #0b1118;
+      border: 1px solid #263242;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .model-command-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.42rem 0.55rem;
+      border-bottom: 1px solid #263242;
+      color: var(--text-muted);
+      font-size: 0.74rem;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .copy-command {
+      border: 1px solid #2b3a4a;
+      background: #121a24;
+      color: #9ed6ff;
+      border-radius: 6px;
+      padding: 0.18rem 0.5rem;
+      font-size: 0.72rem;
+      cursor: pointer;
+    }
+    .copy-command:hover {
+      border-color: var(--orange);
+      color: var(--orange);
+    }
+    .model-command pre {
+      margin: 0;
+      padding: 0.7rem;
+      overflow-x: auto;
+      color: #cfe8ff;
+      line-height: 1.45;
+      font-size: 0.72rem;
+      background: #090e14;
+    }
   </style>
+
+  <div class="runner-callout">
+    <strong>Recommended runner track:</strong> this model page points to the latest hardened v8 command path for hands-on smoke tests. Version pages remain historical snapshots of each engine generation; the cards below show the current practical command to convert, compile, run, and optionally emit the IR visualizer for that family. Large cards such as Gemma4, Nemotron, GLM4, and vision models assume a high-memory CPU host.
+  </div>
 
   <div class="matrix-hero">
 
@@ -268,6 +327,13 @@
       <div class="model-pipeline">
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF, GEMM/GEMV dispatch</span></div>
         <div class="mp-row"><span class="mp-dot training"></span><span class="mp-text">v7 training — IR backprop, AdamW, parity gates</span></div>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen2">Copy</button></div>
+        <pre id="cmd-qwen2"><code>version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen2-0.5B-Instruct-GGUF/qwen2-0_5b-instruct-q4_k_m.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
@@ -286,6 +352,13 @@
       <div class="model-pipeline">
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF, GEMM/GEMV dispatch</span></div>
         <div class="mp-row"><span class="mp-dot training"></span><span class="mp-text">v7 training — IR backprop, AdamW, parity gates</span></div>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen3">Copy</button></div>
+        <pre id="cmd-qwen3"><code>version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
@@ -313,6 +386,13 @@
         <span class="tag learned">gated_deltanet</span>
         <span class="tag learned">0.8B dense compatible</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen35">Copy</button></div>
+        <pre id="cmd-qwen35"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf \
+  --context-len 1034 --force-compile --force-convert --chat-template=qwen35 \
+  --generate-visualizer</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
         <span class="mq-chip">Q8_0</span>
@@ -336,11 +416,53 @@
         <span class="tag fixed">first-divergence @ rope_qk</span>
         <span class="tag fixed">rope_layout contract honored</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma3">Copy</button></div>
+        <pre id="cmd-gemma3"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q8_0 ★</span>
         <span class="mq-chip">Q4_K</span>
         <span class="mq-chip">BF16</span>
         <span class="mq-chip">FP32</span>
+      </div>
+    </div>
+
+
+    <!-- Qwen3-VL -->
+    <div class="model-card mc-qwen3vl">
+      <span class="model-badge">template: qwen3_vl.json + mmproj</span>
+      <div class="model-title">Qwen3-VL 8B Instruct</div>
+      <div class="model-arch">Vision encoder bridge · multimodal token stitching · Qwen3 decoder<br>GGUF decoder + mmproj runtime · thinking-mode control</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 multimodal inference — image preprocessing, bridge, mixed prompt prefill</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Nightly vision smoke — promoted baseline before adding more vision families</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up scope: Qwen3-VL is the current promoted multimodal baseline. It validates that the encoder bridge, image marker contract, and decoder mixed-prefill path work together before Gemma4 vision and later audio lanes are treated as production-ready.
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Qwen3-VL vision smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen3vl">Copy</button></div>
+        <pre id="cmd-qwen3vl"><code>version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
+  --mmproj hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.png \
+  --prompt 'Explain this image.' \
+  --context-len 1024 --force-compile --force-convert \
+  --thinking-mode suppressed</code></pre>
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">multimodal_bridge</span>
+        <span class="tag learned">mixed_prefill</span>
+        <span class="tag fixed">vision nightly smoke</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip preferred">Q4_K_M decoder ★</span>
+        <span class="mq-chip">Q8_0 mmproj</span>
+        <span class="mq-chip">image bridge</span>
       </div>
     </div>
 
@@ -354,12 +476,20 @@
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Conversion/parity harness — GGUF fixes, safetensors declarative map, PyTorch-vs-CK comparator</span></div>
       </div>
       <div class="source-note">
-        Bring-up scope: GLM4 support is currently a low-memory conversion and template lane. The patch adds a declarative safetensors source map, GGUF metadata handling, synthetic safetensors conversion coverage, and a PyTorch-vs-CK parity harness. Full real-model runtime smoke should run on a higher-memory machine.
+        Bring-up scope: GLM4 now has the real GGUF runtime lane plus the safetensors/PyTorch parity lane. The key hardening was making partial pairwise RoPE and projection producer/consumer wiring explicit enough that Q4_K_M GGUF generation stays coherent instead of collapsing at the first token.
       </div>
       <div class="model-tags">
         <span class="tag learned">declarative safetensors map</span>
         <span class="tag learned">partial_rope contract</span>
         <span class="tag fixed">synthetic conversion tested</span>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-glm4">Copy</button></div>
+        <pre id="cmd-glm4"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/GLM-4-9B-0414-GGUF/GLM-4-9B-0414-Q4_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=glm4 \
+  --prompt 'Give me a detailed example of C, Python and SQL code.' \
+  --max-tokens 256 --temperature 0.0 --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip">BF16 safetensors</span>
@@ -386,6 +516,24 @@
         <span class="tag fixed">BF16 PyTorch parity lane</span>
         <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 text smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma4">Copy</button></div>
+        <pre id="cmd-gemma4"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --context-len 2048 --force-compile --force-convert --chat-template=gemma4 \
+  --prompt 'Give me a detailed example of C code.' \
+  --max-tokens 256 --temperature 0.0 --generate-visualizer</code></pre>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Gemma4 vision bridge smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma4-vision">Copy</button></div>
+        <pre id="cmd-gemma4-vision"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --mmproj hf://unsloth/gemma-4-E4B-it-GGUF/mmproj-F16.gguf \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
+  --prompt 'Explain this image in one short paragraph.' \
+  --context-len 1024 --chat-template=gemma4 \
+  --max-tokens 8 --temperature 0.0</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
         <span class="mq-chip">BF16 safetensors</span>
@@ -411,6 +559,14 @@
         <span class="tag fixed">native BPE encode default-on</span>
         <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-nemotron">Copy</button></div>
+        <pre id="cmd-nemotron"><code>version/v8/scripts/cks-v8-run run \
+  hf://bartowski/nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF/nvidia_NVIDIA-Nemotron-Nano-9B-v2-Q4_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --prompt 'Give me a detailed example of C, Python and SQL code.' \
+  --max-tokens 256 --temperature 0.0 --generate-visualizer</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
         <span class="mq-chip">Q5_0</span>
@@ -435,6 +591,13 @@
         <span class="tag learned">untied output.weight</span>
         <span class="tag learned">ChatML auto template</span>
         <span class="tag fixed">template-audit first</span>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-nanbeige">Copy</button></div>
+        <pre id="cmd-nanbeige"><code>version/v8/scripts/cks-v8-run run \
+  hf://mradermacher/Nanbeige4.1-3B-GGUF/Nanbeige4.1-3B.Q4_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip">Q4_K_M</span>
@@ -516,6 +679,26 @@
       <div class="cell dim">No</div>
       <div class="cell ok">Tied</div>
 
+      <div class="cell row-head">Qwen3-VL</div>
+      <div class="cell ok">BPE + image markers</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell ok">RoPE + vision pos</div>
+      <div class="cell ok">Vision bridge + causal</div>
+      <div class="cell ok">SwiGLU</div>
+      <div class="cell ok">Bridge norms</div>
+      <div class="cell ok">LM head</div>
+
+      <div class="cell row-head">GLM4</div>
+      <div class="cell ok">BPE</div>
+      <div class="cell ok">Attention bias</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">Partial pairwise RoPE</div>
+      <div class="cell ok">Causal GQA</div>
+      <div class="cell ok">SwiGLU</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">LM head</div>
+
       <div class="cell row-head">Gemma3</div>
       <div class="cell ok">SentencePiece</div>
       <div class="cell ok">From weights</div>
@@ -535,6 +718,16 @@
       <div class="cell ok">GeGLU</div>
       <div class="cell ok">Yes</div>
       <div class="cell ok">Tied</div>
+
+      <div class="cell row-head">Nemotron-H</div>
+      <div class="cell ok">BPE</div>
+      <div class="cell ok">From weights</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">No-RoPE KV + sparse attn</div>
+      <div class="cell ok">Mamba2 + sparse attn</div>
+      <div class="cell ok">ReLU2</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">LM head</div>
 
       <div class="cell row-head">Llama / Nanbeige</div>
       <div class="cell ok">SentencePiece</div>
@@ -601,6 +794,26 @@
       <div class="cell ok">Yes</div>
       <div class="cell ok">Yes</div>
 
+      <div class="cell row-head">Qwen3-VL</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">BPE + image markers</div>
+      <div class="cell ok">vision_bridge + attn</div>
+      <div class="cell ok">silu_mul</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
+
+      <div class="cell row-head">GLM4</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">BPE + vocab</div>
+      <div class="cell ok">attn + partial_rope</div>
+      <div class="cell ok">silu_mul</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
+
       <div class="cell row-head">Gemma3</div>
       <div class="cell ok">sqrt(dim)</div>
       <div class="cell ok">Yes</div>
@@ -620,6 +833,16 @@
       <div class="cell ok">geglu</div>
       <div class="cell ok">Yes</div>
       <div class="cell ok">Yes</div>
+
+      <div class="cell row-head">Nemotron-H</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">BPE + vocab</div>
+      <div class="cell ok">mamba2 + sparse_attn</div>
+      <div class="cell ok">relu2</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
 
       <div class="cell row-head">Llama / Nanbeige</div>
       <div class="cell dim">No</div>
@@ -717,8 +940,9 @@
       <div class="test-item">unsloth--gemma-4-E4B-it-GGUF / local Q4_K_M BUMP</div>
       <div class="test-item">mradermacher--Nanbeige4.1-3B-GGUF</div>
       <div class="test-item">Qwen--Qwen3.5-0.8B-GGUF</div>
+      <div class="test-item">Qwen--Qwen3-VL-8B-Instruct-GGUF + mmproj</div>
       <div class="test-item">bartowski--nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF / Q4_K_M</div>
-      <div class="test-item">GLM4 synthetic safetensors + GGUF conversion/parity harness</div>
+      <div class="test-item">unsloth--GLM-4-9B-0414-GGUF / Q4_K_M</div>
     </div>
     <p class="source-note" style="margin-top: 0.75rem;">
       Bring-up note: if a Llama-family/Nanbeige first reply starts with <code>&lt;think&gt;</code> or echoes
@@ -746,7 +970,10 @@
         <strong>Nemotron Nano 9B v2:</strong> the first real failure was stitching, not tokenizer or final head: Mamba2 state shape and no-RoPE KV placement had to be explicit in IR. Native BPE encode is now default-on so <code>ck_run_v8.py</code> raw prompts work end-to-end; token-id-only fallback remains available with <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code>.
       </div>
       <div class="test-item">
-        <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK parity harness. This is a conversion/parity lane until full real-model smoke is run on a higher-memory host.
+        <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, PyTorch-vs-CK parity harnesses, and a coherent Q4_K_M GGUF runtime smoke. The important fix was separating semantic stream sources in the template from physical quantized activation buffers in the kernel ABI.
+      </div>
+      <div class="test-item">
+        <strong>Qwen3-VL / Gemma4 vision:</strong> Qwen3-VL remains the promoted vision baseline. Gemma4 vision now has a matching CLIP/mmproj conversion path, a Gemma4 image marker contract, and a correctness-first mixed-prefill bridge; longer semantic parity and speed are still active work.
       </div>
     </div>
   </div>
@@ -770,7 +997,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
   </div>
 
   <div class="roadmap">
-    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4, Nemotron-H, GLM4 conversion/parity scaffolding, plus the Llama/Nanbeige bring-up lane.
+    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Qwen3-VL/Gemma3/Gemma4 text, early Gemma4 vision bridge support, Nemotron-H, GLM4, plus the Llama/Nanbeige bring-up lane.
     Qwen3.5 adds hybrid recurrent-attention coverage with Gated DeltaNet kernels (forward + backward), compatible with the 0.8B dense variant.
     Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, GLM4 adds partial-RoPE/BPE conversion contracts, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
     v7 still targets full training expansion: backward kernels, optimizer state, gradient reduction, and IR‑driven training schedules.
@@ -784,4 +1011,31 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
     <a href="https://www.dartmouth.edu/ai50/" target="_blank" rel="noopener">Dartmouth AI 1956</a>,
     <a href="https://www.nature.com/articles/323533a0" target="_blank" rel="noopener">Nature 1986 — Backpropagation</a>
   </div>
+
+
+  <script>
+    document.addEventListener('click', async function(event) {
+      const button = event.target.closest('[data-copy-command]');
+      if (!button) return;
+      const command = document.getElementById(button.getAttribute('data-copy-command'));
+      const text = command ? command.textContent.trim() : '';
+      if (!text) return;
+      const oldText = button.textContent;
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch (err) {
+        const area = document.createElement('textarea');
+        area.value = text;
+        area.setAttribute('readonly', '');
+        area.style.position = 'absolute';
+        area.style.left = '-9999px';
+        document.body.appendChild(area);
+        area.select();
+        document.execCommand('copy');
+        document.body.removeChild(area);
+      }
+      button.textContent = 'Copied';
+      setTimeout(function() { button.textContent = oldText; }, 1200);
+    });
+  </script>
 </div>

--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -545,8 +545,12 @@
       (<code>make visualizer</code>, <code>make visualizer-full</code>)</li>
     <li><strong>v7 Visualizer Health Gate</strong>: Contract-driven static analysis (160 checks) + JS unit tests (100 test vectors) for IR visualizer, dataset viewer, and IR hub
       (<code>make v7-visualizer-health</code>)</li>
-    <li><strong>v8 Inference Regression</strong>: Family bring-up gate for Gemma3, Qwen2, Qwen3, Qwen3.5, Qwen3-VL, and Nanbeige with build/smoke/coherence/contract checks
+    <li><strong>v8 Inference Regression</strong>: Family bring-up gate for Gemma3, Qwen2, Qwen3, Qwen3.5, and Nanbeige with build/smoke/coherence/contract checks
       (<code>make regression-fast</code>, aliasing the promoted <code>make v8-regression-fast</code> lane)</li>
+    <li><strong>v8 Qwen3-VL Vision Smoke</strong>: Cached image → mmproj → decoder smoke for the 8B multimodal path; skips cleanly when the runner does not have the large artifacts
+      (<code>make test-v8-qwen3vl-e2e-smoke</code>)</li>
+    <li><strong>v8 High-Memory Model Smokes</strong>: Gemma4, Nemotron Nano 9B, and GLM-4 9B run as explicit inference lanes and skip when the runner does not have enough RAM
+      (<code>make test-v8-gemma4-highmem</code>, <code>make test-v8-nemotron9-highmem</code>, <code>make test-v8-glm4-highmem</code>)</li>
     <li><strong>v7 Regression Ledger</strong>: Canonical root-cause log for fixed and monitored bugs, consumed by operators in the visualizer
       (<code>version/v7/reports/REGRESSION_LEDGER.md</code>, <code>version/v7/reports/REGRESSION_LEDGER.json</code>)</li>
     <li><strong>llama.cpp Parity</strong>: CK vs llama.cpp kernel parity flow

--- a/docs/site/_pages/testing.html
+++ b/docs/site/_pages/testing.html
@@ -566,9 +566,11 @@ make v6.6-gate
 
   <p>
     The v8 inference regression manifest currently covers Gemma3, Qwen2, Qwen3,
-    Qwen3.5, Qwen3-VL, and Nanbeige. The Gemma4 high-memory smoke stays in the
-    inference lane but skips unless enough RAM is available. v7 training gates cover
-    train IR, backward synthesis, layout/memory audit, and training-kernel parity.
+    Qwen3.5, and Nanbeige. Qwen3-VL is covered by the explicit vision smoke lane
+    because the 8B decoder + mmproj path needs cached artifacts and more RAM than
+    small CI runners usually provide. Gemma4, Nemotron, and GLM4 high-memory smokes stay
+    in the inference lane but skip unless enough RAM is available. v7 training gates
+    cover train IR, backward synthesis, layout/memory audit, and training-kernel parity.
     v6.6 reports still write under <code>version/v6.6/tools/</code> when run manually.
   </p>
 

--- a/docs/site/_pages/v8-vision-encoder.html
+++ b/docs/site/_pages/v8-vision-encoder.html
@@ -194,6 +194,9 @@
             <li><strong>Host bridge:</strong> <code>version/v8/scripts/run_multimodal_bridge_v8.py</code></li>
             <li><strong>Operator surface:</strong> <code>version/v8/scripts/ck_run_v8.py</code></li>
         </ul>
+        <p>
+            The checked-in smoke image uses <code>.ppm</code>, the Portable Pixmap format. A PPM file is just a small header plus raw RGB pixels, so the bridge can parse it directly and keep CI independent of PNG/JPEG decoder differences. It is a deterministic test fixture format, not a requirement for normal image runs.
+        </p>
         <div class="v8-vision-links">
             <a class="v8-vision-link primary" href="v8-runbook.html">Open v8 Runbook</a>
             <a class="v8-vision-link secondary" href="vision-encoder-parity.html">See Encoder Parity Notes</a>
@@ -408,4 +411,3 @@
         The important thing is not only that Qwen3-VL now captions an image. It is that the same deterministic stack now spans GGUF intake, template lowering, generated vision execution, bridge stitching, and decoder continuation. That is the shape of a real transformer runtime, not an application wrapper.
     </div>
 </div>
-

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -971,6 +971,8 @@
     .model-card.mc-qwen2::before  { background: var(--orange); }
     .model-card.mc-qwen3::before  { background: var(--green); }
     .model-card.mc-qwen35::before { background: #1abc9c; }
+    .model-card.mc-qwen3vl::before { background: #00bcd4; }
+    .model-card.mc-qwen::before   { background: #16a085; }
     .model-card.mc-gemma3::before { background: var(--blue); }
     .model-card.mc-gemma4::before { background: #f39c12; }
     .model-card.mc-llama::before  { background: #e74c3c; }
@@ -1195,7 +1197,64 @@
       font-size: 0.85rem;
       color: var(--text-muted);
     }
+
+    .runner-callout {
+      margin-top: 1.25rem;
+      background: #0f151c;
+      border: 1px solid #263242;
+      border-radius: 12px;
+      padding: 1rem 1.1rem;
+      color: var(--text-secondary);
+      line-height: 1.55;
+    }
+    .runner-callout strong {
+      color: var(--orange);
+    }
+    .model-command {
+      margin: 0.85rem 0 0.75rem;
+      background: #0b1118;
+      border: 1px solid #263242;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .model-command-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.42rem 0.55rem;
+      border-bottom: 1px solid #263242;
+      color: var(--text-muted);
+      font-size: 0.74rem;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .copy-command {
+      border: 1px solid #2b3a4a;
+      background: #121a24;
+      color: #9ed6ff;
+      border-radius: 6px;
+      padding: 0.18rem 0.5rem;
+      font-size: 0.72rem;
+      cursor: pointer;
+    }
+    .copy-command:hover {
+      border-color: var(--orange);
+      color: var(--orange);
+    }
+    .model-command pre {
+      margin: 0;
+      padding: 0.7rem;
+      overflow-x: auto;
+      color: #cfe8ff;
+      line-height: 1.45;
+      font-size: 0.72rem;
+      background: #090e14;
+    }
   </style>
+
+  <div class="runner-callout">
+    <strong>Recommended runner track:</strong> this model page points to the latest hardened v8 command path for hands-on smoke tests. Version pages remain historical snapshots of each engine generation; the cards below show the current practical command to convert, compile, run, and optionally emit the IR visualizer for that family. Large cards such as Gemma4, Nemotron, GLM4, and vision models assume a high-memory CPU host.
+  </div>
 
   <div class="matrix-hero">
 
@@ -1207,6 +1266,13 @@
       <div class="model-pipeline">
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF, GEMM/GEMV dispatch</span></div>
         <div class="mp-row"><span class="mp-dot training"></span><span class="mp-text">v7 training — IR backprop, AdamW, parity gates</span></div>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen2">Copy</button></div>
+        <pre id="cmd-qwen2"><code>version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen2-0.5B-Instruct-GGUF/qwen2-0_5b-instruct-q4_k_m.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
@@ -1225,6 +1291,13 @@
       <div class="model-pipeline">
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF, GEMM/GEMV dispatch</span></div>
         <div class="mp-row"><span class="mp-dot training"></span><span class="mp-text">v7 training — IR backprop, AdamW, parity gates</span></div>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen3">Copy</button></div>
+        <pre id="cmd-qwen3"><code>version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
@@ -1252,6 +1325,13 @@
         <span class="tag learned">gated_deltanet</span>
         <span class="tag learned">0.8B dense compatible</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen35">Copy</button></div>
+        <pre id="cmd-qwen35"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf \
+  --context-len 1034 --force-compile --force-convert --chat-template=qwen35 \
+  --generate-visualizer</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
         <span class="mq-chip">Q8_0</span>
@@ -1275,11 +1355,53 @@
         <span class="tag fixed">first-divergence @ rope_qk</span>
         <span class="tag fixed">rope_layout contract honored</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma3">Copy</button></div>
+        <pre id="cmd-gemma3"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q8_0 ★</span>
         <span class="mq-chip">Q4_K</span>
         <span class="mq-chip">BF16</span>
         <span class="mq-chip">FP32</span>
+      </div>
+    </div>
+
+
+    <!-- Qwen3-VL -->
+    <div class="model-card mc-qwen3vl">
+      <span class="model-badge">template: qwen3_vl.json + mmproj</span>
+      <div class="model-title">Qwen3-VL 8B Instruct</div>
+      <div class="model-arch">Vision encoder bridge · multimodal token stitching · Qwen3 decoder<br>GGUF decoder + mmproj runtime · thinking-mode control</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 multimodal inference — image preprocessing, bridge, mixed prompt prefill</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Nightly vision smoke — promoted baseline before adding more vision families</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up scope: Qwen3-VL is the current promoted multimodal baseline. It validates that the encoder bridge, image marker contract, and decoder mixed-prefill path work together before Gemma4 vision and later audio lanes are treated as production-ready.
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Qwen3-VL vision smoke</span><button class="copy-command" type="button" data-copy-command="cmd-qwen3vl">Copy</button></div>
+        <pre id="cmd-qwen3vl"><code>version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
+  --mmproj hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.png \
+  --prompt 'Explain this image.' \
+  --context-len 1024 --force-compile --force-convert \
+  --thinking-mode suppressed</code></pre>
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">multimodal_bridge</span>
+        <span class="tag learned">mixed_prefill</span>
+        <span class="tag fixed">vision nightly smoke</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip preferred">Q4_K_M decoder ★</span>
+        <span class="mq-chip">Q8_0 mmproj</span>
+        <span class="mq-chip">image bridge</span>
       </div>
     </div>
 
@@ -1293,12 +1415,20 @@
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Conversion/parity harness — GGUF fixes, safetensors declarative map, PyTorch-vs-CK comparator</span></div>
       </div>
       <div class="source-note">
-        Bring-up scope: GLM4 support is currently a low-memory conversion and template lane. The patch adds a declarative safetensors source map, GGUF metadata handling, synthetic safetensors conversion coverage, and a PyTorch-vs-CK parity harness. Full real-model runtime smoke should run on a higher-memory machine.
+        Bring-up scope: GLM4 now has the real GGUF runtime lane plus the safetensors/PyTorch parity lane. The key hardening was making partial pairwise RoPE and projection producer/consumer wiring explicit enough that Q4_K_M GGUF generation stays coherent instead of collapsing at the first token.
       </div>
       <div class="model-tags">
         <span class="tag learned">declarative safetensors map</span>
         <span class="tag learned">partial_rope contract</span>
         <span class="tag fixed">synthetic conversion tested</span>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-glm4">Copy</button></div>
+        <pre id="cmd-glm4"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/GLM-4-9B-0414-GGUF/GLM-4-9B-0414-Q4_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=glm4 \
+  --prompt 'Give me a detailed example of C, Python and SQL code.' \
+  --max-tokens 256 --temperature 0.0 --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip">BF16 safetensors</span>
@@ -1325,6 +1455,24 @@
         <span class="tag fixed">BF16 PyTorch parity lane</span>
         <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 text smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma4">Copy</button></div>
+        <pre id="cmd-gemma4"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --context-len 2048 --force-compile --force-convert --chat-template=gemma4 \
+  --prompt 'Give me a detailed example of C code.' \
+  --max-tokens 256 --temperature 0.0 --generate-visualizer</code></pre>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Gemma4 vision bridge smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma4-vision">Copy</button></div>
+        <pre id="cmd-gemma4-vision"><code>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --mmproj hf://unsloth/gemma-4-E4B-it-GGUF/mmproj-F16.gguf \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
+  --prompt 'Explain this image in one short paragraph.' \
+  --context-len 1024 --chat-template=gemma4 \
+  --max-tokens 8 --temperature 0.0</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
         <span class="mq-chip">BF16 safetensors</span>
@@ -1350,6 +1498,14 @@
         <span class="tag fixed">native BPE encode default-on</span>
         <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
       </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-nemotron">Copy</button></div>
+        <pre id="cmd-nemotron"><code>version/v8/scripts/cks-v8-run run \
+  hf://bartowski/nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF/nvidia_NVIDIA-Nemotron-Nano-9B-v2-Q4_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --prompt 'Give me a detailed example of C, Python and SQL code.' \
+  --max-tokens 256 --temperature 0.0 --generate-visualizer</code></pre>
+      </div>
       <div class="model-quant">
         <span class="mq-chip preferred">Q4_K_M ★</span>
         <span class="mq-chip">Q5_0</span>
@@ -1374,6 +1530,13 @@
         <span class="tag learned">untied output.weight</span>
         <span class="tag learned">ChatML auto template</span>
         <span class="tag fixed">template-audit first</span>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Latest hardened v8 smoke</span><button class="copy-command" type="button" data-copy-command="cmd-nanbeige">Copy</button></div>
+        <pre id="cmd-nanbeige"><code>version/v8/scripts/cks-v8-run run \
+  hf://mradermacher/Nanbeige4.1-3B-GGUF/Nanbeige4.1-3B.Q4_K_M.gguf \
+  --context-len 1024 --force-compile --force-convert --chat-template=auto \
+  --generate-visualizer</code></pre>
       </div>
       <div class="model-quant">
         <span class="mq-chip">Q4_K_M</span>
@@ -1455,6 +1618,26 @@
       <div class="cell dim">No</div>
       <div class="cell ok">Tied</div>
 
+      <div class="cell row-head">Qwen3-VL</div>
+      <div class="cell ok">BPE + image markers</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell ok">RoPE + vision pos</div>
+      <div class="cell ok">Vision bridge + causal</div>
+      <div class="cell ok">SwiGLU</div>
+      <div class="cell ok">Bridge norms</div>
+      <div class="cell ok">LM head</div>
+
+      <div class="cell row-head">GLM4</div>
+      <div class="cell ok">BPE</div>
+      <div class="cell ok">Attention bias</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">Partial pairwise RoPE</div>
+      <div class="cell ok">Causal GQA</div>
+      <div class="cell ok">SwiGLU</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">LM head</div>
+
       <div class="cell row-head">Gemma3</div>
       <div class="cell ok">SentencePiece</div>
       <div class="cell ok">From weights</div>
@@ -1474,6 +1657,16 @@
       <div class="cell ok">GeGLU</div>
       <div class="cell ok">Yes</div>
       <div class="cell ok">Tied</div>
+
+      <div class="cell row-head">Nemotron-H</div>
+      <div class="cell ok">BPE</div>
+      <div class="cell ok">From weights</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">No-RoPE KV + sparse attn</div>
+      <div class="cell ok">Mamba2 + sparse attn</div>
+      <div class="cell ok">ReLU2</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">LM head</div>
 
       <div class="cell row-head">Llama / Nanbeige</div>
       <div class="cell ok">SentencePiece</div>
@@ -1540,6 +1733,26 @@
       <div class="cell ok">Yes</div>
       <div class="cell ok">Yes</div>
 
+      <div class="cell row-head">Qwen3-VL</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">BPE + image markers</div>
+      <div class="cell ok">vision_bridge + attn</div>
+      <div class="cell ok">silu_mul</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
+
+      <div class="cell row-head">GLM4</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">BPE + vocab</div>
+      <div class="cell ok">attn + partial_rope</div>
+      <div class="cell ok">silu_mul</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
+
       <div class="cell row-head">Gemma3</div>
       <div class="cell ok">sqrt(dim)</div>
       <div class="cell ok">Yes</div>
@@ -1559,6 +1772,16 @@
       <div class="cell ok">geglu</div>
       <div class="cell ok">Yes</div>
       <div class="cell ok">Yes</div>
+
+      <div class="cell row-head">Nemotron-H</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
+      <div class="cell ok">BPE + vocab</div>
+      <div class="cell ok">mamba2 + sparse_attn</div>
+      <div class="cell ok">relu2</div>
+      <div class="cell ok">Yes</div>
+      <div class="cell dim">No</div>
 
       <div class="cell row-head">Llama / Nanbeige</div>
       <div class="cell dim">No</div>
@@ -1656,8 +1879,9 @@
       <div class="test-item">unsloth--gemma-4-E4B-it-GGUF / local Q4_K_M BUMP</div>
       <div class="test-item">mradermacher--Nanbeige4.1-3B-GGUF</div>
       <div class="test-item">Qwen--Qwen3.5-0.8B-GGUF</div>
+      <div class="test-item">Qwen--Qwen3-VL-8B-Instruct-GGUF + mmproj</div>
       <div class="test-item">bartowski--nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF / Q4_K_M</div>
-      <div class="test-item">GLM4 synthetic safetensors + GGUF conversion/parity harness</div>
+      <div class="test-item">unsloth--GLM-4-9B-0414-GGUF / Q4_K_M</div>
     </div>
     <p class="source-note" style="margin-top: 0.75rem;">
       Bring-up note: if a Llama-family/Nanbeige first reply starts with <code>&lt;think&gt;</code> or echoes
@@ -1685,7 +1909,10 @@
         <strong>Nemotron Nano 9B v2:</strong> the first real failure was stitching, not tokenizer or final head: Mamba2 state shape and no-RoPE KV placement had to be explicit in IR. Native BPE encode is now default-on so <code>ck_run_v8.py</code> raw prompts work end-to-end; token-id-only fallback remains available with <code>CK_DISABLE_FULL_BPE_TOKENIZER=1</code>.
       </div>
       <div class="test-item">
-        <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK parity harness. This is a conversion/parity lane until full real-model smoke is run on a higher-memory host.
+        <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, PyTorch-vs-CK parity harnesses, and a coherent Q4_K_M GGUF runtime smoke. The important fix was separating semantic stream sources in the template from physical quantized activation buffers in the kernel ABI.
+      </div>
+      <div class="test-item">
+        <strong>Qwen3-VL / Gemma4 vision:</strong> Qwen3-VL remains the promoted vision baseline. Gemma4 vision now has a matching CLIP/mmproj conversion path, a Gemma4 image marker contract, and a correctness-first mixed-prefill bridge; longer semantic parity and speed are still active work.
       </div>
     </div>
   </div>
@@ -1709,7 +1936,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
   </div>
 
   <div class="roadmap">
-    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Gemma3/Gemma4, Nemotron-H, GLM4 conversion/parity scaffolding, plus the Llama/Nanbeige bring-up lane.
+    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Qwen3-VL/Gemma3/Gemma4 text, early Gemma4 vision bridge support, Nemotron-H, GLM4, plus the Llama/Nanbeige bring-up lane.
     Qwen3.5 adds hybrid recurrent-attention coverage with Gated DeltaNet kernels (forward + backward), compatible with the 0.8B dense variant.
     Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, GLM4 adds partial-RoPE/BPE conversion contracts, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
     v7 still targets full training expansion: backward kernels, optimizer state, gradient reduction, and IR‑driven training schedules.
@@ -1723,6 +1950,33 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
     <a href="https://www.dartmouth.edu/ai50/" target="_blank" rel="noopener">Dartmouth AI 1956</a>,
     <a href="https://www.nature.com/articles/323533a0" target="_blank" rel="noopener">Nature 1986 — Backpropagation</a>
   </div>
+
+
+  <script>
+    document.addEventListener('click', async function(event) {
+      const button = event.target.closest('[data-copy-command]');
+      if (!button) return;
+      const command = document.getElementById(button.getAttribute('data-copy-command'));
+      const text = command ? command.textContent.trim() : '';
+      if (!text) return;
+      const oldText = button.textContent;
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch (err) {
+        const area = document.createElement('textarea');
+        area.value = text;
+        area.setAttribute('readonly', '');
+        area.style.position = 'absolute';
+        area.style.left = '-9999px';
+        document.body.appendChild(area);
+        area.select();
+        document.execCommand('copy');
+        document.body.removeChild(area);
+      }
+      button.textContent = 'Copied';
+      setTimeout(function() { button.textContent = oldText; }, 1200);
+    });
+  </script>
 </div>
     </main>
 
@@ -1952,7 +2206,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-22</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1485,8 +1485,12 @@
       (<code>make visualizer</code>, <code>make visualizer-full</code>)</li>
     <li><strong>v7 Visualizer Health Gate</strong>: Contract-driven static analysis (160 checks) + JS unit tests (100 test vectors) for IR visualizer, dataset viewer, and IR hub
       (<code>make v7-visualizer-health</code>)</li>
-    <li><strong>v8 Inference Regression</strong>: Family bring-up gate for Gemma3, Qwen2, Qwen3, Qwen3.5, Qwen3-VL, and Nanbeige with build/smoke/coherence/contract checks
+    <li><strong>v8 Inference Regression</strong>: Family bring-up gate for Gemma3, Qwen2, Qwen3, Qwen3.5, and Nanbeige with build/smoke/coherence/contract checks
       (<code>make regression-fast</code>, aliasing the promoted <code>make v8-regression-fast</code> lane)</li>
+    <li><strong>v8 Qwen3-VL Vision Smoke</strong>: Cached image → mmproj → decoder smoke for the 8B multimodal path; skips cleanly when the runner does not have the large artifacts
+      (<code>make test-v8-qwen3vl-e2e-smoke</code>)</li>
+    <li><strong>v8 High-Memory Model Smokes</strong>: Gemma4, Nemotron Nano 9B, and GLM-4 9B run as explicit inference lanes and skip when the runner does not have enough RAM
+      (<code>make test-v8-gemma4-highmem</code>, <code>make test-v8-nemotron9-highmem</code>, <code>make test-v8-glm4-highmem</code>)</li>
     <li><strong>v7 Regression Ledger</strong>: Canonical root-cause log for fixed and monitored bugs, consumed by operators in the visualizer
       (<code>version/v7/reports/REGRESSION_LEDGER.md</code>, <code>version/v7/reports/REGRESSION_LEDGER.json</code>)</li>
     <li><strong>llama.cpp Parity</strong>: CK vs llama.cpp kernel parity flow
@@ -2336,8 +2340,8 @@ document.addEventListener('DOMContentLoaded', loadResults);
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-20</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
             </div>
         </div>
     </footer>

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -1507,9 +1507,11 @@ make v6.6-gate
 
   <p>
     The v8 inference regression manifest currently covers Gemma3, Qwen2, Qwen3,
-    Qwen3.5, Qwen3-VL, and Nanbeige. The Gemma4 high-memory smoke stays in the
-    inference lane but skips unless enough RAM is available. v7 training gates cover
-    train IR, backward synthesis, layout/memory audit, and training-kernel parity.
+    Qwen3.5, and Nanbeige. Qwen3-VL is covered by the explicit vision smoke lane
+    because the 8B decoder + mmproj path needs cached artifacts and more RAM than
+    small CI runners usually provide. Gemma4, Nemotron, and GLM4 high-memory smokes stay
+    in the inference lane but skip unless enough RAM is available. v7 training gates
+    cover train IR, backward synthesis, layout/memory audit, and training-kernel parity.
     v6.6 reports still write under <code>version/v6.6/tools/</code> when run manually.
   </p>
 
@@ -1874,8 +1876,8 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-20</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -1133,6 +1133,9 @@
             <li><strong>Host bridge:</strong> <code>version/v8/scripts/run_multimodal_bridge_v8.py</code></li>
             <li><strong>Operator surface:</strong> <code>version/v8/scripts/ck_run_v8.py</code></li>
         </ul>
+        <p>
+            The checked-in smoke image uses <code>.ppm</code>, the Portable Pixmap format. A PPM file is just a small header plus raw RGB pixels, so the bridge can parse it directly and keep CI independent of PNG/JPEG decoder differences. It is a deterministic test fixture format, not a requirement for normal image runs.
+        </p>
         <div class="v8-vision-links">
             <a class="v8-vision-link primary" href="v8-runbook.html">Open v8 Runbook</a>
             <a class="v8-vision-link secondary" href="vision-encoder-parity.html">See Encoder Parity Notes</a>
@@ -1574,8 +1577,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
             </div>
         </div>
     </footer>

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -434,6 +434,12 @@ MAKE_TARGETS = {
         "target": "v8-regression-fast",
         "timeout_sec": 5400,
     },
+    "v8_qwen3vl_vision_smoke": {
+        "name": "v8 Qwen3-VL Vision Smoke",
+        "category": "inference",
+        "target": "test-v8-qwen3vl-e2e-smoke",
+        "timeout_sec": 5400,
+    },
     "v8_decoder_matrix_quick": {
         "name": "v8 Decoder Matrix (quick)",
         "category": "inference",
@@ -450,6 +456,12 @@ MAKE_TARGETS = {
         "name": "v8 Nemotron Nano 9B High-Memory Smoke",
         "category": "inference",
         "target": "test-v8-nemotron9-highmem",
+        "timeout_sec": 7200,
+    },
+    "v8_glm4_highmem": {
+        "name": "v8 GLM-4 9B High-Memory Smoke",
+        "category": "inference",
+        "target": "test-v8-glm4-highmem",
         "timeout_sec": 7200,
     },
 }

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -36,5 +36,7 @@ Canonical vision bring-up example:
 
 Notes:
 - For the validated Qwen3-VL 8B path, omitting `--mmproj` now auto-resolves the matching HF companion projector.
+- The `.ppm` regression image is a Portable Pixmap file. CK uses it in CI because the format is simple enough to parse directly: a short header plus raw RGB pixels. That removes PNG/JPEG decoder dependency differences from the vision smoke. It is a test-fixture format, not a requirement for normal use; user-facing runs can still use PNG/JPEG when the local image stack is available.
+- Qwen3-VL is an 8B multimodal lane. `make v8-regression-fast` stays text-family focused, while `make test-v8-qwen3vl-e2e-smoke` runs the cached vision E2E path when the decoder and mmproj artifacts are present.
 
 That keeps `v8` small and honest: the version split now includes the inference runner, local kernel registry/maps, multimodal bridge entrypoint, and the `v8`-named operator tooling surface used by the visualizer, hub, and regression entrypoints.

--- a/version/v8/regression/families.json
+++ b/version/v8/regression/families.json
@@ -202,54 +202,6 @@
       }
     },
     {
-      "id": "qwen3vl",
-      "label": "Qwen3-VL 8B Instruct",
-      "enabled": true,
-      "model": "hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf",
-      "context_len": 1024,
-      "runtime_args": [
-        "--thinking-mode",
-        "suppressed",
-        "--temperature",
-        "0",
-        "--repeat-penalty",
-        "1.1"
-      ],
-      "response_contract": {
-        "stop_text_markers": [
-          "<|im_end|>"
-        ],
-        "strip_think_blocks": true,
-        "strip_trailing_metrics": true,
-        "trim_whitespace": true
-      },
-      "smoke_prompts": [
-        "vision_doc_card",
-        "vision_mamba2_card"
-      ],
-      "runtime_expect": {
-        "stdout_contains_any_of": [
-          "[v8-bridge] done report=",
-          "Wrote bridge report to "
-        ],
-        "config": {
-          "rope_layout": "multi_section_1d"
-        },
-        "manifest": {
-          "config.model": "qwen3vl",
-          "config.chat_contract.name": "qwen",
-          "config.rope_layout": "multi_section_1d"
-        },
-        "lowered_ops": [
-          {
-            "op": "rope_qk",
-            "function_prefix": "mrope_qk_text",
-            "min_matches": 1
-          }
-        ]
-      }
-    },
-    {
       "id": "nanbeige",
       "label": "Nanbeige 4.1 3B",
       "enabled": true,

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -6615,7 +6615,7 @@ WEIGHT_PATTERNS = {
     "bqkv": ["layer.{L}.attn_qkv.bias", "v.blk.{L}.attn_qkv.bias"],
     "mm0_w": ["mm.0.weight"],
     "mm0_b": ["mm.0.bias"],
-    "mm1_w": ["mm.2.weight"],
+    "mm1_w": ["mm.2.weight", "mm.input_projection.weight"],
     "mm1_b": ["mm.2.bias"],
     "attn_qkv": ["layer.{L}.attn_qkv", "layer.{L}.attn_qkv.weight", "v.blk.{L}.attn_qkv.weight"],
     "ln1_gamma": ["layer.{L}.ln1_gamma", "layers.{L}.attention_norm.weight", "layer.{L}.attn_norm", "layer.{L}.block_norm", "v.blk.{L}.ln1.weight"],
@@ -8315,11 +8315,13 @@ def generate_ir_lower_2(
                 raise RuntimeError(
                     "projector_fc2 selected a q8-activation kernel without an explicit quantize stage"
                 )
-            src_buf = activation_buffers.get("mlp_scratch")
+            single_linear_projector = bool(config.get("single_linear_projector") or ir_op.get("params", {}).get("single_linear_projector"))
+            src_buf_name = (last_output_buffer or "embedded_input") if single_linear_projector else "mlp_scratch"
+            src_buf = activation_buffers.get(src_buf_name)
             dst_buf = activation_buffers.get("embedded_input")
             if src_buf:
                 lowered_op["activations"]["A"] = {
-                    "buffer": "mlp_scratch",
+                    "buffer": src_buf_name,
                     "activation_offset": src_buf["offset"],
                     "dtype": "fp32",
                     "ptr_expr": f"activations + {src_buf['offset']}",
@@ -9074,6 +9076,18 @@ def validate_buffer_assignments(lowered_ir: Dict) -> None:
         for k in registry.get("kernels", [])
         if k.get("id")
     }
+    kernel_weight_contract = {}
+    for k in registry.get("kernels", []):
+        kid = k.get("id")
+        if not kid:
+            continue
+        weights = k.get("weights", [])
+        if isinstance(weights, list):
+            kernel_weight_contract[kid] = {
+                str(w.get("name", "")): str(w.get("dtype", "")).lower()
+                for w in weights
+                if isinstance(w, dict) and w.get("name")
+            }
 
     body_projection_ops = {
         "q_proj",
@@ -9098,14 +9112,16 @@ def validate_buffer_assignments(lowered_ir: Dict) -> None:
         # interpreting BF16 payload bytes as FP32 values.
         if kernel_id:
             kernel_weight_dtype = str(kernel_quant.get(kernel_id, {}).get("weight", "")).lower()
+            per_weight_contract = kernel_weight_contract.get(kernel_id, {})
             for weight_name, weight_info in op.get("weights", {}).items():
                 weight_dtype = str(weight_info.get("dtype", "")).lower()
-                if weight_dtype == "bf16" and kernel_weight_dtype != "bf16":
+                expected_weight_dtype = str(per_weight_contract.get(weight_name, kernel_weight_dtype)).lower()
+                if weight_dtype == "bf16" and expected_weight_dtype != "bf16":
                     raise RuntimeError(
                         f"\n❌ HARD FAULT: Weight/kernel dtype mismatch\n"
                         f"   op={op_name} layer={layer} kernel={kernel_id}\n"
                         f"   weight={weight_name} dtype=bf16\n"
-                        f"   kernel weight dtype: {kernel_weight_dtype or '<missing>'}\n"
+                        f"   kernel weight dtype: {expected_weight_dtype or '<missing>'}\n"
                         f"   Fix: ensure quant_summary aliases select BF16 kernels for safetensors/BUMP weights\n"
                     )
 

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -175,6 +175,17 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     args_list = op.get("args", [])
 
     # Handle special auto-inserted ops
+    if op_type == "final_logit_softcap" and str(config.get("logits_layout", "auto")).lower() == "last":
+        vocab_size = int(config.get("vocab_size", 151936))
+        cap = float(config.get("final_logit_softcapping", 0.0) or 0.0)
+        return f"""    /* Op {seq_idx}: {func} ({op_type}) layer={layer} */
+    {func}(
+        (float*)(model->bump + A_LOGITS),
+        1,
+        {vocab_size},
+        {cap}
+    );"""
+
     if op_type == "copy_last_logits":
         vocab_size = config.get("vocab_size", 151936)
         return f"""    /* Op {seq_idx}: copy_last_logits (prefill fixup) */
@@ -455,6 +466,29 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     batch_quant_kind = None
     if func in ("quantize_row_q8_0", "quantize_row_q8_k"):
         batch_quant_kind = func
+
+    if batch_quant_kind:
+        x_expr = arg_expr_by_name.get("x") or arg_expr_by_name.get("input")
+        y_expr = arg_expr_by_name.get("y") or arg_expr_by_name.get("output")
+        k_expr = arg_expr_by_name.get("k") or str(config.get("embed_dim", "EMBED_DIM"))
+        if x_expr and y_expr and k_expr:
+            row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)" if batch_quant_kind == "quantize_row_q8_k" else "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+            lines.append("    {")
+            if profile:
+                lines.append("        CK_PROFILE_BEGIN();")
+            lines.extend([
+                f"        const float *_x_base = (const float*)({x_expr});",
+                f"        uint8_t *_y_base = (uint8_t*)({y_expr});",
+                f"        const int _k = (int)({k_expr});",
+                f"        const size_t _row_bytes = {row_bytes_expr};",
+                "        for (int _t = 0; _t < num_tokens; ++_t) {",
+                f"            {batch_quant_kind}(_x_base + (size_t)_t * (size_t)_k, (void*)(_y_base + (size_t)_t * _row_bytes), _k);",
+                "        }",
+            ])
+            if profile:
+                lines.append(f'        CK_PROFILE_END("prefill", "{batch_quant_kind}", "{op_type}", {layer});')
+            lines.append("    }")
+            return "\n".join(lines)
 
     if op_type == "out_proj" and func in ("gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"):
         a_expr = arg_expr_by_name.get("a")
@@ -1186,6 +1220,40 @@ static void ck_qwen3vl_prefill_deepstack_add(CKModel *model, int layer, int num_
 """
 
 
+def _emit_prefill_quant_rows(op: Dict, seq_idx: int, *, debug_inputs: list[str] | None = None, profile: bool = False) -> str:
+    func = str(op.get("function", "") or "")
+    if func not in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+        raise RuntimeError(f"unsupported prefill quant func={func}")
+    args_list = op.get("args", [])
+    x_expr = _find_arg_expr(args_list, arg_name="x") or _find_arg_expr(args_list, arg_name="input")
+    y_expr = _find_arg_expr(args_list, arg_name="y") or _find_arg_expr(args_list, arg_name="output")
+    k_expr = _find_arg_expr(args_list, arg_name="k")
+    if not x_expr or not y_expr or not k_expr:
+        raise RuntimeError(f"prefill quant rows missing x/y/k args for op={op.get('op')}")
+    row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)" if func == "quantize_row_q8_k" else "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+    lines = [
+        f"    /* Op {seq_idx}: {func} ({op.get('op', 'unknown')}) layer={op.get('layer', -1)} section={op.get('section', 'body')} */",
+    ]
+    for name in debug_inputs or []:
+        lines.append(f"    {name} = (const float*)({x_expr});")
+    lines.append("    {")
+    if profile:
+        lines.append("        CK_PROFILE_BEGIN();")
+    lines.extend([
+        f"        const float *_x_base = (const float*)({x_expr});",
+        f"        uint8_t *_y_base = (uint8_t*)({y_expr});",
+        f"        const int _k = (int)({k_expr});",
+        f"        const size_t _row_bytes = {row_bytes_expr};",
+        "        for (int _t = 0; _t < num_tokens; ++_t) {",
+        f"            {func}(_x_base + (size_t)_t * (size_t)_k, (void*)(_y_base + (size_t)_t * _row_bytes), _k);",
+        "        }",
+    ])
+    if profile:
+        lines.append(f'        CK_PROFILE_END("prefill", "{func}", "{op.get("op", "unknown")}", {int(op.get("layer", -1) or -1)});')
+    lines.append("    }")
+    return "\n".join(lines)
+
+
 def _emit_prefill_quant_debug_override(op: Dict, seq_idx: int, config: Dict, *, debug_flag_name: str, debug_input_name: str, profile: bool = False) -> str:
     func = str(op.get("function", "") or "")
     if func not in {"quantize_row_q8_0", "quantize_row_q8_k"}:
@@ -1429,7 +1497,13 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                 lines.append("")
             continue
 
-        if op_type == "quantize_input_2" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+        if op_type == "quantize_input_0" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+            op_code = _emit_prefill_quant_rows(
+                op,
+                seq_idx,
+                profile=profile,
+            )
+        elif op_type == "quantize_input_2" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
             op_code = _emit_prefill_quant_debug_override(
                 op,
                 seq_idx,

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -2158,8 +2158,9 @@ def main() -> None:
         "general.alignment",
         "general.name",
         "general.finetune",
-        # CLIP/Qwen3-VL vision projector keys
+        # CLIP/Qwen3-VL/Gemma4 vision projector keys
         "clip.projector_type",
+        "clip.vision.projector_type",
         "clip.has_vision_encoder",
         "clip.vision.image_size",
         "clip.vision.patch_size",
@@ -2473,6 +2474,8 @@ def main() -> None:
         template_probe_arch = arch
         if arch == "clip" and str(meta.get("clip.projector_type") or "").strip().lower() == "qwen3vl_merger":
             template_probe_arch = "qwen3_vl_vision"
+        if arch == "clip" and str(meta.get("clip.vision.projector_type") or "").strip().lower() == "gemma4v":
+            template_probe_arch = "gemma4_vision"
 
         # Load template early to check for RoPE (determines if pos_emb is needed)
         template_data = None
@@ -2716,6 +2719,342 @@ def main() -> None:
                 # Upcast FP16 weights to FP32 in bump output (runtime is FP32-only for dense weights).
                 return CK_DT_FP32
             return ck_dtype_from_ggml_type(info.ggml_type)
+
+        clip_vision_projector_type = (meta_str("clip.vision.projector_type") or "").strip().lower()
+        if arch == "clip" and clip_vision_projector_type == "gemma4v":
+            vision_arch = "gemma4_vision"
+
+            image_size = meta_int("clip.vision.image_size")
+            patch_size = meta_int("clip.vision.patch_size")
+            embed_dim = meta_int("clip.vision.embedding_length")
+            num_layers = meta_int("clip.vision.block_count")
+            intermediate = meta_int("clip.vision.feed_forward_length")
+            num_heads = meta_int("clip.vision.attention.head_count")
+            projection_dim = meta_int("clip.vision.projection_dim")
+            image_mean = meta_float_list("clip.vision.image_mean") or [0.0, 0.0, 0.0]
+            image_std = meta_float_list("clip.vision.image_std") or [1.0, 1.0, 1.0]
+            has_vision_encoder = bool(meta_bool("clip.has_vision_encoder"))
+
+            required_meta = {
+                "clip.vision.image_size": image_size,
+                "clip.vision.patch_size": patch_size,
+                "clip.vision.embedding_length": embed_dim,
+                "clip.vision.block_count": num_layers,
+                "clip.vision.feed_forward_length": intermediate,
+                "clip.vision.attention.head_count": num_heads,
+                "clip.vision.projection_dim": projection_dim,
+            }
+            missing_meta = [k for k, v in required_meta.items() if v is None]
+            if missing_meta:
+                raise GGUFError(f"Missing required CLIP/Gemma4 vision metadata: {missing_meta}")
+            if patch_size <= 0 or image_size <= 0:
+                raise GGUFError(f"Invalid CLIP/Gemma4 patch/image size: patch={patch_size}, image={image_size}")
+            if embed_dim % num_heads != 0:
+                raise GGUFError(f"CLIP/Gemma4 embed_dim {embed_dim} not divisible by num_heads {num_heads}")
+
+            head_dim = embed_dim // num_heads
+            vision_grid_h = image_size // patch_size
+            vision_grid_w = image_size // patch_size
+            vision_num_patches = vision_grid_h * vision_grid_w
+            spatial_merge_size = 1
+            spatial_merge_factor = 1
+            vision_merged_tokens = vision_num_patches
+            context_len = vision_num_patches
+            vocab_size = 1
+            num_kv_heads = num_heads
+            aligned_embed_dim = embed_dim
+            aligned_head_dim = head_dim
+            aligned_intermediate = intermediate
+            aligned_context = align_up_elems(context_len, 4, CACHE_ALIGN)
+            projector_type = clip_vision_projector_type
+
+            def clip_weight_dtype(info: TensorInfo, label: str) -> int:
+                supported_types = (
+                    GGML_TYPE_Q4_0, GGML_TYPE_Q4_1,
+                    GGML_TYPE_Q4_K, GGML_TYPE_Q6_K,
+                    GGML_TYPE_Q5_0, GGML_TYPE_Q5_1,
+                    GGML_TYPE_Q5_K,
+                    GGML_TYPE_Q8_0, GGML_TYPE_F16, GGML_TYPE_F32,
+                )
+                if info.ggml_type not in supported_types:
+                    raise GGUFError(
+                        f"{info.name}: expected Q4_0/Q4_1/Q4_K/Q5_0/Q5_1/Q5_K/Q6_K/Q8_0/F16/F32 for {label}, "
+                        f"got {ggml_type_name(info.ggml_type)}"
+                    )
+                return ck_dtype_from_ggml_type(info.ggml_type)
+
+            def clip_shape(info: TensorInfo) -> list[int]:
+                if len(info.dims) <= 1:
+                    return [int(info.ne0)]
+                return [int(d) for d in reversed(info.dims)]
+
+            def clip_plan_entry(src_name: str, *, dst_name: Optional[str] = None, label: Optional[str] = None) -> Dict[str, Any]:
+                info = tensors.get(src_name)
+                if info is None:
+                    raise GGUFError(f"{vision_arch} conversion missing required tensor: {src_name}")
+                dt = clip_weight_dtype(info, label or src_name)
+                entry: Dict[str, Any] = {
+                    "name": dst_name or src_name,
+                    "dtype": ck_dtype_name(dt).lower(),
+                    "shape": clip_shape(info),
+                    "source_dtype": ggml_type_name(info.ggml_type),
+                    "source_name": info.name,
+                    "_info": info,
+                    "_dtype_id": dt,
+                    "_size": ggml_tensor_bytes(info),
+                }
+                if len(info.dims) > 1:
+                    entry["gguf_dims"] = [int(d) for d in info.dims]
+                return entry
+
+            vision_plan: list[Dict[str, Any]] = []
+            consumed_sources: set[str] = set()
+
+            def add_vision_entry(src_name: str, *, dst_name: Optional[str] = None, label: Optional[str] = None) -> None:
+                vision_plan.append(clip_plan_entry(src_name, dst_name=dst_name, label=label))
+                consumed_sources.add(src_name)
+
+            def maybe_add_vision_entry(src_name: str, *, dst_name: Optional[str] = None, label: Optional[str] = None) -> None:
+                if src_name in tensors and src_name not in consumed_sources:
+                    add_vision_entry(src_name, dst_name=dst_name, label=label)
+
+            add_vision_entry("v.patch_embd.weight", label="v.patch_embd.weight")
+            add_vision_entry("v.position_embd.weight", label="v.position_embd.weight")
+            add_vision_entry("mm.input_projection.weight", label="mm.input_projection.weight")
+
+            quant_summary: Dict[str, Any] = {}
+            quant_summary["patch_emb"] = ck_dtype_name(
+                clip_weight_dtype(tensors["v.patch_embd.weight"], "v.patch_embd.weight")
+            ).lower()
+            quant_summary["mm1_w"] = ck_dtype_name(
+                clip_weight_dtype(tensors["mm.input_projection.weight"], "mm.input_projection.weight")
+            ).lower()
+
+            for layer in range(num_layers):
+                layer_key = f"layer.{layer}"
+                q: Dict[str, str] = {}
+                for ck_name, src_name in (
+                    ("wq", f"v.blk.{layer}.attn_q.weight"),
+                    ("wk", f"v.blk.{layer}.attn_k.weight"),
+                    ("wv", f"v.blk.{layer}.attn_v.weight"),
+                    ("wo", f"v.blk.{layer}.attn_out.weight"),
+                    ("w1", f"v.blk.{layer}.ffn_gate.weight"),
+                    ("w2", f"v.blk.{layer}.ffn_down.weight"),
+                    ("w3", f"v.blk.{layer}.ffn_up.weight"),
+                ):
+                    info = tensors.get(src_name)
+                    if info is not None:
+                        q[ck_name] = ck_dtype_name(clip_weight_dtype(info, src_name)).lower()
+                quant_summary[layer_key] = q
+
+                for src_name, dst_name in (
+                    (f"v.blk.{layer}.ln1.weight", f"layer.{layer}.ln1_gamma"),
+                    (f"v.blk.{layer}.ln2.weight", f"layer.{layer}.ln2_gamma"),
+                    (f"v.blk.{layer}.attn_q_norm.weight", f"layer.{layer}.q_norm"),
+                    (f"v.blk.{layer}.attn_k_norm.weight", f"layer.{layer}.k_norm"),
+                    (f"v.blk.{layer}.attn_q.weight", f"layer.{layer}.wq"),
+                    (f"v.blk.{layer}.attn_k.weight", f"layer.{layer}.wk"),
+                    (f"v.blk.{layer}.attn_v.weight", f"layer.{layer}.wv"),
+                    (f"v.blk.{layer}.attn_out.weight", f"layer.{layer}.wo"),
+                    (f"v.blk.{layer}.attn_post_norm.weight", f"layer.{layer}.post_attention_norm"),
+                    (f"v.blk.{layer}.ffn_gate.weight", f"layer.{layer}.w1"),
+                    (f"v.blk.{layer}.ffn_up.weight", f"layer.{layer}.w3"),
+                    (f"v.blk.{layer}.ffn_down.weight", f"layer.{layer}.w2"),
+                    (f"v.blk.{layer}.ffn_post_norm.weight", f"layer.{layer}.post_ffn_norm"),
+                ):
+                    add_vision_entry(src_name, dst_name=dst_name, label=src_name)
+
+            ignored_sources = sorted(
+                name for name in set(tensors.keys()) - consumed_sources
+                if not name.startswith("a.") and not name.startswith("mm.a.")
+            )
+            source_coverage = {
+                "arch": arch,
+                "conversion_arch": vision_arch,
+                "projector_type": projector_type,
+                "total_source_tensors": len([name for name in tensors if not name.startswith("a.") and not name.startswith("mm.a.")]),
+                "consumed_source_tensors": len(consumed_sources),
+                "unconsumed_source_tensors": ignored_sources,
+                "ignored_audio_tensors": len([name for name in tensors if name.startswith("a.") or name.startswith("mm.a.")]),
+                "pass": len(ignored_sources) == 0,
+            }
+
+            projector_info = tensors["mm.input_projection.weight"]
+            projector_in_dim = int(projector_info.ne0)
+            projector_out_dim = int(projector_info.ne1)
+
+            vision_config = _inject_runtime_config_defaults({
+                "model": vision_arch,
+                "arch": vision_arch,
+                "model_type": vision_arch,
+                "image_size": int(image_size),
+                "image_height": int(image_size),
+                "image_width": int(image_size),
+                "patch_size": int(patch_size),
+                "vision_channels": 3,
+                "patch_dim": int(patch_size * patch_size * 3),
+                "vision_grid_h": int(vision_grid_h),
+                "vision_grid_w": int(vision_grid_w),
+                "vision_num_patches": int(vision_num_patches),
+                "image_mean": [float(v) for v in image_mean[:3]],
+                "image_std": [float(v) for v in image_std[:3]],
+                "spatial_merge_size": int(spatial_merge_size),
+                "spatial_merge_factor": int(spatial_merge_factor),
+                "vision_merged_tokens": int(vision_merged_tokens),
+                "embed_dim": int(embed_dim),
+                "attn_out_dim": int(embed_dim),
+                "num_layers": int(num_layers),
+                "num_heads": int(num_heads),
+                "num_kv_heads": int(num_kv_heads),
+                "head_dim": int(head_dim),
+                "q_dim": int(embed_dim),
+                "k_dim": int(embed_dim),
+                "v_dim": int(embed_dim),
+                "intermediate_dim": int(intermediate),
+                "intermediate_size": int(intermediate),
+                "context_length": int(context_len),
+                "max_seq_len": int(context_len),
+                "vocab_size": int(vocab_size),
+                "n_vocab": int(vocab_size),
+                "projector_in_dim": int(projector_in_dim),
+                "projector_hidden_dim": int(projector_in_dim),
+                "projector_out_dim": int(projector_out_dim),
+                "projector_total_out_dim": int(projector_out_dim),
+                "projection_dim": int(projection_dim),
+                "prefer_q8_activation": False,
+                "single_linear_projector": True,
+                "has_vision_encoder": has_vision_encoder,
+                "has_audio_encoder": bool(meta_bool("clip.has_audio_encoder")),
+                "dtype": "fp32",
+            }, vision_arch)
+
+            template_data = load_template_for_arch(vision_arch)
+
+            if args.config_out:
+                os.makedirs(os.path.dirname(args.config_out) or ".", exist_ok=True)
+                with open(args.config_out, "w", encoding="utf-8") as cf:
+                    json.dump(vision_config, cf, indent=2)
+                    cf.write("\n")
+
+            dtype_table_bytes = bytes(int(entry["_dtype_id"]) for entry in vision_plan)
+            os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+            manifest_entries = []
+            current_offset = DATA_START
+            manifest_dict = None
+            num_merges = 0
+            total_vocab_bytes = 0
+
+            def record_vision_entry(plan_entry: Dict[str, Any]) -> None:
+                nonlocal current_offset
+                out_entry = {k: v for k, v in plan_entry.items() if not k.startswith("_")}
+                out_entry["file_offset"] = current_offset
+                out_entry["size"] = int(plan_entry["_size"])
+                manifest_entries.append(out_entry)
+                current_offset += int(plan_entry["_size"])
+
+            with open(args.output, "w+b") as out_f:
+                out_f.write(b"\x00" * HEADER_SIZE)
+                out_f.write(b"\x00" * EXT_METADATA_SIZE)
+                w = HashingWriter(out_f)
+
+                dtype_table_header_size = 4 + len(dtype_table_bytes)
+                current_offset += dtype_table_header_size
+                w.write(struct.pack("<I", len(dtype_table_bytes)))
+                w.write(dtype_table_bytes)
+
+                for plan_entry in vision_plan:
+                    info = plan_entry["_info"]
+                    record_vision_entry(plan_entry)
+                    copy_bytes_stream(f, data_start + info.offset, int(plan_entry["_size"]), w)
+
+                checksum = w.digest()
+                out_f.flush()
+                out_f.seek(0, os.SEEK_SET)
+
+                manifest_dict = {
+                    "version": 5,
+                    "model": vision_arch,
+                    "bump_layout": {
+                        "header_size": HEADER_SIZE,
+                        "ext_metadata_size": EXT_METADATA_SIZE,
+                        "data_start": DATA_START,
+                        "description": "Offsets: [0..header_size) header, [header_size..data_start) ext_metadata, [data_start..] dtype_table + weights"
+                    },
+                    "config": vision_config,
+                    "template": template_data,
+                    "quant_summary": quant_summary,
+                    "num_layers": num_layers,
+                    "embed_dim": embed_dim,
+                    "num_heads": num_heads,
+                    "num_kv_heads": num_kv_heads,
+                    "head_dim": head_dim,
+                    "intermediate_size": intermediate,
+                    "vocab_size": vocab_size,
+                    "context_length": context_len,
+                    "projector_type": projector_type,
+                    "has_vision_encoder": has_vision_encoder,
+                    "source_tensor_coverage": source_coverage,
+                    "entries": manifest_entries,
+                }
+
+                manifest_hash = calculate_manifest_hash(manifest_dict)
+                template_hash = calculate_template_hash(template_data)
+                created_by = f"convert_gguf_to_bump_v8.py v{BUMP_VERSION_V5}"
+                metadata = build_bumpv5_metadata(
+                    template_data=template_data,
+                    config=vision_config,
+                    quant_summary=quant_summary,
+                    manifest_hash=manifest_hash,
+                    created_by=created_by,
+                )
+                metadata["template_hash"] = template_hash
+                metadata_bytes = _canonical_json_bytes(metadata)
+                meta_size = len(metadata_bytes)
+                meta_hash = calculate_metadata_hash(metadata)
+
+                out_f.write(b"BUMPWGT5")
+                out_f.write(struct.pack("<I", 5))
+                out_f.write(struct.pack("<I", 1))
+                out_f.write(struct.pack("<I", int(num_layers)))
+                out_f.write(struct.pack("<I", int(vocab_size)))
+                out_f.write(struct.pack("<I", int(embed_dim)))
+                out_f.write(struct.pack("<I", int(intermediate)))
+                out_f.write(struct.pack("<I", int(context_len)))
+                out_f.write(struct.pack("<I", int(num_heads)))
+                out_f.write(struct.pack("<I", int(num_kv_heads)))
+                out_f.write(struct.pack("<I", int(head_dim)))
+                out_f.write(struct.pack("<Q", int(aligned_embed_dim)))
+                out_f.write(struct.pack("<Q", int(aligned_head_dim)))
+                out_f.write(struct.pack("<Q", int(aligned_intermediate)))
+                out_f.write(struct.pack("<Q", int(aligned_context)))
+                out_f.write(struct.pack("<I", int(num_merges)))
+                out_f.write(struct.pack("<I", int(total_vocab_bytes)))
+                out_f.write(checksum)
+
+                out_f.seek(0, os.SEEK_END)
+                meta_offset = out_f.tell()
+                out_f.write(metadata_bytes)
+                write_bumpv5_footer(out_f, meta_size, meta_hash)
+                print(f"[bumpv5] Metadata: {meta_size} bytes @ offset {meta_offset}")
+                print(f"[bumpv5] Template: {template_data.get('name', vision_arch)}, quant_summary: {len(quant_summary)} items")
+
+            print(
+                f"[gguf->bump] version={args.bump_version} arch={arch}->{vision_arch} layers={num_layers} "
+                f"hidden={embed_dim} heads={num_heads}/{num_kv_heads} ff={intermediate} "
+                f"patches={vision_num_patches} projector={projector_type} -> {args.output}"
+            )
+            print_generic_conversion_report(
+                arch=vision_arch,
+                manifest_entries=manifest_entries,
+                coverage_report=source_coverage,
+            )
+            if args.manifest_out:
+                os.makedirs(os.path.dirname(args.manifest_out) or ".", exist_ok=True)
+                manifest = manifest_dict
+                with open(args.manifest_out, "w", encoding="utf-8") as mf:
+                    json.dump(manifest, mf, indent=2)
+                    mf.write("\n")
+            return
 
         clip_projector_type = (meta_str("clip.projector_type") or "").strip().lower()
         if arch == "clip" and clip_projector_type == "qwen3vl_merger":

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -61,6 +61,21 @@ _CHAT_TEMPLATE_ALIASES = {
     "gemma": "gemma3",
 }
 
+_CHAT_TEMPLATE_CHOICES = [
+    "auto",
+    "none",
+    "qwen",
+    "qwen2",
+    "qwen3",
+    "qwen35",
+    "qwen3vl",
+    "gemma",
+    "gemma3",
+    "gemma4",
+    "glm4",
+    "llama",
+]
+
 
 def _parse_activation_preference_overrides(values: list[str] | None) -> dict[str, str]:
     overrides: dict[str, str] = {}
@@ -1035,13 +1050,16 @@ def _format_prompt_with_chat_contract(
     return formatted if formatted else user_text
 
 
-def _resolve_multimodal_image_markers(contract: dict[str, Any] | None) -> tuple[str, str] | None:
+def _resolve_multimodal_image_markers(contract: dict[str, Any] | None) -> tuple[str, str, bool] | None:
     if not isinstance(contract, dict):
         return None
     image_begin = str(contract.get("image_begin_marker") or "")
     image_end = str(contract.get("image_end_marker") or "")
     if image_begin and image_end:
-        return image_begin, image_end
+        return image_begin, image_end, False
+    single_marker = str(contract.get("image_marker") or contract.get("image_placeholder_marker") or "")
+    if single_marker:
+        return single_marker, "", True
     return None
 
 
@@ -1086,12 +1104,17 @@ def _format_multimodal_prompt_segments(
             "image_end_marker": "",
         }
 
-    image_begin, image_end = markers
+    image_begin, image_end, single_image_marker = markers
     sentinel = "<<CK_IMAGE_EMBED_CHUNK>>"
     if sentinel in str(prompt or ""):
         raise ValueError("prompt contains reserved multimodal bridge sentinel")
+    prompt_with_image = (
+        f"{sentinel}{str(prompt or '')}"
+        if single_image_marker
+        else f"{image_begin}{sentinel}{image_end}{str(prompt or '')}"
+    )
     formatted = _format_prompt_with_chat_contract(
-        f"{image_begin}{sentinel}{image_end}{str(prompt or '')}",
+        prompt_with_image,
         contract,
         thinking_mode=thinking_mode,
         system_prompt=system_prompt,
@@ -1759,6 +1782,8 @@ def _prepare_decoder_runtime(
         str(manifest_path),
         "--mode",
         "prefill",
+        "--logits-layout",
+        "last",
         "--output",
         str(prefill_ir1),
         "--layout-output",
@@ -2097,16 +2122,11 @@ def _run_decoder(
     stream_output: bool = False,
     generation_progress_every: int = 0,
 ) -> dict[str, Any]:
-    # Keep mixed prefix replay on the decode-layout runtime.
-    #
-    # The standalone prefill runtime is useful for batched prefill entrypoints,
-    # but its generated ck_decode() still follows the prefill layout and can
-    # replay full-sequence GEMM/transposes when used for continuation. That
-    # breaks token 2+ after an external prefix. The decode-layout runtime's
-    # ck_model_forward_mixed already stages prefix rows through the true
-    # single-token decode path, which is the correctness-first contract we need
-    # for multimodal bridge parity.
-    model_so = Path(runtime["so_path"])
+    # Mixed image/text prefill must use the prefill-layout runtime: it owns
+    # batched token-major activation rows and last-logits emission. The decode
+    # runtime only has single-token activation buffers, so its mixed helper can
+    # silently collapse multi-row prefixes.
+    model_so = Path(runtime.get("prefill_so_path") or runtime["so_path"])
     lib = _load_decoder_lib(model_so)
     _log_progress("decoder: init start")
     rc = lib.ck_model_init_with_manifest(
@@ -2241,9 +2261,54 @@ def _run_decoder(
                     _log_progress(f"decoder: generation progress tokens={len(generated_token_ids)}")
                 if step + 1 >= int(effective_max_tokens):
                     break
-                rc = lib.ck_model_decode(ctypes.c_int32(int(next_token)), logits)
-                if rc != 0:
-                    raise RuntimeError(f"decoder decode failed with rc={rc} at generated_step={step}")
+                if model_so == Path(runtime.get("prefill_so_path") or ""):
+                    replay_after_ids = after_token_ids + generated_token_ids
+                    replay_after_arr = (ctypes.c_int32 * len(replay_after_ids))(*replay_after_ids) if replay_after_ids else None
+                    if before_token_ids and hasattr(lib, "ck_model_forward_segments_grid_ex"):
+                        grid_x, grid_y = prefix_grid if prefix_grid is not None else (0, 0)
+                        default_text_pos = (
+                            len(before_token_ids) + max(int(grid_x), int(grid_y))
+                            if prefix_grid is not None
+                            else len(before_token_ids) + max(0, int(prefix_tokens))
+                        )
+                        resolved_text_pos = int(prefix_text_pos or default_text_pos)
+                        rc = lib.ck_model_forward_segments_grid_ex(
+                            before_token_arr,
+                            len(before_token_ids),
+                            prefix_ptr,
+                            prefix_tokens,
+                            resolved_prefix_dim,
+                            int(grid_x),
+                            int(grid_y),
+                            resolved_text_pos,
+                            replay_after_arr,
+                            len(replay_after_ids),
+                            logits,
+                        )
+                    elif hasattr(lib, "ck_model_forward_mixed_grid_ex") and prefix_grid is not None:
+                        grid_x, grid_y = prefix_grid
+                        resolved_text_pos = int(prefix_text_pos or max(int(grid_x), int(grid_y), int(prefix_tokens)))
+                        rc = lib.ck_model_forward_mixed_grid_ex(
+                            prefix_ptr,
+                            prefix_tokens,
+                            resolved_prefix_dim,
+                            int(grid_x),
+                            int(grid_y),
+                            resolved_text_pos,
+                            replay_after_arr,
+                            len(replay_after_ids),
+                            logits,
+                        )
+                    elif hasattr(lib, "ck_model_forward_mixed_ex"):
+                        rc = lib.ck_model_forward_mixed_ex(prefix_ptr, prefix_tokens, resolved_prefix_dim, replay_after_arr, len(replay_after_ids), logits)
+                    else:
+                        rc = lib.ck_model_forward_mixed(prefix_ptr, prefix_tokens, replay_after_arr, len(replay_after_ids), logits)
+                    if rc != 0:
+                        raise RuntimeError(f"decoder mixed replay failed with rc={rc} at generated_step={step}")
+                else:
+                    rc = lib.ck_model_decode(ctypes.c_int32(int(next_token)), logits)
+                    if rc != 0:
+                        raise RuntimeError(f"decoder decode failed with rc={rc} at generated_step={step}")
                 current_logits = logits
             if stream_output and generated_token_ids:
                 print("", flush=True)
@@ -2485,7 +2550,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--encoder-gguf", type=Path, default=None, help="Optional vision encoder/mmproj GGUF")
     ap.add_argument("--workdir", type=Path, required=True, help="Artifact/output directory")
     ap.add_argument("--prompt", type=str, default="Describe the image.", help="Prompt text for decoder tokenization")
-    ap.add_argument("--chat-template", choices=["auto", "none", "qwen", "qwen2", "qwen3", "qwen35", "qwen3vl", "gemma", "gemma3"], default="auto")
+    ap.add_argument("--chat-template", choices=_CHAT_TEMPLATE_CHOICES, default="auto")
     ap.add_argument("--no-chat-template", action="store_true")
     ap.add_argument("--allow-raw-prompt", action="store_true", help="Acknowledge raw prompt formatting when chat templates are disabled")
     ap.add_argument("--thinking-mode", choices=["auto", "visible", "suppressed"], default="auto")

--- a/version/v8/templates/gemma4.json
+++ b/version/v8/templates/gemma4.json
@@ -46,9 +46,11 @@
       "token_stop_markers": [
         "<turn|>"
       ],
+      "image_marker": "<|image|>",
       "template_markers": [
         "<|turn>",
-        "<turn|>"
+        "<turn|>",
+        "<|image|>"
       ],
       "min_response_tokens": 8
     },

--- a/version/v8/templates/gemma4_vision.json
+++ b/version/v8/templates/gemma4_vision.json
@@ -1,0 +1,170 @@
+{
+  "version": 3,
+  "name": "gemma4_vision",
+  "family": "vision_transformer",
+  "flags": {
+    "patch_frontend": "patch_proj",
+    "activation": "geglu",
+    "normalization": "layernorm",
+    "projector": "single_linear"
+  },
+  "contract": {
+    "vision_contract": {
+      "input_modality": "image",
+      "position_encoding": "absolute_2d",
+      "output": "vision_embeddings",
+      "projector": "gemma4v"
+    },
+    "attention_contract": {
+      "rope_layout": "none",
+      "position_encoding": "absolute_2d",
+      "kv_layout": "ephemeral_full_context",
+      "attn_variant": "dense_bidirectional",
+      "causal": false
+    },
+    "block_contract": {
+      "norm_type": "layernorm",
+      "mlp_formula": "gate_up -> geglu -> down",
+      "activation": "geglu",
+      "qkv_bias": false,
+      "qk_norm": true,
+      "post_attention_norm": true,
+      "post_ffn_norm": true,
+      "body_type": "dense_bidirectional"
+    },
+    "logits_contract": {
+      "final_norm": "none",
+      "lm_head": "none",
+      "logits_layout": "none"
+    },
+    "quant_contract": {
+      "kernel_select": "weight_dtype_registry",
+      "activation_dtype": "fp32_or_q8_path",
+      "per_tensor_mixed_quant": true
+    },
+    "runtime_invariants": {
+      "required_call_args": {
+        "image_input": true
+      }
+    }
+  },
+  "kernels": {
+    "patch_proj": "gemm_nt_fp32_exact",
+    "position_embeddings": "position_embeddings_add",
+    "layernorm": "layernorm_fp32_exact",
+    "geglu": "geglu_forward_exact",
+    "spatial_merge": "spatial_merge_contiguous_tiled",
+    "projector_fc2": "gemm_nt_f16",
+    "attn_prefill": "attention_forward_full_head_major_gqa_ggml_strided"
+  },
+  "sequence": [
+    "vision_encoder"
+  ],
+  "block_types": {
+    "vision_encoder": {
+      "sequence": [
+        "header",
+        "body",
+        "footer"
+      ],
+      "header": [
+        {
+          "id": "patchify",
+          "op": "patchify"
+        },
+        {
+          "id": "patch_proj",
+          "op": "patch_proj"
+        },
+        {
+          "id": "position_embeddings",
+          "op": "position_embeddings",
+          "params": {
+            "merge_size_from_config": "spatial_merge_size"
+          }
+        }
+      ],
+      "body": {
+        "type": "dense",
+        "ops": [
+          {
+            "id": "attn_norm",
+            "op": "layernorm"
+          },
+          {
+            "id": "q_proj",
+            "op": "q_proj"
+          },
+          {
+            "id": "k_proj",
+            "op": "k_proj"
+          },
+          {
+            "id": "v_proj",
+            "op": "v_proj"
+          },
+          {
+            "id": "qk_norm",
+            "op": "qk_norm"
+          },
+          {
+            "id": "attn",
+            "op": "attn"
+          },
+          {
+            "id": "attn_out_proj",
+            "op": "out_proj"
+          },
+          {
+            "id": "attn_post_norm",
+            "op": "post_attention_norm"
+          },
+          {
+            "id": "attn_residual",
+            "op": "residual_add"
+          },
+          {
+            "id": "ffn_norm",
+            "op": "layernorm"
+          },
+          {
+            "id": "mlp_gate_up",
+            "op": "mlp_gate_up"
+          },
+          {
+            "id": "mlp_geglu",
+            "op": "geglu"
+          },
+          {
+            "id": "mlp_down",
+            "op": "mlp_down"
+          },
+          {
+            "id": "ffn_post_norm",
+            "op": "post_ffn_norm"
+          },
+          {
+            "id": "mlp_residual",
+            "op": "residual_add"
+          }
+        ]
+      },
+      "footer": [
+        {
+          "id": "merge_main",
+          "op": "spatial_merge",
+          "params": {
+            "merge_size_from_config": "spatial_merge_size"
+          }
+        },
+        {
+          "id": "projector",
+          "op": "projector_fc2",
+          "params": {
+            "single_linear_projector": true
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the Gemma4 vision template and bridge/codegen/converter support
- update the model/kernel matrix and model cards for Qwen3-VL, GLM4, Nemotron, Gemma4 vision, and related v8 commands
- keep Qwen3-VL out of the fast text regression lane and expose Qwen3-VL/GLM4 high-memory smoke lanes separately

## Validation
- git diff --check
- .venv/bin/python -m py_compile version/v8/scripts/run_multimodal_bridge_v8.py version/v8/scripts/codegen_prefill_v8.py version/v8/scripts/build_ir_v8.py version/v8/scripts/convert_gguf_to_bump_v8.py
- bash docs/site/build.sh
- make v8-regression-fast
- pre-commit v7/v8 staged regression passed
- pre-push full gate passed