### PR TITLE
docs(seo): allow test report indexing

### DIFF
--- a/docs/site/build.sh
+++ b/docs/site/build.sh
@@ -10,7 +10,7 @@ PARTIALS_DIR="$SCRIPT_DIR/_partials"
 PAGES_DIR="$SCRIPT_DIR/_pages"
 DOCS_DIR="$(dirname "$SCRIPT_DIR")"
 REPO_ROOT="$(dirname "$DOCS_DIR")"
-SITE_URL="${SITE_URL:-https://antshiv.github.io/C-Kernel-Engine}"
+SITE_URL="${SITE_URL:-https://c-kernel-engine.github.io/C-Kernel-Engine}"
 PAGE_METADATA_FILE="$SCRIPT_DIR/page_metadata.json"
 
 # Get current date/time dynamically from system

--- a/docs/site/googlece55eb69a9ccdaae.html
+++ b/docs/site/googlece55eb69a9ccdaae.html
@@ -1,1 +1,0 @@
-google-site-verification: googlece55eb69a9ccdaae.html

--- a/docs/site/page_metadata.json
+++ b/docs/site/page_metadata.json
@@ -72,8 +72,9 @@
     },
     "test-report.html": {
       "title": "Test Report",
-      "robots": "noindex,nofollow",
-      "sitemap": false
+      "description": "Automated C-Kernel-Engine nightly test report with current kernel, inference, architecture contract, and regression status.",
+      "robots": "index,follow",
+      "sitemap": true
     },
     "quantization-math-temp.html": {
       "title": "Quantization Math Deep Dive",

--- a/docs/site/robots.txt
+++ b/docs/site/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://antshiv.github.io/C-Kernel-Engine/sitemap.xml
+Sitemap: https://c-kernel-engine.github.io/C-Kernel-Engine/sitemap.xml

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -1,251 +1,255 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/googlece55eb69a9ccdaae.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
   <url>
-    <loc>https://antshiv.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-06-19</lastmod>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
+    <lastmod>2026-06-23</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
+    <lastmod>2026-06-23</lastmod>
   </url>
 </urlset>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Test Report | C-Kernel-Engine</title>
-    <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
-    <meta name="robots" content="noindex,nofollow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/test-report.html">
+    <meta name="description" content="Automated C-Kernel-Engine nightly test report with current kernel, inference, architecture contract, and regression status.">
+    <meta name="robots" content="index,follow">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html">
     <meta property="og:title" content="Test Report | C-Kernel-Engine">
-    <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <meta property="og:description" content="Automated C-Kernel-Engine nightly test report with current kernel, inference, architecture contract, and regression status.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/test-report.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {


### PR DESCRIPTION
## Summary
- make the docs site canonical host c-kernel-engine.github.io
- allow test-report.html to be indexed and included in the sitemap
- remove the mistaken Google verification HTML file

## Validation
- bash docs/site/build.sh
- git diff --cached --check
- pre-push gate passed