### PR TITLE
feat(v8/vision): harden Gemma4V bridge contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,10 +225,18 @@ V8_QWEN3VL_CACHED_MMPROJ ?= $(V8_QWEN3VL_CACHE_DIR)/mmproj-Qwen3VL-8B-Instruct-Q
 V8_QWEN3VL_IMAGE ?= version/v8/test_assets/v8_vision_doc_card_72.ppm
 V8_QWEN3VL_MAX_TOKENS ?= 32
 V8_GEMMA4_MODEL ?= hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf
+V8_GEMMA4_MMPROJ ?= hf://unsloth/gemma-4-E4B-it-GGUF/mmproj-F16.gguf
+V8_GEMMA4_CACHE_DIR ?= /opt/app-root/src/.cache/ck-engine-v8/models/unsloth--gemma-4-E4B-it-GGUF
+V8_GEMMA4_CACHED_MODEL ?= $(V8_GEMMA4_CACHE_DIR)/gemma-4-E4B-it-Q4_K_M.gguf
+V8_GEMMA4_CACHED_MMPROJ ?= $(V8_GEMMA4_CACHE_DIR)/mmproj-F16.gguf
 V8_GEMMA4_MIN_MEM_GB ?= 50
 V8_GEMMA4_CONTEXT ?= 2048
 V8_GEMMA4_MAX_TOKENS ?= 64
 V8_GEMMA4_PROMPT ?= Give me a short example of C code.
+V8_GEMMA4_VISION_CONTEXT ?= 1024
+V8_GEMMA4_VISION_MAX_TOKENS ?= 8
+V8_GEMMA4_VISION_IMAGE ?= version/v8/test_assets/v8_vision_doc_card_72.ppm
+V8_GEMMA4_VISION_PROMPT ?= Explain this image.
 V8_NEMOTRON9_MODEL ?= hf://bartowski/nvidia_NVIDIA-Nemotron-Nano-9B-v2-GGUF/nvidia_NVIDIA-Nemotron-Nano-9B-v2-Q4_K_M.gguf
 V8_NEMOTRON9_MIN_MEM_GB ?= 70
 V8_NEMOTRON9_CONTEXT ?= 2048
@@ -1220,7 +1228,29 @@ test-v8-qwen3vl-e2e-smoke:
 			--temperature 0.0; \
 	fi
 
-test-v8-vision-smoke: test-v8-vision-kernels test-v8-qwen3vl test-v8-qwen3vl-e2e-smoke
+test-v8-gemma4-vision-smoke:
+	@avail_kb=$$(awk '/MemAvailable:/ {print $$2}' /proc/meminfo 2>/dev/null || echo 0); \
+	threshold_kb=$$(( $(V8_GEMMA4_MIN_MEM_GB) * 1024 * 1024 )); \
+	if [ "$$avail_kb" -lt "$$threshold_kb" ]; then \
+		avail_gb=$$(( $$avail_kb / 1024 / 1024 )); \
+		echo "SKIP: Gemma4 vision smoke needs >=$(V8_GEMMA4_MIN_MEM_GB) GiB MemAvailable; found $${avail_gb} GiB"; \
+	elif [ ! -f "$(V8_GEMMA4_CACHED_MODEL)" ] || [ ! -f "$(V8_GEMMA4_CACHED_MMPROJ)" ]; then \
+		echo "SKIP: Gemma4 cached decoder/mmproj not found under $(V8_GEMMA4_CACHE_DIR)"; \
+	else \
+		echo "Running cached v8 Gemma4 image -> mmproj -> decoder smoke..."; \
+		CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+			version/v8/scripts/cks-v8-run run "$(V8_GEMMA4_CACHED_MODEL)" \
+			--mmproj "$(V8_GEMMA4_CACHED_MMPROJ)" \
+			--image-path "$(V8_GEMMA4_VISION_IMAGE)" \
+			--prompt "$(V8_GEMMA4_VISION_PROMPT)" \
+			--context-len $(V8_GEMMA4_VISION_CONTEXT) \
+			--force-compile \
+			--chat-template gemma4 \
+			--max-tokens $(V8_GEMMA4_VISION_MAX_TOKENS) \
+			--temperature 0.0; \
+	fi
+
+test-v8-vision-smoke: test-v8-vision-kernels test-v8-qwen3vl test-v8-qwen3vl-e2e-smoke test-v8-gemma4-vision-smoke
 
 test-v8-model-smoke: test-v8-template-circuit-audit v8-regression-fast test-v8-gemma4-highmem test-v8-nemotron9-highmem test-v8-glm4-highmem
 
@@ -2587,7 +2617,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-qwen3vl-e2e-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-qwen3vl-e2e-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/docs/site/_pages/model-kernel-matrix.html
+++ b/docs/site/_pages/model-kernel-matrix.html
@@ -507,6 +507,7 @@
       <div class="model-pipeline">
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF Q4_K_M coherent long-answer smoke</span></div>
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">BF16 safetensors → BUMP — PyTorch parity bring-up path</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Vision bridge smoke — Gemma4 mmproj-F16 encoder → mixed decoder prefill</span></div>
       </div>
       <div class="source-note">
         Bring-up fix: Gemma4 keeps the split-half RoPE channel layout, but it cannot use one global cached split-half contract. The template exports per-layer/direct RoPE metadata, and lowering selects <code>rope_forward_qk_split_direct_f32</code> from IR data rather than hard-coding a Gemma-only kernel.
@@ -515,6 +516,7 @@
         <span class="tag fixed">rope_param_mode: per_layer_direct</span>
         <span class="tag fixed">BF16 PyTorch parity lane</span>
         <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
+        <span class="tag learned">vision bridge smoke-tested</span>
       </div>
       <div class="model-command">
         <div class="model-command-head"><span>Latest hardened v8 text smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma4">Copy</button></div>
@@ -973,7 +975,7 @@
         <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, PyTorch-vs-CK parity harnesses, and a coherent Q4_K_M GGUF runtime smoke. The important fix was separating semantic stream sources in the template from physical quantized activation buffers in the kernel ABI.
       </div>
       <div class="test-item">
-        <strong>Qwen3-VL / Gemma4 vision:</strong> Qwen3-VL remains the promoted vision baseline. Gemma4 vision now has a matching CLIP/mmproj conversion path, a Gemma4 image marker contract, and a correctness-first mixed-prefill bridge; longer semantic parity and speed are still active work.
+        <strong>Qwen3-VL / Gemma4 vision:</strong> Qwen3-VL remains the promoted vision baseline. Gemma4 vision now has a matching CLIP/mmproj conversion path, a Gemma4 image marker contract, and a confirmed encoder-prefix-to-decoder mixed-prefill smoke; semantic parity and speed remain active work.
       </div>
     </div>
   </div>
@@ -997,7 +999,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
   </div>
 
   <div class="roadmap">
-    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Qwen3-VL/Gemma3/Gemma4 text, early Gemma4 vision bridge support, Nemotron-H, GLM4, plus the Llama/Nanbeige bring-up lane.
+    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Qwen3-VL/Gemma3/Gemma4 text, Gemma4 vision bridge smoke support, Nemotron-H, GLM4, plus the Llama/Nanbeige bring-up lane.
     Qwen3.5 adds hybrid recurrent-attention coverage with Gated DeltaNet kernels (forward + backward), compatible with the 0.8B dense variant.
     Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, GLM4 adds partial-RoPE/BPE conversion contracts, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
     v7 still targets full training expansion: backward kernels, optimizer state, gradient reduction, and IR‑driven training schedules.

--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -626,6 +626,8 @@
       (<code>make test-architecture-contracts</code>)</li>
     <li><strong>v8 Qwen3-VL Vision Smoke</strong>: Cached image → mmproj → decoder smoke for the 8B multimodal path; skips cleanly when the runner does not have the large artifacts
       (<code>make test-v8-qwen3vl-e2e-smoke</code>)</li>
+    <li><strong>v8 Gemma4 Vision Smoke</strong>: Cached Gemma4 Q4_K_M decoder plus <code>mmproj-F16.gguf</code> image bridge smoke; gated by high-memory and local artifact checks
+      (<code>make test-v8-gemma4-vision-smoke</code>)</li>
     <li><strong>v8 High-Memory Model Smokes</strong>: Gemma4, Nemotron Nano 9B, and GLM-4 9B run as explicit inference lanes and skip when the runner does not have enough RAM
       (<code>make test-v8-gemma4-highmem</code>, <code>make test-v8-nemotron9-highmem</code>, <code>make test-v8-glm4-highmem</code>)</li>
     <li><strong>v7 Regression Ledger</strong>: Canonical root-cause log for fixed and monitored bugs, consumed by operators in the visualizer

--- a/docs/site/_pages/v8-runbook.html
+++ b/docs/site/_pages/v8-runbook.html
@@ -264,15 +264,16 @@ python -m pip install -r requirements-v8.txt</pre>
   --chat-template auto \
   --generate-visualizer</pre>
     </div>
-    <p class="mini-note">Current scope: these are the validated <code>v8</code> text-family operator surfaces. The multimodal Qwen3-VL path is separate and remains the only promoted vision family today.</p>
+    <p class="mini-note">Current scope: these are the validated <code>v8</code> text-family operator surfaces. The multimodal Qwen3-VL path remains the promoted vision baseline; Gemma4 vision now has a high-memory bridge smoke lane for second-family coverage.</p>
 </div>
 
 <div class="card card-yellow">
     <h3 style="margin-top: 0;">High-Memory v8 Smoke Targets</h3>
-    <p>Gemma4 and Nemotron Nano 9B v2 are intentionally tracked as high-memory smoke lanes. They should appear in nightly/test reports, but skip cleanly on smaller runners instead of pretending the model family is untested.</p>
+    <p>Gemma4 text, Gemma4 vision, and Nemotron Nano 9B v2 are intentionally tracked as high-memory smoke lanes. They should appear in nightly/test reports, but skip cleanly on smaller runners instead of pretending the model family is untested.</p>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
 <pre>make test-v8-gemma4-highmem
+make test-v8-gemma4-vision-smoke
 make test-v8-nemotron9-highmem
 
 # Lower the threshold only when you intentionally want to run locally:
@@ -303,6 +304,27 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
         <li><strong>Only optimize after parity is understood.</strong> Once BF16/FP32 graph parity and GGUF coherence are clean, profile Q4_K/Q5_K/Q6_K/Q8_K kernels and threadpool scheduling separately.</li>
     </ol>
     <p class="mini-note">Gemma4 followed this route: BF16 safetensors proved the split-direct RoPE circuit against PyTorch, then the GGUF Q4_K_M path reused the same IR/kernel contract for coherent long-answer smoke testing.</p>
+</div>
+
+<h2>Canonical Gemma4 Vision Bridge Smoke</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Second-Family Vision Bridge</h3>
+    <p>Gemma4 vision uses the Gemma4 text decoder with the matching <code>mmproj-F16.gguf</code> encoder artifact. Use the checked-in PPM test image so the smoke path does not depend on Pillow.</p>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --mmproj hf://unsloth/gemma-4-E4B-it-GGUF/mmproj-F16.gguf \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
+  --prompt "Explain this image." \
+  --context-len 1024 \
+  --force-compile \
+  --chat-template gemma4 \
+  --max-tokens 8 \
+  --temperature 0.0</pre>
+    </div>
+    <p class="v8-note" style="margin-top: 0.55rem; margin-bottom: 0;">A healthy smoke converts or reuses the Gemma4 vision encoder, produces a 196-token vision prefix, completes mixed prefill in the Gemma4 decoder, and writes a bridge report. Current scope is bridge correctness; longer semantic parity remains active work.</p>
 </div>
 
 <h2>Canonical Qwen3-VL Vision Run</h2>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -6,11 +6,11 @@
     <title>Model + Kernel Matrix  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/model-kernel-matrix.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html">
     <meta property="og:title" content="Model + Kernel Matrix  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/model-kernel-matrix.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1446,6 +1446,7 @@
       <div class="model-pipeline">
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Quantized inference — GGUF Q4_K_M coherent long-answer smoke</span></div>
         <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">BF16 safetensors → BUMP — PyTorch parity bring-up path</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Vision bridge smoke — Gemma4 mmproj-F16 encoder → mixed decoder prefill</span></div>
       </div>
       <div class="source-note">
         Bring-up fix: Gemma4 keeps the split-half RoPE channel layout, but it cannot use one global cached split-half contract. The template exports per-layer/direct RoPE metadata, and lowering selects <code>rope_forward_qk_split_direct_f32</code> from IR data rather than hard-coding a Gemma-only kernel.
@@ -1454,6 +1455,7 @@
         <span class="tag fixed">rope_param_mode: per_layer_direct</span>
         <span class="tag fixed">BF16 PyTorch parity lane</span>
         <span class="tag learned">GGUF Q4_K_M smoke-tested</span>
+        <span class="tag learned">vision bridge smoke-tested</span>
       </div>
       <div class="model-command">
         <div class="model-command-head"><span>Latest hardened v8 text smoke</span><button class="copy-command" type="button" data-copy-command="cmd-gemma4">Copy</button></div>
@@ -1912,7 +1914,7 @@
         <strong>GLM4:</strong> v8 now has a template, GLM4 GGUF metadata fixes, declarative safetensors mapping, PyTorch-vs-CK parity harnesses, and a coherent Q4_K_M GGUF runtime smoke. The important fix was separating semantic stream sources in the template from physical quantized activation buffers in the kernel ABI.
       </div>
       <div class="test-item">
-        <strong>Qwen3-VL / Gemma4 vision:</strong> Qwen3-VL remains the promoted vision baseline. Gemma4 vision now has a matching CLIP/mmproj conversion path, a Gemma4 image marker contract, and a correctness-first mixed-prefill bridge; longer semantic parity and speed are still active work.
+        <strong>Qwen3-VL / Gemma4 vision:</strong> Qwen3-VL remains the promoted vision baseline. Gemma4 vision now has a matching CLIP/mmproj conversion path, a Gemma4 image marker contract, and a confirmed encoder-prefix-to-decoder mixed-prefill smoke; semantic parity and speed remain active work.
       </div>
     </div>
   </div>
@@ -1936,7 +1938,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
   </div>
 
   <div class="roadmap">
-    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Qwen3-VL/Gemma3/Gemma4 text, early Gemma4 vision bridge support, Nemotron-H, GLM4, plus the Llama/Nanbeige bring-up lane.
+    <strong>Growth path:</strong> inference coverage now spans Qwen2/Qwen3/Qwen3.5/Qwen3-VL/Gemma3/Gemma4 text, Gemma4 vision bridge smoke support, Nemotron-H, GLM4, plus the Llama/Nanbeige bring-up lane.
     Qwen3.5 adds hybrid recurrent-attention coverage with Gated DeltaNet kernels (forward + backward), compatible with the 0.8B dense variant.
     Gemma now runs on the correct split-half RoPE parity path, Gemma4 adds per-layer direct RoPE plus a safetensors-to-BUMP parity lane, Nemotron-H adds Mamba2 recurrent state coverage, GLM4 adds partial-RoPE/BPE conversion contracts, and Nanbeige has a documented SentencePiece/ChatML bring-up lane on the C tokenizer.
     v7 still targets full training expansion: backward kernels, optimizer state, gradient reduction, and IR‑driven training schedules.
@@ -2206,7 +2208,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1566,6 +1566,8 @@
       (<code>make test-architecture-contracts</code>)</li>
     <li><strong>v8 Qwen3-VL Vision Smoke</strong>: Cached image → mmproj → decoder smoke for the 8B multimodal path; skips cleanly when the runner does not have the large artifacts
       (<code>make test-v8-qwen3vl-e2e-smoke</code>)</li>
+    <li><strong>v8 Gemma4 Vision Smoke</strong>: Cached Gemma4 Q4_K_M decoder plus <code>mmproj-F16.gguf</code> image bridge smoke; gated by high-memory and local artifact checks
+      (<code>make test-v8-gemma4-vision-smoke</code>)</li>
     <li><strong>v8 High-Memory Model Smokes</strong>: Gemma4, Nemotron Nano 9B, and GLM-4 9B run as explicit inference lanes and skip when the runner does not have enough RAM
       (<code>make test-v8-gemma4-highmem</code>, <code>make test-v8-nemotron9-highmem</code>, <code>make test-v8-glm4-highmem</code>)</li>
     <li><strong>v7 Regression Ledger</strong>: Canonical root-cause log for fixed and monitored bugs, consumed by operators in the visualizer
@@ -2534,7 +2536,7 @@ document.addEventListener('DOMContentLoaded', loadResults);
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -6,11 +6,11 @@
     <title>v8 Inference Runbook | C-Kernel-Engine</title>
     <meta name="description" content="Operator runbook for the current C-Kernel-Engine v8 inference lane, covering promoted text-family bring-up and the validated Qwen3-VL multimodal path.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v8-runbook.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html">
     <meta property="og:title" content="v8 Inference Runbook | C-Kernel-Engine">
     <meta property="og:description" content="Operator runbook for the current C-Kernel-Engine v8 inference lane, covering promoted text-family bring-up and the validated Qwen3-VL multimodal path.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v8-runbook.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1203,15 +1203,16 @@ python -m pip install -r requirements-v8.txt</pre>
   --chat-template auto \
   --generate-visualizer</pre>
     </div>
-    <p class="mini-note">Current scope: these are the validated <code>v8</code> text-family operator surfaces. The multimodal Qwen3-VL path is separate and remains the only promoted vision family today.</p>
+    <p class="mini-note">Current scope: these are the validated <code>v8</code> text-family operator surfaces. The multimodal Qwen3-VL path remains the promoted vision baseline; Gemma4 vision now has a high-memory bridge smoke lane for second-family coverage.</p>
 </div>
 
 <div class="card card-yellow">
     <h3 style="margin-top: 0;">High-Memory v8 Smoke Targets</h3>
-    <p>Gemma4 and Nemotron Nano 9B v2 are intentionally tracked as high-memory smoke lanes. They should appear in nightly/test reports, but skip cleanly on smaller runners instead of pretending the model family is untested.</p>
+    <p>Gemma4 text, Gemma4 vision, and Nemotron Nano 9B v2 are intentionally tracked as high-memory smoke lanes. They should appear in nightly/test reports, but skip cleanly on smaller runners instead of pretending the model family is untested.</p>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
 <pre>make test-v8-gemma4-highmem
+make test-v8-gemma4-vision-smoke
 make test-v8-nemotron9-highmem
 
 # Lower the threshold only when you intentionally want to run locally:
@@ -1244,6 +1245,27 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
     <p class="mini-note">Gemma4 followed this route: BF16 safetensors proved the split-direct RoPE circuit against PyTorch, then the GGUF Q4_K_M path reused the same IR/kernel contract for coherent long-answer smoke testing.</p>
 </div>
 
+<h2>Canonical Gemma4 Vision Bridge Smoke</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Second-Family Vision Bridge</h3>
+    <p>Gemma4 vision uses the Gemma4 text decoder with the matching <code>mmproj-F16.gguf</code> encoder artifact. Use the checked-in PPM test image so the smoke path does not depend on Pillow.</p>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --mmproj hf://unsloth/gemma-4-E4B-it-GGUF/mmproj-F16.gguf \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
+  --prompt "Explain this image." \
+  --context-len 1024 \
+  --force-compile \
+  --chat-template gemma4 \
+  --max-tokens 8 \
+  --temperature 0.0</pre>
+    </div>
+    <p class="v8-note" style="margin-top: 0.55rem; margin-bottom: 0;">A healthy smoke converts or reuses the Gemma4 vision encoder, produces a 196-token vision prefix, completes mixed prefill in the Gemma4 decoder, and writes a bridge report. Current scope is bridge correctness; longer semantic parity remains active work.</p>
+</div>
+
 <h2>Canonical Qwen3-VL Vision Run</h2>
 
 <div class="card card-accent">
@@ -1254,7 +1276,7 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
 <pre>version/v8/scripts/cks-v8-run run \
   hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
   --mmproj hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
-  --image-path version/v8/test_assets/v8_vision_doc_card_72.png \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
   --prompt "Explain this image." \
   --context-len 1024 \
   --force-convert --force-compile \
@@ -1599,7 +1621,7 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-22</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -188,6 +188,16 @@ void gemm_nt_f16(const float *A,
                  float *C,
                  int M, int N, int K);
 
+void gemm_nt_f16_clipped(const float *A,
+                         const void *B,
+                         const float *bias,
+                         const float *input_min,
+                         const float *input_max,
+                         const float *output_min,
+                         const float *output_max,
+                         float *C,
+                         int M, int N, int K);
+
 void gemv_bf16(float *y,
                const void *W,
                const float *x,
@@ -1288,6 +1298,19 @@ void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q,
                                                                 int aligned_head_dim,
                                                                 int kv_stride_tokens);
 
+void attention_forward_mixed_visual_chunk_head_major_gqa_flash_strided_gemma4(const float *q,
+                                                                              const float *k,
+                                                                              const float *v,
+                                                                              float *output,
+                                                                              int num_heads,
+                                                                              int num_kv_heads,
+                                                                              int num_tokens,
+                                                                              int head_dim,
+                                                                              int aligned_head_dim,
+                                                                              int kv_stride_tokens,
+                                                                              int visual_start,
+                                                                              int visual_tokens);
+
 // Regular exact full / bidirectional attention for encoder-style prefill.
 // This matches the non-flash CPU reference path more closely than the online
 // flash reduction used by the causal kernels.
@@ -1353,6 +1376,21 @@ void attention_forward_decode_head_major_gqa_flash_gemma4(const float *q_token,
                                                           int cache_capacity,
                                                           int head_dim,
                                                           int aligned_head_dim);
+
+// Chunk decode attention: q_chunk/out_chunk use compact head-major
+// [num_heads, q_tokens, aligned_head_dim] layout while K/V are stored in the
+// persistent cache [num_kv_heads, cache_capacity, aligned_head_dim].
+void attention_forward_chunk_head_major_gqa_flash_gemma4(const float *q_chunk,
+                                                         const float *k_cache,
+                                                         const float *v_cache,
+                                                         float *out_chunk,
+                                                         int num_heads,
+                                                         int num_kv_heads,
+                                                         int q_tokens,
+                                                         int kv_tokens,
+                                                         int cache_capacity,
+                                                         int head_dim,
+                                                         int aligned_head_dim);
 
 // Llama-parity decode flash attention variant that rounds K/V through FP16 before use.
 void attention_forward_decode_head_major_gqa_flash_f16kv(const float *q_token,
@@ -2678,6 +2716,17 @@ void mrope_qk_vision(float *q,
                      float beta_fast,
                      float beta_slow);
 
+void rope_forward_qk_gemma4v_vision_xy(float *q,
+                                       float *k,
+                                       int num_heads,
+                                       int num_kv_heads,
+                                       int num_tokens,
+                                       int head_dim,
+                                       int aligned_head_dim,
+                                       int grid_w,
+                                       int rotary_dim,
+                                       float freq_base);
+
 void mrope_qk_imrope_positions(float *q,
                                float *k,
                                const int32_t *positions,
@@ -2972,6 +3021,12 @@ void embedding_forward_bf16_fp32(const int32_t *token_ids,
 	                                      int embed_dim,
 	                                      int merge_size,
 	                                      int source_grid_size);
+	void position_embeddings_add_gemma4v_xy(float *x,
+	                                       const float *position_embd,
+	                                       int grid_h,
+	                                       int grid_w,
+	                                       int embed_dim,
+	                                       int source_grid_size);
 	void vision_position_ids_2d_merge(int32_t *positions,
 	                                 int grid_h,
 	                                 int grid_w,
@@ -3000,6 +3055,12 @@ void embedding_forward_bf16_fp32(const int32_t *token_ids,
 	                                    int grid_w,
 	                                    int embed_dim,
 	                                    int merge_size);
+	void spatial_average_pool_contiguous(const float *input,
+	                                     float *output,
+	                                     int grid_h,
+	                                     int grid_w,
+	                                     int embed_dim,
+	                                     int merge_size);
 	void feature_concat_2way(const float *main_input,
 	                         const float *branch_input,
 	                         float *output,
@@ -3007,6 +3068,13 @@ void embedding_forward_bf16_fp32(const int32_t *token_ids,
 	                         int main_dim,
 	                         int branch_slice_dim,
 	                         int num_branch_slices);
+void gemma4_vision_projector_prep_forward(const float *input,
+                                           float *output,
+                                           int tokens,
+                                           int dim,
+                                           float scale,
+                                           float eps);
+
 
 	void im2patch_bf16(const uint16_t *image,
 	                   uint16_t *patches,

--- a/scripts/gguf_tokenizer.py
+++ b/scripts/gguf_tokenizer.py
@@ -15,7 +15,7 @@ import struct
 import os
 import re
 from pathlib import Path
-from typing import Dict, List, Optional, Any, BinaryIO, Tuple
+from typing import Dict, List, Optional, Any, Tuple, BinaryIO
 
 # GGUF type constants
 GGUF_TYPE_UINT8 = 0
@@ -200,6 +200,8 @@ class GGUFTokenizer:
         self.scores: List[float] = []
         self.token_to_id: Dict[str, int] = {}
         self.special_ids: set[int] = set()
+        self.special_token_to_id: Dict[str, int] = {}
+        self._special_token_strings_sorted: List[str] = []
         self.bos_id: int = 1
         self.eos_id: int = 2
         self.unk_id: int = 0
@@ -237,6 +239,31 @@ class GGUFTokenizer:
         else:
             self.special_ids = set()
         self.special_ids.update({self.bos_id, self.eos_id, self.pad_id, self.unk_id})
+        self._rebuild_special_token_lookup()
+
+    def _rebuild_special_token_lookup(self) -> None:
+        self.special_token_to_id = {}
+        for tid, token in enumerate(self.tokens):
+            if not isinstance(token, str) or not token:
+                continue
+            is_declared_special = tid in self.special_ids
+            is_control_like = (
+                len(token) >= 3
+                and token.startswith("<")
+                and token.endswith(">")
+                and ("|" in token or token in {"<bos>", "<eos>", "<pad>", "<unk>", "<mask>", "<s>", "</s>"})
+            )
+            if is_declared_special or is_control_like:
+                self.special_token_to_id[token] = int(tid)
+        self._special_token_strings_sorted = sorted(self.special_token_to_id, key=len, reverse=True)
+
+    def _match_special_token(self, text: str, pos: int) -> Optional[Tuple[str, int]]:
+        if not self._special_token_strings_sorted or pos >= len(text) or text[pos] != "<":
+            return None
+        for token in self._special_token_strings_sorted:
+            if text.startswith(token, pos):
+                return token, self.special_token_to_id[token]
+        return None
 
     @classmethod
     def from_gguf(cls, gguf_path: str) -> "GGUFTokenizer":
@@ -429,22 +456,41 @@ class GGUFTokenizer:
         is_gpt2 = self.model_type.lower() in {"gpt2", "bpe"} or "\u0120" in "".join(self.tokens[:1000])
 
         if is_gpt2:
-            mapped = "".join(self._byte_encoder[b] for b in text.encode("utf-8"))
+            def _encode_bytelevel_segment(segment: str) -> list[int]:
+                mapped = "".join(self._byte_encoder[b] for b in segment.encode("utf-8"))
+                out: list[int] = []
+                j = 0
+                while j < len(mapped):
+                    best_len = 0
+                    best_id = self.unk_id
+                    for length in range(min(len(mapped) - j, 128), 0, -1):
+                        chunk = mapped[j:j + length]
+                        if chunk in self.token_to_id:
+                            best_len = length
+                            best_id = self.token_to_id[chunk]
+                            break
+                    if best_len == 0:
+                        best_id = self.token_to_id.get(mapped[j], self.unk_id)
+                        best_len = 1
+                    out.append(best_id)
+                    j += best_len
+                return out
+
+            raw_start = 0
             i = 0
-            while i < len(mapped):
-                best_len = 0
-                best_id = self.unk_id
-                for length in range(min(len(mapped) - i, 128), 0, -1):
-                    chunk = mapped[i:i + length]
-                    if chunk in self.token_to_id:
-                        best_len = length
-                        best_id = self.token_to_id[chunk]
-                        break
-                if best_len == 0:
-                    best_id = self.token_to_id.get(mapped[i], self.unk_id)
-                    best_len = 1
-                ids.append(best_id)
-                i += best_len
+            while i < len(text):
+                match = self._match_special_token(text, i)
+                if match is None:
+                    i += 1
+                    continue
+                token, token_id = match
+                if raw_start < i:
+                    ids.extend(_encode_bytelevel_segment(text[raw_start:i]))
+                ids.append(int(token_id))
+                i += len(token)
+                raw_start = i
+            if raw_start < len(text):
+                ids.extend(_encode_bytelevel_segment(text[raw_start:]))
 
             if add_eos:
                 ids.append(self.eos_id)
@@ -452,6 +498,13 @@ class GGUFTokenizer:
 
         i = 0
         while i < len(text):
+            special_match = self._match_special_token(text, i)
+            if special_match is not None:
+                special_token, special_id = special_match
+                ids.append(int(special_id))
+                i += len(special_token)
+                continue
+
             best_len = 0
             best_id = self.unk_id
 
@@ -463,8 +516,16 @@ class GGUFTokenizer:
                 )
             )
 
-            # Try different lengths, longest first
-            for length in range(min(len(text) - i, 32), 0, -1):
+            max_match_len = min(len(text) - i, 32)
+            if self._special_token_strings_sorted:
+                for probe in range(i + 1, min(len(text), i + max_match_len) + 1):
+                    if self._match_special_token(text, probe) is not None:
+                        max_match_len = probe - i
+                        break
+
+            # Try different lengths, longest first, without crossing a known
+            # special/control token boundary.
+            for length in range(max_match_len, 0, -1):
                 chunk = text[i:i + length]
 
                 # Skip leading space in chunk (it becomes prefix)

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -446,6 +446,12 @@ MAKE_TARGETS = {
         "target": "test-v8-qwen3vl-e2e-smoke",
         "timeout_sec": 5400,
     },
+    "v8_gemma4_vision_smoke": {
+        "name": "v8 Gemma4 Vision Smoke",
+        "category": "inference",
+        "target": "test-v8-gemma4-vision-smoke",
+        "timeout_sec": 5400,
+    },
     "v8_decoder_matrix_quick": {
         "name": "v8 Decoder Matrix (quick)",
         "category": "inference",

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -3055,6 +3055,105 @@ void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q,
                                                 1.0f);
 }
 
+
+void attention_forward_mixed_visual_chunk_head_major_gqa_flash_strided_gemma4(const float *q,
+                                                                              const float *k,
+                                                                              const float *v,
+                                                                              float *output,
+                                                                              int num_heads,
+                                                                              int num_kv_heads,
+                                                                              int num_tokens,
+                                                                              int head_dim,
+                                                                              int aligned_head_dim,
+                                                                              int kv_stride_tokens,
+                                                                              int visual_start,
+                                                                              int visual_tokens)
+{
+    if (!q || !k || !v || !output) {
+        return;
+    }
+    if (num_heads <= 0 || num_kv_heads <= 0 || num_tokens <= 0) {
+        return;
+    }
+    if (kv_stride_tokens < num_tokens || head_dim <= 0 || aligned_head_dim <= 0) {
+        return;
+    }
+    if (visual_start < 0 || visual_tokens <= 0 || visual_start >= num_tokens) {
+        attention_forward_causal_head_major_gqa_flash_strided_gemma4(q, k, v, output,
+                                                                     num_heads, num_kv_heads,
+                                                                     num_tokens, head_dim,
+                                                                     aligned_head_dim,
+                                                                     kv_stride_tokens);
+        return;
+    }
+
+    int visual_end = visual_start + visual_tokens;
+    if (visual_end > num_tokens) {
+        visual_end = num_tokens;
+    }
+    if (visual_end <= visual_start) {
+        attention_forward_causal_head_major_gqa_flash_strided_gemma4(q, k, v, output,
+                                                                     num_heads, num_kv_heads,
+                                                                     num_tokens, head_dim,
+                                                                     aligned_head_dim,
+                                                                     kv_stride_tokens);
+        return;
+    }
+
+    const int T = num_tokens;
+    const size_t kv_head_stride = (size_t)kv_stride_tokens * (size_t)aligned_head_dim;
+    const float scale = 1.0f;
+
+    if (ck_strict_parity_enabled()) {
+        for (int h = 0; h < num_heads; ++h) {
+            int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+            const float *k_head = k + (size_t)kv_head * kv_head_stride;
+            const float *v_head = v + (size_t)kv_head * kv_head_stride;
+
+            for (int i = 0; i < T; ++i) {
+                const float *q_vec = q + qkv_index(h, i, 0, T, aligned_head_dim);
+                float *out_vec = output + qkv_index(h, i, 0, T, aligned_head_dim);
+                const int in_visual = (i >= visual_start && i < visual_end);
+                const int kv_tokens = in_visual ? visual_end : (i + 1);
+                attention_flash_query_causal_exact(q_vec, k_head, v_head,
+                                                   kv_tokens,
+                                                   head_dim, aligned_head_dim,
+                                                   scale, out_vec);
+            }
+        }
+        return;
+    }
+
+#if defined(__AVX512F__)
+    #define FLASH_QUERY_IMPL attention_flash_query_causal_avx512
+#elif defined(__AVX2__)
+    #define FLASH_QUERY_IMPL attention_flash_query_causal_avx2
+#elif defined(__AVX__)
+    #define FLASH_QUERY_IMPL attention_flash_query_causal_avx
+#else
+    #define FLASH_QUERY_IMPL attention_flash_query_causal
+#endif
+
+    for (int h = 0; h < num_heads; ++h) {
+        int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+        const float *k_head = k + (size_t)kv_head * kv_head_stride;
+        const float *v_head = v + (size_t)kv_head * kv_head_stride;
+
+        for (int i = 0; i < T; ++i) {
+            const float *q_vec = q + qkv_index(h, i, 0, T, aligned_head_dim);
+            float *out_vec = output + qkv_index(h, i, 0, T, aligned_head_dim);
+            const int in_visual = (i >= visual_start && i < visual_end);
+            const int kv_tokens = in_visual ? visual_end : (i + 1);
+            FLASH_QUERY_IMPL(q_vec, k_head, v_head,
+                             kv_tokens,
+                             head_dim, aligned_head_dim,
+                             scale, out_vec);
+        }
+    }
+
+#undef FLASH_QUERY_IMPL
+}
+
 void attention_forward_causal_head_major_gqa_flash_strided_f16kv(const float *q,
                                                                  const float *k,
                                                                  const float *v,
@@ -3498,6 +3597,52 @@ void attention_forward_decode_head_major_gqa_flash_gemma4(const float *q_token,
                                1,
                                aligned_head_dim,
                                scale);
+    }
+}
+
+void attention_forward_chunk_head_major_gqa_flash_gemma4(const float *q_chunk,
+                                                         const float *k_cache,
+                                                         const float *v_cache,
+                                                         float *out_chunk,
+                                                         int num_heads,
+                                                         int num_kv_heads,
+                                                         int q_tokens,
+                                                         int kv_tokens,
+                                                         int cache_capacity,
+                                                         int head_dim,
+                                                         int aligned_head_dim)
+{
+    if (!q_chunk || !k_cache || !v_cache || !out_chunk) {
+        return;
+    }
+    if (num_heads <= 0 || num_kv_heads <= 0 || q_tokens <= 0 || kv_tokens <= 0 || cache_capacity <= 0) {
+        return;
+    }
+    if (kv_tokens > cache_capacity || head_dim <= 0 || aligned_head_dim <= 0) {
+        return;
+    }
+
+    const float scale = 1.0f;
+    const size_t cache_head_stride = (size_t)cache_capacity * (size_t)aligned_head_dim;
+    const size_t q_head_stride = (size_t)q_tokens * (size_t)aligned_head_dim;
+
+    for (int h = 0; h < num_heads; ++h) {
+        int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+        const float *k_head = k_cache + (size_t)kv_head * cache_head_stride;
+        const float *v_head = v_cache + (size_t)kv_head * cache_head_stride;
+        for (int t = 0; t < q_tokens; ++t) {
+            const float *q_head = q_chunk + (size_t)h * q_head_stride + (size_t)t * (size_t)aligned_head_dim;
+            float *out_head = out_chunk + (size_t)h * q_head_stride + (size_t)t * (size_t)aligned_head_dim;
+            attention_flash_decode(out_head,
+                                   q_head,
+                                   k_head,
+                                   v_head,
+                                   1,
+                                   kv_tokens,
+                                   1,
+                                   aligned_head_dim,
+                                   scale);
+        }
     }
 }
 

--- a/src/kernels/gemm_kernels_f16.c
+++ b/src/kernels/gemm_kernels_f16.c
@@ -513,6 +513,48 @@ void gemm_nt_f16(const float *A,
     }
 }
 
+void gemm_nt_f16_clipped(const float *A,
+                         const void *B,
+                         const float *bias,
+                         const float *input_min,
+                         const float *input_max,
+                         const float *output_min,
+                         const float *output_max,
+                         float *C,
+                         int M, int N, int K)
+{
+    const float in_min = input_min ? input_min[0] : -3.4028234663852886e38f;
+    const float in_max = input_max ? input_max[0] : 3.4028234663852886e38f;
+    const float out_min = output_min ? output_min[0] : -3.4028234663852886e38f;
+    const float out_max = output_max ? output_max[0] : 3.4028234663852886e38f;
+    const uint16_t *W = (const uint16_t *)B;
+
+#pragma omp parallel for schedule(static) if(M > 1)
+    for (int m = 0; m < M; ++m) {
+        const float *a_row = A + (size_t)m * (size_t)K;
+        uint16_t a_f16[K];
+
+        for (int k = 0; k < K; ++k) {
+            float x = a_row[k];
+            if (x < in_min) x = in_min;
+            if (x > in_max) x = in_max;
+            a_f16[k] = fp32_to_fp16(x);
+        }
+
+        float *c_row = C + (size_t)m * (size_t)N;
+        for (int n = 0; n < N; ++n) {
+            const uint16_t *w_row = W + (size_t)n * (size_t)K;
+            float sum = bias ? bias[n] : 0.0f;
+            for (int k = 0; k < K; ++k) {
+                sum += fp16_to_fp32(w_row[k]) * fp16_to_fp32(a_f16[k]);
+            }
+            if (sum < out_min) sum = out_min;
+            if (sum > out_max) sum = out_max;
+            c_row[n] = sum;
+        }
+    }
+}
+
 /* ============================================================================
  * FP16 Tensor Conversion Utilities
  * ============================================================================ */

--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -929,6 +929,89 @@ void rope_forward_qk_gemma4_direct(float *q,
                                     rotary_dim, freq_base);
 }
 
+
+static void rope_forward_gemma4v_vision_xy_one(float *x,
+                                               int num_heads,
+                                               int num_tokens,
+                                               int head_dim,
+                                               int aligned_head_dim,
+                                               int grid_w,
+                                               int rotary_dim,
+                                               float freq_base)
+{
+    if (!x || num_heads <= 0 || num_tokens <= 0 || head_dim <= 0 || aligned_head_dim <= 0) {
+        return;
+    }
+    if (grid_w <= 0) {
+        grid_w = num_tokens;
+    }
+    if (rotary_dim <= 0 || rotary_dim > head_dim) {
+        rotary_dim = head_dim;
+    }
+    if (freq_base <= 0.0f) {
+        freq_base = 100.0f;
+    }
+
+    /* Gemma4V vision uses llama.cpp's 2D NEOX RoPE contract:
+     * rotate the first half of the rotary span by patch x, and the second
+     * half by patch y. Each half is itself split-half/NEOX rotated.
+     */
+    const int half_span = rotary_dim / 2;
+    const int segment_half = half_span / 2;
+    if (segment_half <= 0) {
+        return;
+    }
+    const size_t head_stride = (size_t)num_tokens * (size_t)aligned_head_dim;
+    const float theta_scale = powf(freq_base, -2.0f / (float)half_span);
+
+    for (int h = 0; h < num_heads; ++h) {
+        float *head = x + (size_t)h * head_stride;
+        for (int t = 0; t < num_tokens; ++t) {
+            const int pos_x = t % grid_w;
+            const int pos_y = t / grid_w;
+            float *row = head + (size_t)t * (size_t)aligned_head_dim;
+            for (int i = 0; i < segment_half; ++i) {
+                const float inv_freq = powf(theta_scale, (float)i);
+
+                const float theta_x = (float)pos_x * inv_freq;
+                const float cx = cosf(theta_x);
+                const float sx = sinf(theta_x);
+                const int x0i = i;
+                const int x1i = i + segment_half;
+                const float x0 = row[x0i];
+                const float x1 = row[x1i];
+                row[x0i] = x0 * cx - x1 * sx;
+                row[x1i] = x1 * cx + x0 * sx;
+
+                const float theta_y = (float)pos_y * inv_freq;
+                const float cy = cosf(theta_y);
+                const float sy = sinf(theta_y);
+                const int y0i = half_span + i;
+                const int y1i = half_span + i + segment_half;
+                const float y0 = row[y0i];
+                const float y1 = row[y1i];
+                row[y0i] = y0 * cy - y1 * sy;
+                row[y1i] = y1 * cy + y0 * sy;
+            }
+        }
+    }
+}
+
+void rope_forward_qk_gemma4v_vision_xy(float *q,
+                                       float *k,
+                                       int num_heads,
+                                       int num_kv_heads,
+                                       int num_tokens,
+                                       int head_dim,
+                                       int aligned_head_dim,
+                                       int grid_w,
+                                       int rotary_dim,
+                                       float freq_base)
+{
+    rope_forward_gemma4v_vision_xy_one(q, num_heads, num_tokens, head_dim, aligned_head_dim, grid_w, rotary_dim, freq_base);
+    rope_forward_gemma4v_vision_xy_one(k, num_kv_heads, num_tokens, head_dim, aligned_head_dim, grid_w, rotary_dim, freq_base);
+}
+
 void rope_forward_qk_with_rotary_dim_cache_stride(float *q,
                                                   float *k,
                                                   const float *cos_cache,

--- a/src/kernels/vision_kernels.c
+++ b/src/kernels/vision_kernels.c
@@ -155,6 +155,38 @@ void position_embeddings_add(float *x,
     }
 }
 
+void position_embeddings_add_gemma4v_xy(float *x,
+                                       const float *position_embd,
+                                       int grid_h,
+                                       int grid_w,
+                                       int embed_dim,
+                                       int source_grid_size)
+{
+    if (x == NULL || position_embd == NULL || grid_h <= 0 || grid_w <= 0 || embed_dim <= 0) {
+        return;
+    }
+    if (source_grid_size <= 0) {
+        source_grid_size = grid_w > grid_h ? grid_w : grid_h;
+    }
+
+    const size_t table_stride = (size_t) source_grid_size * (size_t) embed_dim;
+    const float *table_x = position_embd;
+    const float *table_y = position_embd + table_stride;
+
+    for (int y = 0; y < grid_h; ++y) {
+        const int yy = y < source_grid_size ? y : (source_grid_size - 1);
+        const float *row_y = table_y + (size_t) yy * (size_t) embed_dim;
+        for (int x_pos = 0; x_pos < grid_w; ++x_pos) {
+            const int xx = x_pos < source_grid_size ? x_pos : (source_grid_size - 1);
+            const float *row_x = table_x + (size_t) xx * (size_t) embed_dim;
+            float *dst = x + ((size_t) y * (size_t) grid_w + (size_t) x_pos) * (size_t) embed_dim;
+            for (int d = 0; d < embed_dim; ++d) {
+                dst[d] += row_x[d] + row_y[d];
+            }
+        }
+    }
+}
+
 void position_embeddings_add_tiled_2d(float *x,
                                       const float *position_embd,
                                       int grid_h,
@@ -349,6 +381,69 @@ void spatial_merge_contiguous_tiled(const float *input,
     const size_t merge_factor = (size_t) merge_size * (size_t) merge_size;
     const size_t merged_tokens = num_tokens / merge_factor;
     memcpy(output, input, merged_tokens * (size_t) embed_dim * merge_factor * sizeof(float));
+}
+
+void gemma4_vision_projector_prep_forward(const float *input,
+                                          float *output,
+                                          int tokens,
+                                          int dim,
+                                          float scale,
+                                          float eps)
+{
+    if (input == NULL || output == NULL || tokens <= 0 || dim <= 0) return;
+    if (eps <= 0.0f) eps = 1.0e-6f;
+    for (int t = 0; t < tokens; ++t) {
+        const float *src = input + (size_t)t * (size_t)dim;
+        float *dst = output + (size_t)t * (size_t)dim;
+        double ss = 0.0;
+        for (int i = 0; i < dim; ++i) {
+            const float v = src[i] * scale;
+            ss += (double)v * (double)v;
+        }
+        const float inv_rms = 1.0f / sqrtf((float)(ss / (double)dim) + eps);
+        for (int i = 0; i < dim; ++i) {
+            dst[i] = (src[i] * scale) * inv_rms;
+        }
+    }
+}
+
+void spatial_average_pool_contiguous(const float *input,
+                                     float *output,
+                                     int grid_h,
+                                     int grid_w,
+                                     int embed_dim,
+                                     int merge_size)
+{
+    if (input == NULL || output == NULL || grid_h <= 0 || grid_w <= 0 || embed_dim <= 0 || merge_size <= 0) {
+        return;
+    }
+
+    const int out_h = grid_h / merge_size;
+    const int out_w = grid_w / merge_size;
+    if (out_h <= 0 || out_w <= 0) {
+        return;
+    }
+
+    const float inv_area = 1.0f / (float)(merge_size * merge_size);
+    for (int oy = 0; oy < out_h; ++oy) {
+        for (int ox = 0; ox < out_w; ++ox) {
+            float *dst = output + ((size_t)oy * (size_t)out_w + (size_t)ox) * (size_t)embed_dim;
+            memset(dst, 0, (size_t)embed_dim * sizeof(float));
+            for (int dy = 0; dy < merge_size; ++dy) {
+                const int iy = oy * merge_size + dy;
+                for (int dx = 0; dx < merge_size; ++dx) {
+                    const int ix = ox * merge_size + dx;
+                    const float *src = input + ((size_t)iy * (size_t)grid_w + (size_t)ix) * (size_t)embed_dim;
+                    for (int c = 0; c < embed_dim; ++c) {
+                        dst[c] += src[c];
+                    }
+                }
+            }
+            for (int c = 0; c < embed_dim; ++c) {
+                dst[c] *= inv_area;
+            }
+        }
+    }
 }
 
 void rowwise_bias_add(float *x,

--- a/tests/test_gguf_tokenizer.py
+++ b/tests/test_gguf_tokenizer.py
@@ -46,6 +46,36 @@ class GGUFTokenizerTests(unittest.TestCase):
 
         self.assertEqual(tok.encode("\n", add_bos=False), [1])
 
+    def test_encode_does_not_cross_special_token_boundary(self) -> None:
+        tok = GGUFTokenizer(
+            {
+                "tokenizer.ggml.tokens": [
+                    "<unk>",
+                    ".",
+                    "Explain",
+                    " this",
+                    " image",
+                    ".<",
+                    "<turn|>",
+                    "\n",
+                    "<|turn>",
+                    "model",
+                ],
+                "tokenizer.ggml.model": "spm",
+                "tokenizer.ggml.bos_token_id": 99,
+                "tokenizer.ggml.eos_token_id": 100,
+                "tokenizer.ggml.unknown_token_id": 0,
+                "tokenizer.ggml.padding_token_id": 101,
+                "tokenizer.ggml.add_bos_token": False,
+                "tokenizer.ggml.special_token_ids": [6, 8],
+            }
+        )
+
+        ids = tok.encode("Explain this image.<turn|>\n<|turn>model\n", add_bos=False)
+
+        self.assertEqual(ids, [2, 3, 4, 1, 6, 7, 8, 9, 7])
+        self.assertNotIn(5, ids)
+
     def test_from_json_bytelevel_disables_implicit_bos(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gguf_tok_json_") as td:
             path = Path(td) / "tokenizer.json"

--- a/tests/test_v8_native_bridge_host.py
+++ b/tests/test_v8_native_bridge_host.py
@@ -257,6 +257,106 @@ def _build_tiny_decoder_runtime(workdir: Path) -> tuple[Path, Path, Path]:
 
 
 class V8NativeBridgeHostTests(unittest.TestCase):
+    def test_vision_prefix_position_policy_keeps_qwen_mrope_but_gemma_linear(self) -> None:
+        self.assertEqual(
+            bridge_runner_v8._vision_prefix_position_policy({"model": "qwen3_vl_vision"}),
+            "mrope_2d",
+        )
+        self.assertEqual(
+            bridge_runner_v8._local_prefix_text_pos_for_policy("mrope_2d", 196, 14, 14),
+            14,
+        )
+        self.assertEqual(
+            bridge_runner_v8._vision_prefix_position_policy({"model": "gemma4_vision"}),
+            "linear",
+        )
+        self.assertEqual(
+            bridge_runner_v8._local_prefix_text_pos_for_policy("linear", 196, 14, 14),
+            196,
+        )
+
+    def test_vision_prefix_decode_policy_marks_gemma_visual_chunk_non_causal(self) -> None:
+        self.assertEqual(
+            bridge_runner_v8._vision_prefix_decode_policy({"model": "qwen3_vl_vision"}),
+            "causal_mixed_prefix",
+        )
+        self.assertEqual(
+            bridge_runner_v8._vision_prefix_decode_policy({"model": "gemma4_vision"}),
+            "non_causal_visual_chunk",
+        )
+        self.assertEqual(
+            bridge_runner_v8._vision_prefix_decode_policy({"model": "gemma3_vision"}),
+            "non_causal_visual_chunk",
+        )
+
+    def test_vision_prefix_policy_prefers_template_bridge_contract(self) -> None:
+        layout_cfg = {
+            "model": "qwen3_vl_vision",
+            "contract": {
+                "multimodal_bridge": {
+                    "position_policy": "linear",
+                    "decode_policy": "non_causal_visual_chunk",
+                }
+            },
+        }
+        self.assertEqual(bridge_runner_v8._vision_prefix_position_policy(layout_cfg), "linear")
+        self.assertEqual(
+            bridge_runner_v8._vision_prefix_decode_policy(layout_cfg),
+            "non_causal_visual_chunk",
+        )
+
+    def test_vision_templates_declare_multimodal_bridge_contracts(self) -> None:
+        gemma = build_ir_v8._load_builtin_template_doc("gemma4_vision")
+        qwen = build_ir_v8._load_builtin_template_doc("qwen3_vl_vision")
+        self.assertIsNotNone(gemma)
+        self.assertIsNotNone(qwen)
+
+        gemma_bridge = gemma["contract"]["multimodal_bridge"]
+        self.assertEqual(gemma_bridge["producer_activation"], "vision_output")
+        self.assertEqual(gemma_bridge["position_policy"], "linear")
+        self.assertEqual(gemma_bridge["decode_policy"], "non_causal_visual_chunk")
+        self.assertEqual(gemma_bridge["image_begin_marker"], "<|image>")
+        self.assertEqual(gemma_bridge["image_end_marker"], "<image|>")
+        self.assertNotIn("image_marker", gemma_bridge)
+
+        qwen_bridge = qwen["contract"]["multimodal_bridge"]
+        self.assertEqual(qwen_bridge["producer_activation"], "vision_output")
+        self.assertEqual(qwen_bridge["position_policy"], "mrope_2d")
+        self.assertEqual(qwen_bridge["decode_policy"], "causal_mixed_prefix")
+        self.assertEqual(qwen_bridge["grid_policy"], "merged_hw")
+
+    def test_gemma4_vision_patch_projection_uses_fp16_weight_kernel(self) -> None:
+        gemma = build_ir_v8._load_builtin_template_doc("gemma4_vision")
+        self.assertIsNotNone(gemma)
+        self.assertEqual(gemma["kernels"]["patch_proj"], "gemm_nt_f16")
+
+    def test_gemma4_vision_rope_theta_overrides_common_rope_default(self) -> None:
+        source = V8_BUILD_PATH.read_text(encoding="utf-8")
+        marker = 'ir_op.get("kernel", "") == "rope_forward_qk_gemma4v_vision_xy"'
+        self.assertIn(marker, source)
+        block = source[source.index(marker):source.index(marker) + 700]
+        self.assertIn('config.get("vision_rope_theta", 100.0)', block)
+        self.assertIn('params["freq_base"] = gemma4v_freq_base', block)
+        self.assertIn('params["rope_freq_base"] = gemma4v_freq_base', block)
+        self.assertNotIn('params.setdefault("freq_base"', block)
+
+    def test_gemma4_geometry_override_uses_pooled_projector_tokens(self) -> None:
+        with mock.patch.object(bridge_runner_v8, "_image_source_size", return_value=(72, 72)):
+            overrides = bridge_runner_v8._gemma4_geometry_overrides(
+                {"patch_size": 16, "spatial_merge_size": 3},
+                Path("tiny.ppm"),
+            )
+
+        self.assertEqual(overrides["image_width"], 336)
+        self.assertEqual(overrides["image_height"], 336)
+        self.assertEqual(overrides["vision_grid_w"], 21)
+        self.assertEqual(overrides["vision_grid_h"], 21)
+        self.assertEqual(overrides["vision_num_patches"], 441)
+        self.assertEqual(overrides["vision_merged_tokens"], 49)
+        self.assertEqual(overrides["merged_grid_x"], 7)
+        self.assertEqual(overrides["merged_grid_y"], 7)
+        self.assertEqual(overrides["spatial_merge_factor"], 9)
+
     def test_ck_run_v8_step_run_chat_uses_detected_default_threads(self) -> None:
         with tempfile.TemporaryDirectory(prefix="v8_step_run_chat_threads_") as tmpdir:
             tmp = Path(tmpdir)
@@ -509,6 +609,51 @@ class V8NativeBridgeHostTests(unittest.TestCase):
             segments["formatted_prompt"],
             "<|im_start|>user\n<|vision_start|><image_embeds><|vision_end|>Describe the image.<|im_end|>\n<|im_start|>assistant\n",
         )
+
+    def test_format_multimodal_prompt_segments_wraps_gemma4v_image_chunk(self) -> None:
+        template_doc = build_ir_v8._load_builtin_template_doc("gemma4")
+        self.assertIsNotNone(template_doc)
+        contract = template_doc["contract"]["chat_contract"]
+
+        segments = bridge_runner_v8._format_multimodal_prompt_segments(
+            "Explain this image.",
+            contract,
+            include_image=True,
+        )
+
+        self.assertTrue(segments["uses_image_chunks"])
+        self.assertEqual(segments["before_text"], "<bos><|turn>user\n<|image>")
+        self.assertEqual(segments["after_text"], "<image|>Explain this image.<turn|>\n<|turn>model\n")
+        self.assertEqual(
+            segments["formatted_prompt"],
+            "<bos><|turn>user\n<|image><image_embeds><image|>Explain this image.<turn|>\n<|turn>model\n",
+        )
+
+    def test_prompt_segment_encoding_does_not_add_bos_after_image(self) -> None:
+        class FakeTokenizer:
+            bos_id = 2
+
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, bool]] = []
+
+            def encode(self, text: str, add_bos: bool = True) -> list[int]:
+                self.calls.append((text, bool(add_bos)))
+                ids = [100 + len(self.calls)]
+                return ([self.bos_id] if add_bos else []) + ids
+
+        tokenizer = FakeTokenizer()
+        before = "<bos><|turn>user\n"
+        after = "Explain this image.<turn|>\n<|turn>model\n"
+        before_ids = bridge_runner_v8._encode_prompt_segment(
+            tokenizer,
+            before,
+            add_bos=not bridge_runner_v8._segment_text_has_bos_prefix(before),
+        )
+        after_ids = bridge_runner_v8._encode_prompt_segment(tokenizer, after, add_bos=False)
+
+        self.assertEqual(before_ids, [101])
+        self.assertEqual(after_ids, [102])
+        self.assertEqual(tokenizer.calls, [(before, False), (after, False)])
 
     def test_fallback_chat_contract_from_template_text_preserves_vision_markers(self) -> None:
         template = (
@@ -1201,7 +1346,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 [1, 2],
             )
 
-        self.assertEqual(used_paths, [ROOT / "decode_runtime.so"])
+        self.assertEqual(used_paths, [ROOT / "prefill_runtime.so"])
         self.assertEqual(result["runtime_mode"], "decode")
         self.assertEqual(result["vocab_size"], 4)
 

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -18535,6 +18535,112 @@
       "notes": "Build merged vision position IDs for 2D M-RoPE style encoders.",
       "name": "vision_position_ids_2d_merge",
       "_source_file": "vision_position_ids_2d_merge.json"
+    },
+    {
+      "id": "spatial_average_pool_contiguous",
+      "op": "spatial_merge",
+      "variant": "fp32_spatial_average_pool",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Token-major activation stream arranged as a dense HxW patch grid"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T/(M*M)",
+            "E"
+          ],
+          "desc": "Pooled stream formed by averaging each merge_size x merge_size patch tile"
+        }
+      ],
+      "dims": [
+        "grid_h",
+        "grid_w",
+        "embed_dim",
+        "merge_size"
+      ],
+      "impl": {
+        "function": "spatial_average_pool_contiguous",
+        "c_declaration": "void spatial_average_pool_contiguous(const float *input, float *output, int grid_h, int grid_w, int embed_dim, int merge_size);",
+        "sources": [
+          "src/kernels/vision_kernels.c"
+        ]
+      },
+      "notes": "Average-pool merge_size x merge_size spatial tiles while preserving embedding width; used by Gemma4V before the projector.",
+      "name": "spatial_average_pool_contiguous",
+      "_source_file": "spatial_average_pool_contiguous.json"
+    },
+    {
+      "id": "gemma4_vision_projector_prep_forward",
+      "op": "projector_prep",
+      "variant": "fp32_scale_unit_rmsnorm",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Pooled Gemma4V visual tokens"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Scaled and unit-RMS-normalized projector input"
+        }
+      ],
+      "dims": [
+        "tokens",
+        "dim"
+      ],
+      "params": [
+        {
+          "name": "scale",
+          "dtype": "float32",
+          "desc": "Pre-RMS scale, usually sqrt(vision_embed_dim)"
+        },
+        {
+          "name": "eps",
+          "dtype": "float32",
+          "desc": "RMSNorm epsilon"
+        }
+      ],
+      "impl": {
+        "function": "gemma4_vision_projector_prep_forward",
+        "c_declaration": "void gemma4_vision_projector_prep_forward(const float *input, float *output, int tokens, int dim, float scale, float eps);",
+        "sources": [
+          "src/kernels/vision_kernels.c"
+        ]
+      },
+      "notes": "Gemma4V projector preparation: pool output is scaled by sqrt(embed_dim), then unit-gamma RMSNorm is applied before mm.input_projection.weight.",
+      "name": "gemma4_vision_projector_prep_forward",
+      "_source_file": "gemma4_vision_projector_prep_forward.json"
     }
   ]
 }

--- a/version/v8/kernel_maps/gemm_nt_f16_clipped.json
+++ b/version/v8/kernel_maps/gemm_nt_f16_clipped.json
@@ -1,0 +1,99 @@
+{
+  "id": "gemm_nt_f16_clipped",
+  "op": "gemm",
+  "variant": "f16_w_fp32_a_fp32_out_clipped",
+  "quant": {
+    "weight": "fp16|f16",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "A",
+      "dtype": "fp32",
+      "shape": [
+        "M",
+        "K"
+      ],
+      "desc": "Activation matrix [M,K], clamped before FP16 rounding"
+    },
+    {
+      "name": "B",
+      "dtype": "fp16",
+      "shape": [
+        "N",
+        "K"
+      ],
+      "desc": "Weight matrix [N,K] FP16"
+    },
+    {
+      "name": "bias",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ],
+      "optional": true
+    },
+    {
+      "name": "input_min",
+      "dtype": "fp32",
+      "shape": [
+        1
+      ],
+      "optional": true
+    },
+    {
+      "name": "input_max",
+      "dtype": "fp32",
+      "shape": [
+        1
+      ],
+      "optional": true
+    },
+    {
+      "name": "output_min",
+      "dtype": "fp32",
+      "shape": [
+        1
+      ],
+      "optional": true
+    },
+    {
+      "name": "output_max",
+      "dtype": "fp32",
+      "shape": [
+        1
+      ],
+      "optional": true
+    }
+  ],
+  "outputs": [
+    {
+      "name": "C",
+      "dtype": "fp32",
+      "shape": [
+        "M",
+        "N"
+      ]
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "M",
+    "N",
+    "K"
+  ],
+  "impl": {
+    "function": "gemm_nt_f16_clipped",
+    "c_declaration": "void gemm_nt_f16_clipped(const float *A, const void *B, const float *bias, const float *input_min, const float *input_max, const float *output_min, const float *output_max, float *C, int M, int N, int K);",
+    "sources": [
+      "src/kernels/gemm_kernels_f16.c"
+    ]
+  },
+  "tests": {
+    "unit": [
+      "tests/test_v8_native_bridge_host.py"
+    ]
+  },
+  "notes": "Gemma4V ClippableLinear: clamp input, F16 matmul, clamp output."
+}

--- a/version/v8/kernel_maps/gemma4_vision_projector_prep_forward.json
+++ b/version/v8/kernel_maps/gemma4_vision_projector_prep_forward.json
@@ -1,0 +1,57 @@
+{
+  "id": "gemma4_vision_projector_prep_forward",
+  "op": "projector_prep",
+  "variant": "fp32_scale_unit_rmsnorm",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "input",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Pooled Gemma4V visual tokens"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Scaled and unit-RMS-normalized projector input"
+    }
+  ],
+  "dims": [
+    "tokens",
+    "dim"
+  ],
+  "params": [
+    {
+      "name": "scale",
+      "dtype": "float32",
+      "desc": "Pre-RMS scale, usually sqrt(vision_embed_dim)"
+    },
+    {
+      "name": "eps",
+      "dtype": "float32",
+      "desc": "RMSNorm epsilon"
+    }
+  ],
+  "impl": {
+    "function": "gemma4_vision_projector_prep_forward",
+    "c_declaration": "void gemma4_vision_projector_prep_forward(const float *input, float *output, int tokens, int dim, float scale, float eps);",
+    "sources": [
+      "src/kernels/vision_kernels.c"
+    ]
+  },
+  "notes": "Gemma4V projector preparation: pool output is scaled by sqrt(embed_dim), then unit-gamma RMSNorm is applied before mm.input_projection.weight.",
+  "name": "gemma4_vision_projector_prep_forward"
+}

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -2339,6 +2339,241 @@
           "source": "dim:relu2_elems"
         }
       ]
+    },
+    "spatial_average_pool_contiguous": {
+      "note": "Average-pool merge_size x merge_size spatial tiles while preserving embedding width.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
+        },
+        {
+          "name": "grid_h",
+          "source": "dim:vision_grid_h"
+        },
+        {
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "merge_size",
+          "source": "dim:merge_size"
+        }
+      ]
+    },
+    "gemma4_vision_projector_prep_forward": {
+      "note": "Gemma4V scale + unit-RMSNorm before projector.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "input",
+          "source": "activation:input"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:output"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:rows"
+        },
+        {
+          "name": "dim",
+          "source": "dim:dim"
+        },
+        {
+          "name": "scale",
+          "source": "param:scale"
+        },
+        {
+          "name": "eps",
+          "source": "param:eps"
+        }
+      ]
+    },
+    "position_embeddings_add_gemma4v_xy": {
+      "note": "Gemma4V learned 2D positional embeddings: add x-table[col] plus y-table[row] from [2, source_grid, dim].",
+      "params": [
+        {
+          "name": "x",
+          "source": "output:x",
+          "cast": "float*"
+        },
+        {
+          "name": "position_embd",
+          "source": "weight:pos_emb",
+          "cast": "const float*"
+        },
+        {
+          "name": "grid_h",
+          "source": "dim:vision_grid_h"
+        },
+        {
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "source_grid_size",
+          "source": "dim:source_grid_size"
+        }
+      ]
+    },
+    "rope_forward_qk_gemma4v_vision_xy": {
+      "note": "Gemma4V vision 2D NEOX RoPE: first half uses x patch position, second half uses y patch position.",
+      "params": [
+        {
+          "name": "q",
+          "source": "scratch:q_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "rotary_dim",
+          "source": "dim:rotary_dim"
+        },
+        {
+          "name": "freq_base",
+          "source": "dim:freq_base"
+        }
+      ]
+    },
+    "gemm_nt_f16_clipped": {
+      "note": "Gemma4V clippable FP16 dense GEMM. The alt lists select the clamp scalars matching the projection weight present on this op.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "A",
+          "source": "activation:a"
+        },
+        {
+          "name": "B",
+          "source": "weight:_first_weight"
+        },
+        {
+          "name": "bias",
+          "source": "weight_f:_bias"
+        },
+        {
+          "cast": "const float*",
+          "name": "input_min",
+          "source": "weight_f:_input_min",
+          "alt": [
+            "wq_input_min",
+            "wk_input_min",
+            "wv_input_min",
+            "wo_input_min",
+            "w1_input_min",
+            "w2_input_min",
+            "w3_input_min",
+            "mm1_w_input_min"
+          ]
+        },
+        {
+          "cast": "const float*",
+          "name": "input_max",
+          "source": "weight_f:_input_max",
+          "alt": [
+            "wq_input_max",
+            "wk_input_max",
+            "wv_input_max",
+            "wo_input_max",
+            "w1_input_max",
+            "w2_input_max",
+            "w3_input_max",
+            "mm1_w_input_max"
+          ]
+        },
+        {
+          "cast": "const float*",
+          "name": "output_min",
+          "source": "weight_f:_output_min",
+          "alt": [
+            "wq_output_min",
+            "wk_output_min",
+            "wv_output_min",
+            "wo_output_min",
+            "w1_output_min",
+            "w2_output_min",
+            "w3_output_min",
+            "mm1_w_output_min"
+          ]
+        },
+        {
+          "cast": "const float*",
+          "name": "output_max",
+          "source": "weight_f:_output_max",
+          "alt": [
+            "wq_output_max",
+            "wk_output_max",
+            "wv_output_max",
+            "wo_output_max",
+            "w1_output_max",
+            "w2_output_max",
+            "w3_output_max",
+            "mm1_w_output_max"
+          ]
+        },
+        {
+          "cast": "float*",
+          "name": "C",
+          "source": "output:c"
+        },
+        {
+          "name": "M",
+          "source": "dim:_m"
+        },
+        {
+          "name": "N",
+          "source": "dim:_output_dim"
+        },
+        {
+          "name": "K",
+          "source": "dim:_input_dim"
+        }
+      ]
     }
   }
 }

--- a/version/v8/kernel_maps/position_embeddings_add_gemma4v_xy.json
+++ b/version/v8/kernel_maps/position_embeddings_add_gemma4v_xy.json
@@ -1,0 +1,30 @@
+{
+  "id": "position_embeddings_add_gemma4v_xy",
+  "op": "position_embeddings",
+  "family": "vision",
+  "description": "Add Gemma4V learned 2D x/y positional embeddings to patch embeddings.",
+  "inputs": [
+    {
+      "name": "x",
+      "type": "float*",
+      "shape": "[grid_h*grid_w, embed_dim]"
+    },
+    {
+      "name": "position_embd",
+      "type": "const float*",
+      "shape": "[2, source_grid_size, embed_dim]"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "x",
+      "type": "float*",
+      "shape": "[grid_h*grid_w, embed_dim]"
+    }
+  ],
+  "c_function": {
+    "name": "position_embeddings_add_gemma4v_xy",
+    "header": "include/ckernel_engine.h",
+    "source": "src/kernels/vision_kernels.c"
+  }
+}

--- a/version/v8/kernel_maps/rope_forward_qk_gemma4v_vision_xy.json
+++ b/version/v8/kernel_maps/rope_forward_qk_gemma4v_vision_xy.json
@@ -1,0 +1,69 @@
+{
+  "id": "rope_forward_qk_gemma4v_vision_xy",
+  "op": "rope",
+  "variant": "fp32_head_major_gemma4v_vision_xy_neox",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ],
+      "desc": "Query tensor rotated in-place"
+    },
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "D"
+      ],
+      "desc": "Key tensor rotated in-place"
+    }
+  ],
+  "weights": [],
+  "outputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "T",
+        "D"
+      ]
+    },
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "D"
+      ]
+    }
+  ],
+  "dims": [
+    "H",
+    "KV",
+    "T",
+    "D",
+    "grid_w",
+    "rotary_dim"
+  ],
+  "impl": {
+    "function": "rope_forward_qk_gemma4v_vision_xy",
+    "c_declaration": "void rope_forward_qk_gemma4v_vision_xy(float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int grid_w, int rotary_dim, float freq_base);",
+    "sources": [
+      "src/kernels/rope_kernels.c"
+    ]
+  },
+  "notes": "Gemma4V vision tower Q/K RoPE matching llama.cpp: x-position rotation on first half of the rotary span and y-position rotation on the second half, using NEOX split-half layout inside each half."
+}

--- a/version/v8/kernel_maps/spatial_average_pool_contiguous.json
+++ b/version/v8/kernel_maps/spatial_average_pool_contiguous.json
@@ -1,0 +1,47 @@
+{
+  "id": "spatial_average_pool_contiguous",
+  "op": "spatial_merge",
+  "variant": "fp32_spatial_average_pool",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "input",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Token-major activation stream arranged as a dense HxW patch grid"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "T/(M*M)",
+        "E"
+      ],
+      "desc": "Pooled stream formed by averaging each merge_size x merge_size patch tile"
+    }
+  ],
+  "dims": [
+    "grid_h",
+    "grid_w",
+    "embed_dim",
+    "merge_size"
+  ],
+  "impl": {
+    "function": "spatial_average_pool_contiguous",
+    "c_declaration": "void spatial_average_pool_contiguous(const float *input, float *output, int grid_h, int grid_w, int embed_dim, int merge_size);",
+    "sources": [
+      "src/kernels/vision_kernels.c"
+    ]
+  },
+  "notes": "Average-pool merge_size x merge_size spatial tiles while preserving embedding width; used by Gemma4V before the projector.",
+  "name": "spatial_average_pool_contiguous"
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -769,6 +769,10 @@ OP_DATAFLOW = {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "projector_prep": {
+        "inputs": {"input": "main_stream"},
+        "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
+    },
     "branch_spatial_merge": {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "branch_stream", "dtype": "fp32"}},
@@ -2031,6 +2035,7 @@ TEMPLATE_TO_KERNEL_OP = {
     "gelu": "gelu",
     "mlp_down": "matmul",  # gemv (decode) or gemm (prefill)
     "spatial_merge": "spatial_merge",
+    "projector_prep": "projector_prep",
     "branch_spatial_merge": "spatial_merge",
     "branch_layernorm": "layernorm",
     "projector_fc1": "matmul",
@@ -4583,6 +4588,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "mlp_up": ["w3"],
         "mlp_down": ["w2"],
         "projector_fc1": ["mm0_w"],
+        "projector_prep": [],
         "projector_fc2": ["mm1_w"],
         "branch_fc1": ["branch_fc1_w"],
         "branch_fc2": ["branch_fc2_w"],
@@ -4639,6 +4645,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "silu_mul": None,
         "geglu": None,
         "spatial_merge": None,
+        "projector_prep": None,
         "branch_spatial_merge": None,
         "branch_layernorm": None,
         "projector_gelu": None,
@@ -4716,7 +4723,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         # Explicit no-weight math ops. These are real kernels, but they must not
         # flow through the header/footer weighted path below, which would invent
         # a q8_0 weight requirement and fail to bind kernels such as Gemma4 V RMSNorm.
-        if op in {"v_norm", "group_limited_topk_router", "mamba_in_proj_split"}:
+        if op in {"v_norm", "projector_prep", "group_limited_topk_router", "mamba_in_proj_split"}:
             kernel_id = find_kernel(
                 registry,
                 op=kernel_op,
@@ -6678,10 +6685,10 @@ TEMPLATE_OP_WEIGHTS = {
     "final_rmsnorm": ["final_ln_weight", "final_ln_bias"],
     "qkv_proj": ["wq", "wk", "wv", "bq", "bk", "bv"],  # QKV + optional biases (for fused kernel)
     "qkv_packed_proj": ["attn_qkv", "bqkv"],
-    "q_proj": ["wq", "bq"],  # Q projection only (when split)
+    "q_proj": ["wq", "bq", "wq_input_min", "wq_input_max", "wq_output_min", "wq_output_max"],  # Q projection only (when split)
     "q_gate_proj": ["wq", "bq"],  # Joint Q + gate projection
-    "k_proj": ["wk", "bk"],  # K projection only (when split)
-    "v_proj": ["wv", "bv"],  # V projection only (when split)
+    "k_proj": ["wk", "bk", "wk_input_min", "wk_input_max", "wk_output_min", "wk_output_max"],  # K projection only (when split)
+    "v_proj": ["wv", "bv", "wv_input_min", "wv_input_max", "wv_output_min", "wv_output_max"],  # V projection only (when split)
     "split_q_gate": [],
     "recurrent_packed_proj": ["attn_qkv", "attn_gate", "ssm_alpha", "ssm_beta"],
     "recurrent_qkv_proj": ["attn_qkv"],
@@ -6716,23 +6723,24 @@ TEMPLATE_OP_WEIGHTS = {
     "attn": [],  # No model weights
     "attn_sliding": [],  # No model weights (kernel op handles windowing)
     "attn_gate_sigmoid_mul": [],  # No model weights
-    "out_proj": ["wo", "bo"],  # Output projection + optional bias
+    "out_proj": ["wo", "bo", "wo_input_min", "wo_input_max", "wo_output_min", "wo_output_max"],  # Output projection + optional bias
     "residual_add": [],  # No model weights
     "add_stream": [],
 
     # MLP block
-    "mlp_gate_up": ["w1", "w3", "b1"],  # Gate + up projection
+    "mlp_gate_up": ["w1", "w3", "b1", "w1_input_min", "w1_input_max", "w1_output_min", "w1_output_max", "w3_input_min", "w3_input_max", "w3_output_min", "w3_output_max"],  # Gate + up projection
     "mlp_up": ["w3", "b1"],  # Plain up projection
     "silu_mul": [],  # No model weights
     "geglu": [],  # No model weights
     "gelu": [],  # No model weights
-    "mlp_down": ["w2", "b2"],  # Down projection
+    "mlp_down": ["w2", "b2", "w2_input_min", "w2_input_max", "w2_output_min", "w2_output_max"],  # Down projection
     "spatial_merge": [],
+    "projector_prep": [],
     "branch_spatial_merge": [],
     "branch_layernorm": ["branch_norm_gamma", "branch_norm_beta"],
     "projector_fc1": ["mm0_w", "mm0_b"],
     "projector_gelu": [],
-    "projector_fc2": ["mm1_w", "mm1_b"],
+    "projector_fc2": ["mm1_w", "mm1_b", "mm1_w_input_min", "mm1_w_input_max", "mm1_w_output_min", "mm1_w_output_max"],
     "branch_fc1": ["branch_fc1_w", "branch_fc1_b"],
     "branch_gelu": [],
     "branch_fc2": ["branch_fc2_w", "branch_fc2_b"],
@@ -8274,6 +8282,28 @@ def generate_ir_lower_2(
                 last_output_buffer = output_buf_name
                 current_input_buffer = output_buf_name
                 current_output_buffer = "embedded_input" if output_buf_name == "layer_input" else "layer_input"
+        elif op_type == "projector_prep":
+            input_buf_name = last_output_buffer or current_input_buffer
+            output_buf_name = "layer_input" if input_buf_name == "embedded_input" else "embedded_input"
+            src_buf = activation_buffers.get(input_buf_name)
+            dst_buf = activation_buffers.get(output_buf_name)
+            if src_buf:
+                lowered_op["activations"]["input"] = {
+                    "buffer": input_buf_name,
+                    "activation_offset": src_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {src_buf['offset']}",
+                }
+            if dst_buf:
+                lowered_op["outputs"]["output"] = {
+                    "buffer": output_buf_name,
+                    "activation_offset": dst_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {dst_buf['offset']}",
+                }
+                last_output_buffer = output_buf_name
+                current_input_buffer = output_buf_name
+                current_output_buffer = "embedded_input" if output_buf_name == "layer_input" else "layer_input"
         elif op_type == "projector_fc1":
             input_buf_name = last_output_buffer or "embedded_input"
             src_buf = activation_buffers.get(input_buf_name)
@@ -8318,7 +8348,8 @@ def generate_ir_lower_2(
             single_linear_projector = bool(config.get("single_linear_projector") or ir_op.get("params", {}).get("single_linear_projector"))
             src_buf_name = (last_output_buffer or "embedded_input") if single_linear_projector else "mlp_scratch"
             src_buf = activation_buffers.get(src_buf_name)
-            dst_buf = activation_buffers.get("embedded_input")
+            dst_buf_name = "vision_output" if "vision_output" in activation_buffers else "embedded_input"
+            dst_buf = activation_buffers.get(dst_buf_name)
             if src_buf:
                 lowered_op["activations"]["A"] = {
                     "buffer": src_buf_name,
@@ -8328,12 +8359,12 @@ def generate_ir_lower_2(
                 }
             if dst_buf:
                 lowered_op["outputs"]["C"] = {
-                    "buffer": "embedded_input",
+                    "buffer": dst_buf_name,
                     "activation_offset": dst_buf["offset"],
                     "dtype": "fp32",
                     "ptr_expr": f"activations + {dst_buf['offset']}",
                 }
-                last_output_buffer = "embedded_input"
+                last_output_buffer = dst_buf_name
         elif op_type == "logits":
             # Footer logits projection: input buffer must match kernel activation dtype.
             # - fp32 activation kernels (gemv_q8_0 / gemm_nt_q8_0) read embedded_input
@@ -8815,11 +8846,13 @@ def generate_ir_lower_2(
             "position_embeddings",
             "patch_bias_add",
             "spatial_merge",
+            "projector_prep",
             "branch_spatial_merge",
             "branch_layernorm",
             "mrope_qk",
             "projector_fc1",
             "projector_gelu",
+            "projector_prep",
             "projector_fc2",
             "branch_fc1",
             "branch_gelu",
@@ -8865,6 +8898,11 @@ def generate_ir_lower_2(
                 params.setdefault("source_grid_size", source_grid_size)
         if op_type in ("spatial_merge", "branch_spatial_merge"):
             params["merge_size"] = _required_template_int_param(params, "merge_size", config, op_type)
+        if op_type == "projector_prep":
+            params.setdefault("rows", int(config.get("vision_merged_tokens", params.get("seq_len", 0)) or 0))
+            params.setdefault("dim", int(config.get("projector_in_dim", config.get("embed_dim", 0)) or 0))
+            params.setdefault("scale", float(config.get("gemma4_vision_pool_scale", 1.0) or 1.0))
+            params.setdefault("eps", float(config.get("gemma4_vision_projector_eps", config.get("rms_eps", 1.0e-6)) or 1.0e-6))
         if op_type in ("projector_gelu", "branch_gelu"):
             merged_tokens = int(params.get("vision_merged_tokens", 0) or 0)
             hidden_dim = int(params.get("projector_hidden_dim", 0) or 0)
@@ -8893,6 +8931,14 @@ def generate_ir_lower_2(
                 "num_branch_slices",
                 _template_int_param(params, "num_branch_slices", config, int(params.get("num_deepstack_layers", 0) or 0)),
             )
+        if op_type == "rope_qk" and ir_op.get("kernel", "") == "rope_forward_qk_gemma4v_vision_xy":
+            params.setdefault("vision_grid_w", int(config.get("vision_grid_w", 0) or config.get("image_grid_w", 0) or 0))
+            if int(params.get("vision_grid_w", 0) or 0) <= 0:
+                params["vision_grid_w"] = int(max(1, round(float(config.get("vision_num_patches", 1) or 1) ** 0.5)))
+            params.setdefault("rotary_dim", int(config.get("rotary_dim", params.get("head_dim", 0)) or params.get("head_dim", 0) or 0))
+            gemma4v_freq_base = float(config.get("vision_rope_theta", 100.0) or 100.0)
+            params["freq_base"] = gemma4v_freq_base
+            params["rope_freq_base"] = gemma4v_freq_base
         if op_type == "mrope_qk" or (op_type == "rope_qk" and ir_op.get("kernel", "") == "mrope_qk_vision"):
             sections = config.get("vision_mrope_sections")
             if not isinstance(sections, list) or len(sections) != 4:
@@ -9025,7 +9071,7 @@ def generate_ir_lower_2(
             current_output_buffer = "layer_input"
         elif op_type in ("q_proj", "q_gate_proj", "split_q_gate", "split_qkv_packed", "attn_gate_sigmoid_mul", "k_proj", "v_proj", "qkv_proj", "qkv_packed_proj", "rope_qk", "mrope_qk",
                          "recurrent_qk_l2_norm",
-                         "mlp_gate_up", "mlp_up", "silu_mul", "geglu", "gelu", "mlp_down", "projector_fc1", "projector_gelu", "projector_fc2", "branch_fc1", "branch_gelu", "branch_fc2", "branch_concat", "spatial_merge", "bias_add") or \
+                         "mlp_gate_up", "mlp_up", "silu_mul", "geglu", "gelu", "mlp_down", "projector_fc1", "projector_gelu", "projector_prep", "projector_fc2", "branch_fc1", "branch_gelu", "branch_fc2", "branch_concat", "spatial_merge", "bias_add") or \
                 (ir_op.get("section", "") == "branch" and op_type == "layernorm") or \
                 (mode == "prefill" and op_type in ("attn", "attn_sliding")):
             # Ops that don't advance the token-major stream, don't ping-pong

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1172,7 +1172,12 @@ def run_pipeline(args: argparse.Namespace) -> int:
         context_len=args.context_len,
         logits_layout=args.logits_layout,
     )
-    model_c_path = step_codegen(work_dir, ir_paths, force=args.force_compile, profile=args.profile)
+    model_c_path = step_codegen(
+        work_dir,
+        ir_paths,
+        force=args.force_compile,
+        profile=getattr(args, "profile", False),
+    )
     lib_path = step_compile(model_c_path, work_dir, force=args.force_compile)
 
     if getattr(args, "sweep_kernels", False):

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -1527,7 +1527,47 @@ def emit_op(
                 f'{row_count_expr});'
             )
 
-    if op_name == "residual_add":
+    if op_name == "patchify":
+        patch_h = f"(({_hidden_arg('H')}) / ({_hidden_arg('P')}))" if _hidden_arg("H") and _hidden_arg("P") else None
+        patch_w = f"(({_hidden_arg('W')}) / ({_hidden_arg('P')}))" if _hidden_arg("W") and _hidden_arg("P") else None
+        patch_dim = _mul_expr(_hidden_arg("C"), _hidden_arg("P"), _hidden_arg("P"))
+        _emit_hidden_export(_hidden_arg("patches", "output", "out"), "vision_patchify", _mul_expr(patch_h, patch_w, patch_dim))
+    elif op_name in ("patch_proj", "patch_proj_aux"):
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        count_expr = _mul_expr(_hidden_arg("M", "rows", "tokens"), _hidden_arg("N", "out_dim", "embed_dim"))
+        label = "vision_patch_proj_aux" if op_name == "patch_proj_aux" else "vision_patch_proj"
+        _emit_hidden_export(out_expr, label, count_expr)
+        _emit_hidden_export_last_row(out_expr, label, _hidden_arg("N", "out_dim", "embed_dim"))
+    elif op_name in ("position_embeddings", "patch_bias_add", "add_stream"):
+        out_expr = _hidden_arg("x", "main_inout", "output", "out", "c", "y")
+        count_expr = _mul_expr(_hidden_arg("grid_h", "rows", "tokens"), _hidden_arg("grid_w"), _hidden_arg("embed_dim"))
+        if count_expr is None:
+            count_expr = _mul_expr(_hidden_arg("rows", "tokens", "num_tokens"), _hidden_arg("dim", "embed_dim"))
+        label = {
+            "position_embeddings": "vision_position_embeddings",
+            "patch_bias_add": "vision_patch_bias",
+            "add_stream": "vision_patch_sum",
+        }.get(op_name, op_name)
+        _emit_hidden_export(out_expr, label, count_expr)
+    elif op_name == "spatial_merge":
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        grid_h = _hidden_arg("grid_h")
+        grid_w = _hidden_arg("grid_w")
+        merge = _hidden_arg("merge_size") or "1"
+        count_expr = f"(({grid_h}) / ({merge})) * (({grid_w}) / ({merge})) * ({_hidden_arg('embed_dim')})" if grid_h and grid_w and _hidden_arg("embed_dim") else None
+        _emit_hidden_export(out_expr, "vision_spatial_merge", count_expr)
+    elif op_name == "projector_prep":
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        count_expr = _mul_expr(_hidden_arg("tokens", "rows", "M"), _hidden_arg("dim", "embed_dim", "K"))
+        _emit_hidden_export(out_expr, "vision_projector_prep", count_expr)
+        _emit_hidden_export_last_row(out_expr, "vision_projector_prep", _hidden_arg("dim", "embed_dim", "K"))
+    elif op_name in ("projector_fc1", "projector_fc2"):
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        count_expr = _mul_expr(_hidden_arg("M", "rows", "tokens"), _hidden_arg("N", "out_dim", "embed_dim"))
+        label = "vision_projector_out" if op_name == "projector_fc2" else "vision_projector_fc1"
+        _emit_hidden_export(out_expr, label, count_expr)
+        _emit_hidden_export_last_row(out_expr, label, _hidden_arg("N", "out_dim", "embed_dim"))
+    elif op_name == "residual_add":
         out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
         residual_expr = _hidden_raw(_hidden_arg("b"))
         if op_instance_idx == 0 and residual_expr:

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -727,6 +727,32 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             )
             lines.append("        }")
             lines.append("    }")
+    elif (
+        op_type in {"attn", "attn_sliding"}
+        and func in {
+            "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+            "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+        }
+    ):
+        mixed_func = "attention_forward_mixed_visual_chunk_head_major_gqa_flash_strided_gemma4"
+        mixed_args = args[:10]
+        lines.append("    if (bridge_noncausal_visual_chunk && bridge_visual_start >= 0 && bridge_visual_tokens > 0) {")
+        lines.append(f"        {mixed_func}(")
+        for i, arg in enumerate(mixed_args):
+            lines.append(f"            {arg},")
+        lines.append("            bridge_visual_start,")
+        lines.append("            bridge_visual_tokens")
+        lines.append("        );")
+        lines.append("    } else {")
+        if len(args) <= 3:
+            lines.append(f"        {func}({', '.join(args)});")
+        else:
+            lines.append(f"        {func}(")
+            for i, arg in enumerate(args):
+                comma = "," if i < len(args) - 1 else ""
+                lines.append(f"            {arg}{comma}")
+            lines.append("        );")
+        lines.append("    }")
     else:
         if len(args) <= 3:
             # Short call on one line
@@ -978,6 +1004,12 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
 
     const char *stop_env = getenv("CK_STOP_OP");
     int stop_seq = stop_env ? atoi(stop_env) : -1;
+    const char *bridge_noncausal_env = getenv("CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK");
+    int bridge_noncausal_visual_chunk = bridge_noncausal_env ? (atoi(bridge_noncausal_env) != 0) : 0;
+    const char *bridge_visual_start_env = getenv("CK_BRIDGE_VISUAL_START");
+    int bridge_visual_start = bridge_visual_start_env ? atoi(bridge_visual_start_env) : -1;
+    const char *bridge_visual_tokens_env = getenv("CK_BRIDGE_VISUAL_TOKENS");
+    int bridge_visual_tokens = bridge_visual_tokens_env ? atoi(bridge_visual_tokens_env) : 0;
     const char *debug_outproj_env = getenv("CK_V7_DEBUG_OUTPROJ_FP32");
     int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;
     const float *ck_debug_outproj_fp32_input = NULL;
@@ -1061,17 +1093,28 @@ def _find_embedding_header_op(ops: List[Dict]) -> Optional[Dict]:
 def _emit_embedding_scale_block(num_tokens_expr: str, dump: bool) -> str:
     lines: List[str] = [
         """    /* Gemma embedding contract:
-     * llama.cpp applies inp_scaled = inp_embd * sqrt(n_embd) before layer-0.
-     * Without this, residual path parity diverges at sa_out even if q/k/v look close.
+     * llama.cpp scales token embeddings by sqrt(n_embd), but raw multimodal
+     * embedding chunks are not scaled.  In the mixed bridge path, the visual
+     * segment is marked by CK_BRIDGE_VISUAL_START/TOKENS.
      */
     {
         const float emb_scale = sqrtf((float)EMBED_DIM);
         float *emb = (float*)(model->bump + A_EMBEDDED_INPUT);
-        const int n = """
+        const int rows = """
         + num_tokens_expr
-        + """ * EMBED_DIM;
-        for (int i = 0; i < n; ++i) {
-            emb[i] *= emb_scale;
+        + """;
+        const int visual_begin = (bridge_noncausal_visual_chunk && bridge_visual_start >= 0 && bridge_visual_tokens > 0)
+            ? bridge_visual_start
+            : -1;
+        const int visual_end = (visual_begin >= 0) ? (visual_begin + bridge_visual_tokens) : -1;
+        for (int row = 0; row < rows; ++row) {
+            if (visual_begin >= 0 && row >= visual_begin && row < visual_end) {
+                continue;
+            }
+            float *dst = emb + (size_t)row * (size_t)EMBED_DIM;
+            for (int i = 0; i < EMBED_DIM; ++i) {
+                dst[i] *= emb_scale;
+            }
         }
     }"""
     ]
@@ -1437,6 +1480,12 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
 
     const char *stop_env = getenv("CK_STOP_OP");
     int stop_seq = stop_env ? atoi(stop_env) : -1;
+    const char *bridge_noncausal_env = getenv("CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK");
+    int bridge_noncausal_visual_chunk = bridge_noncausal_env ? (atoi(bridge_noncausal_env) != 0) : 0;
+    const char *bridge_visual_start_env = getenv("CK_BRIDGE_VISUAL_START");
+    int bridge_visual_start = bridge_visual_start_env ? atoi(bridge_visual_start_env) : -1;
+    const char *bridge_visual_tokens_env = getenv("CK_BRIDGE_VISUAL_TOKENS");
+    int bridge_visual_tokens = bridge_visual_tokens_env ? atoi(bridge_visual_tokens_env) : 0;
     const char *debug_outproj_env = getenv("CK_V7_DEBUG_OUTPROJ_FP32");
     int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;
     const float *ck_debug_outproj_fp32_input = NULL;

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -2756,9 +2756,11 @@ def main() -> None:
             vision_grid_h = image_size // patch_size
             vision_grid_w = image_size // patch_size
             vision_num_patches = vision_grid_h * vision_grid_w
-            spatial_merge_size = 1
-            spatial_merge_factor = 1
-            vision_merged_tokens = vision_num_patches
+            spatial_merge_size = meta_int("clip.vision.spatial_merge_size") or meta_int("clip.vision.proj_scale_factor") or 3
+            spatial_merge_factor = spatial_merge_size * spatial_merge_size
+            vision_merged_tokens = (vision_grid_h // spatial_merge_size) * (vision_grid_w // spatial_merge_size)
+            vision_projector_scale = float(embed_dim) ** 0.5
+            vision_projector_eps = float(meta_float("clip.vision.attention.layer_norm_epsilon") or 1.0e-6)
             context_len = vision_num_patches
             vocab_size = 1
             num_kv_heads = num_heads
@@ -2818,9 +2820,27 @@ def main() -> None:
                 if src_name in tensors and src_name not in consumed_sources:
                     add_vision_entry(src_name, dst_name=dst_name, label=label)
 
+            def maybe_add_gemma4v_clamps(weight_src: str, dst_prefix: str) -> None:
+                if vision_arch != "gemma4_vision":
+                    return
+                if not weight_src.endswith(".weight"):
+                    return
+                clamp_suffixes = (
+                    ("input_min", "input_min"),
+                    ("input_max", "input_max"),
+                    ("output_min", "output_min"),
+                    ("output_max", "output_max"),
+                )
+                base = weight_src[:-len(".weight")]
+                for src_suffix, dst_suffix in clamp_suffixes:
+                    src = f"{base}.{src_suffix}"
+                    if src in tensors:
+                        add_vision_entry(src, dst_name=f"{dst_prefix}_{dst_suffix}", label=src)
+
             add_vision_entry("v.patch_embd.weight", label="v.patch_embd.weight")
             add_vision_entry("v.position_embd.weight", label="v.position_embd.weight")
             add_vision_entry("mm.input_projection.weight", label="mm.input_projection.weight")
+            maybe_add_gemma4v_clamps("mm.input_projection.weight", "mm1_w")
 
             quant_summary: Dict[str, Any] = {}
             quant_summary["patch_emb"] = ck_dtype_name(
@@ -2863,6 +2883,56 @@ def main() -> None:
                     (f"v.blk.{layer}.ffn_post_norm.weight", f"layer.{layer}.post_ffn_norm"),
                 ):
                     add_vision_entry(src_name, dst_name=dst_name, label=src_name)
+                    clamp_prefix = None
+                    if dst_name:
+                        if dst_name.endswith(".wq"):
+                            clamp_prefix = f"layer.{layer}.wq"
+                        elif dst_name.endswith(".wk"):
+                            clamp_prefix = f"layer.{layer}.wk"
+                        elif dst_name.endswith(".wv"):
+                            clamp_prefix = f"layer.{layer}.wv"
+                        elif dst_name.endswith(".wo"):
+                            clamp_prefix = f"layer.{layer}.wo"
+                        elif dst_name.endswith(".w1"):
+                            clamp_prefix = f"layer.{layer}.w1"
+                        elif dst_name.endswith(".w2"):
+                            clamp_prefix = f"layer.{layer}.w2"
+                        elif dst_name.endswith(".w3"):
+                            clamp_prefix = f"layer.{layer}.w3"
+                    if clamp_prefix is not None:
+                        maybe_add_gemma4v_clamps(src_name, clamp_prefix)
+
+            if vision_arch == "gemma4_vision":
+                # The Gemma4V template currently computes gate/up as one fused
+                # mlp_gate_up GEMM rooted at w1 with output_dim=2*ffn_dim. That
+                # requires w1 bytes to be immediately followed by w3 bytes in
+                # BUMP. Keep clippable-linear scalar tensors after the fused
+                # weight payload so the implicit physical packing is not broken.
+                by_name = {str(e.get("name")): e for e in vision_plan}
+                reordered: list[Dict[str, Any]] = []
+                moved: set[str] = set()
+                for entry in vision_plan:
+                    name = str(entry.get("name"))
+                    if name in moved:
+                        continue
+                    if name.endswith(".w1"):
+                        prefix = name[:-len(".w1")]
+                        reordered.append(entry)
+                        w3_name = f"{prefix}.w3"
+                        w3_entry = by_name.get(w3_name)
+                        if w3_entry is not None:
+                            reordered.append(w3_entry)
+                            moved.add(w3_name)
+                        for stem in ("w1", "w3"):
+                            for suffix in ("input_min", "input_max", "output_min", "output_max"):
+                                clamp_name = f"{prefix}.{stem}_{suffix}"
+                                clamp_entry = by_name.get(clamp_name)
+                                if clamp_entry is not None:
+                                    reordered.append(clamp_entry)
+                                    moved.add(clamp_name)
+                        continue
+                    reordered.append(entry)
+                vision_plan = reordered
 
             ignored_sources = sorted(
                 name for name in set(tensors.keys()) - consumed_sources
@@ -2882,6 +2952,15 @@ def main() -> None:
             projector_info = tensors["mm.input_projection.weight"]
             projector_in_dim = int(projector_info.ne0)
             projector_out_dim = int(projector_info.ne1)
+            position_info = tensors.get("v.position_embd.weight")
+            position_grid_size = int(position_info.ne1) if position_info is not None and len(position_info.dims) >= 2 else 0
+
+            if vision_arch == "gemma4_vision":
+                # llama.cpp Gemma4V applies inp_raw = inp_raw * 2 - 1 inside the graph.
+                # CK performs image normalization before patchify, so encode the same
+                # contract as mean/std = 0.5/0.5 for RGB inputs.
+                image_mean = [0.5, 0.5, 0.5]
+                image_std = [0.5, 0.5, 0.5]
 
             vision_config = _inject_runtime_config_defaults({
                 "model": vision_arch,
@@ -2896,11 +2975,16 @@ def main() -> None:
                 "vision_grid_h": int(vision_grid_h),
                 "vision_grid_w": int(vision_grid_w),
                 "vision_num_patches": int(vision_num_patches),
+                "position_grid_size": int(position_grid_size),
                 "image_mean": [float(v) for v in image_mean[:3]],
                 "image_std": [float(v) for v in image_std[:3]],
                 "spatial_merge_size": int(spatial_merge_size),
                 "spatial_merge_factor": int(spatial_merge_factor),
                 "vision_merged_tokens": int(vision_merged_tokens),
+                "gemma4_vision_pool_scale": float(vision_projector_scale),
+                "gemma4_vision_projector_eps": float(vision_projector_eps),
+                "rms_eps": float(vision_projector_eps),
+                "rms_norm_eps": float(vision_projector_eps),
                 "embed_dim": int(embed_dim),
                 "attn_out_dim": int(embed_dim),
                 "num_layers": int(num_layers),
@@ -2929,6 +3013,8 @@ def main() -> None:
             }, vision_arch)
 
             template_data = load_template_for_arch(vision_arch)
+            if isinstance(template_data.get("contract"), dict):
+                vision_config["contract"] = copy.deepcopy(template_data["contract"])
 
             if args.config_out:
                 os.makedirs(os.path.dirname(args.config_out) or ".", exist_ok=True)
@@ -3285,6 +3371,13 @@ def main() -> None:
             projector_hidden_dim = int(mm0.ne1)
             projector_out_dim = int(mm1.ne1)
 
+            if vision_arch == "gemma4_vision":
+                # llama.cpp Gemma4V applies inp_raw = inp_raw * 2 - 1 inside the graph.
+                # CK performs image normalization before patchify, so encode the same
+                # contract as mean/std = 0.5/0.5 for RGB inputs.
+                image_mean = [0.5, 0.5, 0.5]
+                image_std = [0.5, 0.5, 0.5]
+
             vision_config = _inject_runtime_config_defaults({
                 "model": vision_arch,
                 "arch": vision_arch,
@@ -3298,6 +3391,7 @@ def main() -> None:
                 "vision_grid_h": int(vision_grid_h),
                 "vision_grid_w": int(vision_grid_w),
                 "vision_num_patches": int(vision_num_patches),
+                "position_grid_size": int(position_grid_size),
                 "image_mean": [float(v) for v in image_mean[:3]],
                 "image_std": [float(v) for v in image_std[:3]],
                 "image_min_pixels": int(image_min_pixels),
@@ -3335,6 +3429,8 @@ def main() -> None:
             }, vision_arch)
 
             template_data = load_template_for_arch(vision_arch)
+            if isinstance(template_data.get("contract"), dict):
+                vision_config["contract"] = copy.deepcopy(template_data["contract"])
 
             if args.config_out:
                 os.makedirs(os.path.dirname(args.config_out) or ".", exist_ok=True)

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -9,6 +9,7 @@ import heapq
 import importlib.util
 import json
 import math
+import os
 import random
 import subprocess
 import sys
@@ -75,6 +76,53 @@ _CHAT_TEMPLATE_CHOICES = [
     "glm4",
     "llama",
 ]
+
+
+def _vision_bridge_contract(layout_cfg: dict[str, Any]) -> dict[str, Any]:
+    contract = layout_cfg.get("contract")
+    if isinstance(contract, dict):
+        bridge = contract.get("multimodal_bridge")
+        if isinstance(bridge, dict):
+            return bridge
+    bridge = layout_cfg.get("multimodal_bridge")
+    if isinstance(bridge, dict):
+        return bridge
+    return {}
+
+
+def _vision_prefix_position_policy(layout_cfg: dict[str, Any]) -> str:
+    """Return how visual prefix rows advance decoder text positions."""
+    bridge = _vision_bridge_contract(layout_cfg)
+    policy = str(bridge.get("position_policy") or "").strip().lower()
+    if policy:
+        return policy
+    model = str(layout_cfg.get("model", layout_cfg.get("arch", "")) or "").lower()
+    if model in {"qwen3_vl_vision", "qwen2_vl_vision"}:
+        return "mrope_2d"
+    return "linear"
+
+
+def _vision_prefix_decode_policy(layout_cfg: dict[str, Any]) -> str:
+    """Return how decoder should replay encoder-produced visual prefix rows."""
+    bridge = _vision_bridge_contract(layout_cfg)
+    policy = str(bridge.get("decode_policy") or "").strip().lower()
+    if policy:
+        return policy
+    model = str(layout_cfg.get("model", layout_cfg.get("arch", "")) or "").lower()
+    if model in {"gemma3_vision", "gemma4_vision"}:
+        return "non_causal_visual_chunk"
+    return "causal_mixed_prefix"
+
+
+def _local_prefix_text_pos_for_policy(
+    policy: str,
+    prefix_tokens: int,
+    grid_x: int,
+    grid_y: int,
+) -> int:
+    if policy == "mrope_2d" and grid_x > 0 and grid_y > 0:
+        return max(int(grid_x), int(grid_y))
+    return max(0, int(prefix_tokens))
 
 
 def _parse_activation_preference_overrides(values: list[str] | None) -> dict[str, str]:
@@ -826,6 +874,8 @@ def _runtime_fingerprint(
         "parity_dump": bool(parity_dump),
         "build_ir_script": _path_identity(SCRIPT_DIR / "build_ir_v8.py", hash_content=True),
         "codegen_script": _path_identity(SCRIPT_DIR / "codegen_v8.py", hash_content=True),
+        "codegen_prefill_script": _path_identity(SCRIPT_DIR / "codegen_prefill_v8.py", hash_content=True),
+        "bridge_script": _path_identity(SCRIPT_DIR / "run_multimodal_bridge_v8.py", hash_content=True),
     }
 
 
@@ -1139,6 +1189,24 @@ def _format_multimodal_prompt_segments(
     }
 
 
+def _segment_text_has_bos_prefix(text: str) -> bool:
+    stripped = str(text or "").lstrip()
+    return stripped.startswith(("<bos>", "<s>", "<|begin_of_text|>"))
+
+
+def _encode_prompt_segment(tokenizer: Any, text: str, *, add_bos: bool) -> list[int]:
+    if not text:
+        return []
+    try:
+        return [int(tok) for tok in tokenizer.encode(text, add_bos=bool(add_bos))]
+    except TypeError:
+        ids = [int(tok) for tok in tokenizer.encode(text)]
+        bos_id = int(getattr(tokenizer, "bos_id", -1) or -1)
+        if not add_bos and bos_id >= 0 and ids and int(ids[0]) == bos_id:
+            ids = ids[1:]
+        return ids
+
+
 def _ensure_engine_lib(openmp: bool = False) -> None:
     cmd = ["make"]
     if openmp:
@@ -1335,16 +1403,16 @@ def _resize_rgb8_bilinear(
         ]
 
     out: list[tuple[int, int, int]] = []
-    scale_x = float(src_width) / float(dst_width)
-    scale_y = float(src_height) / float(dst_height)
+    x_ratio = float(src_width - 1) / float(dst_width - 1) if dst_width > 1 else 0.0
+    y_ratio = float(src_height - 1) / float(dst_height - 1) if dst_height > 1 else 0.0
     for y in range(dst_height):
-        src_y = ((float(y) + 0.5) * scale_y) - 0.5
-        y0 = max(0, min(src_height - 1, int(math.floor(src_y))))
+        src_y = float(y) * y_ratio
+        y0 = max(0, min(src_height - 1, int(src_y)))
         y1 = max(0, min(src_height - 1, y0 + 1))
         wy = max(0.0, min(1.0, src_y - float(y0)))
         for x in range(dst_width):
-            src_x = ((float(x) + 0.5) * scale_x) - 0.5
-            x0 = max(0, min(src_width - 1, int(math.floor(src_x))))
+            src_x = float(x) * x_ratio
+            x0 = max(0, min(src_width - 1, int(src_x)))
             x1 = max(0, min(src_width - 1, x0 + 1))
             wx = max(0.0, min(1.0, src_x - float(x0)))
 
@@ -1365,7 +1433,7 @@ def _resize_rgb8_bilinear(
                 top = c00 * (1.0 - wx) + c10 * wx
                 bot = c01 * (1.0 - wx) + c11 * wx
                 value = top * (1.0 - wy) + bot * wy
-                return int(max(0, min(255, round(value))))
+                return int(max(0, min(255, value)))
 
             out.append(
                 (
@@ -1420,6 +1488,59 @@ def _qwen3vl_geometry_overrides(config: dict[str, Any], image_path: Path) -> dic
         "max_seq_len": int(vision_num_patches),
         "merged_grid_x": int(merged_grid_x),
         "merged_grid_y": int(merged_grid_y),
+        "image_source_width": int(source_width),
+        "image_source_height": int(source_height),
+    }
+
+
+def _gemma4_geometry_overrides(config: dict[str, Any], image_path: Path) -> dict[str, Any]:
+    source_width, source_height = _image_source_size(image_path)
+    patch_size = int(config.get("patch_size", 0) or 0)
+    merge_size = int(config.get("spatial_merge_size", 3) or 3)
+    if patch_size <= 0 or merge_size <= 0:
+        raise RuntimeError(f"invalid Gemma4V patch/merge config patch={patch_size} merge={merge_size}")
+
+    # llama.cpp's Gemma4V projector average-pools merge_size x merge_size patch
+    # tiles before the decoder prefix. For small images, it upsizes to satisfy
+    # the projector's minimum visual-token budget; keep the bridge geometry in
+    # the same pooled-token contract instead of exposing raw patch rows.
+    min_tokens = int(config.get("image_min_tokens", config.get("vision_min_tokens", 40)) or 40)
+    max_tokens = int(config.get("image_max_tokens", config.get("vision_max_tokens", 280)) or 280)
+    min_tokens = max(1, min_tokens)
+    max_tokens = max(min_tokens, max_tokens)
+
+    aspect = float(source_width) / max(1.0, float(source_height))
+    pooled_h = max(1, int(round(math.sqrt(float(min_tokens) / max(aspect, 1.0e-6)))))
+    pooled_w = max(1, int(math.ceil(float(min_tokens) / float(pooled_h))))
+    if pooled_w * pooled_h < min_tokens:
+        pooled_w += 1
+    while pooled_w * pooled_h > max_tokens and pooled_w > 1:
+        pooled_w -= 1
+    while pooled_w * pooled_h > max_tokens and pooled_h > 1:
+        pooled_h -= 1
+    if source_width == source_height:
+        side = max(1, int(math.ceil(math.sqrt(float(min_tokens)))))
+        pooled_w = pooled_h = side
+
+    vision_grid_w = pooled_w * merge_size
+    vision_grid_h = pooled_h * merge_size
+    image_width = vision_grid_w * patch_size
+    image_height = vision_grid_h * patch_size
+    vision_num_patches = vision_grid_w * vision_grid_h
+    vision_merged_tokens = pooled_w * pooled_h
+    return {
+        "image_width": int(image_width),
+        "image_height": int(image_height),
+        "vision_grid_w": int(vision_grid_w),
+        "vision_grid_h": int(vision_grid_h),
+        "vision_num_patches": int(vision_num_patches),
+        "vision_merged_tokens": int(vision_merged_tokens),
+        "spatial_merge_size": int(merge_size),
+        "spatial_merge_factor": int(merge_size * merge_size),
+        "context_length": int(vision_num_patches),
+        "max_seq_len": int(vision_num_patches),
+        "merged_grid_x": int(pooled_w),
+        "merged_grid_y": int(pooled_h),
         "image_source_width": int(source_width),
         "image_source_height": int(source_height),
     }
@@ -1583,12 +1704,18 @@ def _prepare_encoder_runtime(
 ) -> dict[str, Any]:
     manifest, manifest_path, bump_path, config_path = _run_converter(gguf_path, output_dir)
     config = dict(manifest.get("config", {}) or {})
-    if str(config.get("model", config.get("arch", ""))).lower() == "qwen3_vl_vision":
+    encoder_model = str(config.get("model", config.get("arch", ""))).lower()
+    if encoder_model == "qwen3_vl_vision":
         base_image = int(config.get("image_size", 0) or 0)
         config.setdefault("image_height", base_image)
         config.setdefault("image_width", base_image)
         if image_path is not None:
             config.update(_qwen3vl_geometry_overrides(config, image_path))
+    elif encoder_model == "gemma4_vision":
+        config.setdefault("spatial_merge_size", 3)
+        config.setdefault("spatial_merge_factor", int(config.get("spatial_merge_size", 3) or 3) ** 2)
+        if image_path is not None:
+            config.update(_gemma4_geometry_overrides(config, image_path))
     config = _apply_activation_preference_overrides(config, activation_overrides)
     manifest["config"] = config
     _json_write(manifest_path, manifest)
@@ -2016,6 +2143,8 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
         merge_size = int(layout_cfg.get("spatial_merge_size", 1) or 1)
         merged_grid_x = int(layout_cfg.get("merged_grid_x", 0) or 0)
         merged_grid_y = int(layout_cfg.get("merged_grid_y", 0) or 0)
+        prefix_position_policy = _vision_prefix_position_policy(layout_cfg)
+        prefix_decode_policy = _vision_prefix_decode_policy(layout_cfg)
 
         if image_path is not None:
             image_report = _load_image_file(
@@ -2072,17 +2201,25 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
         output_len = output_nbytes // ctypes.sizeof(ctypes.c_float)
         if output_ptr == 0 or output_len <= 0 or output_len % embed_dim != 0:
             raise RuntimeError(f"invalid encoder bridge output: output_len={output_len} embed_dim={embed_dim}")
+        prefix_tokens = output_len // embed_dim
+        prefix_grid_x = int(merged_grid_x or max(1, int(layout_cfg.get("vision_grid_w", 0) or 0) // max(1, merge_size)))
+        prefix_grid_y = int(merged_grid_y or max(1, int(layout_cfg.get("vision_grid_h", 0) or 0) // max(1, merge_size)))
+        local_prefix_text_pos = _local_prefix_text_pos_for_policy(
+            prefix_position_policy,
+            prefix_tokens,
+            prefix_grid_x,
+            prefix_grid_y,
+        )
         output_arr = (ctypes.c_float * output_len).from_address(output_ptr)
         return {
             "embed_dim": embed_dim,
-            "prefix_tokens": output_len // embed_dim,
+            "prefix_tokens": prefix_tokens,
             "embeddings": array("f", output_arr),
-            "prefix_grid_x": int(merged_grid_x or max(1, int(layout_cfg.get("vision_grid_w", 0) or 0) // max(1, merge_size))),
-            "prefix_grid_y": int(merged_grid_y or max(1, int(layout_cfg.get("vision_grid_h", 0) or 0) // max(1, merge_size))),
-            "prefix_text_pos": int(max(
-                int(merged_grid_x or max(1, int(layout_cfg.get("vision_grid_w", 0) or 0) // max(1, merge_size))),
-                int(merged_grid_y or max(1, int(layout_cfg.get("vision_grid_h", 0) or 0) // max(1, merge_size))),
-            )),
+            "prefix_grid_x": prefix_grid_x,
+            "prefix_grid_y": prefix_grid_y,
+            "prefix_text_pos": int(local_prefix_text_pos),
+            "prefix_position_policy": prefix_position_policy,
+            "prefix_decode_policy": prefix_decode_policy,
             "bridge_activation": bridge_name or str(bridge["fallback_buffer_name"]),
             "bridge_reason": str(bridge["reason"]),
             "image_source": str(image_report["image_source"]),
@@ -2108,6 +2245,7 @@ def _run_decoder(
     prefix_embed_dim: int | None = None,
     prefix_grid: tuple[int, int] | None = None,
     prefix_text_pos: int | None = None,
+    prefix_decode_policy: str = "causal_mixed_prefix",
     strict_parity: bool = False,
     tokenizer: GGUFTokenizer | Any | None = None,
     stop_token_ids: list[int] | None = None,
@@ -2139,6 +2277,17 @@ def _run_decoder(
         _log_progress("decoder: init done")
         if hasattr(lib, "ck_set_strict_parity"):
             lib.ck_set_strict_parity(1 if strict_parity else 0)
+        old_bridge_noncausal_env = os.environ.get("CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK")
+        old_bridge_visual_start_env = os.environ.get("CK_BRIDGE_VISUAL_START")
+        old_bridge_visual_tokens_env = os.environ.get("CK_BRIDGE_VISUAL_TOKENS")
+        if str(prefix_decode_policy or "").strip().lower() == "non_causal_visual_chunk":
+            os.environ["CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK"] = "1"
+            os.environ["CK_BRIDGE_VISUAL_START"] = str(len(tokens_before or []))
+            os.environ["CK_BRIDGE_VISUAL_TOKENS"] = str(int(prefix_tokens))
+        else:
+            os.environ.pop("CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK", None)
+            os.environ.pop("CK_BRIDGE_VISUAL_START", None)
+            os.environ.pop("CK_BRIDGE_VISUAL_TOKENS", None)
         vocab_size = int(lib.ck_model_get_vocab_size())
         if vocab_size <= 0:
             vocab_size = int(runtime["vocab_size"])
@@ -2167,7 +2316,7 @@ def _run_decoder(
             "decoder: forward_mixed start "
             f"prefix_tokens={prefix_tokens} prefix_dim={resolved_prefix_dim} "
             f"prompt_tokens_before={len(before_token_ids)} prompt_tokens_after={len(after_token_ids)} "
-            f"grid={prefix_grid}"
+            f"grid={prefix_grid} prefix_decode_policy={prefix_decode_policy}"
         )
         forward_t0 = time.perf_counter()
         if before_token_ids and hasattr(lib, "ck_model_forward_segments_grid_ex"):
@@ -2333,6 +2482,19 @@ def _run_decoder(
             "streamed_output": bool(stream_output and tokenizer is not None and max_tokens > 0),
         }
     finally:
+        if 'old_bridge_noncausal_env' in locals():
+            if old_bridge_noncausal_env is None:
+                os.environ.pop("CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK", None)
+            else:
+                os.environ["CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK"] = old_bridge_noncausal_env
+            if old_bridge_visual_start_env is None:
+                os.environ.pop("CK_BRIDGE_VISUAL_START", None)
+            else:
+                os.environ["CK_BRIDGE_VISUAL_START"] = old_bridge_visual_start_env
+            if old_bridge_visual_tokens_env is None:
+                os.environ.pop("CK_BRIDGE_VISUAL_TOKENS", None)
+            else:
+                os.environ["CK_BRIDGE_VISUAL_TOKENS"] = old_bridge_visual_tokens_env
         if hasattr(lib, "ck_set_strict_parity"):
             lib.ck_set_strict_parity(0)
         lib.ck_model_free()
@@ -2559,6 +2721,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--synthetic-prefix-tokens", type=int, default=0, help="Use zero prefix embeddings when a real encoder bridge is unavailable")
     ap.add_argument("--decoder-context-len", type=int, default=None, help="Override decoder context length; default is prompt+prefix budget with small headroom")
     ap.add_argument("--dump-prefix-f32", type=Path, default=None, help="Optional output path for resolved float32 prefix embeddings")
+    ap.add_argument("--dump-logits-f32", type=Path, default=None, help="Optional output path for first mixed-prefill logits as float32")
     ap.add_argument("--max-tokens", type=int, default=0, help="Generate up to N tokens after multimodal prefill; 0 reports first-token logits only")
     ap.add_argument("--report-top-k", "--top-k", dest="report_top_k", type=int, default=8, help="How many top logits to report in bridge_report.json")
     ap.add_argument("--print-json-report", action="store_true", help="Print the full bridge_report.json payload to stdout instead of concise operator output")
@@ -2599,8 +2762,22 @@ def main(argv: list[str] | None = None) -> int:
         thinking_mode=args.thinking_mode,
     )
     formatted_prompt = str(prompt_segments["formatted_prompt"])
-    prompt_prefix_token_ids = tokenizer.encode(str(prompt_segments["before_text"])) if str(prompt_segments["before_text"]) else []
-    token_ids = tokenizer.encode(str(prompt_segments["after_text"])) if str(prompt_segments["after_text"]) else []
+    prompt_before_text = str(prompt_segments["before_text"])
+    prompt_after_text = str(prompt_segments["after_text"])
+    before_add_bos = not _segment_text_has_bos_prefix(prompt_before_text)
+    prompt_prefix_token_ids = _encode_prompt_segment(
+        tokenizer,
+        prompt_before_text,
+        add_bos=bool(before_add_bos),
+    ) if prompt_before_text else []
+    after_add_bos = not bool(prompt_prefix_token_ids or prompt_segments["uses_image_chunks"])
+    if after_add_bos and _segment_text_has_bos_prefix(prompt_after_text):
+        after_add_bos = False
+    token_ids = _encode_prompt_segment(
+        tokenizer,
+        prompt_after_text,
+        add_bos=bool(after_add_bos),
+    ) if prompt_after_text else []
     total_text_prompt_tokens = len(prompt_prefix_token_ids) + len(token_ids)
     contract_name = str((chat_contract or {}).get("name") or "none")
     _log_progress(
@@ -2614,6 +2791,8 @@ def main(argv: list[str] | None = None) -> int:
     prefix_embeddings = array("f")
     prefix_grid: tuple[int, int] | None = None
     prefix_text_pos: int | None = None
+    prefix_position_policy = "linear" if chat_template_mode in {"gemma3", "gemma4"} else "mrope_2d"
+    prefix_decode_policy = "non_causal_visual_chunk" if chat_template_mode in {"gemma3", "gemma4"} else "causal_mixed_prefix"
     encoder_report: dict[str, Any] | None = None
     dim_mismatch: dict[str, int] | None = None
 
@@ -2672,9 +2851,19 @@ def main(argv: list[str] | None = None) -> int:
             grid_x = int(encoder_report.get("prefix_grid_x", 0) or 0)
             grid_y = int(encoder_report.get("prefix_grid_y", 0) or 0)
             if grid_x > 0 and grid_y > 0:
-                prefix_grid = (grid_x, grid_y)
+                policy = str(encoder_report.get("prefix_position_policy", prefix_position_policy) or prefix_position_policy)
+                prefix_position_policy = policy
+                prefix_decode_policy = str(encoder_report.get("prefix_decode_policy", prefix_decode_policy) or prefix_decode_policy)
+                if policy == "mrope_2d":
+                    prefix_grid = (grid_x, grid_y)
+                default_local_text_pos = _local_prefix_text_pos_for_policy(
+                    policy,
+                    prefix_tokens,
+                    grid_x,
+                    grid_y,
+                )
                 local_prefix_text_pos = int(
-                    encoder_report.get("prefix_text_pos", max(grid_x, grid_y)) or max(grid_x, grid_y)
+                    encoder_report.get("prefix_text_pos", default_local_text_pos) or default_local_text_pos
                 )
                 prefix_text_pos = len(prompt_prefix_token_ids) + local_prefix_text_pos
         else:
@@ -2691,8 +2880,15 @@ def main(argv: list[str] | None = None) -> int:
         prefix_embeddings = array("f", [0.0] * (prefix_tokens * prefix_embed_dim))
         side = int(math.isqrt(int(prefix_tokens)))
         if prefix_tokens > 0 and side > 0 and side * side == int(prefix_tokens):
-            prefix_grid = (side, side)
-            prefix_text_pos = len(prompt_prefix_token_ids) + side
+            if prefix_position_policy == "mrope_2d":
+                prefix_grid = (side, side)
+            local_prefix_text_pos = _local_prefix_text_pos_for_policy(
+                prefix_position_policy,
+                prefix_tokens,
+                side,
+                side,
+            )
+            prefix_text_pos = len(prompt_prefix_token_ids) + local_prefix_text_pos
 
     if prefix_source == "none":
         raise SystemExit(
@@ -2720,6 +2916,7 @@ def main(argv: list[str] | None = None) -> int:
         prefix_embed_dim=prefix_embed_dim,
         prefix_grid=prefix_grid,
         prefix_text_pos=prefix_text_pos,
+        prefix_decode_policy=prefix_decode_policy,
         tokenizer=tokenizer,
         stop_token_ids=list(stop_policy["stop_ids"]),
         max_tokens=max(0, int(args.max_tokens)),
@@ -2733,6 +2930,10 @@ def main(argv: list[str] | None = None) -> int:
         stream_output=bool(args.max_tokens) and not bool(args.no_stream_output),
         generation_progress_every=int(args.generation_progress_every),
     )
+    if args.dump_logits_f32 is not None:
+        args.dump_logits_f32.parent.mkdir(parents=True, exist_ok=True)
+        with args.dump_logits_f32.open("wb") as f:
+            decoder_report["logits"].tofile(f)
     _log_progress("report assembly start")
     top = _topk(decoder_report["logits"], max(1, args.report_top_k))
     top_tokens = [
@@ -2767,6 +2968,7 @@ def main(argv: list[str] | None = None) -> int:
         "prefix_grid_x": None if prefix_grid is None else int(prefix_grid[0]),
         "prefix_grid_y": None if prefix_grid is None else int(prefix_grid[1]),
         "prefix_text_pos": None if prefix_text_pos is None else int(prefix_text_pos),
+        "prefix_decode_policy": str(prefix_decode_policy),
         "prefix_dump_path": dumped_prefix_path,
         "total_prefill_tokens": len(prompt_prefix_token_ids) + prefix_tokens + len(token_ids),
         "decoder_runtime": {
@@ -2804,9 +3006,12 @@ def main(argv: list[str] | None = None) -> int:
             "prefix_grid_x": int(encoder_report.get("prefix_grid_x", 0) or 0),
             "prefix_grid_y": int(encoder_report.get("prefix_grid_y", 0) or 0),
             "prefix_text_pos": int(encoder_report.get("prefix_text_pos", 0) or 0),
+            "prefix_position_policy": str(encoder_report.get("prefix_position_policy", "") or ""),
+            "prefix_decode_policy": str(encoder_report.get("prefix_decode_policy", "") or ""),
             "activation_preference_overrides": dict(vision_activation_overrides),
         } if encoder_report is not None else None,
         "dim_mismatch": dim_mismatch,
+        "logits_dump_path": str(args.dump_logits_f32.resolve()) if args.dump_logits_f32 is not None else None,
         "top_logits": top_tokens,
         "generated_token_ids": [int(tok) for tok in decoder_report.get("generated_token_ids", [])],
         "generated_token_count": int(len(decoder_report.get("generated_token_ids", []) or [])),

--- a/version/v8/templates/gemma4.json
+++ b/version/v8/templates/gemma4.json
@@ -46,13 +46,14 @@
       "token_stop_markers": [
         "<turn|>"
       ],
-      "image_marker": "<|image|>",
       "template_markers": [
         "<|turn>",
         "<turn|>",
         "<|image|>"
       ],
-      "min_response_tokens": 8
+      "min_response_tokens": 8,
+      "image_begin_marker": "<|image>",
+      "image_end_marker": "<image|>"
     },
     "attention_contract": {
       "rope_layout": "split",
@@ -95,6 +96,10 @@
           "dim:_kv_copy_bytes"
         ]
       }
+    },
+    "multimodal_bridge": {
+      "image_begin_marker": "<|image>",
+      "image_end_marker": "<image|>"
     }
   },
   "kernels": {

--- a/version/v8/templates/gemma4_vision.json
+++ b/version/v8/templates/gemma4_vision.json
@@ -5,7 +5,7 @@
   "flags": {
     "patch_frontend": "patch_proj",
     "activation": "geglu",
-    "normalization": "layernorm",
+    "normalization": "rmsnorm",
     "projector": "single_linear"
   },
   "contract": {
@@ -16,14 +16,15 @@
       "projector": "gemma4v"
     },
     "attention_contract": {
-      "rope_layout": "none",
-      "position_encoding": "absolute_2d",
+      "rope_layout": "gemma4v_xy_neox",
+      "position_encoding": "absolute_2d_plus_qk_rope_xy",
       "kv_layout": "ephemeral_full_context",
       "attn_variant": "dense_bidirectional",
-      "causal": false
+      "causal": false,
+      "attention_scale": 1.0
     },
     "block_contract": {
-      "norm_type": "layernorm",
+      "norm_type": "rmsnorm",
       "mlp_formula": "gate_up -> geglu -> down",
       "activation": "geglu",
       "qkv_bias": false,
@@ -46,16 +47,37 @@
       "required_call_args": {
         "image_input": true
       }
+    },
+    "multimodal_bridge": {
+      "producer_activation": "vision_output",
+      "position_policy": "linear",
+      "decode_policy": "non_causal_visual_chunk",
+      "grid_policy": "pooled_hw",
+      "image_begin_marker": "<|image>",
+      "image_end_marker": "<image|>"
+    },
+    "chat_contract": {
+      "image_begin_marker": "<|image>",
+      "image_end_marker": "<image|>"
     }
   },
   "kernels": {
-    "patch_proj": "gemm_nt_fp32_exact",
-    "position_embeddings": "position_embeddings_add",
+    "patch_proj": "gemm_nt_f16",
+    "position_embeddings": "position_embeddings_add_gemma4v_xy",
     "layernorm": "layernorm_fp32_exact",
     "geglu": "geglu_forward_exact",
-    "spatial_merge": "spatial_merge_contiguous_tiled",
-    "projector_fc2": "gemm_nt_f16",
-    "attn_prefill": "attention_forward_full_head_major_gqa_ggml_strided"
+    "spatial_merge": "spatial_average_pool_contiguous",
+    "projector_prep": "gemma4_vision_projector_prep_forward",
+    "projector_fc2": "gemm_nt_f16_clipped",
+    "attn_prefill": "attention_forward_full_head_major_gqa_flash_strided_gemma4",
+    "rope_qk": "rope_forward_qk_gemma4v_vision_xy",
+    "rmsnorm": "rmsnorm_forward",
+    "q_proj": "gemm_nt_f16_clipped",
+    "k_proj": "gemm_nt_f16_clipped",
+    "v_proj": "gemm_nt_f16_clipped",
+    "out_proj": "gemm_nt_f16_clipped",
+    "mlp_gate_up": "gemm_nt_f16_clipped",
+    "mlp_down": "gemm_nt_f16_clipped"
   },
   "sequence": [
     "vision_encoder"
@@ -89,7 +111,7 @@
         "ops": [
           {
             "id": "attn_norm",
-            "op": "layernorm"
+            "op": "rmsnorm"
           },
           {
             "id": "q_proj",
@@ -104,8 +126,16 @@
             "op": "v_proj"
           },
           {
+            "id": "v_norm",
+            "op": "v_norm"
+          },
+          {
             "id": "qk_norm",
             "op": "qk_norm"
+          },
+          {
+            "id": "rope_qk",
+            "op": "rope_qk"
           },
           {
             "id": "attn",
@@ -125,7 +155,7 @@
           },
           {
             "id": "ffn_norm",
-            "op": "layernorm"
+            "op": "rmsnorm"
           },
           {
             "id": "mlp_gate_up",
@@ -156,6 +186,10 @@
           "params": {
             "merge_size_from_config": "spatial_merge_size"
           }
+        },
+        {
+          "id": "projector_prep",
+          "op": "projector_prep"
         },
         {
           "id": "projector",

--- a/version/v8/templates/qwen3_vl_vision.json
+++ b/version/v8/templates/qwen3_vl_vision.json
@@ -49,6 +49,14 @@
       "required_call_args": {
         "image_input": true
       }
+    },
+    "multimodal_bridge": {
+      "producer_activation": "vision_output",
+      "position_policy": "mrope_2d",
+      "decode_policy": "causal_mixed_prefix",
+      "grid_policy": "merged_hw",
+      "image_begin_marker": "<|vision_start|>",
+      "image_end_marker": "<|vision_end|>"
     }
   },
   "kernels": {


### PR DESCRIPTION
## Summary
- add Gemma4V bridge/runtime contract support, kernel maps, and tokenizer guardrails
- add memory-gated Gemma4V vision smoke target that skips on low-memory runners
- update v8 docs/test report/model matrix for the Gemma4V bridge path
- fix guardrails found during local validation: tolerate missing args.profile in scripted namespaces and align mixed-prefix runtime expectation with the prefill-layout runtime contract

## Validation
- .venv/bin/python -m py_compile scripts/gguf_tokenizer.py version/v8/scripts/build_ir_v8.py version/v8/scripts/codegen_core_v8.py version/v8/scripts/codegen_prefill_v8.py version/v8/scripts/convert_gguf_to_bump_v8.py version/v8/scripts/run_multimodal_bridge_v8.py version/v8/scripts/ck_run_v8.py tests/test_gguf_tokenizer.py tests/test_v8_native_bridge_host.py
- .venv/bin/python -m unittest tests.test_gguf_tokenizer tests.test_v8_native_bridge_host
- make test-v8-gemma4-vision-smoke: skipped on this laptop, 8 GiB available vs 50 GiB gate
- make test-v8-vision-kernels
- bash docs/site/build.sh
- pre-commit: v7-regression-fast passed, v8-regression-fast passed
- pre-push: build, kernel parity, v8 E2E text smoke, v8 contracts, v7 training smoke, v7/v8 fast regression, and v7 training-kernel parity all passed