### PR TITLE
feat(v8/perf): add shape-gated Q4 prefill x8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2507,6 +2507,15 @@ test-q4-q5-prefill-thread-sweep-quick: $(LIB)
 		--engine-lib build/libckernel_engine.so \
 		--json-out build/q4_q5_prefill_$${CK_Q4_Q5_SWEEP_SHAPE:-qwen35_gate_up_q4_k}_thread_sweep.json
 
+profile-v8-prefill-perf-stat: ck-cli-v8
+	@echo "Collecting safe perf stat comparison for v8 prefill (CK vs llama.cpp)..."
+	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+		$(PYTHON) $(PYTHONFLAGS) scripts/perf_stat_v8_prefill_compare.py \
+		--engine $${CK_V8_PREFILL_PERF_ENGINE:-both} \
+		--prompt $${CK_V8_PREFILL_PERF_PROMPT:-128} \
+		--decode $${CK_V8_PREFILL_PERF_DECODE:-1} \
+		--threads $${CK_NUM_THREADS:-12}
+
 test-v8-decoder-matrix: ck-cli-v8
 	@echo "Running v8 decoder matrix benchmark (CKE vs llama.cpp)..."
 	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
@@ -2617,7 +2626,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-qwen3vl-e2e-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-qwen3vl-e2e-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/benchmarks/bench_q4k_dispatch_matrix.c
+++ b/benchmarks/bench_q4k_dispatch_matrix.c
@@ -7,6 +7,7 @@
  *   - CK packed-meta M-split threadpool
  *   - CK packed-meta N-split threadpool
  *   - CK experimental packed-meta x8 N-tile threadpool
+ *   - CK experimental packed-meta x8 MxN-tile threadpool
  *   - llama.cpp test shim, when llama.cpp/libggml_kernel_test.so is available
  *
  * The llama.cpp shim currently accepts FP32 activations and quantizes them to
@@ -54,6 +55,13 @@ extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(const void *A_q8,
                                                              float *C,
                                                              int M, int N, int K,
                                                              int threads);
+extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(const void *A_q8,
+                                                            const void *B_packed_x8,
+                                                            const float *bias,
+                                                            float *C,
+                                                            int M, int N, int K,
+                                                            int tile_m,
+                                                            int threads);
 
 typedef void (*llama_gemm_q4_k_fn)(const void *, const float *, float *, int, int, int);
 
@@ -146,6 +154,7 @@ typedef struct {
     int N;
     int K;
     int threads;
+    int x8mt_tile_m;
     llama_gemm_q4_k_fn llama_fn;
 } bench_ctx_t;
 
@@ -172,6 +181,11 @@ static void call_ck_packed_nsplit(void *p) {
 static void call_ck_packed_x8_nsplit(void *p) {
     bench_ctx_t *c = (bench_ctx_t *)p;
     gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(c->A_q8, c->W_packed_x8, c->bias, c->C, c->M, c->N, c->K, c->threads);
+}
+
+static void call_ck_packed_x8_mtile(void *p) {
+    bench_ctx_t *c = (bench_ctx_t *)p;
+    gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(c->A_q8, c->W_packed_x8, c->bias, c->C, c->M, c->N, c->K, c->x8mt_tile_m, c->threads);
 }
 
 static void call_llama(void *p) {
@@ -204,6 +218,13 @@ static int parse_threads(void) {
     return n > 0 ? n : 0;
 }
 
+static int parse_env_int(const char *name, int fallback) {
+    const char *v = getenv(name);
+    if (!v || !v[0]) return fallback;
+    const int n = atoi(v);
+    return n > 0 ? n : fallback;
+}
+
 int main(int argc, char **argv) {
     int quick = 0;
     int iters = 20;
@@ -221,6 +242,7 @@ int main(int argc, char **argv) {
     ck_threadpool_t *pool = ck_threadpool_global();
     const int pool_threads = pool ? ck_threadpool_n_threads(pool) : 1;
     const int threads = parse_threads() > 0 ? parse_threads() : pool_threads;
+    const int x8mt_tile_m = parse_env_int("CK_Q4K_PACKED_META_X8MT_TILE_M", 2);
     llama_gemm_q4_k_fn llama_fn = load_llama_gemm();
 
     const shape_t quick_shapes[] = {
@@ -246,10 +268,10 @@ int main(int argc, char **argv) {
     const shape_t *shapes = quick ? quick_shapes : full_shapes;
 
     printf("Q4_K x Q8_K prefill dispatch matrix; lower ms is better\n");
-    printf("threads=%d warmup=%d iters=%d llama=%s\n", threads, warmup, iters, llama_fn ? "yes" : "no");
-    printf("%-14s %5s %6s %6s %10s %10s %10s %10s %10s %10s %8s %8s %8s %9s %9s %9s %9s\n",
-           "shape", "M", "N", "K", "serial", "pool", "packed-M", "packed-N", "packed-x8", "llama*",
-           "pool/x", "packN/x", "x8/x", "d_pool", "d_packN", "d_x8", "d_llama");
+    printf("threads=%d warmup=%d iters=%d x8mt_tile_m=%d llama=%s\n", threads, warmup, iters, x8mt_tile_m, llama_fn ? "yes" : "no");
+    printf("%-14s %5s %6s %6s %10s %10s %10s %10s %10s %10s %10s %8s %8s %8s %8s %9s %9s %9s %9s %9s\n",
+           "shape", "M", "N", "K", "serial", "pool", "packed-M", "packed-N", "packed-x8", "x8mt", "llama*",
+           "pool/x", "packN/x", "x8/x", "x8mt/x", "d_pool", "d_packN", "d_x8", "d_x8mt", "d_llama");
 
     for (int s = 0; shapes[s].name; ++s) {
         const int M = shapes[s].M;
@@ -297,6 +319,7 @@ int main(int argc, char **argv) {
             .N = N,
             .K = K,
             .threads = threads,
+            .x8mt_tile_m = x8mt_tile_m,
             .llama_fn = llama_fn,
         };
 
@@ -322,6 +345,10 @@ int main(int argc, char **argv) {
         const double t_packed_x8 = bench_ms(call_ck_packed_x8_nsplit, &ctx, warmup, iters);
         const float d_packed_x8 = max_abs_diff(C_ref, C, out_elems);
 
+        memset(C, 0, out_elems * sizeof(float));
+        const double t_packed_x8mt = bench_ms(call_ck_packed_x8_mtile, &ctx, warmup, iters);
+        const float d_packed_x8mt = max_abs_diff(C_ref, C, out_elems);
+
         double t_llama = 0.0;
         float d_llama = 0.0f;
         if (llama_fn) {
@@ -330,20 +357,22 @@ int main(int argc, char **argv) {
             d_llama = max_abs_diff(C_ref, C_llama, out_elems);
         }
 
-        printf("%-14s %5d %6d %6d %10.3f %10.3f %10.3f %10.3f %10.3f ",
-               shapes[s].name, M, N, K, t_serial, t_pool, t_packed_m, t_packed_n, t_packed_x8);
+        printf("%-14s %5d %6d %6d %10.3f %10.3f %10.3f %10.3f %10.3f %10.3f ",
+               shapes[s].name, M, N, K, t_serial, t_pool, t_packed_m, t_packed_n, t_packed_x8, t_packed_x8mt);
         if (llama_fn) {
             printf("%10.3f ", t_llama);
         } else {
             printf("%10s ", "n/a");
         }
-        printf("%8.2fx %8.2fx %8.2fx %9.2g %9.2g %9.2g %9.2g\n",
+        printf("%8.2fx %8.2fx %8.2fx %8.2fx %9.2g %9.2g %9.2g %9.2g %9.2g\n",
                t_serial / t_pool,
                t_serial / t_packed_n,
                t_serial / t_packed_x8,
+               t_serial / t_packed_x8mt,
                d_pool,
                d_packed_n,
                d_packed_x8,
+               d_packed_x8mt,
                d_llama);
 
         free(A);

--- a/benchmarks/bench_q4k_dispatch_matrix.c
+++ b/benchmarks/bench_q4k_dispatch_matrix.c
@@ -6,6 +6,7 @@
  *   - CK canonical v8 threadpool dispatch
  *   - CK packed-meta M-split threadpool
  *   - CK packed-meta N-split threadpool
+ *   - CK experimental packed-meta x8 N-tile threadpool
  *   - llama.cpp test shim, when llama.cpp/libggml_kernel_test.so is available
  *
  * The llama.cpp shim currently accepts FP32 activations and quantizes them to
@@ -32,7 +33,9 @@ extern void gemm_nt_q4_k_q8_k_parallel_dispatch(const void *A, const void *B,
                                                 const float *bias, float *C,
                                                 int M, int N, int K);
 extern size_t q4_k_packed_meta_block_size(void);
+extern size_t q4_k_packed_meta_x8_block_size(void);
 extern void pack_q4_k_to_packed_meta(const void *src, void *dst, int N, int K);
+extern void pack_q4_k_to_packed_meta_x8(const void *src, void *dst, int N, int K);
 extern void gemm_nt_q4_k_packed_meta_q8_k_threaded(const void *A_q8,
                                                    const void *B_packed,
                                                    const float *bias,
@@ -45,6 +48,12 @@ extern void gemm_nt_q4_k_packed_meta_q8_k_threaded_nsplit(const void *A_q8,
                                                           float *C,
                                                           int M, int N, int K,
                                                           int threads);
+extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(const void *A_q8,
+                                                             const void *B_packed_x8,
+                                                             const float *bias,
+                                                             float *C,
+                                                             int M, int N, int K,
+                                                             int threads);
 
 typedef void (*llama_gemm_q4_k_fn)(const void *, const float *, float *, int, int, int);
 
@@ -53,6 +62,7 @@ typedef struct {
     int M;
     int N;
     int K;
+    const char *comment;
 } shape_t;
 
 static double now_ms(void) {
@@ -128,6 +138,7 @@ typedef struct {
     const uint8_t *A_q8;
     const uint8_t *W_q4;
     const uint8_t *W_packed;
+    const uint8_t *W_packed_x8;
     const float *A_fp32;
     const float *bias;
     float *C;
@@ -156,6 +167,11 @@ static void call_ck_packed_msplit(void *p) {
 static void call_ck_packed_nsplit(void *p) {
     bench_ctx_t *c = (bench_ctx_t *)p;
     gemm_nt_q4_k_packed_meta_q8_k_threaded_nsplit(c->A_q8, c->W_packed, c->bias, c->C, c->M, c->N, c->K, c->threads);
+}
+
+static void call_ck_packed_x8_nsplit(void *p) {
+    bench_ctx_t *c = (bench_ctx_t *)p;
+    gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(c->A_q8, c->W_packed_x8, c->bias, c->C, c->M, c->N, c->K, c->threads);
 }
 
 static void call_llama(void *p) {
@@ -208,24 +224,32 @@ int main(int argc, char **argv) {
     llama_gemm_q4_k_fn llama_fn = load_llama_gemm();
 
     const shape_t quick_shapes[] = {
-        {"small", 8, 256, 256},
-        {"qwen35_down", 32, 896, 4864},
-        {"wide", 64, 1024, 2560},
-        {NULL, 0, 0, 0},
+        /* Tiny smoke shape: validates dispatch overhead and tail handling. */
+        {"small", 8, 256, 256, "tiny smoke"},
+        /* Qwen3.5/Nemotron-style compact MLP-down projection: smaller N, large K. */
+        {"qwen35_down", 32, 896, 4864, "compact down"},
+        /* Medium/wide prefill projection: enough N to expose output-tile layout wins. */
+        {"wide", 64, 1024, 2560, "medium wide"},
+        {NULL, 0, 0, 0, NULL},
     };
     const shape_t full_shapes[] = {
-        {"qwen35_qkv", 32, 1024, 1024},
-        {"qwen35_down", 32, 896, 4864},
-        {"prefill128", 128, 896, 4864},
-        {"wide_mlp", 64, 2560, 10240},
-        {NULL, 0, 0, 0},
+        /* Qwen3.5 attention projection scale: square-ish, bandwidth sensitive. */
+        {"qwen35_qkv", 32, 1024, 1024, "attention proj"},
+        /* Qwen3.5/Nemotron compact down projection: hot prefill MLP shape. */
+        {"qwen35_down", 32, 896, 4864, "compact down"},
+        /* Longer-prompt version of the compact down shape. */
+        {"prefill128", 128, 896, 4864, "long compact down"},
+        /* Wide MLP shape: stresses output tiling and thread occupancy. */
+        {"wide_mlp", 64, 2560, 10240, "wide mlp"},
+        {NULL, 0, 0, 0, NULL},
     };
     const shape_t *shapes = quick ? quick_shapes : full_shapes;
 
     printf("Q4_K x Q8_K prefill dispatch matrix; lower ms is better\n");
     printf("threads=%d warmup=%d iters=%d llama=%s\n", threads, warmup, iters, llama_fn ? "yes" : "no");
-    printf("%-14s %5s %6s %6s %10s %10s %10s %10s %10s %8s %8s %9s %9s %9s\n",
-           "shape", "M", "N", "K", "serial", "pool", "packed-M", "packed-N", "llama*", "pool/x", "packN/x", "d_pool", "d_packN", "d_llama");
+    printf("%-14s %5s %6s %6s %10s %10s %10s %10s %10s %10s %8s %8s %8s %9s %9s %9s %9s\n",
+           "shape", "M", "N", "K", "serial", "pool", "packed-M", "packed-N", "packed-x8", "llama*",
+           "pool/x", "packN/x", "x8/x", "d_pool", "d_packN", "d_x8", "d_llama");
 
     for (int s = 0; shapes[s].name; ++s) {
         const int M = shapes[s].M;
@@ -237,16 +261,18 @@ int main(int argc, char **argv) {
         const size_t q4_bytes = (size_t)N * (size_t)(K / QK_K) * sizeof(block_q4_K);
         const size_t q8_bytes = (size_t)M * (size_t)(K / QK_K) * sizeof(block_q8_K);
         const size_t packed_bytes = (size_t)N * (size_t)(K / QK_K) * q4_k_packed_meta_block_size();
+        const size_t packed_x8_bytes = (size_t)((N + 7) / 8) * (size_t)(K / QK_K) * q4_k_packed_meta_x8_block_size();
 
         float *A = (float *)malloc((size_t)M * (size_t)K * sizeof(float));
         uint8_t *A_q8 = (uint8_t *)malloc(q8_bytes);
         uint8_t *W = (uint8_t *)malloc(q4_bytes);
         uint8_t *W_packed = (uint8_t *)malloc(packed_bytes);
+        uint8_t *W_packed_x8 = (uint8_t *)malloc(packed_x8_bytes);
         float *bias = (float *)malloc((size_t)N * sizeof(float));
         float *C_ref = (float *)calloc(out_elems, sizeof(float));
         float *C = (float *)calloc(out_elems, sizeof(float));
         float *C_llama = (float *)calloc(out_elems, sizeof(float));
-        if (!A || !A_q8 || !W || !W_packed || !bias || !C_ref || !C || !C_llama) {
+        if (!A || !A_q8 || !W || !W_packed || !W_packed_x8 || !bias || !C_ref || !C || !C_llama) {
             fprintf(stderr, "allocation failed for %s\n", shapes[s].name);
             return 2;
         }
@@ -257,11 +283,13 @@ int main(int argc, char **argv) {
         fill_q4k(W, N, K);
         quantize_acts_q8k(A, A_q8, M, K);
         pack_q4_k_to_packed_meta(W, W_packed, N, K);
+        pack_q4_k_to_packed_meta_x8(W, W_packed_x8, N, K);
 
         bench_ctx_t ctx = {
             .A_q8 = A_q8,
             .W_q4 = W,
             .W_packed = W_packed,
+            .W_packed_x8 = W_packed_x8,
             .A_fp32 = A,
             .bias = bias,
             .C = C,
@@ -290,6 +318,10 @@ int main(int argc, char **argv) {
         const double t_packed_n = bench_ms(call_ck_packed_nsplit, &ctx, warmup, iters);
         const float d_packed_n = max_abs_diff(C_ref, C, out_elems);
 
+        memset(C, 0, out_elems * sizeof(float));
+        const double t_packed_x8 = bench_ms(call_ck_packed_x8_nsplit, &ctx, warmup, iters);
+        const float d_packed_x8 = max_abs_diff(C_ref, C, out_elems);
+
         double t_llama = 0.0;
         float d_llama = 0.0f;
         if (llama_fn) {
@@ -298,24 +330,27 @@ int main(int argc, char **argv) {
             d_llama = max_abs_diff(C_ref, C_llama, out_elems);
         }
 
-        printf("%-14s %5d %6d %6d %10.3f %10.3f %10.3f %10.3f ",
-               shapes[s].name, M, N, K, t_serial, t_pool, t_packed_m, t_packed_n);
+        printf("%-14s %5d %6d %6d %10.3f %10.3f %10.3f %10.3f %10.3f ",
+               shapes[s].name, M, N, K, t_serial, t_pool, t_packed_m, t_packed_n, t_packed_x8);
         if (llama_fn) {
             printf("%10.3f ", t_llama);
         } else {
             printf("%10s ", "n/a");
         }
-        printf("%8.2fx %8.2fx %9.2g %9.2g %9.2g\n",
+        printf("%8.2fx %8.2fx %8.2fx %9.2g %9.2g %9.2g %9.2g\n",
                t_serial / t_pool,
                t_serial / t_packed_n,
+               t_serial / t_packed_x8,
                d_pool,
                d_packed_n,
+               d_packed_x8,
                d_llama);
 
         free(A);
         free(A_q8);
         free(W);
         free(W_packed);
+        free(W_packed_x8);
         free(bias);
         free(C_ref);
         free(C);
@@ -324,5 +359,6 @@ int main(int argc, char **argv) {
 
     ck_threadpool_global_destroy();
     printf("\n* llama column uses the local llama.cpp parity shim and includes FP32->Q8_K activation quantization.\n");
+    printf("* shapes: small=tiny overhead smoke; qwen35_qkv=attention projection; qwen35_down/prefill128=compact MLP-down; wide/wide_mlp=wide output-tile stress.\n");
     return 0;
 }

--- a/benchmarks/compare_ck_llama_v8.py
+++ b/benchmarks/compare_ck_llama_v8.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Standardized CKE v8 vs llama.cpp benchmark runner.
+
+This runner keeps two lanes separate:
+
+* perf: fixed token IDs for CKE and llama-bench pp/tg for llama.cpp. This is
+  the kernel/runtime throughput lane.
+* prompts: fixed human prompts for output sanity. This is useful for regressions
+  in tokenization/chat/output, but it is not a strict performance comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = PROJECT_ROOT / "build" / "reports" / "v8_ck_llama_compare"
+CK_MODEL_CACHE = Path.home() / ".cache" / "ck-engine-v8" / "models"
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    key: str
+    name: str
+    quant: str
+    gguf: Path
+    ck_model: str
+
+
+MODELS: list[ModelSpec] = [
+    ModelSpec(
+        "gemma3_270m",
+        "Gemma3 270M",
+        "Q5_K_M",
+        Path.home() / ".cache/ck-engine-v8/models/unsloth--gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf",
+        "gemma-3-270m-it-Q5_K_M",
+    ),
+    ModelSpec(
+        "qwen2_05b",
+        "Qwen2 0.5B",
+        "Q4_K_M",
+        Path.home() / ".cache/ck-engine-v8/models/Qwen--Qwen2-0.5B-Instruct-GGUF/qwen2-0_5b-instruct-q4_k_m.gguf",
+        "qwen2-0_5b-instruct-q4_k_m",
+    ),
+    ModelSpec(
+        "qwen3_06b",
+        "Qwen3 0.6B",
+        "Q8_0",
+        Path.home() / ".cache/ck-engine-v8/models/Qwen--Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf",
+        "Qwen3-0.6B-Q8_0",
+    ),
+    ModelSpec(
+        "qwen35_08b",
+        "Qwen3.5 0.8B",
+        "Q4_K_M",
+        Path.home() / ".cache/ck-engine-v8/models/unsloth--Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf",
+        "unsloth--Qwen3.5-0.8B-GGUF",
+    ),
+    ModelSpec(
+        "nanbeige41_3b",
+        "Nanbeige4.1 3B",
+        "Q4_K_M",
+        Path.home() / ".cache/ck-engine-v8/models/mradermacher--Nanbeige4.1-3B-GGUF/Nanbeige4.1-3B.Q4_K_M.gguf",
+        "mradermacher--Nanbeige4.1-3B-GGUF",
+    ),
+]
+
+
+PROMPTS: dict[str, str] = {
+    "hello": "Hello! Reply with one short sentence.",
+    "c_code": "Give me an example of C code that sums an array of integers.",
+    "doc_summary": (
+        "Summarize this document in three bullet points:\n\n"
+        "C-Kernel-Engine is a CPU-only distributed inference and training engine "
+        "built from the kernel layer up. It targets sovereign AI and enterprise "
+        "deployments where GPU dependency is expensive, scarce, or operationally "
+        "risky. The runtime focuses on quantized models, agentic workloads, "
+        "long-context memory-heavy serving, and CPU-native training."
+    ),
+}
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+CK_TIMING_RE = re.compile(
+    r"prefill\s+(?P<prompt_tokens>\d+)\s+tok.*?"
+    r"(?P<prompt_ms>[0-9.]+)\s+ms\s+(?P<prompt_tok_s>[0-9.]+)\s+tok/s.*?"
+    r"decode\s+(?P<decode_tokens>\d+)\s+tok\s+"
+    r"(?P<decode_ms>[0-9.]+)\s+ms\s+(?P<decode_tok_s>[0-9.]+)\s+tok/s",
+    re.S,
+)
+LLAMA_TIMING_RE = re.compile(
+    r"prompt eval time\s*=\s*[^/]+/\s*(?P<prompt_tokens>\d+)\s+tokens\s*"
+    r"\([^,]+,\s*(?P<prompt_tok_s>[0-9.]+)\s+tokens per second\).*?"
+    r"eval time\s*=\s*[^/]+/\s*(?P<decode_tokens>\d+)\s+runs\s*"
+    r"\([^,]+,\s*(?P<decode_tok_s>[0-9.]+)\s+tokens per second\)",
+    re.S,
+)
+
+
+def run_cmd(cmd: list[str], *, env: dict[str, str] | None = None, timeout: int | None = None) -> dict[str, Any]:
+    print("+ " + " ".join(shlex.quote(part) for part in cmd), flush=True)
+    proc = subprocess.run(
+        cmd,
+        cwd=PROJECT_ROOT,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+    return {
+        "cmd": cmd,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def clean_text(text: str) -> str:
+    return ANSI_RE.sub("", text).replace("\r", "")
+
+
+def selected_models(keys: list[str]) -> list[ModelSpec]:
+    if not keys or keys == ["all"]:
+        return MODELS
+    by_key = {model.key: model for model in MODELS}
+    missing = [key for key in keys if key not in by_key]
+    if missing:
+        raise SystemExit(f"Unknown model key(s): {', '.join(missing)}")
+    return [by_key[key] for key in keys]
+
+
+def ck_runtime_args(model: ModelSpec) -> list[str]:
+    run_dir = CK_MODEL_CACHE / model.ck_model
+    lib = run_dir / "libmodel.so"
+    weights = run_dir / "weights.bump"
+    if lib.exists() and weights.exists():
+        return ["--lib", str(lib), "--weights", str(weights)]
+    return ["--model", model.ck_model]
+
+
+def parse_llama_bench(rows: list[dict[str, Any]]) -> dict[str, float]:
+    prompt = next((row for row in rows if int(row.get("n_prompt", 0)) > 0), None)
+    decode = next((row for row in rows if int(row.get("n_gen", 0)) > 0), None)
+    if not prompt or not decode:
+        raise ValueError("llama-bench JSON did not contain prompt and decode rows")
+    return {
+        "prompt_tok_s": float(prompt["avg_ts"]),
+        "decode_tok_s": float(decode["avg_ts"]),
+        "prompt_ms": float(prompt["avg_ns"]) / 1_000_000.0,
+        "decode_ms": float(decode["avg_ns"]) / 1_000_000.0,
+    }
+
+
+def parse_ck_timing(output: str) -> dict[str, float]:
+    text = clean_text(output)
+    match = CK_TIMING_RE.search(text)
+    if not match:
+        raise ValueError("CK timing line not found")
+    return {
+        "prompt_tokens": int(match.group("prompt_tokens")),
+        "decode_tokens": int(match.group("decode_tokens")),
+        "prompt_ms": float(match.group("prompt_ms")),
+        "decode_ms": float(match.group("decode_ms")),
+        "prompt_tok_s": float(match.group("prompt_tok_s")),
+        "decode_tok_s": float(match.group("decode_tok_s")),
+    }
+
+
+def parse_llama_cli_timing(output: str) -> dict[str, float] | None:
+    text = clean_text(output)
+    match = LLAMA_TIMING_RE.search(text)
+    if not match:
+        return None
+    return {
+        "prompt_tokens": int(match.group("prompt_tokens")),
+        "decode_tokens": int(match.group("decode_tokens")),
+        "prompt_tok_s": float(match.group("prompt_tok_s")),
+        "decode_tok_s": float(match.group("decode_tok_s")),
+    }
+
+
+def extract_ck_generated(stdout: str) -> str:
+    text = clean_text(stdout)
+    marker = "Type /help for commands, Ctrl+C to stop generation"
+    if marker in text:
+        text = text.split(marker, 1)[1]
+    text = re.split(r"\nprefill\s+\d+\s+tok\b", text, maxsplit=1)[0]
+    return text.strip()
+
+
+def run_perf(args: argparse.Namespace, models: list[ModelSpec]) -> list[dict[str, Any]]:
+    llama_bench = PROJECT_ROOT / "llama.cpp/build/bin/llama-bench"
+    ck_cli = PROJECT_ROOT / "build/ck-cli-v8"
+    token_csv = ",".join([str(args.prompt_token_id)] * args.prompt_tokens)
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(args.threads)
+    env["OMP_NUM_THREADS"] = str(args.omp_threads)
+
+    results: list[dict[str, Any]] = []
+    for model in models:
+        if not model.gguf.exists():
+            print(f"SKIP missing GGUF: {model.gguf}", file=sys.stderr)
+            continue
+
+        llama_cmd = [
+            str(llama_bench),
+            "-m",
+            str(model.gguf),
+            "-p",
+            str(args.prompt_tokens),
+            "-n",
+            str(args.decode_tokens),
+            "-t",
+            str(args.threads),
+            "-ngl",
+            "0",
+            "-r",
+            str(args.repetitions),
+            "-o",
+            "json",
+        ]
+        llama_run = run_cmd(llama_cmd, env=env, timeout=args.timeout)
+        if llama_run["returncode"] != 0:
+            llama_metrics = {"error": llama_run["stderr"][-2000:]}
+        else:
+            llama_metrics = parse_llama_bench(json.loads(llama_run["stdout"]))
+
+        ck_cmd = [
+            str(ck_cli),
+            *ck_runtime_args(model),
+            "--prompt-tokens",
+            token_csv,
+            "--max-tokens",
+            str(args.decode_tokens + 1),
+            "--context",
+            str(max(args.context, args.prompt_tokens + args.decode_tokens + 8)),
+            "--temperature",
+            "0",
+            "--ignore-eos",
+            "--quiet-output",
+            "--no-chat-template",
+            "--no-stream",
+            "--timing",
+        ]
+        ck_run = run_cmd(ck_cmd, env=env, timeout=args.timeout)
+        if ck_run["returncode"] != 0:
+            ck_metrics = {"error": ck_run["stderr"][-2000:]}
+        else:
+            ck_metrics = parse_ck_timing(ck_run["stdout"] + ck_run["stderr"])
+
+        entry = {
+            "model_key": model.key,
+            "model": model.name,
+            "quant": model.quant,
+            "llama": llama_metrics,
+            "cke": ck_metrics,
+        }
+        if "error" not in llama_metrics and "error" not in ck_metrics:
+            entry["ratios"] = {
+                "prompt": ck_metrics["prompt_tok_s"] / llama_metrics["prompt_tok_s"],
+                "decode": ck_metrics["decode_tok_s"] / llama_metrics["decode_tok_s"],
+            }
+        results.append(entry)
+    return results
+
+
+def run_prompts(args: argparse.Namespace, models: list[ModelSpec]) -> list[dict[str, Any]]:
+    llama_cli = PROJECT_ROOT / "llama.cpp/build/bin/llama-cli"
+    ck_cli = PROJECT_ROOT / "build/ck-cli-v8"
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(args.threads)
+    env["OMP_NUM_THREADS"] = str(args.omp_threads)
+
+    results: list[dict[str, Any]] = []
+    for model in models:
+        if not model.gguf.exists():
+            print(f"SKIP missing GGUF: {model.gguf}", file=sys.stderr)
+            continue
+        for prompt_key, prompt in PROMPTS.items():
+            ck_cmd = [
+                str(ck_cli),
+                *ck_runtime_args(model),
+                "--prompt",
+                prompt,
+                "--max-tokens",
+                str(args.prompt_max_tokens + 1),
+                "--context",
+                str(args.context),
+                "--temperature",
+                "0",
+                "--no-stream",
+                "--timing",
+            ]
+            ck_run = run_cmd(ck_cmd, env=env, timeout=args.timeout)
+            ck_text = clean_text(ck_run["stdout"] + ck_run["stderr"])
+
+            llama_result: dict[str, Any] | None = None
+            if args.prompt_engine in {"llama", "both"}:
+                llama_cmd = [
+                    str(llama_cli),
+                    "-m",
+                    str(model.gguf),
+                    "-p",
+                    prompt,
+                    "-n",
+                    str(args.prompt_max_tokens),
+                    "-c",
+                    str(args.context),
+                    "-t",
+                    str(args.threads),
+                    "-tb",
+                    str(args.threads),
+                    "-ngl",
+                    "0",
+                    "--temp",
+                    "0",
+                    "--no-display-prompt",
+                    "--no-conversation",
+                    "--no-warmup",
+                    "--simple-io",
+                    "--show-timings",
+                ]
+                llama_run = run_cmd(llama_cmd, env=env, timeout=args.prompt_timeout)
+                llama_text = clean_text(llama_run["stdout"] + llama_run["stderr"])
+                llama_result = {
+                    "returncode": llama_run["returncode"],
+                    "timing": parse_llama_cli_timing(llama_text),
+                    "output": llama_text[-6000:],
+                }
+
+            results.append(
+                {
+                    "model_key": model.key,
+                    "model": model.name,
+                    "quant": model.quant,
+                    "prompt_key": prompt_key,
+                    "prompt": prompt,
+                    "cke": {
+                        "returncode": ck_run["returncode"],
+                        "timing": parse_ck_timing(ck_text) if "prefill" in ck_text and "decode" in ck_text else None,
+                        "generated": extract_ck_generated(ck_run["stdout"]),
+                        "output": ck_text[-6000:],
+                    },
+                    "llama": llama_result,
+                }
+            )
+    return results
+
+
+def write_markdown(report: dict[str, Any], path: Path) -> None:
+    lines: list[str] = [
+        "# CKE v8 vs llama.cpp Standard Benchmark",
+        "",
+        f"Generated: `{report['generated_at']}`",
+        "",
+        "## Configuration",
+        "",
+        f"- Threads: `{report['config']['threads']}`",
+        f"- OMP threads: `{report['config']['omp_threads']}`",
+        f"- Perf prompt/decode: `{report['config']['prompt_tokens']}` / `{report['config']['decode_tokens']}`",
+                f"- Prompt max tokens: `{report['config']['prompt_max_tokens']}`",
+                "- CKE CLI receives `max_tokens + 1` because current v8 timing reports one fewer decode step than the argument.",
+                "",
+    ]
+
+    perf = report.get("perf") or []
+    if perf:
+        lines += [
+            "## Fixed-Token Perf",
+            "",
+            "| Model | Quant | llama prompt | CKE prompt | CKE/llama | llama decode | CKE decode | CKE/llama |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+        for row in perf:
+            llama = row["llama"]
+            cke = row["cke"]
+            if "error" in llama or "error" in cke:
+                lines.append(f"| {row['model']} | {row['quant']} | error | error | - | error | error | - |")
+                continue
+            ratios = row["ratios"]
+            lines.append(
+                f"| {row['model']} | {row['quant']} | "
+                f"{llama['prompt_tok_s']:.1f} tok/s | {cke['prompt_tok_s']:.1f} tok/s | {ratios['prompt']:.2f}x | "
+                f"{llama['decode_tok_s']:.1f} tok/s | {cke['decode_tok_s']:.1f} tok/s | {ratios['decode']:.2f}x |"
+            )
+        lines.append("")
+
+    prompt_runs = report.get("prompt_runs") or []
+    if prompt_runs:
+        lines += ["## Standard Prompts", ""]
+        for key, prompt in PROMPTS.items():
+            lines += [f"### `{key}`", "", "```text", prompt, "```", ""]
+        lines += ["## Prompt Output Smoke", ""]
+        for row in prompt_runs:
+            lines += [
+                f"### {row['model']} / `{row['prompt_key']}`",
+                "",
+                "**CKE tail output:**",
+                "",
+                "```text",
+                (row["cke"].get("generated") or row["cke"]["output"]).strip()[-2000:],
+                "```",
+                "",
+            ]
+            if row.get("llama") is not None:
+                lines += [
+                    "**llama.cpp tail output:**",
+                    "",
+                    "```text",
+                    row["llama"]["output"].strip()[-2000:],
+                    "```",
+                    "",
+                ]
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lane", choices=["perf", "prompts", "both"], default="both")
+    parser.add_argument("--model", action="append", default=[], help="Model key to run, or all")
+    parser.add_argument("--threads", type=int, default=12)
+    parser.add_argument("--omp-threads", type=int, default=1)
+    parser.add_argument("--prompt-tokens", type=int, default=512)
+    parser.add_argument("--decode-tokens", type=int, default=128)
+    parser.add_argument("--prompt-token-id", type=int, default=100)
+    parser.add_argument("--prompt-max-tokens", type=int, default=128)
+    parser.add_argument("--prompt-engine", choices=["cke", "llama", "both"], default="cke")
+    parser.add_argument("--prompt-timeout", type=int, default=90)
+    parser.add_argument("--context", type=int, default=1024)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--quick", action="store_true", help="Run Qwen3 only with smaller perf and prompt limits")
+    args = parser.parse_args()
+
+    if args.quick:
+        args.model = ["qwen3_06b"]
+        args.prompt_tokens = min(args.prompt_tokens, 128)
+        args.decode_tokens = min(args.decode_tokens, 32)
+        args.prompt_max_tokens = min(args.prompt_max_tokens, 24)
+        args.repetitions = 1
+
+    models = selected_models(args.model or ["all"])
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    report: dict[str, Any] = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "config": {
+            "threads": args.threads,
+            "omp_threads": args.omp_threads,
+            "prompt_tokens": args.prompt_tokens,
+            "decode_tokens": args.decode_tokens,
+            "prompt_token_id": args.prompt_token_id,
+            "prompt_max_tokens": args.prompt_max_tokens,
+            "prompt_engine": args.prompt_engine,
+            "context": args.context,
+            "repetitions": args.repetitions,
+        },
+        "models": [model.__dict__ | {"gguf": str(model.gguf)} for model in models],
+        "prompts": PROMPTS,
+    }
+    if args.lane in {"perf", "both"}:
+        report["perf"] = run_perf(args, models)
+    if args.lane in {"prompts", "both"}:
+        report["prompt_runs"] = run_prompts(args, models)
+
+    json_path = args.out_dir / "ck_llama_v8_compare.json"
+    md_path = args.out_dir / "ck_llama_v8_compare.md"
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    write_markdown(report, md_path)
+    print(f"wrote {json_path}")
+    print(f"wrote {md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/site/_pages/concepts.html
+++ b/docs/site/_pages/concepts.html
@@ -32,6 +32,8 @@
     <li><a href="#mamba2-reference">Mamba2 Reference Kernels</a></li>
     <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
+    <li><a href="#vision-patch">Vision Patch Embedding</a></li>
+    <li><a href="#vision-position">&mdash; 1D Text vs 2D Vision Position (RoPE)</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
 </ul>
 
@@ -853,6 +855,84 @@ value = x @ W_up            # The actual content
 output = gate * value       # Gate controls information flow
     </pre>
     <p>This gives the network more expressive power: it can learn to completely shut off certain dimensions for certain inputs.</p>
+</div>
+
+<hr>
+
+<h2 id="vision-patch">Vision Patch Embedding</h2>
+
+<p>Multimodal families (Qwen3-VL, Gemma4 Vision, the standalone SigLIP ViT tower) start by turning a raw image into a sequence of encoder tokens. There is no attention or MLP here yet &mdash; this is the <em>frontend</em> that the transformer body consumes. In CK-Engine these steps are concrete kernels in <code>src/kernels/vision_kernels.c</code>, not hidden preprocessing, which is what lets the vision encoder share the same lowering and memory plan as the text decoder.</p>
+
+<div class="img-container svg-viewer" data-title="Vision Patch Embedding: im2patch, projection, 2x2 spatial merge, tiled 2D position">
+    <img src="assets/concept-vision-patch-embedding.svg" alt="Vision patch embedding kernel dataflow">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">The Frontend Contract</h3>
+        <pre>
+im2patch:        [C,H,W] -> [N, C*P*P]    (N = (H/P)*(W/P))
+patch embed:     [N, C*P*P] -> [N, d]     (dual proj + stream merge + bias)
+spatial_merge_2x2: group 4 patches -> [N/4, 4*d]
++ tiled 2D pos:  position_embeddings_add_tiled_2d + 2D RoPE
+        </pre>
+        <p>Each patch is a <code>P&times;P</code> tile across all channels, flattened into one row. <code>spatial_merge_2x2</code> then groups a 2&times;2 block of patches into a single token using <code>tile_order_index_2d</code>, which is why the encoder works on a coarser grid than the raw patch grid.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why Depthwise / Why Strided</h3>
+        <p><code>im2patch</code> reads strided pixel rows directly rather than materializing reshaped copies, keeping the frontend allocation-free. The same kernels serve two merge policies:</p>
+        <ul>
+            <li><strong>Qwen3-VL:</strong> <code>spatial_merge_2x2</code> + <code>position_embeddings_add_tiled_2d</code></li>
+            <li><strong>Gemma4 Vision:</strong> <code>spatial_average_pool_contiguous</code> + <code>position_embeddings_add_gemma4v_xy</code></li>
+            <li><strong>Deepstack:</strong> <code>feature_concat</code> stitches selected layer taps before the projector footer</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <p>The patch frontend is validated as part of the <code>v8</code> Qwen3-VL encoder parity path. The remaining flagged item is the layout <code>memcpy</code> in <code>im2patch</code> (one row copy per patch row) tracked in <code>KERNEL_STATUS.md</code> for conversion to fully strided access. See the <a href="v8-vision-encoder.html">v8 Vision Encoder</a> page for the full encoder &rarr; bridge &rarr; decoder pipeline.</p>
+</div>
+
+<h3 id="vision-position">How a Patch Knows Where It Is: 1D Text vs 2D Vision RoPE</h3>
+
+<p>Your intuition is exactly right. In text, a token's "position" is a single number &mdash; its index <code>t</code> in the sequence (0, 1, 2, &hellip;). RoPE turns that index into a rotation angle and rotates every <code>(x<sub>i</sub>, x<sub>i+d/2</sub>)</code> dimension pair of Q and K by it. Because rotation is relative, attention automatically recovers "how many tokens apart" two positions are. Position lives on <strong>one line</strong>.</p>
+
+<p>An image patch has no single index that means anything &mdash; what matters is <em>where on the grid</em> it sits. So instead of one scalar, a patch token carries <strong>two</strong> coordinates: its row <code>y</code> and its column <code>x</code> on the patch grid (the grid being <code>(H/P) &times; (W/P)</code>). This is the "context is basically the row and the height/column of the i-th patch" idea you described.</p>
+
+<div class="img-container svg-viewer" data-title="Position encoding: 1D text RoPE vs 2D vision M-RoPE">
+    <img src="assets/concept-vision-position-encoding.svg" alt="Comparison of 1D text RoPE position and 2D vision patch position encoding">
+</div>
+
+<p>CK encodes this two ways at once, both grounded in <code>src/kernels/vision_kernels.c</code>:</p>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">1. Multi-section (M-)RoPE &mdash; the rotation path</h3>
+        <p>It is the <em>same</em> RoPE math, just applied to two indices. The head dimension is split into sections: one slice of dims is rotated by an angle derived from the <strong>row</strong> <code>&theta;(y)</code>, another slice by an angle derived from the <strong>column</strong> <code>&theta;(x)</code>.</p>
+        <pre>
+text   :  angle = t * base^(-2i/d)          // one index
+vision :  y-dims rotate by  y * base^(-2i/d)
+          x-dims rotate by  x * base^(-2i/d) // two indices
+        </pre>
+        <p><code>vision_position_ids_2d_merge</code> builds the position buffer as four flattened streams <code>[y | x | y | x]</code>, emitted in the same 2&times;2 merged-tile order the patches use, so a token's coordinates line up with its embedding row. After rotation, attention can recover both vertical and horizontal distance between patches &mdash; true 2D relative position.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">2. Learned 2D position table &mdash; the additive path</h3>
+        <p>On top of (or instead of) rotation, vision encoders also keep a <strong>learned</strong> position embedding table indexed by grid cell &mdash; the direct analogue of GPT-2's learned 1D positional embedding, but 2D.</p>
+        <p><code>position_embeddings_add_tiled_2d</code> takes a table trained at a fixed <code>source_grid &times; source_grid</code> resolution and <strong>bilinearly interpolates</strong> it to whatever grid the current image actually produced, then adds it row-by-row. That is what lets one trained table serve images of different sizes.</p>
+        <p style="margin-bottom:0;">Gemma4 vision uses the XY variant <code>position_embeddings_add_gemma4v_xy</code>, which adds separate per-row and per-column components instead of a single interpolated grid.</p>
+    </div>
+</div>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The one-line summary</strong><br>
+        Text RoPE answers &ldquo;how far along the sequence?&rdquo; with one index. Vision M-RoPE answers &ldquo;which row and which column?&rdquo; with two &mdash; same rotation trick, applied to a 2D grid coordinate, with an interpolatable learned table layered on top.
+    </div>
 </div>
 
 <hr>

--- a/docs/site/_pages/deltanet-deep-dive.html
+++ b/docs/site/_pages/deltanet-deep-dive.html
@@ -520,6 +520,497 @@
     </div>
 </div>
 
+<!-- ═══════════════════════════════════════════════════════════════════
+     SECTION 8: DeltaNet vs SSM (Mamba)
+     ═══════════════════════════════════════════════════════════════════ -->
+
+<h2>DeltaNet vs SSM (Mamba): Two Paths Beyond Attention</h2>
+
+<p>Both DeltaNet and Mamba-style SSMs solve the same fundamental problem: <strong>constant-cost per-token inference without a growing KV-cache</strong>. But they arrive at that solution through entirely different mathematical paths. C-Kernel-Engine implements both — <code>deltanet_kernels.c</code> (767 lines) and <code>ssm_kernels.c</code> (143 lines) — which gives us a concrete basis for comparison.</p>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Kernel Sources</strong><br>
+        DeltaNet: <code>src/kernels/deltanet_kernels.c</code> — Gated delta rule with AVX/AVX2/AVX-512<br>
+        SSM: <code>src/kernels/ssm_kernels.c</code> — Causal depthwise conv1d for Mamba-style layers<br>
+        Supporting: <code>recurrent_state_kernels.c</code>, <code>recurrent_gate_kernels.c</code>, <code>recurrent_norm_kernels.c</code>
+    </div>
+</div>
+
+<h3>The Core Difference</h3>
+
+<p>The difference is best understood as <em>what the state represents</em> and <em>how it gets updated</em>:</p>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3>DeltaNet: Corrective Associative Memory</h3>
+        <p>The state is a <strong>d×d matrix</strong> — a learned key-value associative memory. Each step:</p>
+        <ol>
+            <li>Probe the memory: <code>kv_mem = Sᵀ · k̂</code></li>
+            <li>Compute the error: <code>δ = β_s · (v − kv_mem)</code></li>
+            <li>Write the correction: <code>S += outer(k̂, δ)</code></li>
+        </ol>
+        <p>The state is <em>repaired</em> at every step. Information that is already correct costs nothing to maintain. Only errors drive updates.</p>
+    </div>
+    <div class="card">
+        <h3>SSM (Mamba): Input-Dependent Linear Recurrence</h3>
+        <p>The state is a <strong>d-dimensional hidden vector</strong>. Each step:</p>
+        <ol>
+            <li>Decay: <code>h_t = A_t · h_{t-1}</code></li>
+            <li>Inject: <code>h_t += B_t · x_t</code></li>
+            <li>Read: <code>y_t = C_t · h_t</code></li>
+        </ol>
+        <p>The state is a <em>linear dynamical system</em>. Information decays continuously via A_t. New inputs are injected via B_t. The output is a learned projection C_t.</p>
+    </div>
+</div>
+
+<h3>Mathematical Comparison</h3>
+
+<div class="card">
+<pre><code>═══════════════════════════════════════════════════════════════
+GATED DELTANET (per head, per token)
+═══════════════════════════════════════════════════════════════
+State:    S ∈ ℝ^{d × d}     (matrix — stores key-value associations)
+Decay:    S ← exp(g) · S     (element-wise scalar decay)
+Retrieve: kv_mem = Sᵀ · k̂    (what does memory say for this key?)
+Error:    δ = σ(β) · (v − kv_mem)  (correction signal)
+Update:   S ← S + outer(k̂, δ)     (rank-1 write)
+Output:   out = Sᵀ · q̂             (read with query)
+
+Total per step:  O(d²)  — dominated by state matrix operations
+
+═══════════════════════════════════════════════════════════════
+MAMBA-2 SSM (per channel, per token)
+═══════════════════════════════════════════════════════════════
+State:    h ∈ ℝ^d            (vector — linear dynamical system)
+Decay:    h ← A_t · h        (input-selective diagonal decay)
+Inject:   h ← h + B_t · x_t  (input-selective injection)
+Output:   y_t = C_t · h       (input-selective readout)
+
+Conv:     Pre-SSM depthwise conv1d with learned kernel
+
+Total per step:  O(d) for the recurrence + O(k·d) for conv1d
+
+═══════════════════════════════════════════════════════════════
+KEY DISTINCTION
+═══════════════════════════════════════════════════════════════
+DeltaNet writes CORRECTIONS. It asks "what is wrong with my memory?"
+SSM writes INPUTS. It asks "what should I add to my state?"
+
+DeltaNet has d² state. SSM has d state.
+DeltaNet has one update rule. SSM has conv1d + recurrence.</code></pre>
+</div>
+
+<h3>Comparison Table</h3>
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Gated DeltaNet</th>
+            <th>Mamba-2 SSM</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><strong>State shape</strong></td>
+            <td>Matrix: d × d per head</td>
+            <td>Vector: d per channel</td>
+        </tr>
+        <tr>
+            <td><strong>State size (typical)</strong></td>
+            <td>128² × 4B = 64 KB/head</td>
+            <td>~16–64 × 4B = 64–256 B/channel</td>
+        </tr>
+        <tr>
+            <td><strong>Update rule</strong></td>
+            <td>Delta rule: write the error</td>
+            <td>Linear recurrence: decay + inject</td>
+        </tr>
+        <tr>
+            <td><strong>Selectivity</strong></td>
+            <td>β gate (how much to correct) + g gate (how much to forget)</td>
+            <td>A, B, C are all input-dependent (selective scan)</td>
+        </tr>
+        <tr>
+            <td><strong>Pre-processing</strong></td>
+            <td>L2 normalization of q, k</td>
+            <td>Depthwise conv1d (short kernel, typically k=4)</td>
+        </tr>
+        <tr>
+            <td><strong>Compute per token</strong></td>
+            <td>O(d²) — state matrix sweep</td>
+            <td>O(k·d) conv + O(d) recurrence</td>
+        </tr>
+        <tr>
+            <td><strong>Memory per head/layer</strong></td>
+            <td>O(d²) — can be large for high-d</td>
+            <td>O(d + k) — very compact</td>
+        </tr>
+        <tr>
+            <td><strong>Prefill strategy</strong></td>
+            <td>Chunked: process T tokens in chunks, update S incrementally</td>
+            <td>Parallel scan (associative scan over the recurrence)</td>
+        </tr>
+        <tr>
+            <td><strong>What it resembles</strong></td>
+            <td>Adaptive filter / Hopfield network</td>
+            <td>Control-theory state observer / IIR filter</td>
+        </tr>
+        <tr>
+            <td><strong>Strength</strong></td>
+            <td>Precise associative recall from compressed memory</td>
+            <td>Fast streaming, efficient long-range dependency modeling</td>
+        </tr>
+        <tr>
+            <td><strong>Weakness</strong></td>
+            <td>d² cost limits head dimension; rank-1 updates can collide</td>
+            <td>Diagonal A limits expressive capacity per step</td>
+        </tr>
+        <tr>
+            <td><strong>Used by</strong></td>
+            <td>Qwen3.5 / qwen3next (recurrent layers)</td>
+            <td>Nemotron 3, Mamba, Mamba-2, Jamba</td>
+        </tr>
+    </tbody>
+</table>
+
+<h3>The Kernel Engineer's View</h3>
+
+<p>From an implementation standpoint, these two families have very different performance profiles:</p>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3>DeltaNet Kernel Profile</h3>
+        <ul>
+            <li><strong>Compute-bound</strong> for large state_dim (d ≥ 128)</li>
+            <li>The state sweep is a dense d×d matrix operation — perfect for SIMD</li>
+            <li>AVX-512 gives 16 floats/iter → the inner loop is tight</li>
+            <li>The outer product <code>outer(k̂, δ)</code> is a rank-1 update — maps to FMA chains</li>
+            <li>Memory layout: state is row-major [d×d], vector ops stride by d</li>
+            <li>767 lines in CK-Engine with 4 ISA tiers (ref/avx/avx2/avx512)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3>SSM Conv1d Kernel Profile</h3>
+        <ul>
+            <li><strong>Memory-bandwidth-bound</strong> for typical kernel sizes (k=4)</li>
+            <li>Depthwise conv1d: each channel has its own tiny filter</li>
+            <li>Very little arithmetic intensity — just k multiplies per output</li>
+            <li>Benefits from prefetch and streaming access patterns</li>
+            <li>Memory layout: [num_seqs × num_channels × (history + tokens)]</li>
+            <li>143 lines in CK-Engine — the simplicity is the point</li>
+        </ul>
+    </div>
+</div>
+
+<h3>Why Hybrid Architectures Use Both (or One + Attention)</h3>
+
+<p>Neither DeltaNet nor SSM can fully replace attention. Each trades exact token-by-token recall for efficiency. Modern architectures solve this by interleaving:</p>
+
+<div class="card">
+<pre><code>Qwen3.5 strategy:
+  Layer 0: DeltaNet (recurrent)
+  Layer 1: DeltaNet (recurrent)
+  Layer 2: DeltaNet (recurrent)
+  Layer 3: Full Attention        ← exact recall every 4th layer
+  Layer 4: DeltaNet (recurrent)
+  ...
+
+Nemotron 3 strategy:
+  Layer 0: Mamba-2 SSM
+  Layer 1: Mamba-2 SSM
+  Layer 2: Mamba-2 SSM
+  Layer 3: Full Attention        ← similar interleaving
+  Layer 4: Mamba-2 SSM
+  ...
+
+Both keep ~75% of layers as constant-cost recurrent.
+The remaining ~25% attention layers handle precise retrieval.</code></pre>
+</div>
+
+<p>The <em>hypothesis</em> behind both approaches: most tokens in a long context only need approximate memory (streaming summary), but some tokens need exact recall (names, numbers, specific facts). The hybrid gives you both.</p>
+
+<h3>SSM Kernel Internals — The Conv1d Path</h3>
+
+<p>The SSM kernel in CK-Engine implements the <em>causal depthwise convolution</em> that precedes the SSM recurrence in Mamba-style models. This is not the full Mamba forward pass — it is the conv1d stage that prepares inputs for the selective scan.</p>
+
+<div class="card">
+<pre><code>// ssm_kernels.c — forward pass structure
+
+void ssm_conv1d_forward_ref(
+    const float *conv_x,     // [num_seqs, num_channels, kernel_size-1 + num_tokens]
+    const float *kernel,     // [num_channels, kernel_size]
+    float *out,              // [num_seqs, num_tokens, num_channels]
+    int kernel_size,         // typically 4
+    int num_channels,        // model dim / num_heads
+    int num_tokens,          // sequence length
+    int num_seqs             // batch
+)
+
+// For each (seq, token, channel):
+//   out[seq][tok][ch] = dot(conv_x[seq][ch][tok : tok+kernel_size], kernel[ch][:])
+//
+// This is a depthwise (channel-independent) causal convolution.
+// Each channel has its own learned kernel of size k (typically 4).
+// The conv_x buffer carries history from previous chunks (kernel_size-1 slots).</code></pre>
+</div>
+
+<p>The <code>recurrent_state_kernels.c</code> file handles the <em>state management pipeline</em> — copying history into the conv buffer, appending new q/k/v tokens, and extracting the updated state for the next chunk:</p>
+
+<div class="card">
+<pre><code>// recurrent_state_kernels.c — state pipeline
+
+void recurrent_conv_state_update_forward(
+    const float *state_in,   // previous history [num_seqs × channels × history_len]
+    const float *q, *k, *v,  // new token projections
+    float *conv_x,           // assembled conv buffer [num_seqs × channels × total_len]
+    float *state_out,        // updated history for next call
+    int history_len,         // kernel_size - 1
+    int num_seqs, num_tokens,
+    int q_dim, k_dim, v_dim
+)
+
+// Step 1: Copy old history into conv buffer positions [0 : history_len]
+// Step 2: Append new tokens into positions [history_len : history_len + num_tokens]
+// Step 3: Extract updated history (last history_len positions) → state_out
+//
+// This is the "shift register" that feeds the causal conv1d kernel.</code></pre>
+</div>
+
+<p>The diagram below shows what <code>ssm_conv1d_forward_ref</code> actually computes: a per-channel sliding window of width <code>kernel_size</code> walks across the token axis, and each output is a dot product against that channel's own learned kernel. Because every channel uses its own filter and never mixes with neighbours, it is a <em>depthwise</em> convolution — cheap, embarrassingly parallel across channels, and causal by construction.</p>
+
+<div style="overflow-x:auto; margin:1.5rem 0;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 380" style="max-width:1000px;width:100%;height:auto;font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <marker id="ssm-a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#0891b2"/>
+    </marker>
+    <style>
+      .ssm-t{fill:#f5f5f5;font-size:15px;font-weight:700;}
+      .ssm-s{fill:#b0b0b0;font-size:12px;font-family:'JetBrains Mono',monospace;}
+      .ssm-lab{fill:#9aa7b4;font-size:12px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;}
+    </style>
+  </defs>
+
+  <text x="20" y="30" class="ssm-lab">conv_x[seq, ch, ·]  — history + tokens</text>
+
+  <!-- history cells -->
+  <g>
+    <rect x="20"  y="46" width="48" height="48" rx="6" fill="rgba(148,163,184,0.12)" stroke="#5a6b78" stroke-width="1.3"/>
+    <rect x="68"  y="46" width="48" height="48" rx="6" fill="rgba(148,163,184,0.12)" stroke="#5a6b78" stroke-width="1.3"/>
+    <rect x="116" y="46" width="48" height="48" rx="6" fill="rgba(148,163,184,0.12)" stroke="#5a6b78" stroke-width="1.3"/>
+    <text x="92" y="118" text-anchor="middle" class="ssm-s" fill="#7f8c99">history (k−1)</text>
+    <!-- new tokens -->
+    <rect x="164" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="212" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="260" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="308" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="356" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <text x="84"  y="76" text-anchor="middle" class="ssm-s">h₋₂</text>
+    <text x="92"  y="76" text-anchor="middle" class="ssm-s"></text>
+    <text x="188" y="76" text-anchor="middle" class="ssm-s">x₀</text>
+    <text x="236" y="76" text-anchor="middle" class="ssm-s">x₁</text>
+    <text x="284" y="76" text-anchor="middle" class="ssm-s">x₂</text>
+    <text x="332" y="76" text-anchor="middle" class="ssm-s">x₃</text>
+    <text x="380" y="76" text-anchor="middle" class="ssm-s">x₄</text>
+    <text x="262" y="118" text-anchor="middle" class="ssm-s" fill="#7fd8e6">new tokens (num_tokens)</text>
+  </g>
+
+  <!-- sliding window highlight for token x2 -->
+  <rect x="164" y="40" width="192" height="60" rx="8" fill="none" stroke="#ffb400" stroke-width="2.6"/>
+  <text x="260" y="36" text-anchor="middle" class="ssm-s" fill="#ffb400">window for out[x₂] = 4 taps</text>
+
+  <!-- kernel -->
+  <text x="560" y="30" class="ssm-lab">kernel[ch, :]  — per-channel filter</text>
+  <g>
+    <rect x="560" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <rect x="602" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <rect x="644" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <rect x="686" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <text x="581" y="76" text-anchor="middle" class="ssm-s">w₀</text>
+    <text x="623" y="76" text-anchor="middle" class="ssm-s">w₁</text>
+    <text x="665" y="76" text-anchor="middle" class="ssm-s">w₂</text>
+    <text x="707" y="76" text-anchor="middle" class="ssm-s">w₃</text>
+    <text x="644" y="118" text-anchor="middle" class="ssm-s" fill="#ffce5a">kernel_size = 4</text>
+  </g>
+
+  <!-- dot product node -->
+  <circle cx="500" cy="200" r="34" fill="rgba(6,182,212,0.16)" stroke="#06b6d4" stroke-width="2"/>
+  <text x="500" y="198" text-anchor="middle" class="ssm-t" font-size="20">Σ</text>
+  <text x="500" y="216" text-anchor="middle" class="ssm-s" fill="#7fd8e6">dot</text>
+
+  <path d="M260,100 C320,150 420,170 470,186" fill="none" stroke="#0891b2" stroke-width="1.6" marker-end="url(#ssm-a)"/>
+  <path d="M644,100 C600,150 560,170 530,186" fill="none" stroke="#0891b2" stroke-width="1.6" marker-end="url(#ssm-a)"/>
+
+  <!-- output -->
+  <rect x="430" y="278" width="140" height="56" rx="10" fill="#2f2f2f" stroke="#06b6d4" stroke-width="1.6"/>
+  <text x="500" y="304" text-anchor="middle" class="ssm-t" font-size="14">out[seq, x₂, ch]</text>
+  <text x="500" y="324" text-anchor="middle" class="ssm-s" fill="#7fd8e6">one scalar / channel</text>
+  <path d="M500,234 L500,276" fill="none" stroke="#0891b2" stroke-width="1.8" marker-end="url(#ssm-a)"/>
+
+  <!-- depthwise note -->
+  <text x="760" y="200" class="ssm-lab">depthwise</text>
+  <text x="760" y="224" class="ssm-s" fill="#b0b0b0">channel c uses only</text>
+  <text x="760" y="242" class="ssm-s" fill="#b0b0b0">kernel[c] — no cross-</text>
+  <text x="760" y="260" class="ssm-s" fill="#b0b0b0">channel mixing.</text>
+  <text x="760" y="288" class="ssm-s" fill="#7f8c99">Output then feeds the</text>
+  <text x="760" y="306" class="ssm-s" fill="#7f8c99">selective scan recurrence.</text>
+</svg>
+</div>
+
+<h3>The Fundamental Analogy</h3>
+
+<div style="overflow-x:auto; margin:2rem 0;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 440" style="max-width:1000px; width:100%; height:auto; font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <linearGradient id="gDeltaGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#d97706"/>
+    </linearGradient>
+    <linearGradient id="gSSMGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="gAttnGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1000" height="440" rx="12" fill="#1e1e2e"/>
+  <rect x="1" y="1" width="998" height="438" rx="11" fill="none" stroke="#334155" stroke-width="1"/>
+
+  <text x="500" y="35" text-anchor="middle" font-size="16" font-weight="700" fill="#f5f5f5" letter-spacing="1">THREE MEMORY PARADIGMS</text>
+
+  <!-- Attention column -->
+  <rect x="30" y="60" width="290" height="360" rx="10" fill="#262637" stroke="#8b5cf6" stroke-width="1.5"/>
+  <rect x="30" y="60" width="290" height="42" rx="10" fill="url(#gAttnGrad)"/>
+  <rect x="30" y="90" width="290" height="12" fill="url(#gAttnGrad)"/>
+  <text x="175" y="86" text-anchor="middle" font-size="14" font-weight="700" fill="#fff">STANDARD ATTENTION</text>
+
+  <text x="50" y="130" font-size="11" fill="#c4b5fd" font-weight="600">Analogy:</text>
+  <text x="50" y="148" font-size="11" fill="#94a3b8">Perfect notebook. Write everything.</text>
+  <text x="50" y="165" font-size="11" fill="#94a3b8">Search the whole book each time.</text>
+
+  <text x="50" y="195" font-size="11" fill="#c4b5fd" font-weight="600">State:</text>
+  <text x="50" y="213" font-size="11" fill="#94a3b8">KV-cache: all past keys + values</text>
+  <text x="50" y="230" font-size="11" fill="#94a3b8">Shape: [T × d] — grows with T</text>
+
+  <text x="50" y="260" font-size="11" fill="#c4b5fd" font-weight="600">Update:</text>
+  <text x="50" y="278" font-size="11" fill="#94a3b8">Append new row. Never modify old.</text>
+
+  <text x="50" y="308" font-size="11" fill="#c4b5fd" font-weight="600">Read:</text>
+  <text x="50" y="326" font-size="11" fill="#94a3b8">Softmax over ALL past keys.</text>
+  <text x="50" y="343" font-size="11" fill="#94a3b8">Cost: O(T) per query.</text>
+
+  <text x="50" y="380" font-size="11" fill="#c4b5fd" font-weight="600">Tradeoff:</text>
+  <text x="50" y="398" font-size="11" fill="#94a3b8">Perfect recall ↔ linear cost growth</text>
+
+  <!-- DeltaNet column -->
+  <rect x="355" y="60" width="290" height="360" rx="10" fill="#262637" stroke="#f59e0b" stroke-width="1.5"/>
+  <rect x="355" y="60" width="290" height="42" rx="10" fill="url(#gDeltaGrad)"/>
+  <rect x="355" y="90" width="290" height="12" fill="url(#gDeltaGrad)"/>
+  <text x="500" y="86" text-anchor="middle" font-size="14" font-weight="700" fill="#fff">GATED DELTANET</text>
+
+  <text x="375" y="130" font-size="11" fill="#fcd34d" font-weight="600">Analogy:</text>
+  <text x="375" y="148" font-size="11" fill="#94a3b8">Whiteboard. Fixed size. Erase and</text>
+  <text x="375" y="165" font-size="11" fill="#94a3b8">rewrite only what's wrong.</text>
+
+  <text x="375" y="195" font-size="11" fill="#fcd34d" font-weight="600">State:</text>
+  <text x="375" y="213" font-size="11" fill="#94a3b8">Matrix S: associative memory</text>
+  <text x="375" y="230" font-size="11" fill="#94a3b8">Shape: [d × d] — always fixed</text>
+
+  <text x="375" y="260" font-size="11" fill="#fcd34d" font-weight="600">Update:</text>
+  <text x="375" y="278" font-size="11" fill="#94a3b8">Delta rule: S += outer(k̂, δ)</text>
+  <text x="375" y="295" font-size="11" fill="#94a3b8">Write the correction, not the value.</text>
+
+  <text x="375" y="325" font-size="11" fill="#fcd34d" font-weight="600">Read:</text>
+  <text x="375" y="343" font-size="11" fill="#94a3b8">out = Sᵀ · q̂. Cost: O(d²) always.</text>
+
+  <text x="375" y="380" font-size="11" fill="#fcd34d" font-weight="600">Tradeoff:</text>
+  <text x="375" y="398" font-size="11" fill="#94a3b8">Fixed cost ↔ lossy (rank-1 collisions)</text>
+
+  <!-- SSM column -->
+  <rect x="680" y="60" width="290" height="360" rx="10" fill="#262637" stroke="#06b6d4" stroke-width="1.5"/>
+  <rect x="680" y="60" width="290" height="42" rx="10" fill="url(#gSSMGrad)"/>
+  <rect x="680" y="90" width="290" height="12" fill="url(#gSSMGrad)"/>
+  <text x="825" y="86" text-anchor="middle" font-size="14" font-weight="700" fill="#fff">MAMBA-2 SSM</text>
+
+  <text x="700" y="130" font-size="11" fill="#67e8f9" font-weight="600">Analogy:</text>
+  <text x="700" y="148" font-size="11" fill="#94a3b8">Sliding-window sensor. Measure the</text>
+  <text x="700" y="165" font-size="11" fill="#94a3b8">stream. Decay old, inject new.</text>
+
+  <text x="700" y="195" font-size="11" fill="#67e8f9" font-weight="600">State:</text>
+  <text x="700" y="213" font-size="11" fill="#94a3b8">Hidden vector h: dynamical system</text>
+  <text x="700" y="230" font-size="11" fill="#94a3b8">Shape: [d] — compact</text>
+
+  <text x="700" y="260" font-size="11" fill="#67e8f9" font-weight="600">Update:</text>
+  <text x="700" y="278" font-size="11" fill="#94a3b8">h = A·h + B·x (linear recurrence)</text>
+  <text x="700" y="295" font-size="11" fill="#94a3b8">A, B, C are input-dependent.</text>
+
+  <text x="700" y="325" font-size="11" fill="#67e8f9" font-weight="600">Read:</text>
+  <text x="700" y="343" font-size="11" fill="#94a3b8">y = C·h. Cost: O(d) always.</text>
+
+  <text x="700" y="380" font-size="11" fill="#67e8f9" font-weight="600">Tradeoff:</text>
+  <text x="700" y="398" font-size="11" fill="#94a3b8">Cheapest cost ↔ limited capacity/step</text>
+</svg>
+</div>
+
+<h3>When Each Wins</h3>
+
+<table>
+    <thead>
+        <tr>
+            <th>Scenario</th>
+            <th>Best choice</th>
+            <th>Why</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Exact retrieval from long context</td>
+            <td>Attention</td>
+            <td>Nothing is lost — full KV-cache scan</td>
+        </tr>
+        <tr>
+            <td>Long streaming decode (100K+ tokens)</td>
+            <td>SSM (Mamba)</td>
+            <td>O(d) per step, no memory growth, fast</td>
+        </tr>
+        <tr>
+            <td>Learned key-value associations</td>
+            <td>DeltaNet</td>
+            <td>d² state has capacity; delta rule is precise</td>
+        </tr>
+        <tr>
+            <td>High throughput, memory-constrained</td>
+            <td>SSM (Mamba)</td>
+            <td>Smallest state footprint</td>
+        </tr>
+        <tr>
+            <td>Chunked prefill with state reuse</td>
+            <td>DeltaNet</td>
+            <td>State survives chunks; no parallel scan needed</td>
+        </tr>
+        <tr>
+            <td>CPU inference (SIMD-friendly)</td>
+            <td>DeltaNet</td>
+            <td>Dense d×d operations map perfectly to AVX/AVX-512</td>
+        </tr>
+        <tr>
+            <td>GPU inference (parallel scan)</td>
+            <td>SSM (Mamba)</td>
+            <td>Parallel associative scan maps to GPU warps</td>
+        </tr>
+    </tbody>
+</table>
+
+<p><strong>The kernel engineer's takeaway:</strong> DeltaNet is compute-bound and SIMD-friendly — it rewards wide vector units and dense FMA throughput. SSM conv1d is bandwidth-bound and simple — it rewards prefetch and streaming memory access. On a Xeon with AVX-512, DeltaNet's d×d sweep can actually be faster than you'd expect because the arithmetic intensity is high enough to hide memory latency. SSM's conv with k=4 hits the memory wall almost immediately.</p>
+
 <div class="card card-accent" style="margin-top:2rem;">
     <h3>📊 Back to Kernel Catalog</h3>
     <p>For the full list of CK-Engine kernels (GEMM, RoPE, Softmax, Loss, etc.), see:</p>

--- a/docs/site/_pages/gemm-optimization.html
+++ b/docs/site/_pages/gemm-optimization.html
@@ -576,6 +576,19 @@
             <span class="hero-badge">1.44x Faster than PyTorch/MKL</span>
         </section>
 
+        <div class="card" style="border-left: 4px solid var(--orange);">
+            <h3>Current v8 Prefill Target: Q4_K Repacking</h3>
+            <p>
+                The next CK prefill gap is not generic GEMM theory or thread count. It is Q4_K_M layout:
+                CK now has Q8_K activations, persistent threadpool dispatch, packed metadata, and a safe CK-vs-llama perf lane,
+                but Qwen3.5 prefill still trails llama.cpp because llama uses an interleaved/repacked Q4_K GEMM hot loop.
+            </p>
+            <p style="margin: 0;">
+                See <a href="prefill-performance-roadmap.html">Prefill Performance Roadmap</a> for the Q8 activation contract,
+                threadpool, packed-meta, 2D scheduler, and 8x8 repacked Q4_K microkernel plan.
+            </p>
+        </div>
+
         <!-- Performance Stats -->
         <div class="grid-4">
             <div class="stat-card">
@@ -595,6 +608,135 @@
                 <div class="stat-label">Register Tile</div>
             </div>
         </div>
+
+        <h2 id="gemm-vs-gemv-production">GEMM vs GEMV in Production LLM Serving</h2>
+        <p>
+            In transformer inference, most expensive linear layers reduce to either GEMM or GEMV. The distinction matters because a kernel that is good for one can be poor for the other.
+        </p>
+
+        <div class="grid-2">
+            <div class="card">
+                <h3>GEMV: decode latency</h3>
+                <p>
+                    GEMV is matrix-vector multiplication: one new token is multiplied by a weight matrix. This is the common decode path after the prompt is already in the KV cache.
+                </p>
+                <pre><code>// Decode, one token
+output[1, N] = activation[1, K] x weight[N, K]</code></pre>
+                <p>
+                    GEMV is usually memory-bandwidth bound. Each output row streams weight bytes, does a dot product, and has limited reuse of the activation vector. The important questions are:
+                </p>
+                <ul>
+                    <li>Are weights read sequentially in the inner loop?</li>
+                    <li>Are quantized blocks decoded with SIMD instead of scalar code?</li>
+                    <li>Is thread overhead smaller than the work per row?</li>
+                    <li>Does the final logits projection avoid tiny-task oversubscription?</li>
+                </ul>
+            </div>
+
+            <div class="card">
+                <h3>GEMM: prefill throughput</h3>
+                <p>
+                    GEMM is matrix-matrix multiplication: many prompt tokens are processed together. This is the prefill path and the dominant cost for long prompts.
+                </p>
+                <pre><code>// Prefill, M prompt tokens
+output[M, N] = activations[M, K] x weight[N, K]</code></pre>
+                <p>
+                    GEMM can reuse weights and activations across many outputs, so a production kernel must create reuse deliberately:
+                </p>
+                <ul>
+                    <li>Tile M, N, and K so hot data fits in L1/L2/L3.</li>
+                    <li>Keep a small accumulator tile in registers.</li>
+                    <li>Pack or interleave weights when the canonical layout is not enough.</li>
+                    <li>Use a thread split that creates enough work without saturating memory bandwidth.</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3>Why simple correctness kernels are not production kernels</h3>
+            <p>
+                A reference kernel proves the math. A production kernel has to prove the data movement. The same equation can run 3x slower if it repeatedly reloads cache lines, transposes buffers between operators, dispatches too many tiny tasks, or decodes quantized blocks in a layout that SIMD cannot consume efficiently.
+            </p>
+            <p>
+                This is why CK keeps scalar/reference, ISA-specific, tiled, packed, and dispatch-selected kernels separate. The reference path protects parity. The optimized path earns its place only when it matches parity and wins on the shapes used by real models.
+            </p>
+        </div>
+
+        <h2 id="production-kernel-checklist">Production Kernel Checklist</h2>
+        <div class="grid-3">
+            <div class="card">
+                <h3>1. Shape first</h3>
+                <p>
+                    Measure real model shapes, not synthetic square matrices only. Qwen2, Qwen3, Gemma, Nanbeige, and vision models stress different M/N/K regimes.
+                </p>
+            </div>
+            <div class="card">
+                <h3>2. Layout before instruction count</h3>
+                <p>
+                    If the weight layout forces scattered loads or repeated unpacking, more SIMD instructions will not fix the bottleneck. Repacking and interleaving often matter more than another arithmetic trick.
+                </p>
+            </div>
+            <div class="card">
+                <h3>3. Cache reuse</h3>
+                <p>
+                    Fast GEMM keeps reused A/B tiles close to the core. Fast GEMV streams weights predictably and avoids extra copies around activations, logits, and head-major attention output.
+                </p>
+            </div>
+            <div class="card">
+                <h3>4. Threading policy</h3>
+                <p>
+                    More threads are not automatically better. Small GEMV and tiny-M prefill can regress when threadpool overhead and memory contention exceed useful work.
+                </p>
+            </div>
+            <div class="card">
+                <h3>5. Quantization path</h3>
+                <p>
+                    Quantized inference is usually Q4_K/Q5_K/Q6_K weights times Q8_K or Q8_0 activations. Test the actual mixed-format kernel, not only dequantize-to-FP32 fallback.
+                </p>
+            </div>
+            <div class="card">
+                <h3>6. Parity gates</h3>
+                <p>
+                    Keep exact/reference kernels available. Enable optimized kernels by dispatch only after they pass llama.cpp/PyTorch parity for the relevant format and shape.
+                </p>
+            </div>
+        </div>
+
+        <h2 id="how-to-profile-gemm-gemv">How to Tell What Is Slow</h2>
+        <p>
+            A useful performance investigation separates raw kernel speed from model-level orchestration.
+        </p>
+        <table>
+            <tr>
+                <th>Symptom</th>
+                <th>Likely Cause</th>
+                <th>What to Run</th>
+            </tr>
+            <tr>
+                <td>Decode is slow, prompt is acceptable</td>
+                <td>GEMV/logits path is bandwidth-bound or overscheduled</td>
+                <td><code>make llamacpp-parity-perf</code>, <code>make test-gemv-comprehensive</code></td>
+            </tr>
+            <tr>
+                <td>Prompt/prefill is slow, standalone GEMM is fast</td>
+                <td>Model executor overhead: quantization, transposes, per-op boundaries</td>
+                <td>v8 op-level profiling and lowered prefill call inspection</td>
+            </tr>
+            <tr>
+                <td>Large shapes improve, small shapes regress</td>
+                <td>Thread split or tiled kernel not shape-gated</td>
+                <td><code>make test-q6k-prefill-dispatch-sweep-quick</code></td>
+            </tr>
+            <tr>
+                <td>CK matches parity but trails llama.cpp</td>
+                <td>Packed/interleaved layout or graph scheduling gap</td>
+                <td>Compare against llama.cpp repacked paths and kernel-level speed lanes</td>
+            </tr>
+        </table>
+
+        <p>
+            The practical rule is simple: first prove the kernel is mathematically correct, then prove it wins for the exact shapes, formats, thread counts, and hardware where dispatch will select it.
+        </p>
 
         <!-- Inspiration Section -->
         <h2>Standing on the Shoulders of Giants</h2>

--- a/docs/site/_pages/index.html
+++ b/docs/site/_pages/index.html
@@ -208,6 +208,13 @@
 
 <p>The intended deployment model is dependency-light execution, not dependency-free development. The generated runtime can be compiled with GCC or Clang, but the preferred path is to use the strongest native CPU toolchain for the target machine: Intel oneAPI/ICX on Intel CPUs, tuned GCC/Clang on AMD CPUs, ARM toolchains on ARM systems, and standard systems libraries for cluster execution.</p>
 
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Generated C, Planned Memory</h3>
+    <p>C-Kernel-Engine uses C as an <strong>auditable compiler target</strong>, not as a large hand-written pointer maze. The model graph, tensor shapes, lifetimes, kernel contracts, and memory sections are resolved before code emission. The generated C then reads and writes deterministic offsets from planned buffers instead of allocating or guessing inside the hot path.</p>
+    <p>This is the memory-safety model: avoid most ordinary C mistakes by not hand-authoring the model body in C in the first place. The compiler pipeline emits explicit offsets, optional bounds/canary checks, cache-aligned sections, and reproducible layout reports; ASAN, Valgrind, PyTorch parity, llama.cpp parity, perf, VTune, and Advisor validate the artifact from correctness down to memory behavior.</p>
+    <p style="margin-bottom: 0;">The result is still native C, but the important contract is visible: <code>IR op -> tensor lifetime -> byte offset -> generated pointer -> kernel call</code>. That makes the execution path deterministic, inspectable, and measurable for applications where memory layout is the application.</p>
+</div>
+
 <p>The north star is distributed CPU inference and training: model/layer ownership across CPU nodes, explicit activation and gradient movement, MPI/RDMA-style communication where available, and pipeline parallelism over hardware that can be bought, powered, audited, and scaled incrementally.</p>
 
 <p>The first version of C-Kernel-Engine tried to drive generation from HuggingFace <code>config.json</code> alone. That was not enough: config metadata does not fully capture quantized weight packing/layout details, nor all runtime stitching constraints needed for reliable kernel binding.</p>

--- a/docs/site/_pages/model-kernel-matrix.html
+++ b/docs/site/_pages/model-kernel-matrix.html
@@ -33,6 +33,8 @@
     .model-card.mc-qwen3::before  { background: var(--green); }
     .model-card.mc-qwen35::before { background: #1abc9c; }
     .model-card.mc-qwen3vl::before { background: #00bcd4; }
+    .model-card.mc-gemma4v::before { background: #ff6f91; }
+    .model-card.mc-siglip::before  { background: #a78bfa; }
     .model-card.mc-qwen::before   { background: #16a085; }
     .model-card.mc-gemma3::before { background: var(--blue); }
     .model-card.mc-gemma4::before { background: #f39c12; }
@@ -316,6 +318,135 @@
   <div class="runner-callout">
     <strong>Recommended runner track:</strong> this model page points to the latest hardened v8 command path for hands-on smoke tests. Version pages remain historical snapshots of each engine generation; the cards below show the current practical command to convert, compile, run, and optionally emit the IR visualizer for that family. Large cards such as Gemma4, Nemotron, GLM4, and vision models assume a high-memory CPU host.
   </div>
+
+  <h2 style="color: var(--orange); margin-top: 2rem;">One Pipeline, Every Model</h2>
+  <p class="lead" style="margin-top: 0;">
+    Every supported family enters through the same deterministic compile path. The artifact (GGUF) carries the numbers,
+    the template carries the structure, and lowering turns both into a concrete C runtime with a fixed memory plan.
+    Vision families add a second lane that produces an encoder prefix and bridges it into the decoder.
+  </p>
+
+  <svg viewBox="0 0 1180 520" width="100%" role="img"
+       aria-label="C-Kernel-Engine model compilation pipeline: GGUF and template lower to IR, memory plan, codegen and runtime, with a vision encoder lane bridging into the decoder."
+       style="max-width: 1180px; margin: 0.5rem auto 1.75rem; display: block; font-family: 'Inter', system-ui, sans-serif;">
+    <defs>
+      <linearGradient id="mk-text" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#ffb400"/><stop offset="1" stop-color="#e5a200"/>
+      </linearGradient>
+      <linearGradient id="mk-vision" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#07adf8"/><stop offset="1" stop-color="#00bcd4"/>
+      </linearGradient>
+      <linearGradient id="mk-run" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#47b475"/><stop offset="1" stop-color="#2f8d59"/>
+      </linearGradient>
+      <marker id="mk-arrow" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+        <path d="M0,0 L7,3 L0,6 Z" fill="#8aa0b4"/>
+      </marker>
+      <marker id="mk-arrow-v" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+        <path d="M0,0 L7,3 L0,6 Z" fill="#07adf8"/>
+      </marker>
+      <style>
+        .mk-stage{fill:#323232;stroke:#454545;stroke-width:1.4;rx:12;}
+        .mk-title{fill:#f5f5f5;font-size:18px;font-weight:700;}
+        .mk-sub{fill:#b0b0b0;font-size:12.5px;font-family:'JetBrains Mono',monospace;}
+        .mk-band{fill:#9aa7b4;font-size:13px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;}
+        .mk-chip{fill:#0f151c;stroke:#263242;stroke-width:1;rx:6;}
+        .mk-chip-t{fill:#9ed6ff;font-size:12px;font-family:'JetBrains Mono',monospace;}
+      </style>
+    </defs>
+
+    <!-- band labels -->
+    <text x="24" y="40" class="mk-band">Source of truth</text>
+    <text x="24" y="250" class="mk-band">Deterministic compile</text>
+    <text x="24" y="430" class="mk-band">Vision lane (multimodal families)</text>
+
+    <!-- Row 1: sources -->
+    <g>
+      <rect class="mk-stage" x="24"  y="58" width="250" height="92" rx="12"/>
+      <text x="44" y="92"  class="mk-title">GGUF artifact</text>
+      <text x="44" y="116" class="mk-sub">tensors · dtypes · shapes</text>
+      <text x="44" y="134" class="mk-sub">tokenizer · vision metadata</text>
+
+      <rect class="mk-stage" x="320" y="58" width="250" height="92" rx="12"/>
+      <text x="340" y="92"  class="mk-title">Template <tspan class="mk-sub">.json</tspan></text>
+      <text x="340" y="116" class="mk-sub">header / body / footer graph</text>
+      <text x="340" y="134" class="mk-sub">kernel ids · contracts</text>
+    </g>
+    <!-- supported template chips -->
+    <g>
+      <rect class="mk-chip" x="616" y="58"  width="120" height="26" rx="6"/><text x="676" y="76" text-anchor="middle" class="mk-chip-t">qwen2/3/3.5</text>
+      <rect class="mk-chip" x="746" y="58"  width="120" height="26" rx="6"/><text x="806" y="76" text-anchor="middle" class="mk-chip-t">gemma3/4</text>
+      <rect class="mk-chip" x="876" y="58"  width="120" height="26" rx="6"/><text x="936" y="76" text-anchor="middle" class="mk-chip-t">glm4</text>
+      <rect class="mk-chip" x="1006" y="58" width="150" height="26" rx="6"/><text x="1081" y="76" text-anchor="middle" class="mk-chip-t">nemotron_h</text>
+      <rect class="mk-chip" x="616" y="92"  width="120" height="26" rx="6"/><text x="676" y="110" text-anchor="middle" class="mk-chip-t">llama</text>
+      <rect class="mk-chip" x="746" y="92"  width="120" height="26" rx="6"/><text x="806" y="110" text-anchor="middle" class="mk-chip-t">qwen3vl</text>
+      <rect class="mk-chip" x="876" y="92"  width="160" height="26" rx="6"/><text x="956" y="110" text-anchor="middle" class="mk-chip-t" fill="#9ed6ff">gemma4_vision</text>
+      <rect class="mk-chip" x="1046" y="92" width="110" height="26" rx="6"/><text x="1101" y="110" text-anchor="middle" class="mk-chip-t" fill="#cbb6ff">siglip_vit</text>
+      <text x="616" y="140" class="mk-sub" fill="#808080">11 templates resolve into the same lowering passes</text>
+    </g>
+
+    <!-- arrows sources -> compile -->
+    <path d="M149,150 L149,200" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+    <path d="M445,150 L445,200" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+
+    <!-- Row 2: compile pipeline -->
+    <g>
+      <rect class="mk-stage" x="24"   y="266" width="200" height="86" rx="12"/>
+      <text x="44" y="300" class="mk-title">IR lowering</text>
+      <text x="44" y="324" class="mk-sub">build_ir_v8.py</text>
+      <text x="44" y="342" class="mk-sub">template → kernel calls</text>
+
+      <rect class="mk-stage" x="264" y="266" width="200" height="86" rx="12"/>
+      <text x="284" y="300" class="mk-title">Memory plan</text>
+      <text x="284" y="324" class="mk-sub">bump offsets</text>
+      <text x="284" y="342" class="mk-sub">no malloc at runtime</text>
+
+      <rect class="mk-stage" x="504" y="266" width="200" height="86" rx="12"/>
+      <text x="524" y="300" class="mk-title">C codegen</text>
+      <text x="524" y="324" class="mk-sub">kernel dispatch</text>
+      <text x="524" y="342" class="mk-sub">SIMD tier select</text>
+
+      <rect x="744" y="266" width="220" height="86" rx="12" fill="url(#mk-run)" opacity="0.16" stroke="#47b475" stroke-width="1.6"/>
+      <text x="764" y="300" class="mk-title">Runtime</text>
+      <text x="764" y="324" class="mk-sub" fill="#a7e0bf">native C · deterministic</text>
+      <text x="764" y="342" class="mk-sub" fill="#a7e0bf">GEMM/GEMV · attention</text>
+    </g>
+    <path d="M224,309 L260,309" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+    <path d="M464,309 L500,309" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+    <path d="M704,309 L740,309" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+
+    <!-- text decoder feeds runtime token stream -->
+    <rect class="mk-stage" x="994" y="266" width="162" height="86" rx="12"/>
+    <text x="1014" y="300" class="mk-title">Decoder</text>
+    <text x="1014" y="324" class="mk-sub">prefill + decode</text>
+    <text x="1014" y="342" class="mk-sub">token stream out</text>
+    <path d="M964,309 L990,309" fill="none" stroke="#47b475" stroke-width="1.8" marker-end="url(#mk-arrow)"/>
+
+    <!-- Row 3: vision lane -->
+    <g>
+      <rect x="24"  y="446" width="190" height="58" rx="12" fill="url(#mk-vision)" opacity="0.14" stroke="#07adf8" stroke-width="1.5"/>
+      <text x="44" y="472" class="mk-title" font-size="16">Image in</text>
+      <text x="44" y="492" class="mk-sub" fill="#9ed6ff">resize · normalize</text>
+
+      <rect x="244" y="446" width="210" height="58" rx="12" fill="url(#mk-vision)" opacity="0.14" stroke="#07adf8" stroke-width="1.5"/>
+      <text x="264" y="472" class="mk-title" font-size="16">Patch frontend</text>
+      <text x="264" y="492" class="mk-sub" fill="#9ed6ff">im2patch · pos · merge</text>
+
+      <rect x="484" y="446" width="210" height="58" rx="12" fill="url(#mk-vision)" opacity="0.14" stroke="#07adf8" stroke-width="1.5"/>
+      <text x="504" y="472" class="mk-title" font-size="16">ViT encoder</text>
+      <text x="504" y="492" class="mk-sub" fill="#9ed6ff">attn · MLP · deepstack</text>
+
+      <rect x="724" y="446" width="210" height="58" rx="12" fill="url(#mk-vision)" opacity="0.22" stroke="#00bcd4" stroke-width="1.8"/>
+      <text x="744" y="472" class="mk-title" font-size="16">Bridge prefix</text>
+      <text x="744" y="492" class="mk-sub" fill="#9ed6ff">projector rows → decoder</text>
+    </g>
+    <path d="M214,475 L240,475" fill="none" stroke="#07adf8" stroke-width="1.6" marker-end="url(#mk-arrow-v)"/>
+    <path d="M454,475 L480,475" fill="none" stroke="#07adf8" stroke-width="1.6" marker-end="url(#mk-arrow-v)"/>
+    <path d="M694,475 L720,475" fill="none" stroke="#07adf8" stroke-width="1.6" marker-end="url(#mk-arrow-v)"/>
+    <!-- bridge climbs into decoder -->
+    <path d="M934,460 C1010,440 1060,400 1070,354" fill="none" stroke="#00bcd4" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#mk-arrow-v)"/>
+    <text x="750" y="400" class="mk-sub" fill="#7fd8ec">prefix rows stitch in before text tokens</text>
+  </svg>
 
   <div class="matrix-hero">
 
@@ -623,6 +754,55 @@
         <span class="mq-chip">Q5_0</span>
         <span class="mq-chip">Q8_0</span>
         <span class="mq-chip">FP32</span>
+      </div>
+    </div>
+
+    <!-- Gemma4 Vision -->
+    <div class="model-card mc-gemma4v">
+      <span class="model-badge">template: gemma4_vision.json</span>
+      <div class="model-title">Gemma4 Vision</div>
+      <div class="model-arch">SigLIP-style ViT encoder · XY position embeddings · average-pool merge<br>projector prep → Gemma4 decoder bridge · deterministic patch frontend</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 multimodal inference — patch frontend, encoder graph, projector bridge</span></div>
+        <div class="mp-row"><span class="mp-dot no"></span><span class="mp-text dim">Bring-up lane — staged behind the promoted Qwen3-VL baseline</span></div>
+      </div>
+      <div class="source-note">
+        Vision lane scope: shares the same lowering + memory-planning stack as Qwen3-VL. Uses <code>position_embeddings_add_gemma4v_xy</code> and <code>spatial_average_pool_contiguous</code> for the Gemma4 merge path instead of Qwen3-VL's 2×2 spatial merge.
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">gemma4v_xy_posemb</span>
+        <span class="tag learned">avgpool_merge</span>
+        <span class="tag learned">projector_bridge</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip preferred">Q4_K_M decoder ★</span>
+        <span class="mq-chip">Q8_0 mmproj</span>
+        <span class="mq-chip">FP32 encoder</span>
+        <span class="mq-chip">image bridge</span>
+      </div>
+    </div>
+
+    <!-- SigLIP ViT -->
+    <div class="model-card mc-siglip">
+      <span class="model-badge">template: siglip_vit.json</span>
+      <div class="model-title">SigLIP ViT (encoder)</div>
+      <div class="model-arch">Standalone vision tower · im2patch → patch embed · LayerNorm · full attention<br>learned position embeddings · GELU MLP · reusable encoder contract</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 encoder graph — patch frontend, transformer body, projector footer</span></div>
+        <div class="mp-row"><span class="mp-dot no"></span><span class="mp-text dim">Encoder-only — pairs with a decoder template via the bridge contract</span></div>
+      </div>
+      <div class="source-note">
+        Why it exists: SigLIP is the shared ViT backbone behind several vision-language families. Templating it on its own keeps the encoder reusable, so a new VLM can be brought up by swapping the decoder + projector instead of rewriting the vision tower.
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">reusable_vit</span>
+        <span class="tag learned">im2patch</span>
+        <span class="tag learned">encoder_contract</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip">FP32</span>
+        <span class="mq-chip">BF16</span>
+        <span class="mq-chip">encoder prefix</span>
       </div>
     </div>
 

--- a/docs/site/_pages/prefill-performance-roadmap.html
+++ b/docs/site/_pages/prefill-performance-roadmap.html
@@ -69,9 +69,9 @@
       </tr>
       <tr>
         <td>Token-tile x output-tile GEMM</td>
-        <td>Extend x8 into a true <code>token_tile x output_tile</code> microkernel.</td>
-        <td>This should reuse both activation rows and weight metadata across a two-dimensional tile, not just eight output rows for one token row.</td>
-        <td>Next target</td>
+        <td>Add an opt-in <code>x8mt</code> lane that schedules small token tiles against eight-row output tiles.</td>
+        <td>This reuses the same packed Q4_K group across multiple Q8_K token rows and is the first step toward a true register-blocked GEMM microkernel.</td>
+        <td>Experimental benchmark/runtime lane</td>
       </tr>
       <tr>
         <td>Fused MLP kernels</td>
@@ -124,6 +124,21 @@
   <pre><code>for token_tile:
   for output_tile:
     compute multiple tokens x multiple output rows together</code></pre>
+
+  <p>
+    The current experimental <code>x8mt</code> path takes the first step:
+  </p>
+  <pre><code>CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL=1 \
+CK_Q4K_PACKED_META_X8MT_TILE_M=2 \
+make profile-v8-prefill-perf-stat</code></pre>
+
+  <p>
+    In the local dispatch matrix, <code>x8mt</code> with <code>tile_m=2</code> edged out plain x8 on the measured
+    Q4_K shapes, including the longer <code>M=128,N=896,K=4864</code> compact-down shape. It remains opt-in because
+    end-to-end Qwen2 timings on the laptop were noisy and not yet a stable promotion signal. The next real kernel
+    improvement is to keep the tile accumulators in registers across the token tile instead of using x8mt mostly as
+    a scheduling/data-reuse step.
+  </p>
 
   <h2>Why 2D Scheduling Was Not Enough</h2>
   <p>

--- a/docs/site/_pages/prefill-performance-roadmap.html
+++ b/docs/site/_pages/prefill-performance-roadmap.html
@@ -1,0 +1,174 @@
+<!-- TITLE: Prefill Performance Roadmap -->
+<!-- NAV: profiling -->
+
+<div class="container">
+  <h1>Prefill Performance Roadmap</h1>
+  <p class="lead">
+    The current CK prefill path is correct and auditable, but the Q4_K_M gap against llama.cpp is now mostly a layout and microkernel problem.
+  </p>
+
+  <div class="alert alert-info">
+    <strong>Current signal:</strong>
+    Qwen3.5 0.8B Q4_K_M decode is close enough to be useful for model bring-up. The first safe perf lane showed
+    canonical CK prefill around <code>31 tok/s</code> while llama.cpp was around <code>78 tok/s</code> on the local i7.
+    After x8 testing, the dispatch matrix showed x8 winning for short/medium prefill shapes and losing for the
+    longer <code>M=128,N=896,K=4864</code> compact-down shape. Treat the exact numbers as host-local; the durable
+    signal is that layout and shape-gated dispatch, not math, are the bottlenecks.
+  </div>
+
+  <h2>Why Prefill Is Different</h2>
+  <p>
+    Decode is mostly GEMV: one activation vector times many weight rows. Prefill is GEMM: many token rows times many output rows.
+    A fast decode kernel can still leave prefill slow because prefill needs to reuse both activation rows and weight blocks across a two-dimensional tile.
+  </p>
+  <p>
+    The key mistake is to treat prefill as many independent GEMV calls. That preserves correctness, but it reloads metadata and activation blocks too often.
+    llama.cpp's faster path uses repacked/interleaved layouts so the hot loop computes a block of rows and columns together.
+  </p>
+
+  <h2>Optimization Ladder</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Step</th>
+        <th>What Changed</th>
+        <th>Why It Matters</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Q8 activation contract</td>
+        <td>Quantize prefill activations to <code>Q8_K</code> before mixed-quant GEMM.</td>
+        <td>Stops repeatedly feeding FP32 into quantized weights and aligns CK with llama-style quantized dot products.</td>
+        <td>Active</td>
+      </tr>
+      <tr>
+        <td>Persistent threadpool</td>
+        <td>Use CK's pthread pool instead of creating OpenMP regions around every kernel.</td>
+        <td>Reduces launch overhead and gives the runtime explicit control over active threads, row splitting, and phase-specific dispatch.</td>
+        <td>Active</td>
+      </tr>
+      <tr>
+        <td>Shape-gated dispatch</td>
+        <td>Choose serial, row-split, N-split, or 2D dispatch based on <code>M,N,K</code> and thread count.</td>
+        <td>Small shapes can regress when parallel overhead or activation rereads dominate; wide shapes need more jobs to fill cores.</td>
+        <td>Active for Q6; experimental for Q4</td>
+      </tr>
+      <tr>
+        <td>Packed Q4_K metadata</td>
+        <td>Pre-unpack Q4_K scales/mins into a cached packed-meta layout.</td>
+        <td>Moves repeated metadata decoding out of the hottest dot-product path.</td>
+        <td>Active, but not enough</td>
+      </tr>
+      <tr>
+        <td>Q4_K 8x8 repacked GEMM</td>
+        <td>Pack eight Q4_K output rows together and compute an output-row tile for each Q8_K token row.</td>
+        <td>This captures the first llama.cpp-style layout win: each Q8 activation load is reused across multiple output lanes instead of one row at a time.</td>
+        <td>Shape-gated default for measured short/medium Q4_K prefill shapes</td>
+      </tr>
+      <tr>
+        <td>Token-tile x output-tile GEMM</td>
+        <td>Extend x8 into a true <code>token_tile x output_tile</code> microkernel.</td>
+        <td>This should reuse both activation rows and weight metadata across a two-dimensional tile, not just eight output rows for one token row.</td>
+        <td>Next target</td>
+      </tr>
+      <tr>
+        <td>Fused MLP kernels</td>
+        <td>Fuse norm/projection/SwiGLU/down or similar sequences after the base GEMM is competitive.</td>
+        <td>Useful, but premature while the Q4_K prefill GEMM itself is still the dominant gap.</td>
+        <td>Later</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>The Q4_K Repack Target</h2>
+  <p>
+    The current CK packed-meta path is shaped like this:
+  </p>
+  <pre><code>for each token m:
+  for each output row n:
+    for each Q4_K block b:
+      dot_one_q4k_block_with_one_q8k_block()</code></pre>
+
+  <p>
+    That is simple and auditable, but it is still scalar at the tile level. The next target is shaped more like this:
+  </p>
+  <pre><code>for token tile Mx4 or Mx8:
+  pack Q8_K activations into an interleaved tile
+  for output tile Nx8:
+    read one interleaved Q4_K weight tile
+    accumulate an MxN output tile in registers
+    apply Q4_K scale/min metadata once per tile lane</code></pre>
+
+  <p>
+    This mirrors the idea behind llama.cpp's <code>ggml_gemm_q4_K_8x8_q8_K</code>: the math is the same, but the memory layout changes so the CPU hot loop does less bookkeeping per useful multiply.
+    The important part is not copying llama.cpp blindly; the important part is matching the dataflow: interleave weights, interleave activations, compute a small output tile, and keep metadata close to the SIMD lanes.
+  </p>
+  <p>
+    CK keeps the canonical <code>for token -> for output row -> dot()</code> kernel as the reliable fallback.
+    The <code>packed-x8</code> lane groups eight Q4_K output rows per K block and uses a SIMD tile accumulator that loads each Q8 activation chunk once, then reuses it across the active output lanes.
+    It is now the default for measured short/medium Qwen/Nemotron-family Q4_K prefill shapes, with
+    <code>CK_DISABLE_Q4K_PACKED_META_X8_PREFILL=1</code> as the escape hatch and
+    <code>CK_FORCE_Q4K_PACKED_META_X8_PREFILL=1</code> for new hardware sweeps.
+  </p>
+  <p>
+    The current x8 shape is still closer to:
+  </p>
+  <pre><code>for token:
+  for output_row_group_of_8:
+    compute 8 output rows for one Q8_K token row</code></pre>
+  <p>
+    The stronger target remains:
+  </p>
+  <pre><code>for token_tile:
+  for output_tile:
+    compute multiple tokens x multiple output rows together</code></pre>
+
+  <h2>Why 2D Scheduling Was Not Enough</h2>
+  <p>
+    CK now has an opt-in Q4_K packed-meta 2D scheduler:
+  </p>
+  <pre><code>CK_ENABLE_Q4K_PACKED_META_2D_PREFILL=1 \
+CK_FORCE_Q4K_PACKED_META_2D_PREFILL=1 \
+CK_Q4K_PACKED_META_TILE_M=8 \
+CK_Q4K_PACKED_META_TILE_N=512 \
+CK_V8_PREFILL_PERF_ENGINE=ck \
+make profile-v8-prefill-perf-stat</code></pre>
+
+  <p>
+    Local tests showed only a small and noisy improvement. That is expected: 2D scheduling creates better work distribution, but the hot loop still computes one output value at a time.
+    The x8 layout fixed the more important part first: reuse one activation chunk across multiple output lanes.
+    The next step is a true token-tile/output-tile microkernel.
+  </p>
+
+  <h2>Measurement Contract</h2>
+  <p>
+    Use the safe perf lane for routine iteration:
+  </p>
+  <pre><code>make profile-v8-prefill-perf-stat</code></pre>
+
+  <p>
+    The report records prefill/decode tok/s, milliseconds, cycles, instructions, IPC, cache misses, cache miss rate, and context switches.
+    This is the default lane because VTune/Advisor deep collection can load kernel drivers that destabilized the local Linux profiling host.
+  </p>
+
+  <h2>Promotion Rule</h2>
+  <ol>
+    <li>Keep every new layout behind a shape gate and an escape hatch.</li>
+    <li>Prove parity against canonical CK for synthetic Q4_K/Q8_K blocks.</li>
+    <li>Benchmark micro-shapes: Qwen3.5 gate/up, down, qkv/out, compact MLP, and wider MLP shapes.</li>
+    <li>Benchmark end-to-end Qwen3.5 v8 prefill against llama.cpp with the same cached GGUF.</li>
+    <li>Promote only the shapes where the sweep wins; keep canonical dispatch as the fallback.</li>
+  </ol>
+
+  <h2>Related Files</h2>
+  <ul>
+    <li><code>src/kernels/gemm_kernels_q4k_q8k_vnni.c</code> - Q4_K x Q8_K packed-meta kernels.</li>
+    <li><code>version/v8/src/ck_parallel_prefill_v8.c</code> - v8 prefill dispatch policy.</li>
+    <li><code>scripts/perf_stat_v8_prefill_compare.py</code> - safe CK-vs-llama perf counter lane.</li>
+    <li><code>benchmarks/compare_ck_llama_v8.py</code> - standardized v8 model-family comparison.</li>
+    <li><a href="q6-prefill-roofline.html">Q6_K Prefill Roofline Notes</a> - shape-gating precedent for Q6_K.</li>
+    <li><a href="profiling.html">Profiling Guide</a> - safe profiling commands and VTune/Advisor warning.</li>
+  </ul>
+</div>

--- a/docs/site/_pages/profiling.html
+++ b/docs/site/_pages/profiling.html
@@ -18,6 +18,55 @@
     <p style="margin: 0;">Use the dedicated <a href="v7-profiling.html"><code>v7-profiling.html</code></a> runbook for VTune (<code>hotspots</code>/<code>memory-access</code>/<code>uarch-exploration</code>), Advisor roofline, perf/flamegraph capture, and run-dir artifact flow.</p>
 </div>
 
+<div class="alert alert-warning">
+    <strong>Intel VTune / Advisor host-driver warning:</strong>
+    VTune and Advisor are useful for CK-vs-llama.cpp hotspot, memory, uarch, and roofline work, but some collection modes load Intel out-of-tree kernel drivers
+    such as <code>sep5</code>, <code>vtsspp</code>, <code>socwatch2_16</code>, and <code>pax</code>. On the local ThinkPad i7 / Linux 6.14 profiling host, a deeper
+    collection triggered repeated <code>BUG: scheduling while atomic</code> traces in <code>sep5</code>, followed by unrelated <code>runc</code>/<code>nmcli</code>
+    core dumps and an unclean reboot. That signature points to the profiler driver path, not CK user-space math.
+    Prefer <code>perf stat</code>, <code>perf record</code>, flamegraphs, and CK-vs-llama timing gates for routine iteration; run VTune/Advisor deep collections only on a
+    disposable profiling boot, server host, or after accepting that the whole machine may need a reboot.
+</div>
+
+<h2>Safe v8 Prefill Counter Lane</h2>
+
+<p>For CK-vs-llama.cpp prefill work, start with the safe <code>perf stat</code> lane instead of VTune deep counters:</p>
+
+<pre><code>make profile-v8-prefill-perf-stat</code></pre>
+
+<p>The target compares the cached v8 Qwen3.5 Q4_K_M runtime against the local llama.cpp build with a fixed-token
+128-token prefill and one decode token. It writes a timestamped Markdown and JSON report under
+<code>profile_results/v8_prefill_perf_stat/</code> with prefill/decode tok/s, milliseconds, cycles, instructions, IPC,
+cache misses, cache miss rate, and context switches.</p>
+
+<p>The Q4_K packed-meta x8 prefill kernel is shape-gated on by default for measured short/medium
+Qwen/Nemotron-family prefill shapes. Use this escape hatch when validating a new CPU or bisecting a regression:</p>
+
+<pre><code>CK_DISABLE_Q4K_PACKED_META_X8_PREFILL=1 \
+CK_V8_PREFILL_PERF_ENGINE=ck \
+make profile-v8-prefill-perf-stat</code></pre>
+
+<p>On the local ThinkPad i7, the dispatch matrix showed the x8 layout winning at <code>M=32</code> and
+<code>M=64</code> Q4_K prefill shapes, while the longer <code>M=128,N=896,K=4864</code> compact-down shape
+lost to the canonical pool path. That is why the default gate has both a minimum and maximum token tile size.
+Treat these as host-local engineering numbers, not a universal benchmark: the llama lane uses <code>llama-bench</code>,
+run-to-run variance exists, and the important signal is the shape-gated layout win.</p>
+
+<p>Use these environment knobs when testing the older Q4_K packed-meta 2D scheduler without changing the default dispatcher:</p>
+
+<pre><code>CK_ENABLE_Q4K_PACKED_META_2D_PREFILL=1 \
+CK_FORCE_Q4K_PACKED_META_2D_PREFILL=1 \
+CK_Q4K_PACKED_META_TILE_M=8 \
+CK_Q4K_PACKED_META_TILE_N=512 \
+CK_V8_PREFILL_PERF_ENGINE=ck \
+make profile-v8-prefill-perf-stat</code></pre>
+
+<p>The local ThinkPad i7 data showed only a small win from 2D packed-meta scheduling. The stronger win came from
+the x8 packed-meta layout, which groups eight Q4_K output rows per K block so the hot loop reuses each Q8 activation
+load across multiple output lanes. Force it explicitly for new sweeps with
+<code>CK_FORCE_Q4K_PACKED_META_X8_PREFILL=1</code>. See
+<a href="prefill-performance-roadmap.html">Prefill Performance Roadmap</a> for the optimization ladder and promotion rules.</p>
+
 <nav class="toc">
     <h3>Contents</h3>
     <ul>

--- a/docs/site/_pages/profiling.html
+++ b/docs/site/_pages/profiling.html
@@ -67,6 +67,16 @@ load across multiple output lanes. Force it explicitly for new sweeps with
 <code>CK_FORCE_Q4K_PACKED_META_X8_PREFILL=1</code>. See
 <a href="prefill-performance-roadmap.html">Prefill Performance Roadmap</a> for the optimization ladder and promotion rules.</p>
 
+<p>The token-tile/output-tile experiment is separate from the default x8 path:</p>
+
+<pre><code>CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL=1 \
+CK_Q4K_PACKED_META_X8MT_TILE_M=2 \
+CK_V8_PREFILL_PERF_ENGINE=ck \
+make profile-v8-prefill-perf-stat</code></pre>
+
+<p>Use this to test the first two-dimensional Q4_K prefill path. It is intentionally opt-in until model-level
+timings are stable across hardware and prompt lengths.</p>
+
 <nav class="toc">
     <h3>Contents</h3>
     <ul>

--- a/docs/site/_pages/spec-training-results.html
+++ b/docs/site/_pages/spec-training-results.html
@@ -156,7 +156,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-05 05:12 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-24 18:49 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>

--- a/docs/site/_pages/v8-vision-encoder.html
+++ b/docs/site/_pages/v8-vision-encoder.html
@@ -249,6 +249,129 @@
     </div>
 </div>
 
+<svg viewBox="0 0 1180 430" width="100%" role="img"
+     aria-label="Qwen3-VL vision pipeline: image to patch frontend to ViT encoder to projector bridge prefix, stitched into the Qwen3 decoder prefill and decode."
+     style="max-width:1180px;margin:0.5rem auto 1.5rem;display:block;font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <linearGradient id="vp-enc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#07adf8"/><stop offset="1" stop-color="#00bcd4"/>
+    </linearGradient>
+    <linearGradient id="vp-dec" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffb400"/><stop offset="1" stop-color="#e5a200"/>
+    </linearGradient>
+    <linearGradient id="vp-bridge" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00bcd4"/><stop offset="1" stop-color="#ffb400"/>
+    </linearGradient>
+    <marker id="vp-a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#8aa0b4"/>
+    </marker>
+    <style>
+      .vp-card{fill:#2f2f2f;stroke:#454545;stroke-width:1.4;}
+      .vp-t{fill:#f5f5f5;font-size:15px;font-weight:700;}
+      .vp-s{fill:#b0b0b0;font-size:11.5px;font-family:'JetBrains Mono',monospace;}
+      .vp-band{fill:#9aa7b4;font-size:12px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;}
+    </style>
+  </defs>
+
+  <!-- ENCODER LANE -->
+  <rect x="14" y="34" width="690" height="170" rx="14" fill="rgba(7,173,248,0.06)" stroke="#1d4a5e" stroke-width="1.2"/>
+  <text x="34" y="58" class="vp-band" fill="#56c7f5">Vision encoder graph · template-driven</text>
+
+  <rect class="vp-card" x="34"  y="74" width="120" height="110" rx="11"/>
+  <text x="94" y="104" text-anchor="middle" class="vp-t">Image</text>
+  <text x="94" y="126" text-anchor="middle" class="vp-s">RGB · resize</text>
+  <text x="94" y="142" text-anchor="middle" class="vp-s">normalize</text>
+  <text x="94" y="166" text-anchor="middle" class="vp-s" fill="#56c7f5">[C,H,W]</text>
+
+  <rect class="vp-card" x="178" y="74" width="150" height="110" rx="11" stroke="#07adf8"/>
+  <text x="253" y="104" text-anchor="middle" class="vp-t">Patch frontend</text>
+  <text x="253" y="126" text-anchor="middle" class="vp-s">im2patch · dual proj</text>
+  <text x="253" y="142" text-anchor="middle" class="vp-s">merge · bias</text>
+  <text x="253" y="158" text-anchor="middle" class="vp-s">tiled 2D pos + RoPE</text>
+  <text x="253" y="176" text-anchor="middle" class="vp-s" fill="#56c7f5">[patches, d]</text>
+
+  <rect class="vp-card" x="352" y="74" width="150" height="110" rx="11" stroke="#07adf8"/>
+  <text x="427" y="104" text-anchor="middle" class="vp-t">Transformer body</text>
+  <text x="427" y="126" text-anchor="middle" class="vp-s">LN · packed QKV</text>
+  <text x="427" y="142" text-anchor="middle" class="vp-s">full attn · out proj</text>
+  <text x="427" y="158" text-anchor="middle" class="vp-s">residual · MLP</text>
+  <text x="427" y="176" text-anchor="middle" class="vp-s" fill="#56c7f5">× N layers</text>
+
+  <rect class="vp-card" x="526" y="74" width="158" height="110" rx="11" stroke="#07adf8"/>
+  <text x="605" y="104" text-anchor="middle" class="vp-t">Deepstack + proj</text>
+  <text x="605" y="126" text-anchor="middle" class="vp-s">layer taps merged</text>
+  <text x="605" y="142" text-anchor="middle" class="vp-s">branch MLP blocks</text>
+  <text x="605" y="158" text-anchor="middle" class="vp-s">projector footer</text>
+  <text x="605" y="176" text-anchor="middle" class="vp-s" fill="#56c7f5">[rows, d_model]</text>
+
+  <path d="M154,129 L176,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+  <path d="M328,129 L350,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+  <path d="M502,129 L524,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+
+  <!-- BRIDGE -->
+  <rect x="724" y="74" width="120" height="110" rx="11" fill="url(#vp-bridge)" opacity="0.9"/>
+  <text x="784" y="120" text-anchor="middle" fill="#101317" font-size="15" font-weight="800">BRIDGE</text>
+  <text x="784" y="142" text-anchor="middle" fill="#1a1f24" font-size="11" font-family="'JetBrains Mono',monospace">named activation</text>
+  <text x="784" y="158" text-anchor="middle" fill="#1a1f24" font-size="11" font-family="'JetBrains Mono',monospace">prefix rows + grid</text>
+  <path d="M684,129 L722,129" fill="none" stroke="#8aa0b4" stroke-width="1.8" marker-end="url(#vp-a)"/>
+
+  <!-- DECODER LANE -->
+  <rect x="864" y="34" width="302" height="170" rx="14" fill="rgba(255,180,0,0.06)" stroke="#5e4d1d" stroke-width="1.2"/>
+  <text x="884" y="58" class="vp-band" fill="#ffce5a">Qwen3 decoder · decode-layout runtime</text>
+
+  <rect class="vp-card" x="884" y="74" width="124" height="110" rx="11" stroke="#ffb400"/>
+  <text x="946" y="108" text-anchor="middle" class="vp-t">Mixed prefill</text>
+  <text x="946" y="130" text-anchor="middle" class="vp-s">vision rows</text>
+  <text x="946" y="146" text-anchor="middle" class="vp-s">+ text tokens</text>
+  <text x="946" y="170" text-anchor="middle" class="vp-s" fill="#ffce5a">staged prefix</text>
+
+  <rect class="vp-card" x="1024" y="74" width="124" height="110" rx="11" stroke="#ffb400"/>
+  <text x="1086" y="108" text-anchor="middle" class="vp-t">Decode</text>
+  <text x="1086" y="130" text-anchor="middle" class="vp-s">KV cache</text>
+  <text x="1086" y="146" text-anchor="middle" class="vp-s">token stream</text>
+  <text x="1086" y="170" text-anchor="middle" class="vp-s" fill="#ffce5a">caption out</text>
+
+  <path d="M844,129 L882,129" fill="none" stroke="#8aa0b4" stroke-width="1.8" marker-end="url(#vp-a)"/>
+  <path d="M1008,129 L1022,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+
+  <!-- COMPILE SUBSTRATE -->
+  <rect x="14" y="248" width="1152" height="150" rx="14" fill="#262626" stroke="#3a3a3a" stroke-width="1.2"/>
+  <text x="34" y="276" class="vp-band">One deterministic stack underneath both lanes</text>
+  <g>
+    <rect class="vp-card" x="34"   y="294" width="206" height="84" rx="10"/>
+    <text x="54" y="324" class="vp-t" font-size="14">GGUF intake</text>
+    <text x="54" y="346" class="vp-s">tensors · vision metadata</text>
+    <text x="54" y="364" class="vp-s">convert_gguf_to_bump_v8</text>
+
+    <rect class="vp-card" x="262" y="294" width="206" height="84" rx="10"/>
+    <text x="282" y="324" class="vp-t" font-size="14">Template resolve</text>
+    <text x="282" y="346" class="vp-s">qwen3_vl_vision.json</text>
+    <text x="282" y="364" class="vp-s">graph order + kernel ids</text>
+
+    <rect class="vp-card" x="490" y="294" width="206" height="84" rx="10"/>
+    <text x="510" y="324" class="vp-t" font-size="14">IR + memory plan</text>
+    <text x="510" y="346" class="vp-s">build_ir_v8.py</text>
+    <text x="510" y="364" class="vp-s">offsets · buffers · no malloc</text>
+
+    <rect class="vp-card" x="718" y="294" width="206" height="84" rx="10"/>
+    <text x="738" y="324" class="vp-t" font-size="14">Codegen</text>
+    <text x="738" y="346" class="vp-s">encoder_v8.c</text>
+    <text x="738" y="364" class="vp-s">kernel dispatch · SIMD tier</text>
+
+    <rect x="946" y="294" width="206" height="84" rx="10" fill="rgba(71,180,117,0.14)" stroke="#47b475" stroke-width="1.5"/>
+    <text x="966" y="324" class="vp-t" font-size="14" fill="#a7e0bf">Bridge host</text>
+    <text x="966" y="346" class="vp-s" fill="#a7e0bf">run_multimodal_bridge_v8</text>
+    <text x="966" y="364" class="vp-s" fill="#a7e0bf">maps rows → decoder prefix</text>
+  </g>
+  <path d="M240,336 L260,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <path d="M468,336 L488,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <path d="M696,336 L716,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <path d="M924,336 L944,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <!-- substrate feeds both lanes -->
+  <path d="M340,294 L340,210 L340,206" fill="none" stroke="#5a6b78" stroke-width="1.3" stroke-dasharray="4 4" marker-end="url(#vp-a)"/>
+  <path d="M1049,294 L1049,210 L1049,206" fill="none" stroke="#5a6b78" stroke-width="1.3" stroke-dasharray="4 4" marker-end="url(#vp-a)"/>
+</svg>
+
 <h2>Source of Truth Stack</h2>
 
 <div class="v8-vision-contracts">
@@ -347,6 +470,103 @@
         That matters because the engine is not “calling an external encoder.” It is lowering and running the encoder as part of the same system.
     </p>
 </div>
+
+<h2>Inside the Patch Frontend</h2>
+
+<p>
+    The patch frontend is where a raw image becomes encoder tokens. These steps map directly to kernels in
+    <code>src/kernels/vision_kernels.c</code> &mdash; there is no hidden Python preprocessing doing the heavy lifting.
+</p>
+
+<svg viewBox="0 0 1180 360" width="100%" role="img"
+     aria-label="Vision patch embedding: im2patch slices the image into a patch grid, each patch is flattened and projected, then 2x2 spatial merge groups patches and tiled 2D position ids are added."
+     style="max-width:1180px;margin:0.5rem auto 1.25rem;display:block;font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <marker id="pf-a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#8aa0b4"/>
+    </marker>
+    <style>
+      .pf-t{fill:#f5f5f5;font-size:14px;font-weight:700;}
+      .pf-s{fill:#b0b0b0;font-size:11px;font-family:'JetBrains Mono',monospace;}
+      .pf-k{fill:#56c7f5;font-size:10.5px;font-family:'JetBrains Mono',monospace;}
+      .pf-step{fill:#9aa7b4;font-size:11px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;}
+    </style>
+  </defs>
+
+  <!-- Step 1: image grid -->
+  <text x="20" y="32" class="pf-step">1 · im2patch</text>
+  <g stroke="#3a6072" stroke-width="1.2" fill="rgba(7,173,248,0.08)">
+    <rect x="20" y="44" width="40" height="40"/><rect x="60" y="44" width="40" height="40"/><rect x="100" y="44" width="40" height="40"/><rect x="140" y="44" width="40" height="40"/>
+    <rect x="20" y="84" width="40" height="40"/><rect x="60" y="84" width="40" height="40"/><rect x="100" y="84" width="40" height="40"/><rect x="140" y="84" width="40" height="40"/>
+    <rect x="20" y="124" width="40" height="40"/><rect x="60" y="124" width="40" height="40"/><rect x="100" y="124" width="40" height="40"/><rect x="140" y="124" width="40" height="40"/>
+    <rect x="20" y="164" width="40" height="40"/><rect x="60" y="164" width="40" height="40"/><rect x="100" y="164" width="40" height="40"/><rect x="140" y="164" width="40" height="40"/>
+  </g>
+  <rect x="20" y="44" width="80" height="80" fill="none" stroke="#ffb400" stroke-width="2.4"/>
+  <text x="20" y="224" class="pf-s">image [C,H,W]</text>
+  <text x="20" y="240" class="pf-k">patch P×P · grid (H/P)×(W/P)</text>
+
+  <path d="M188,124 L228,124" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 2: flattened patch rows -->
+  <text x="244" y="32" class="pf-step">2 · flatten</text>
+  <g>
+    <rect x="244" y="44" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#ffb400" stroke-width="1.6"/>
+    <rect x="244" y="68" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#454545"/>
+    <rect x="244" y="92" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#454545"/>
+    <rect x="244" y="116" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#454545"/>
+    <text x="319" y="148" text-anchor="middle" class="pf-s">⋮</text>
+  </g>
+  <text x="244" y="224" class="pf-s">patches</text>
+  <text x="244" y="240" class="pf-k">[num_patches, C·P·P]</text>
+
+  <path d="M402,100 L442,100" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 3: dual patch projection -->
+  <text x="458" y="32" class="pf-step">3 · patch embed</text>
+  <rect x="458" y="44" width="180" height="120" rx="11" fill="#2f2f2f" stroke="#07adf8" stroke-width="1.5"/>
+  <text x="548" y="78" text-anchor="middle" class="pf-t">Dual patch proj</text>
+  <text x="548" y="100" text-anchor="middle" class="pf-s">GEMM W_patch</text>
+  <text x="548" y="118" text-anchor="middle" class="pf-s">+ stream merge</text>
+  <text x="548" y="136" text-anchor="middle" class="pf-s">+ patch bias</text>
+  <text x="458" y="224" class="pf-s">embedded</text>
+  <text x="458" y="240" class="pf-k">[num_patches, d]</text>
+
+  <path d="M646,104 L686,104" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 4: 2x2 spatial merge -->
+  <text x="702" y="32" class="pf-step">4 · spatial_merge_2x2</text>
+  <g stroke="#454545" stroke-width="1.1" fill="#2f2f2f">
+    <rect x="702" y="44" width="22" height="22"/><rect x="724" y="44" width="22" height="22"/>
+    <rect x="702" y="66" width="22" height="22"/><rect x="724" y="66" width="22" height="22"/>
+  </g>
+  <rect x="702" y="44" width="44" height="44" fill="none" stroke="#00bcd4" stroke-width="2.2"/>
+  <path d="M756,66 L792,66" fill="none" stroke="#00bcd4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+  <rect x="794" y="50" width="64" height="34" rx="6" fill="rgba(0,188,212,0.16)" stroke="#00bcd4" stroke-width="1.4"/>
+  <text x="826" y="72" text-anchor="middle" class="pf-k" fill="#7fe6f5">merged tok</text>
+  <text x="702" y="116" class="pf-s">4 patches → 1 row</text>
+  <text x="702" y="132" class="pf-k">tile_order_index_2d</text>
+  <text x="702" y="148" class="pf-k">(merge_size = 2)</text>
+  <text x="702" y="224" class="pf-s">merged grid</text>
+  <text x="702" y="240" class="pf-k">[rows, 4·d]</text>
+
+  <path d="M870,90 L908,120" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 5: tiled 2D position -->
+  <text x="924" y="32" class="pf-step">5 · +2D position</text>
+  <rect x="924" y="44" width="236" height="120" rx="11" fill="#2f2f2f" stroke="#07adf8" stroke-width="1.5"/>
+  <text x="1042" y="76" text-anchor="middle" class="pf-t">Tiled 2D pos + RoPE</text>
+  <text x="1042" y="98" text-anchor="middle" class="pf-s">position_embeddings_add_tiled_2d</text>
+  <text x="1042" y="116" text-anchor="middle" class="pf-s">vision_position_ids_2d_merge</text>
+  <text x="1042" y="134" text-anchor="middle" class="pf-s">multi-section RoPE</text>
+  <text x="1042" y="152" text-anchor="middle" class="pf-k" fill="#56c7f5">→ ready for transformer body</text>
+
+  <!-- footer note -->
+  <text x="20" y="300" class="pf-s" fill="#808080">Gemma4 vision swaps step 4/5 for </text>
+  <text x="320" y="300" class="pf-k">spatial_average_pool_contiguous</text>
+  <text x="600" y="300" class="pf-s" fill="#808080"> + </text>
+  <text x="624" y="300" class="pf-k">position_embeddings_add_gemma4v_xy</text>
+  <text x="20" y="322" class="pf-s" fill="#808080">All steps are pure, bump-allocated kernels — deterministic and reproducible across runs.</text>
+</svg>
 
 <h2>Important Artifacts</h2>
 

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-06-04 22:12</span>
+        <span class="folder-updated">Updated: 2026-06-24 11:49</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -6,11 +6,11 @@
     <title>API Reference  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/api.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/api.html">
     <meta property="og:title" content="API Reference  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/api.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/api.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -12969,8 +12969,8 @@ rmsnorm_backward(d_norm_out, input, gamma, rstd_cache, d_input, d_gamma, tokens,
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture-links.html
+++ b/docs/site/architecture-links.html
@@ -6,11 +6,11 @@
     <title>Architecture Links | C-Kernel-Engine</title>
     <meta name="description" content="Index of architecture, runbook, parity, and design pages for C-Kernel-Engine, including the current v8 multimodal inference documentation.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/architecture-links.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html">
     <meta property="og:title" content="Architecture Links | C-Kernel-Engine">
     <meta property="og:description" content="Index of architecture, runbook, parity, and design pages for C-Kernel-Engine, including the current v8 multimodal inference documentation.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/architecture-links.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1454,8 +1454,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -6,11 +6,11 @@
     <title>Architecture  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/architecture.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html">
     <meta property="og:title" content="Architecture  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/architecture.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1217,7 +1217,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-06-04 22:12</span>
+        <span class="folder-updated">Updated: 2026-06-24 11:49</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1586,8 +1586,8 @@ version/v7
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/assets/concept-vision-patch-embedding.svg
+++ b/docs/site/assets/concept-vision-patch-embedding.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="600" viewBox="0 0 1100 600" role="img" aria-labelledby="vpe-title vpe-desc">
+  <title id="vpe-title">Vision patch embedding kernel dataflow</title>
+  <desc id="vpe-desc">How im2patch slices an image into a patch grid, each patch is flattened and projected to the model dimension, a 2x2 spatial merge groups neighbouring patches, and tiled 2D position ids are added before the transformer body.</desc>
+  <defs>
+    <linearGradient id="vpe-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#07111f"/>
+      <stop offset="0.55" stop-color="#0f1b2d"/>
+      <stop offset="1" stop-color="#17243a"/>
+    </linearGradient>
+    <linearGradient id="vpe-proj" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="#0284c7" stop-opacity="0.85"/>
+    </linearGradient>
+    <filter id="vpe-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000000" flood-opacity="0.25"/>
+    </filter>
+    <marker id="vpe-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7dd3fc"/>
+    </marker>
+    <marker id="vpe-arrow-amber" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/>
+    </marker>
+  </defs>
+
+  <rect width="1100" height="600" fill="url(#vpe-bg)"/>
+  <g opacity="0.25" stroke="#26364f" stroke-width="1">
+    <path d="M0 80H1100M0 160H1100M0 240H1100M0 320H1100M0 400H1100M0 480H1100M0 560H1100"/>
+    <path d="M100 0V600M300 0V600M500 0V600M700 0V600M900 0V600"/>
+  </g>
+
+  <text x="50" y="54" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Vision Patch Embedding: image to encoder tokens</text>
+  <text x="50" y="84" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="14">src/kernels/vision_kernels.c — pure, bump-allocated, deterministic. No malloc, no OpenMP inside the kernel.</text>
+
+  <!-- 1. im2patch -->
+  <g transform="translate(50 120)" filter="url(#vpe-shadow)">
+    <rect x="0" y="0" width="230" height="270" rx="12" fill="#0b1220" stroke="#23334f"/>
+    <text x="20" y="32" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">1 · im2patch</text>
+    <text x="20" y="54" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">[C,H,W] &#8594; [N, C·P·P]</text>
+    <g transform="translate(35 72)" stroke="#2b6f8c" stroke-width="1.2" fill="#0e2233">
+      <rect x="0" y="0" width="40" height="40"/><rect x="40" y="0" width="40" height="40"/><rect x="80" y="0" width="40" height="40"/><rect x="120" y="0" width="40" height="40"/>
+      <rect x="0" y="40" width="40" height="40"/><rect x="40" y="40" width="40" height="40"/><rect x="80" y="40" width="40" height="40"/><rect x="120" y="40" width="40" height="40"/>
+      <rect x="0" y="80" width="40" height="40"/><rect x="40" y="80" width="40" height="40"/><rect x="80" y="80" width="40" height="40"/><rect x="120" y="80" width="40" height="40"/>
+      <rect x="0" y="120" width="40" height="40"/><rect x="40" y="120" width="40" height="40"/><rect x="80" y="120" width="40" height="40"/><rect x="120" y="120" width="40" height="40"/>
+    </g>
+    <rect x="35" y="72" width="80" height="80" fill="none" stroke="#fbbf24" stroke-width="2.6"/>
+    <text x="20" y="258" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">grid = (H/P) × (W/P)</text>
+  </g>
+
+  <line x1="285" y1="255" x2="330" y2="255" stroke="#7dd3fc" stroke-width="2.4" marker-end="url(#vpe-arrow)"/>
+
+  <!-- 2. flatten + project -->
+  <g transform="translate(335 120)" filter="url(#vpe-shadow)">
+    <rect x="0" y="0" width="250" height="270" rx="12" fill="#0b1220" stroke="#23334f"/>
+    <text x="20" y="32" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">2 · patch embed</text>
+    <text x="20" y="54" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">dual proj + merge + bias</text>
+    <g transform="translate(20 72)">
+      <rect x="0" y="0" width="120" height="18" rx="3" fill="#0e2233" stroke="#fbbf24" stroke-width="1.6"/>
+      <rect x="0" y="24" width="120" height="18" rx="3" fill="#0e2233" stroke="#2b3b55"/>
+      <rect x="0" y="48" width="120" height="18" rx="3" fill="#0e2233" stroke="#2b3b55"/>
+      <text x="60" y="92" text-anchor="middle" fill="#6b7d99" font-family="JetBrains Mono, Consolas, monospace" font-size="13">&#8942;</text>
+      <line x1="128" y1="33" x2="158" y2="33" stroke="#7dd3fc" stroke-width="2" marker-end="url(#vpe-arrow)"/>
+      <rect x="160" y="6" width="60" height="54" rx="8" fill="url(#vpe-proj)"/>
+      <text x="190" y="30" text-anchor="middle" fill="#04121f" font-family="JetBrains Mono, Consolas, monospace" font-size="12" font-weight="700">GEMM</text>
+      <text x="190" y="46" text-anchor="middle" fill="#04121f" font-family="JetBrains Mono, Consolas, monospace" font-size="11">W_patch</text>
+    </g>
+    <text x="20" y="200" fill="#e5f2ff" font-family="JetBrains Mono, Consolas, monospace" font-size="12">+ add_stream_reorder_2d</text>
+    <text x="20" y="222" fill="#e5f2ff" font-family="JetBrains Mono, Consolas, monospace" font-size="12">+ rowwise_bias_add</text>
+    <text x="20" y="258" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">&#8594; [N, d_model]</text>
+  </g>
+
+  <line x1="590" y1="255" x2="635" y2="255" stroke="#7dd3fc" stroke-width="2.4" marker-end="url(#vpe-arrow)"/>
+
+  <!-- 3. spatial merge 2x2 -->
+  <g transform="translate(640 120)" filter="url(#vpe-shadow)">
+    <rect x="0" y="0" width="230" height="270" rx="12" fill="#0b1220" stroke="#23334f"/>
+    <text x="20" y="32" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">3 · spatial_merge_2x2</text>
+    <text x="20" y="54" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">tile_order_index_2d</text>
+    <g transform="translate(40 80)" stroke="#2b3b55" stroke-width="1.2" fill="#0e2233">
+      <rect x="0" y="0" width="34" height="34"/><rect x="34" y="0" width="34" height="34"/>
+      <rect x="0" y="34" width="34" height="34"/><rect x="34" y="34" width="34" height="34"/>
+    </g>
+    <rect x="40" y="80" width="68" height="68" fill="none" stroke="#0ea5e9" stroke-width="2.6"/>
+    <line x1="120" y1="114" x2="150" y2="114" stroke="#7dd3fc" stroke-width="2" marker-end="url(#vpe-arrow)"/>
+    <rect x="152" y="96" width="56" height="36" rx="7" fill="#0e2233" stroke="#0ea5e9" stroke-width="1.6"/>
+    <text x="180" y="119" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono, Consolas, monospace" font-size="11">1 row</text>
+    <text x="20" y="190" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="13">4 neighbouring patches</text>
+    <text x="20" y="210" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="13">concat &#8594; 1 merged token</text>
+    <text x="20" y="258" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="12">&#8594; [N/4, 4·d]</text>
+  </g>
+
+  <!-- 4. positions -->
+  <g transform="translate(50 415)" filter="url(#vpe-shadow)">
+    <rect x="0" y="0" width="820" height="100" rx="12" fill="#111c2f" stroke="#2b3b55"/>
+    <text x="22" y="34" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">4 · tiled 2D position + RoPE</text>
+    <text x="22" y="60" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">position_embeddings_add_tiled_2d &#183; vision_position_ids_2d_merge &#183; multi-section RoPE</text>
+    <text x="22" y="82" fill="#7dd3fc" font-family="JetBrains Mono, Consolas, monospace" font-size="13">Each token learns where it sits on the 2D grid before attention mixes patches.</text>
+    <line x1="700" y1="50" x2="788" y2="50" stroke="#fbbf24" stroke-width="2.4" marker-end="url(#vpe-arrow-amber)"/>
+    <text x="724" y="34" fill="#fbbf24" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">to body</text>
+  </g>
+
+  <!-- gemma4 note -->
+  <g transform="translate(50 535)">
+    <rect x="0" y="0" width="1000" height="44" rx="10" fill="#08111f" stroke="#24344f"/>
+    <text x="22" y="28" fill="#9fb6d8" font-family="Inter, Arial, sans-serif" font-size="14">
+      Gemma4 vision swaps step 3/4 for spatial_average_pool_contiguous + position_embeddings_add_gemma4v_xy; both lanes reuse the same im2patch frontend and bump-allocated memory plan.
+    </text>
+  </g>
+</svg>

--- a/docs/site/assets/concept-vision-position-encoding.svg
+++ b/docs/site/assets/concept-vision-position-encoding.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="680" viewBox="0 0 1100 680" role="img" aria-labelledby="vpos-title vpos-desc">
+  <title id="vpos-title">Position encoding: 1D text RoPE vs 2D vision RoPE</title>
+  <desc id="vpos-desc">Text tokens carry a single position index that drives standard RoPE across head-dimension pairs. Image patch tokens carry two coordinates, a row and a column, and multi-section RoPE rotates one slice of the head dimension by the row angle and another slice by the column angle, while a learned 2D position table is bilinearly interpolated and added.</desc>
+  <defs>
+    <linearGradient id="vpos-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#07111f"/>
+      <stop offset="0.55" stop-color="#0f1b2d"/>
+      <stop offset="1" stop-color="#17243a"/>
+    </linearGradient>
+    <filter id="vpos-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000000" flood-opacity="0.25"/>
+    </filter>
+    <marker id="vpos-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7dd3fc"/>
+    </marker>
+    <marker id="vpos-arrow-amber" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24"/>
+    </marker>
+  </defs>
+
+  <rect width="1100" height="680" fill="url(#vpos-bg)"/>
+  <g opacity="0.22" stroke="#26364f" stroke-width="1">
+    <path d="M0 80H1100M0 160H1100M0 240H1100M0 320H1100M0 400H1100M0 480H1100M0 560H1100M0 640H1100"/>
+  </g>
+
+  <text x="50" y="50" fill="#e5f2ff" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">How a token knows where it is: 1D text vs 2D vision</text>
+  <text x="50" y="80" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="14">Same RoPE idea — rotate Q/K by a position angle. Text has one index; a patch has two: (row y, col x).</text>
+
+  <!-- ===================== LEFT: TEXT 1D ===================== -->
+  <g transform="translate(40 110)" filter="url(#vpos-shadow)">
+    <rect x="0" y="0" width="500" height="510" rx="14" fill="#0b1220" stroke="#23334f"/>
+    <text x="24" y="38" fill="#7dd3fc" font-family="Inter, Arial, sans-serif" font-size="19" font-weight="700">TEXT &#8212; 1D RoPE</text>
+    <text x="24" y="62" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">position = token index t (0,1,2,&#8230;)</text>
+
+    <!-- token row -->
+    <g transform="translate(24 84)">
+      <rect x="0"   y="0" width="84" height="44" rx="8" fill="#10243a" stroke="#38bdf8"/>
+      <rect x="92"  y="0" width="84" height="44" rx="8" fill="#10243a" stroke="#38bdf8"/>
+      <rect x="184" y="0" width="84" height="44" rx="8" fill="#10243a" stroke="#38bdf8"/>
+      <rect x="276" y="0" width="84" height="44" rx="8" fill="#10243a" stroke="#38bdf8"/>
+      <rect x="368" y="0" width="84" height="44" rx="8" fill="#10243a" stroke="#38bdf8"/>
+      <text x="42"  y="22" text-anchor="middle" fill="#e5f2ff" font-family="Inter" font-size="13">The</text>
+      <text x="134" y="22" text-anchor="middle" fill="#e5f2ff" font-family="Inter" font-size="13">cat</text>
+      <text x="226" y="22" text-anchor="middle" fill="#e5f2ff" font-family="Inter" font-size="13">sat</text>
+      <text x="318" y="22" text-anchor="middle" fill="#e5f2ff" font-family="Inter" font-size="13">on</text>
+      <text x="410" y="22" text-anchor="middle" fill="#e5f2ff" font-family="Inter" font-size="13">mat</text>
+      <text x="42"  y="38" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">t=0</text>
+      <text x="134" y="38" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">t=1</text>
+      <text x="226" y="38" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">t=2</text>
+      <text x="318" y="38" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">t=3</text>
+      <text x="410" y="38" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">t=4</text>
+    </g>
+
+    <text x="24" y="178" fill="#cbd5e1" font-family="Inter" font-size="14">RoPE angle for dim-pair i:</text>
+    <rect x="24" y="190" width="452" height="40" rx="8" fill="#111c2f" stroke="#2b3b55"/>
+    <text x="40" y="215" fill="#fbbf24" font-family="JetBrains Mono" font-size="15">&#952;&#7522;(t) = t &#183; base^(&#8722;2i/d)</text>
+
+    <!-- head dim pairs -->
+    <text x="24" y="266" fill="#cbd5e1" font-family="Inter" font-size="14">One angle rotates every (x&#7522;, x&#7522;&#8323;&#8260;&#8322;) pair across head_dim:</text>
+    <g transform="translate(24 282)">
+      <rect x="0"   y="0" width="446" height="54" rx="8" fill="#0e1b2c" stroke="#38bdf8" stroke-opacity="0.5"/>
+      <g font-family="JetBrains Mono" font-size="12" fill="#7dd3fc">
+        <rect x="12"  y="12" width="64" height="30" rx="5" fill="#10243a" stroke="#38bdf8"/><text x="44"  y="32" text-anchor="middle">pair 0</text>
+        <rect x="84"  y="12" width="64" height="30" rx="5" fill="#10243a" stroke="#38bdf8"/><text x="116" y="32" text-anchor="middle">pair 1</text>
+        <rect x="156" y="12" width="64" height="30" rx="5" fill="#10243a" stroke="#38bdf8"/><text x="188" y="32" text-anchor="middle">pair 2</text>
+        <rect x="228" y="12" width="64" height="30" rx="5" fill="#10243a" stroke="#38bdf8"/><text x="260" y="32" text-anchor="middle">&#8230;</text>
+        <rect x="300" y="12" width="134" height="30" rx="5" fill="#10243a" stroke="#38bdf8"/><text x="367" y="32" text-anchor="middle">pair d/2&#8722;1</text>
+      </g>
+    </g>
+    <text x="24" y="372" fill="#9fb6d8" font-family="Inter" font-size="13">All pairs share the same scalar t &#8212; order along one line.</text>
+
+    <!-- summary chip -->
+    <rect x="24" y="392" width="452" height="92" rx="10" fill="#08111f" stroke="#24344f"/>
+    <text x="40" y="418" fill="#e5f2ff" font-family="Inter" font-size="14" font-weight="700">Mental model</text>
+    <text x="40" y="442" fill="#9fb6d8" font-family="Inter" font-size="13">Position is a point on a line. Attention sees</text>
+    <text x="40" y="462" fill="#9fb6d8" font-family="Inter" font-size="13">relative distance (t&#7522; &#8722; t&#11388;) automatically from the</text>
+    <text x="40" y="482" fill="#9fb6d8" font-family="Inter" font-size="13">rotation &#8212; "how far apart in the sequence".</text>
+  </g>
+
+  <!-- ===================== RIGHT: VISION 2D ===================== -->
+  <g transform="translate(560 110)" filter="url(#vpos-shadow)">
+    <rect x="0" y="0" width="500" height="510" rx="14" fill="#0b1220" stroke="#23334f"/>
+    <text x="24" y="38" fill="#fbbf24" font-family="Inter, Arial, sans-serif" font-size="19" font-weight="700">VISION &#8212; 2D M-RoPE</text>
+    <text x="24" y="62" fill="#9fb6d8" font-family="JetBrains Mono, Consolas, monospace" font-size="13">position = (row y, col x) on the patch grid</text>
+
+    <!-- patch grid -->
+    <g transform="translate(24 80)">
+      <g stroke="#5a4a1a" stroke-width="1.2" fill="#1c1606">
+        <rect x="0"  y="0"  width="44" height="44"/><rect x="44" y="0"  width="44" height="44"/><rect x="88" y="0"  width="44" height="44"/><rect x="132" y="0" width="44" height="44"/>
+        <rect x="0"  y="44" width="44" height="44"/><rect x="44" y="44" width="44" height="44"/><rect x="88" y="44" width="44" height="44"/><rect x="132" y="44" width="44" height="44"/>
+        <rect x="0"  y="88" width="44" height="44"/><rect x="44" y="88" width="44" height="44"/><rect x="88" y="88" width="44" height="44"/><rect x="132" y="88" width="44" height="44"/>
+      </g>
+      <!-- highlight a patch -->
+      <rect x="44" y="44" width="44" height="44" fill="none" stroke="#fbbf24" stroke-width="2.8"/>
+      <text x="66" y="70" text-anchor="middle" fill="#fde68a" font-family="JetBrains Mono" font-size="11">(1,1)</text>
+      <!-- axis labels -->
+      <text x="-10" y="24" text-anchor="end" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">y=0</text>
+      <text x="-10" y="68" text-anchor="end" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">y=1</text>
+      <text x="-10" y="112" text-anchor="end" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">y=2</text>
+      <text x="22"  y="148" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">x=0</text>
+      <text x="66"  y="148" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">x=1</text>
+      <text x="110" y="148" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="11">x=2</text>
+    </g>
+
+    <!-- two coords -->
+    <text x="240" y="104" fill="#cbd5e1" font-family="Inter" font-size="14">Each patch token carries</text>
+    <text x="240" y="124" fill="#cbd5e1" font-family="Inter" font-size="14">two indices instead of one:</text>
+    <rect x="240" y="136" width="110" height="34" rx="7" fill="#10243a" stroke="#38bdf8"/>
+    <text x="295" y="158" text-anchor="middle" fill="#7dd3fc" font-family="JetBrains Mono" font-size="13">y = row</text>
+    <rect x="360" y="136" width="110" height="34" rx="7" fill="#2a1b08" stroke="#fbbf24"/>
+    <text x="415" y="158" text-anchor="middle" fill="#fde68a" font-family="JetBrains Mono" font-size="13">x = col</text>
+
+    <!-- head dim split -->
+    <text x="24" y="252" fill="#cbd5e1" font-family="Inter" font-size="14">head_dim is split into sections &#8212; each rotated by its own coordinate:</text>
+    <g transform="translate(24 266)">
+      <rect x="0"   y="0" width="223" height="54" rx="8" fill="#0e1b2c" stroke="#38bdf8"/>
+      <text x="112" y="22" text-anchor="middle" fill="#7dd3fc" font-family="Inter" font-size="13" font-weight="700">y-section</text>
+      <text x="112" y="42" text-anchor="middle" fill="#9fb6d8" font-family="JetBrains Mono" font-size="11">&#952;(y) = y &#183; base^(&#8722;2i/d)</text>
+      <rect x="227" y="0" width="219" height="54" rx="8" fill="#20170b" stroke="#fbbf24"/>
+      <text x="336" y="22" text-anchor="middle" fill="#fde68a" font-family="Inter" font-size="13" font-weight="700">x-section</text>
+      <text x="336" y="42" text-anchor="middle" fill="#f3d27a" font-family="JetBrains Mono" font-size="11">&#952;(x) = x &#183; base^(&#8722;2i/d)</text>
+    </g>
+
+    <!-- position id buffer -->
+    <text x="24" y="356" fill="#cbd5e1" font-family="Inter" font-size="13">vision_position_ids_2d_merge &#8594; buffer [4 &#215; N]:</text>
+    <g transform="translate(24 366)" font-family="JetBrains Mono" font-size="11">
+      <rect x="0"   y="0" width="110" height="26" rx="5" fill="#10243a" stroke="#38bdf8"/><text x="55"  y="17" text-anchor="middle" fill="#7dd3fc">y stream</text>
+      <rect x="114" y="0" width="110" height="26" rx="5" fill="#2a1b08" stroke="#fbbf24"/><text x="169" y="17" text-anchor="middle" fill="#fde68a">x stream</text>
+      <rect x="228" y="0" width="108" height="26" rx="5" fill="#10243a" stroke="#38bdf8"/><text x="282" y="17" text-anchor="middle" fill="#7dd3fc">y dup</text>
+      <rect x="340" y="0" width="106" height="26" rx="5" fill="#2a1b08" stroke="#fbbf24"/><text x="393" y="17" text-anchor="middle" fill="#fde68a">x dup</text>
+    </g>
+
+    <!-- learned table note -->
+    <rect x="24" y="406" width="452" height="78" rx="10" fill="#08111f" stroke="#24344f"/>
+    <text x="40" y="430" fill="#e5f2ff" font-family="Inter" font-size="14" font-weight="700">Plus a learned 2D table</text>
+    <text x="40" y="452" fill="#9fb6d8" font-family="Inter" font-size="12.5">position_embeddings_add_tiled_2d bilinearly resizes a</text>
+    <text x="40" y="470" fill="#9fb6d8" font-family="Inter" font-size="12.5">source_grid&#215;source_grid table to this image&#8217;s grid and adds it.</text>
+  </g>
+
+  <!-- bottom takeaway -->
+  <g transform="translate(40 632)">
+    <rect x="0" y="0" width="1020" height="34" rx="10" fill="#0b1f17" stroke="#1f5c3f"/>
+    <text x="20" y="22" fill="#a7e0bf" font-family="Inter, Arial, sans-serif" font-size="13.5">
+      Same rotation trick, richer index: text rotates by "how far along the line"; a patch rotates by "which row" and "which column" so attention recovers 2D spatial distance.
+    </text>
+  </g>
+</svg>

--- a/docs/site/codegen.html
+++ b/docs/site/codegen.html
@@ -6,11 +6,11 @@
     <title>Code Generation  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/codegen.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html">
     <meta property="og:title" content="Code Generation  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/codegen.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1759,8 +1759,8 @@ static size_t bump(size_t *off, size_t bytes) {
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -6,11 +6,11 @@
     <title>Deep Dive: LLM Concepts  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/concepts.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html">
     <meta property="og:title" content="Deep Dive: LLM Concepts  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/concepts.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -959,6 +959,7 @@
     <li><a href="#architecture">Transformer Architecture Overview</a></li>
     <li><a href="#rope">RoPE: Rotary Position Embedding</a></li>
     <li><a href="#rope-layouts">RoPE Layouts: Pairwise vs Split-Half</a></li>
+    <li><a href="#glm4-rope">GLM-4 RoPE: Pairwise Partial Rotary</a></li>
     <li><a href="#gemma4-rope">Gemma4 RoPE: Per-Layer Direct Split-Half</a></li>
     <li><a href="#attention">Attention Mechanisms</a></li>
     <li><a href="#flash-attention">Flash Attention</a></li>
@@ -970,6 +971,8 @@
     <li><a href="#mamba2-reference">Mamba2 Reference Kernels</a></li>
     <li><a href="#moe-routing">Mixture of Experts: Router + ReLU2 Experts</a></li>
     <li><a href="#activations">Activations: ReLU2, SwiGLU, GeGLU, GELU</a></li>
+    <li><a href="#vision-patch">Vision Patch Embedding</a></li>
+    <li><a href="#vision-position">&mdash; 1D Text vs 2D Vision Position (RoPE)</a></li>
     <li><a href="#weight-tying">Weight Tying</a></li>
 </ul>
 
@@ -1129,7 +1132,7 @@ Backward:
 <div class="grid grid-2">
     <div class="card card-accent">
         <h3 style="margin-top: 0;">Pairwise / Consecutive RoPE</h3>
-        <p>This is the layout used by <strong>Llama-family checkpoints</strong>, including Nanbeige in our v7 work.</p>
+        <p>This is the layout used by <strong>Llama-family checkpoints</strong>, including Nanbeige in our v7 work, and by <strong>GLM-4</strong> for its rotary slice.</p>
         <pre>(0,1), (2,3), (4,5), ...</pre>
         <p>Each even/odd pair is treated as one 2D rotation plane. That makes the math read exactly like the textbook RoPE formula:</p>
         <pre>x'[2i]   = x[2i] * cos - x[2i+1] * sin
@@ -1198,8 +1201,30 @@ Split-half:
     </div>
     <div>
         <strong>Implementation note in CK right now</strong><br>
-        The older split-half path already has AVX/AVX-512 SIMD specialization. The pairwise path was added to match Llama-family semantics, and the direct split-half path was added for model families that need per-layer rotary parameters instead of one global cache contract.
+        The older split-half path already has AVX/AVX-512 SIMD specialization. The pairwise path is selected through template/model-map metadata for model families that rotate adjacent even/odd pairs, including Llama-style layouts and GLM-4 partial RoPE. The direct split-half path was added for model families that need per-layer rotary parameters instead of one global cache contract.
     </div>
+</div>
+
+<h3 id="glm4-rope">GLM-4 RoPE: Pairwise Partial Rotary</h3>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">What changed for GLM-4?</h3>
+    <p>GLM-4 uses the pairwise/interleaved RoPE layout, but only on the configured rotary slice of each attention head. For example, with a 128-dimensional head and a 64-dimensional rotary slice, CK rotates adjacent pairs inside the first 64 dimensions and leaves the remaining 64 dimensions unchanged.</p>
+    <pre>Pairwise partial RoPE:
+  rotate:      (x0, x1), (x2, x3), ... within rotary_dim
+  pass-through: dimensions rotary_dim .. head_dim-1
+
+GLM template/model map:
+  rope_layout       = pairwise
+  partial_rotary    = true
+  rope_qk override  = rope_forward_qk_pairwise</pre>
+    <p>This is a model compatibility feature, not a tuning knob. If GLM-4 is lowered with split-half RoPE, the projection kernels can still be correct, but Q/K diverge immediately after RoPE and the attention output drifts from PyTorch.</p>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">How CK controls this</h3>
+    <p>The GLM template declares the circuit-level RoPE policy with <code>rope_layout: "pairwise"</code> and the safetensors model map carries the same architecture contract. Lowering reads that metadata and emits <code>rope_forward_qk_pairwise</code> for the Q/K rotary operation. The kernel itself is generic: it implements pairwise partial rotary math and does not know that the caller is GLM.</p>
+    <p>This keeps the DSL/compiler path deterministic. Templates and model maps describe the semantic contract; kernel maps bind that contract to an implementation; generated C should not infer or guess the rotary convention from tensor shape alone.</p>
 </div>
 
 <h3 id="gemma4-rope">Gemma4 RoPE: Per-Layer Direct Split-Half</h3>
@@ -1773,6 +1798,84 @@ output = gate * value       # Gate controls information flow
 
 <hr>
 
+<h2 id="vision-patch">Vision Patch Embedding</h2>
+
+<p>Multimodal families (Qwen3-VL, Gemma4 Vision, the standalone SigLIP ViT tower) start by turning a raw image into a sequence of encoder tokens. There is no attention or MLP here yet &mdash; this is the <em>frontend</em> that the transformer body consumes. In CK-Engine these steps are concrete kernels in <code>src/kernels/vision_kernels.c</code>, not hidden preprocessing, which is what lets the vision encoder share the same lowering and memory plan as the text decoder.</p>
+
+<div class="img-container svg-viewer" data-title="Vision Patch Embedding: im2patch, projection, 2x2 spatial merge, tiled 2D position">
+    <img src="assets/concept-vision-patch-embedding.svg" alt="Vision patch embedding kernel dataflow">
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">The Frontend Contract</h3>
+        <pre>
+im2patch:        [C,H,W] -> [N, C*P*P]    (N = (H/P)*(W/P))
+patch embed:     [N, C*P*P] -> [N, d]     (dual proj + stream merge + bias)
+spatial_merge_2x2: group 4 patches -> [N/4, 4*d]
++ tiled 2D pos:  position_embeddings_add_tiled_2d + 2D RoPE
+        </pre>
+        <p>Each patch is a <code>P&times;P</code> tile across all channels, flattened into one row. <code>spatial_merge_2x2</code> then groups a 2&times;2 block of patches into a single token using <code>tile_order_index_2d</code>, which is why the encoder works on a coarser grid than the raw patch grid.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">Why Depthwise / Why Strided</h3>
+        <p><code>im2patch</code> reads strided pixel rows directly rather than materializing reshaped copies, keeping the frontend allocation-free. The same kernels serve two merge policies:</p>
+        <ul>
+            <li><strong>Qwen3-VL:</strong> <code>spatial_merge_2x2</code> + <code>position_embeddings_add_tiled_2d</code></li>
+            <li><strong>Gemma4 Vision:</strong> <code>spatial_average_pool_contiguous</code> + <code>position_embeddings_add_gemma4v_xy</code></li>
+            <li><strong>Deepstack:</strong> <code>feature_concat</code> stitches selected layer taps before the projector footer</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Current CK Coverage</h3>
+    <p>The patch frontend is validated as part of the <code>v8</code> Qwen3-VL encoder parity path. The remaining flagged item is the layout <code>memcpy</code> in <code>im2patch</code> (one row copy per patch row) tracked in <code>KERNEL_STATUS.md</code> for conversion to fully strided access. See the <a href="v8-vision-encoder.html">v8 Vision Encoder</a> page for the full encoder &rarr; bridge &rarr; decoder pipeline.</p>
+</div>
+
+<h3 id="vision-position">How a Patch Knows Where It Is: 1D Text vs 2D Vision RoPE</h3>
+
+<p>Your intuition is exactly right. In text, a token's "position" is a single number &mdash; its index <code>t</code> in the sequence (0, 1, 2, &hellip;). RoPE turns that index into a rotation angle and rotates every <code>(x<sub>i</sub>, x<sub>i+d/2</sub>)</code> dimension pair of Q and K by it. Because rotation is relative, attention automatically recovers "how many tokens apart" two positions are. Position lives on <strong>one line</strong>.</p>
+
+<p>An image patch has no single index that means anything &mdash; what matters is <em>where on the grid</em> it sits. So instead of one scalar, a patch token carries <strong>two</strong> coordinates: its row <code>y</code> and its column <code>x</code> on the patch grid (the grid being <code>(H/P) &times; (W/P)</code>). This is the "context is basically the row and the height/column of the i-th patch" idea you described.</p>
+
+<div class="img-container svg-viewer" data-title="Position encoding: 1D text RoPE vs 2D vision M-RoPE">
+    <img src="assets/concept-vision-position-encoding.svg" alt="Comparison of 1D text RoPE position and 2D vision patch position encoding">
+</div>
+
+<p>CK encodes this two ways at once, both grounded in <code>src/kernels/vision_kernels.c</code>:</p>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">1. Multi-section (M-)RoPE &mdash; the rotation path</h3>
+        <p>It is the <em>same</em> RoPE math, just applied to two indices. The head dimension is split into sections: one slice of dims is rotated by an angle derived from the <strong>row</strong> <code>&theta;(y)</code>, another slice by an angle derived from the <strong>column</strong> <code>&theta;(x)</code>.</p>
+        <pre>
+text   :  angle = t * base^(-2i/d)          // one index
+vision :  y-dims rotate by  y * base^(-2i/d)
+          x-dims rotate by  x * base^(-2i/d) // two indices
+        </pre>
+        <p><code>vision_position_ids_2d_merge</code> builds the position buffer as four flattened streams <code>[y | x | y | x]</code>, emitted in the same 2&times;2 merged-tile order the patches use, so a token's coordinates line up with its embedding row. After rotation, attention can recover both vertical and horizontal distance between patches &mdash; true 2D relative position.</p>
+    </div>
+    <div class="card card-accent">
+        <h3 style="margin-top: 0;">2. Learned 2D position table &mdash; the additive path</h3>
+        <p>On top of (or instead of) rotation, vision encoders also keep a <strong>learned</strong> position embedding table indexed by grid cell &mdash; the direct analogue of GPT-2's learned 1D positional embedding, but 2D.</p>
+        <p><code>position_embeddings_add_tiled_2d</code> takes a table trained at a fixed <code>source_grid &times; source_grid</code> resolution and <strong>bilinearly interpolates</strong> it to whatever grid the current image actually produced, then adds it row-by-row. That is what lets one trained table serve images of different sizes.</p>
+        <p style="margin-bottom:0;">Gemma4 vision uses the XY variant <code>position_embeddings_add_gemma4v_xy</code>, which adds separate per-row and per-column components instead of a single interpolated grid.</p>
+    </div>
+</div>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The one-line summary</strong><br>
+        Text RoPE answers &ldquo;how far along the sequence?&rdquo; with one index. Vision M-RoPE answers &ldquo;which row and which column?&rdquo; with two &mdash; same rotation trick, applied to a 2D grid coordinate, with an interpolatable learned table layered on top.
+    </div>
+</div>
+
+<hr>
+
 <h2 id="weight-tying">Weight Tying</h2>
 
 <p>Weight tying shares parameters between the input embedding and output projection, reducing model size with minimal quality loss.</p>
@@ -2106,8 +2209,8 @@ With weight tying: W = E  (same matrix!)
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-20</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/contributing.html
+++ b/docs/site/contributing.html
@@ -6,11 +6,11 @@
     <title>Developer Guide  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/contributing.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html">
     <meta property="og:title" content="Developer Guide  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/contributing.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1269,8 +1269,8 @@ make test</code></pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions-dynamic.html
+++ b/docs/site/decisions-dynamic.html
@@ -6,11 +6,11 @@
     <title>Architecture Decisions  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/decisions-dynamic.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html">
     <meta property="og:title" content="Architecture Decisions  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/decisions-dynamic.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1455,8 +1455,8 @@ details.adr pre {
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions.html
+++ b/docs/site/decisions.html
@@ -6,11 +6,11 @@
     <title>Architecture Decisions  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/decisions.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html">
     <meta property="og:title" content="Architecture Decisions  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/decisions.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1929,8 +1929,8 @@ weight_mapping:
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deltanet-deep-dive.html
+++ b/docs/site/deltanet-deep-dive.html
@@ -6,11 +6,11 @@
     <title>Gated DeltaNet Deep Dive | C-Kernel-Engine</title>
     <meta name="description" content="Architecture and kernel notes for the Gated DeltaNet path in C-Kernel-Engine, including the Qwen3.5-style recurrent attention work.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/deltanet-deep-dive.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html">
     <meta property="og:title" content="Gated DeltaNet Deep Dive | C-Kernel-Engine">
     <meta property="og:description" content="Architecture and kernel notes for the Gated DeltaNet path in C-Kernel-Engine, including the Qwen3.5-style recurrent attention work.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/deltanet-deep-dive.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1459,6 +1459,497 @@
     </div>
 </div>
 
+<!-- ═══════════════════════════════════════════════════════════════════
+     SECTION 8: DeltaNet vs SSM (Mamba)
+     ═══════════════════════════════════════════════════════════════════ -->
+
+<h2>DeltaNet vs SSM (Mamba): Two Paths Beyond Attention</h2>
+
+<p>Both DeltaNet and Mamba-style SSMs solve the same fundamental problem: <strong>constant-cost per-token inference without a growing KV-cache</strong>. But they arrive at that solution through entirely different mathematical paths. C-Kernel-Engine implements both — <code>deltanet_kernels.c</code> (767 lines) and <code>ssm_kernels.c</code> (143 lines) — which gives us a concrete basis for comparison.</p>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Kernel Sources</strong><br>
+        DeltaNet: <code>src/kernels/deltanet_kernels.c</code> — Gated delta rule with AVX/AVX2/AVX-512<br>
+        SSM: <code>src/kernels/ssm_kernels.c</code> — Causal depthwise conv1d for Mamba-style layers<br>
+        Supporting: <code>recurrent_state_kernels.c</code>, <code>recurrent_gate_kernels.c</code>, <code>recurrent_norm_kernels.c</code>
+    </div>
+</div>
+
+<h3>The Core Difference</h3>
+
+<p>The difference is best understood as <em>what the state represents</em> and <em>how it gets updated</em>:</p>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3>DeltaNet: Corrective Associative Memory</h3>
+        <p>The state is a <strong>d×d matrix</strong> — a learned key-value associative memory. Each step:</p>
+        <ol>
+            <li>Probe the memory: <code>kv_mem = Sᵀ · k̂</code></li>
+            <li>Compute the error: <code>δ = β_s · (v − kv_mem)</code></li>
+            <li>Write the correction: <code>S += outer(k̂, δ)</code></li>
+        </ol>
+        <p>The state is <em>repaired</em> at every step. Information that is already correct costs nothing to maintain. Only errors drive updates.</p>
+    </div>
+    <div class="card">
+        <h3>SSM (Mamba): Input-Dependent Linear Recurrence</h3>
+        <p>The state is a <strong>d-dimensional hidden vector</strong>. Each step:</p>
+        <ol>
+            <li>Decay: <code>h_t = A_t · h_{t-1}</code></li>
+            <li>Inject: <code>h_t += B_t · x_t</code></li>
+            <li>Read: <code>y_t = C_t · h_t</code></li>
+        </ol>
+        <p>The state is a <em>linear dynamical system</em>. Information decays continuously via A_t. New inputs are injected via B_t. The output is a learned projection C_t.</p>
+    </div>
+</div>
+
+<h3>Mathematical Comparison</h3>
+
+<div class="card">
+<pre><code>═══════════════════════════════════════════════════════════════
+GATED DELTANET (per head, per token)
+═══════════════════════════════════════════════════════════════
+State:    S ∈ ℝ^{d × d}     (matrix — stores key-value associations)
+Decay:    S ← exp(g) · S     (element-wise scalar decay)
+Retrieve: kv_mem = Sᵀ · k̂    (what does memory say for this key?)
+Error:    δ = σ(β) · (v − kv_mem)  (correction signal)
+Update:   S ← S + outer(k̂, δ)     (rank-1 write)
+Output:   out = Sᵀ · q̂             (read with query)
+
+Total per step:  O(d²)  — dominated by state matrix operations
+
+═══════════════════════════════════════════════════════════════
+MAMBA-2 SSM (per channel, per token)
+═══════════════════════════════════════════════════════════════
+State:    h ∈ ℝ^d            (vector — linear dynamical system)
+Decay:    h ← A_t · h        (input-selective diagonal decay)
+Inject:   h ← h + B_t · x_t  (input-selective injection)
+Output:   y_t = C_t · h       (input-selective readout)
+
+Conv:     Pre-SSM depthwise conv1d with learned kernel
+
+Total per step:  O(d) for the recurrence + O(k·d) for conv1d
+
+═══════════════════════════════════════════════════════════════
+KEY DISTINCTION
+═══════════════════════════════════════════════════════════════
+DeltaNet writes CORRECTIONS. It asks "what is wrong with my memory?"
+SSM writes INPUTS. It asks "what should I add to my state?"
+
+DeltaNet has d² state. SSM has d state.
+DeltaNet has one update rule. SSM has conv1d + recurrence.</code></pre>
+</div>
+
+<h3>Comparison Table</h3>
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Gated DeltaNet</th>
+            <th>Mamba-2 SSM</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><strong>State shape</strong></td>
+            <td>Matrix: d × d per head</td>
+            <td>Vector: d per channel</td>
+        </tr>
+        <tr>
+            <td><strong>State size (typical)</strong></td>
+            <td>128² × 4B = 64 KB/head</td>
+            <td>~16–64 × 4B = 64–256 B/channel</td>
+        </tr>
+        <tr>
+            <td><strong>Update rule</strong></td>
+            <td>Delta rule: write the error</td>
+            <td>Linear recurrence: decay + inject</td>
+        </tr>
+        <tr>
+            <td><strong>Selectivity</strong></td>
+            <td>β gate (how much to correct) + g gate (how much to forget)</td>
+            <td>A, B, C are all input-dependent (selective scan)</td>
+        </tr>
+        <tr>
+            <td><strong>Pre-processing</strong></td>
+            <td>L2 normalization of q, k</td>
+            <td>Depthwise conv1d (short kernel, typically k=4)</td>
+        </tr>
+        <tr>
+            <td><strong>Compute per token</strong></td>
+            <td>O(d²) — state matrix sweep</td>
+            <td>O(k·d) conv + O(d) recurrence</td>
+        </tr>
+        <tr>
+            <td><strong>Memory per head/layer</strong></td>
+            <td>O(d²) — can be large for high-d</td>
+            <td>O(d + k) — very compact</td>
+        </tr>
+        <tr>
+            <td><strong>Prefill strategy</strong></td>
+            <td>Chunked: process T tokens in chunks, update S incrementally</td>
+            <td>Parallel scan (associative scan over the recurrence)</td>
+        </tr>
+        <tr>
+            <td><strong>What it resembles</strong></td>
+            <td>Adaptive filter / Hopfield network</td>
+            <td>Control-theory state observer / IIR filter</td>
+        </tr>
+        <tr>
+            <td><strong>Strength</strong></td>
+            <td>Precise associative recall from compressed memory</td>
+            <td>Fast streaming, efficient long-range dependency modeling</td>
+        </tr>
+        <tr>
+            <td><strong>Weakness</strong></td>
+            <td>d² cost limits head dimension; rank-1 updates can collide</td>
+            <td>Diagonal A limits expressive capacity per step</td>
+        </tr>
+        <tr>
+            <td><strong>Used by</strong></td>
+            <td>Qwen3.5 / qwen3next (recurrent layers)</td>
+            <td>Nemotron 3, Mamba, Mamba-2, Jamba</td>
+        </tr>
+    </tbody>
+</table>
+
+<h3>The Kernel Engineer's View</h3>
+
+<p>From an implementation standpoint, these two families have very different performance profiles:</p>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3>DeltaNet Kernel Profile</h3>
+        <ul>
+            <li><strong>Compute-bound</strong> for large state_dim (d ≥ 128)</li>
+            <li>The state sweep is a dense d×d matrix operation — perfect for SIMD</li>
+            <li>AVX-512 gives 16 floats/iter → the inner loop is tight</li>
+            <li>The outer product <code>outer(k̂, δ)</code> is a rank-1 update — maps to FMA chains</li>
+            <li>Memory layout: state is row-major [d×d], vector ops stride by d</li>
+            <li>767 lines in CK-Engine with 4 ISA tiers (ref/avx/avx2/avx512)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3>SSM Conv1d Kernel Profile</h3>
+        <ul>
+            <li><strong>Memory-bandwidth-bound</strong> for typical kernel sizes (k=4)</li>
+            <li>Depthwise conv1d: each channel has its own tiny filter</li>
+            <li>Very little arithmetic intensity — just k multiplies per output</li>
+            <li>Benefits from prefetch and streaming access patterns</li>
+            <li>Memory layout: [num_seqs × num_channels × (history + tokens)]</li>
+            <li>143 lines in CK-Engine — the simplicity is the point</li>
+        </ul>
+    </div>
+</div>
+
+<h3>Why Hybrid Architectures Use Both (or One + Attention)</h3>
+
+<p>Neither DeltaNet nor SSM can fully replace attention. Each trades exact token-by-token recall for efficiency. Modern architectures solve this by interleaving:</p>
+
+<div class="card">
+<pre><code>Qwen3.5 strategy:
+  Layer 0: DeltaNet (recurrent)
+  Layer 1: DeltaNet (recurrent)
+  Layer 2: DeltaNet (recurrent)
+  Layer 3: Full Attention        ← exact recall every 4th layer
+  Layer 4: DeltaNet (recurrent)
+  ...
+
+Nemotron 3 strategy:
+  Layer 0: Mamba-2 SSM
+  Layer 1: Mamba-2 SSM
+  Layer 2: Mamba-2 SSM
+  Layer 3: Full Attention        ← similar interleaving
+  Layer 4: Mamba-2 SSM
+  ...
+
+Both keep ~75% of layers as constant-cost recurrent.
+The remaining ~25% attention layers handle precise retrieval.</code></pre>
+</div>
+
+<p>The <em>hypothesis</em> behind both approaches: most tokens in a long context only need approximate memory (streaming summary), but some tokens need exact recall (names, numbers, specific facts). The hybrid gives you both.</p>
+
+<h3>SSM Kernel Internals — The Conv1d Path</h3>
+
+<p>The SSM kernel in CK-Engine implements the <em>causal depthwise convolution</em> that precedes the SSM recurrence in Mamba-style models. This is not the full Mamba forward pass — it is the conv1d stage that prepares inputs for the selective scan.</p>
+
+<div class="card">
+<pre><code>// ssm_kernels.c — forward pass structure
+
+void ssm_conv1d_forward_ref(
+    const float *conv_x,     // [num_seqs, num_channels, kernel_size-1 + num_tokens]
+    const float *kernel,     // [num_channels, kernel_size]
+    float *out,              // [num_seqs, num_tokens, num_channels]
+    int kernel_size,         // typically 4
+    int num_channels,        // model dim / num_heads
+    int num_tokens,          // sequence length
+    int num_seqs             // batch
+)
+
+// For each (seq, token, channel):
+//   out[seq][tok][ch] = dot(conv_x[seq][ch][tok : tok+kernel_size], kernel[ch][:])
+//
+// This is a depthwise (channel-independent) causal convolution.
+// Each channel has its own learned kernel of size k (typically 4).
+// The conv_x buffer carries history from previous chunks (kernel_size-1 slots).</code></pre>
+</div>
+
+<p>The <code>recurrent_state_kernels.c</code> file handles the <em>state management pipeline</em> — copying history into the conv buffer, appending new q/k/v tokens, and extracting the updated state for the next chunk:</p>
+
+<div class="card">
+<pre><code>// recurrent_state_kernels.c — state pipeline
+
+void recurrent_conv_state_update_forward(
+    const float *state_in,   // previous history [num_seqs × channels × history_len]
+    const float *q, *k, *v,  // new token projections
+    float *conv_x,           // assembled conv buffer [num_seqs × channels × total_len]
+    float *state_out,        // updated history for next call
+    int history_len,         // kernel_size - 1
+    int num_seqs, num_tokens,
+    int q_dim, k_dim, v_dim
+)
+
+// Step 1: Copy old history into conv buffer positions [0 : history_len]
+// Step 2: Append new tokens into positions [history_len : history_len + num_tokens]
+// Step 3: Extract updated history (last history_len positions) → state_out
+//
+// This is the "shift register" that feeds the causal conv1d kernel.</code></pre>
+</div>
+
+<p>The diagram below shows what <code>ssm_conv1d_forward_ref</code> actually computes: a per-channel sliding window of width <code>kernel_size</code> walks across the token axis, and each output is a dot product against that channel's own learned kernel. Because every channel uses its own filter and never mixes with neighbours, it is a <em>depthwise</em> convolution — cheap, embarrassingly parallel across channels, and causal by construction.</p>
+
+<div style="overflow-x:auto; margin:1.5rem 0;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 380" style="max-width:1000px;width:100%;height:auto;font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <marker id="ssm-a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#0891b2"/>
+    </marker>
+    <style>
+      .ssm-t{fill:#f5f5f5;font-size:15px;font-weight:700;}
+      .ssm-s{fill:#b0b0b0;font-size:12px;font-family:'JetBrains Mono',monospace;}
+      .ssm-lab{fill:#9aa7b4;font-size:12px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;}
+    </style>
+  </defs>
+
+  <text x="20" y="30" class="ssm-lab">conv_x[seq, ch, ·]  — history + tokens</text>
+
+  <!-- history cells -->
+  <g>
+    <rect x="20"  y="46" width="48" height="48" rx="6" fill="rgba(148,163,184,0.12)" stroke="#5a6b78" stroke-width="1.3"/>
+    <rect x="68"  y="46" width="48" height="48" rx="6" fill="rgba(148,163,184,0.12)" stroke="#5a6b78" stroke-width="1.3"/>
+    <rect x="116" y="46" width="48" height="48" rx="6" fill="rgba(148,163,184,0.12)" stroke="#5a6b78" stroke-width="1.3"/>
+    <text x="92" y="118" text-anchor="middle" class="ssm-s" fill="#7f8c99">history (k−1)</text>
+    <!-- new tokens -->
+    <rect x="164" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="212" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="260" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="308" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <rect x="356" y="46" width="48" height="48" rx="6" fill="rgba(6,182,212,0.14)" stroke="#06b6d4" stroke-width="1.3"/>
+    <text x="84"  y="76" text-anchor="middle" class="ssm-s">h₋₂</text>
+    <text x="92"  y="76" text-anchor="middle" class="ssm-s"></text>
+    <text x="188" y="76" text-anchor="middle" class="ssm-s">x₀</text>
+    <text x="236" y="76" text-anchor="middle" class="ssm-s">x₁</text>
+    <text x="284" y="76" text-anchor="middle" class="ssm-s">x₂</text>
+    <text x="332" y="76" text-anchor="middle" class="ssm-s">x₃</text>
+    <text x="380" y="76" text-anchor="middle" class="ssm-s">x₄</text>
+    <text x="262" y="118" text-anchor="middle" class="ssm-s" fill="#7fd8e6">new tokens (num_tokens)</text>
+  </g>
+
+  <!-- sliding window highlight for token x2 -->
+  <rect x="164" y="40" width="192" height="60" rx="8" fill="none" stroke="#ffb400" stroke-width="2.6"/>
+  <text x="260" y="36" text-anchor="middle" class="ssm-s" fill="#ffb400">window for out[x₂] = 4 taps</text>
+
+  <!-- kernel -->
+  <text x="560" y="30" class="ssm-lab">kernel[ch, :]  — per-channel filter</text>
+  <g>
+    <rect x="560" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <rect x="602" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <rect x="644" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <rect x="686" y="46" width="42" height="48" rx="6" fill="rgba(255,180,0,0.14)" stroke="#ffb400" stroke-width="1.3"/>
+    <text x="581" y="76" text-anchor="middle" class="ssm-s">w₀</text>
+    <text x="623" y="76" text-anchor="middle" class="ssm-s">w₁</text>
+    <text x="665" y="76" text-anchor="middle" class="ssm-s">w₂</text>
+    <text x="707" y="76" text-anchor="middle" class="ssm-s">w₃</text>
+    <text x="644" y="118" text-anchor="middle" class="ssm-s" fill="#ffce5a">kernel_size = 4</text>
+  </g>
+
+  <!-- dot product node -->
+  <circle cx="500" cy="200" r="34" fill="rgba(6,182,212,0.16)" stroke="#06b6d4" stroke-width="2"/>
+  <text x="500" y="198" text-anchor="middle" class="ssm-t" font-size="20">Σ</text>
+  <text x="500" y="216" text-anchor="middle" class="ssm-s" fill="#7fd8e6">dot</text>
+
+  <path d="M260,100 C320,150 420,170 470,186" fill="none" stroke="#0891b2" stroke-width="1.6" marker-end="url(#ssm-a)"/>
+  <path d="M644,100 C600,150 560,170 530,186" fill="none" stroke="#0891b2" stroke-width="1.6" marker-end="url(#ssm-a)"/>
+
+  <!-- output -->
+  <rect x="430" y="278" width="140" height="56" rx="10" fill="#2f2f2f" stroke="#06b6d4" stroke-width="1.6"/>
+  <text x="500" y="304" text-anchor="middle" class="ssm-t" font-size="14">out[seq, x₂, ch]</text>
+  <text x="500" y="324" text-anchor="middle" class="ssm-s" fill="#7fd8e6">one scalar / channel</text>
+  <path d="M500,234 L500,276" fill="none" stroke="#0891b2" stroke-width="1.8" marker-end="url(#ssm-a)"/>
+
+  <!-- depthwise note -->
+  <text x="760" y="200" class="ssm-lab">depthwise</text>
+  <text x="760" y="224" class="ssm-s" fill="#b0b0b0">channel c uses only</text>
+  <text x="760" y="242" class="ssm-s" fill="#b0b0b0">kernel[c] — no cross-</text>
+  <text x="760" y="260" class="ssm-s" fill="#b0b0b0">channel mixing.</text>
+  <text x="760" y="288" class="ssm-s" fill="#7f8c99">Output then feeds the</text>
+  <text x="760" y="306" class="ssm-s" fill="#7f8c99">selective scan recurrence.</text>
+</svg>
+</div>
+
+<h3>The Fundamental Analogy</h3>
+
+<div style="overflow-x:auto; margin:2rem 0;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 440" style="max-width:1000px; width:100%; height:auto; font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <linearGradient id="gDeltaGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#d97706"/>
+    </linearGradient>
+    <linearGradient id="gSSMGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="gAttnGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1000" height="440" rx="12" fill="#1e1e2e"/>
+  <rect x="1" y="1" width="998" height="438" rx="11" fill="none" stroke="#334155" stroke-width="1"/>
+
+  <text x="500" y="35" text-anchor="middle" font-size="16" font-weight="700" fill="#f5f5f5" letter-spacing="1">THREE MEMORY PARADIGMS</text>
+
+  <!-- Attention column -->
+  <rect x="30" y="60" width="290" height="360" rx="10" fill="#262637" stroke="#8b5cf6" stroke-width="1.5"/>
+  <rect x="30" y="60" width="290" height="42" rx="10" fill="url(#gAttnGrad)"/>
+  <rect x="30" y="90" width="290" height="12" fill="url(#gAttnGrad)"/>
+  <text x="175" y="86" text-anchor="middle" font-size="14" font-weight="700" fill="#fff">STANDARD ATTENTION</text>
+
+  <text x="50" y="130" font-size="11" fill="#c4b5fd" font-weight="600">Analogy:</text>
+  <text x="50" y="148" font-size="11" fill="#94a3b8">Perfect notebook. Write everything.</text>
+  <text x="50" y="165" font-size="11" fill="#94a3b8">Search the whole book each time.</text>
+
+  <text x="50" y="195" font-size="11" fill="#c4b5fd" font-weight="600">State:</text>
+  <text x="50" y="213" font-size="11" fill="#94a3b8">KV-cache: all past keys + values</text>
+  <text x="50" y="230" font-size="11" fill="#94a3b8">Shape: [T × d] — grows with T</text>
+
+  <text x="50" y="260" font-size="11" fill="#c4b5fd" font-weight="600">Update:</text>
+  <text x="50" y="278" font-size="11" fill="#94a3b8">Append new row. Never modify old.</text>
+
+  <text x="50" y="308" font-size="11" fill="#c4b5fd" font-weight="600">Read:</text>
+  <text x="50" y="326" font-size="11" fill="#94a3b8">Softmax over ALL past keys.</text>
+  <text x="50" y="343" font-size="11" fill="#94a3b8">Cost: O(T) per query.</text>
+
+  <text x="50" y="380" font-size="11" fill="#c4b5fd" font-weight="600">Tradeoff:</text>
+  <text x="50" y="398" font-size="11" fill="#94a3b8">Perfect recall ↔ linear cost growth</text>
+
+  <!-- DeltaNet column -->
+  <rect x="355" y="60" width="290" height="360" rx="10" fill="#262637" stroke="#f59e0b" stroke-width="1.5"/>
+  <rect x="355" y="60" width="290" height="42" rx="10" fill="url(#gDeltaGrad)"/>
+  <rect x="355" y="90" width="290" height="12" fill="url(#gDeltaGrad)"/>
+  <text x="500" y="86" text-anchor="middle" font-size="14" font-weight="700" fill="#fff">GATED DELTANET</text>
+
+  <text x="375" y="130" font-size="11" fill="#fcd34d" font-weight="600">Analogy:</text>
+  <text x="375" y="148" font-size="11" fill="#94a3b8">Whiteboard. Fixed size. Erase and</text>
+  <text x="375" y="165" font-size="11" fill="#94a3b8">rewrite only what's wrong.</text>
+
+  <text x="375" y="195" font-size="11" fill="#fcd34d" font-weight="600">State:</text>
+  <text x="375" y="213" font-size="11" fill="#94a3b8">Matrix S: associative memory</text>
+  <text x="375" y="230" font-size="11" fill="#94a3b8">Shape: [d × d] — always fixed</text>
+
+  <text x="375" y="260" font-size="11" fill="#fcd34d" font-weight="600">Update:</text>
+  <text x="375" y="278" font-size="11" fill="#94a3b8">Delta rule: S += outer(k̂, δ)</text>
+  <text x="375" y="295" font-size="11" fill="#94a3b8">Write the correction, not the value.</text>
+
+  <text x="375" y="325" font-size="11" fill="#fcd34d" font-weight="600">Read:</text>
+  <text x="375" y="343" font-size="11" fill="#94a3b8">out = Sᵀ · q̂. Cost: O(d²) always.</text>
+
+  <text x="375" y="380" font-size="11" fill="#fcd34d" font-weight="600">Tradeoff:</text>
+  <text x="375" y="398" font-size="11" fill="#94a3b8">Fixed cost ↔ lossy (rank-1 collisions)</text>
+
+  <!-- SSM column -->
+  <rect x="680" y="60" width="290" height="360" rx="10" fill="#262637" stroke="#06b6d4" stroke-width="1.5"/>
+  <rect x="680" y="60" width="290" height="42" rx="10" fill="url(#gSSMGrad)"/>
+  <rect x="680" y="90" width="290" height="12" fill="url(#gSSMGrad)"/>
+  <text x="825" y="86" text-anchor="middle" font-size="14" font-weight="700" fill="#fff">MAMBA-2 SSM</text>
+
+  <text x="700" y="130" font-size="11" fill="#67e8f9" font-weight="600">Analogy:</text>
+  <text x="700" y="148" font-size="11" fill="#94a3b8">Sliding-window sensor. Measure the</text>
+  <text x="700" y="165" font-size="11" fill="#94a3b8">stream. Decay old, inject new.</text>
+
+  <text x="700" y="195" font-size="11" fill="#67e8f9" font-weight="600">State:</text>
+  <text x="700" y="213" font-size="11" fill="#94a3b8">Hidden vector h: dynamical system</text>
+  <text x="700" y="230" font-size="11" fill="#94a3b8">Shape: [d] — compact</text>
+
+  <text x="700" y="260" font-size="11" fill="#67e8f9" font-weight="600">Update:</text>
+  <text x="700" y="278" font-size="11" fill="#94a3b8">h = A·h + B·x (linear recurrence)</text>
+  <text x="700" y="295" font-size="11" fill="#94a3b8">A, B, C are input-dependent.</text>
+
+  <text x="700" y="325" font-size="11" fill="#67e8f9" font-weight="600">Read:</text>
+  <text x="700" y="343" font-size="11" fill="#94a3b8">y = C·h. Cost: O(d) always.</text>
+
+  <text x="700" y="380" font-size="11" fill="#67e8f9" font-weight="600">Tradeoff:</text>
+  <text x="700" y="398" font-size="11" fill="#94a3b8">Cheapest cost ↔ limited capacity/step</text>
+</svg>
+</div>
+
+<h3>When Each Wins</h3>
+
+<table>
+    <thead>
+        <tr>
+            <th>Scenario</th>
+            <th>Best choice</th>
+            <th>Why</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Exact retrieval from long context</td>
+            <td>Attention</td>
+            <td>Nothing is lost — full KV-cache scan</td>
+        </tr>
+        <tr>
+            <td>Long streaming decode (100K+ tokens)</td>
+            <td>SSM (Mamba)</td>
+            <td>O(d) per step, no memory growth, fast</td>
+        </tr>
+        <tr>
+            <td>Learned key-value associations</td>
+            <td>DeltaNet</td>
+            <td>d² state has capacity; delta rule is precise</td>
+        </tr>
+        <tr>
+            <td>High throughput, memory-constrained</td>
+            <td>SSM (Mamba)</td>
+            <td>Smallest state footprint</td>
+        </tr>
+        <tr>
+            <td>Chunked prefill with state reuse</td>
+            <td>DeltaNet</td>
+            <td>State survives chunks; no parallel scan needed</td>
+        </tr>
+        <tr>
+            <td>CPU inference (SIMD-friendly)</td>
+            <td>DeltaNet</td>
+            <td>Dense d×d operations map perfectly to AVX/AVX-512</td>
+        </tr>
+        <tr>
+            <td>GPU inference (parallel scan)</td>
+            <td>SSM (Mamba)</td>
+            <td>Parallel associative scan maps to GPU warps</td>
+        </tr>
+    </tbody>
+</table>
+
+<p><strong>The kernel engineer's takeaway:</strong> DeltaNet is compute-bound and SIMD-friendly — it rewards wide vector units and dense FMA throughput. SSM conv1d is bandwidth-bound and simple — it rewards prefetch and streaming memory access. On a Xeon with AVX-512, DeltaNet's d×d sweep can actually be faster than you'd expect because the arithmetic intensity is high enough to hide memory latency. SSM's conv with k=4 hits the memory wall almost immediately.</p>
+
 <div class="card card-accent" style="margin-top:2rem;">
     <h3>📊 Back to Kernel Catalog</h3>
     <p>For the full list of CK-Engine kernels (GEMM, RoPE, Softmax, Loss, etc.), see:</p>
@@ -1691,8 +2182,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deterministic-memory.html
+++ b/docs/site/deterministic-memory.html
@@ -6,11 +6,11 @@
     <title>Deterministic Memory  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/deterministic-memory.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html">
     <meta property="og:title" content="Deterministic Memory  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/deterministic-memory.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1610,8 +1610,8 @@ class TrainingObserver:
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/developer-guide.html
+++ b/docs/site/developer-guide.html
@@ -6,11 +6,11 @@
     <title>Developer Guide  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/developer-guide.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html">
     <meta property="og:title" content="Developer Guide  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/developer-guide.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1729,8 +1729,8 @@ make emit CONFIG=x.json OUT=out.c  # Generate runtime</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/flash_attention.html
+++ b/docs/site/flash_attention.html
@@ -6,11 +6,11 @@
     <title>Flash Attention Analysis  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/flash_attention.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html">
     <meta property="og:title" content="Flash Attention Analysis  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/flash_attention.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1716,8 +1716,8 @@ pthread_setaffinity_np(pthread_self(),
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout-temp.html
+++ b/docs/site/gemm-memory-layout-temp.html
@@ -6,11 +6,11 @@
     <title>GEMM Memory Layout Deep Dive | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="noindex,nofollow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/gemm-memory-layout-temp.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout-temp.html">
     <meta property="og:title" content="GEMM Memory Layout Deep Dive | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/gemm-memory-layout-temp.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout-temp.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1394,8 +1394,8 @@ for (m_tile = 0; m_tile < M; m_tile += MB) {
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout.html
+++ b/docs/site/gemm-memory-layout.html
@@ -6,11 +6,11 @@
     <title>GEMM Memory Layout  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/gemm-memory-layout.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html">
     <meta property="og:title" content="GEMM Memory Layout  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/gemm-memory-layout.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1650,8 +1650,8 @@ Token 2: offset 1972    ✗ Kernel expects 1904!</code></pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-optimization.html
+++ b/docs/site/gemm-optimization.html
@@ -6,11 +6,11 @@
     <title>GEMM Optimization  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/gemm-optimization.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html">
     <meta property="og:title" content="GEMM Optimization  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/gemm-optimization.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1514,6 +1514,19 @@
             <span class="hero-badge">1.44x Faster than PyTorch/MKL</span>
         </section>
 
+        <div class="card" style="border-left: 4px solid var(--orange);">
+            <h3>Current v8 Prefill Target: Q4_K Repacking</h3>
+            <p>
+                The next CK prefill gap is not generic GEMM theory or thread count. It is Q4_K_M layout:
+                CK now has Q8_K activations, persistent threadpool dispatch, packed metadata, and a safe CK-vs-llama perf lane,
+                but Qwen3.5 prefill still trails llama.cpp because llama uses an interleaved/repacked Q4_K GEMM hot loop.
+            </p>
+            <p style="margin: 0;">
+                See <a href="prefill-performance-roadmap.html">Prefill Performance Roadmap</a> for the Q8 activation contract,
+                threadpool, packed-meta, 2D scheduler, and 8x8 repacked Q4_K microkernel plan.
+            </p>
+        </div>
+
         <!-- Performance Stats -->
         <div class="grid-4">
             <div class="stat-card">
@@ -1533,6 +1546,135 @@
                 <div class="stat-label">Register Tile</div>
             </div>
         </div>
+
+        <h2 id="gemm-vs-gemv-production">GEMM vs GEMV in Production LLM Serving</h2>
+        <p>
+            In transformer inference, most expensive linear layers reduce to either GEMM or GEMV. The distinction matters because a kernel that is good for one can be poor for the other.
+        </p>
+
+        <div class="grid-2">
+            <div class="card">
+                <h3>GEMV: decode latency</h3>
+                <p>
+                    GEMV is matrix-vector multiplication: one new token is multiplied by a weight matrix. This is the common decode path after the prompt is already in the KV cache.
+                </p>
+                <pre><code>// Decode, one token
+output[1, N] = activation[1, K] x weight[N, K]</code></pre>
+                <p>
+                    GEMV is usually memory-bandwidth bound. Each output row streams weight bytes, does a dot product, and has limited reuse of the activation vector. The important questions are:
+                </p>
+                <ul>
+                    <li>Are weights read sequentially in the inner loop?</li>
+                    <li>Are quantized blocks decoded with SIMD instead of scalar code?</li>
+                    <li>Is thread overhead smaller than the work per row?</li>
+                    <li>Does the final logits projection avoid tiny-task oversubscription?</li>
+                </ul>
+            </div>
+
+            <div class="card">
+                <h3>GEMM: prefill throughput</h3>
+                <p>
+                    GEMM is matrix-matrix multiplication: many prompt tokens are processed together. This is the prefill path and the dominant cost for long prompts.
+                </p>
+                <pre><code>// Prefill, M prompt tokens
+output[M, N] = activations[M, K] x weight[N, K]</code></pre>
+                <p>
+                    GEMM can reuse weights and activations across many outputs, so a production kernel must create reuse deliberately:
+                </p>
+                <ul>
+                    <li>Tile M, N, and K so hot data fits in L1/L2/L3.</li>
+                    <li>Keep a small accumulator tile in registers.</li>
+                    <li>Pack or interleave weights when the canonical layout is not enough.</li>
+                    <li>Use a thread split that creates enough work without saturating memory bandwidth.</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3>Why simple correctness kernels are not production kernels</h3>
+            <p>
+                A reference kernel proves the math. A production kernel has to prove the data movement. The same equation can run 3x slower if it repeatedly reloads cache lines, transposes buffers between operators, dispatches too many tiny tasks, or decodes quantized blocks in a layout that SIMD cannot consume efficiently.
+            </p>
+            <p>
+                This is why CK keeps scalar/reference, ISA-specific, tiled, packed, and dispatch-selected kernels separate. The reference path protects parity. The optimized path earns its place only when it matches parity and wins on the shapes used by real models.
+            </p>
+        </div>
+
+        <h2 id="production-kernel-checklist">Production Kernel Checklist</h2>
+        <div class="grid-3">
+            <div class="card">
+                <h3>1. Shape first</h3>
+                <p>
+                    Measure real model shapes, not synthetic square matrices only. Qwen2, Qwen3, Gemma, Nanbeige, and vision models stress different M/N/K regimes.
+                </p>
+            </div>
+            <div class="card">
+                <h3>2. Layout before instruction count</h3>
+                <p>
+                    If the weight layout forces scattered loads or repeated unpacking, more SIMD instructions will not fix the bottleneck. Repacking and interleaving often matter more than another arithmetic trick.
+                </p>
+            </div>
+            <div class="card">
+                <h3>3. Cache reuse</h3>
+                <p>
+                    Fast GEMM keeps reused A/B tiles close to the core. Fast GEMV streams weights predictably and avoids extra copies around activations, logits, and head-major attention output.
+                </p>
+            </div>
+            <div class="card">
+                <h3>4. Threading policy</h3>
+                <p>
+                    More threads are not automatically better. Small GEMV and tiny-M prefill can regress when threadpool overhead and memory contention exceed useful work.
+                </p>
+            </div>
+            <div class="card">
+                <h3>5. Quantization path</h3>
+                <p>
+                    Quantized inference is usually Q4_K/Q5_K/Q6_K weights times Q8_K or Q8_0 activations. Test the actual mixed-format kernel, not only dequantize-to-FP32 fallback.
+                </p>
+            </div>
+            <div class="card">
+                <h3>6. Parity gates</h3>
+                <p>
+                    Keep exact/reference kernels available. Enable optimized kernels by dispatch only after they pass llama.cpp/PyTorch parity for the relevant format and shape.
+                </p>
+            </div>
+        </div>
+
+        <h2 id="how-to-profile-gemm-gemv">How to Tell What Is Slow</h2>
+        <p>
+            A useful performance investigation separates raw kernel speed from model-level orchestration.
+        </p>
+        <table>
+            <tr>
+                <th>Symptom</th>
+                <th>Likely Cause</th>
+                <th>What to Run</th>
+            </tr>
+            <tr>
+                <td>Decode is slow, prompt is acceptable</td>
+                <td>GEMV/logits path is bandwidth-bound or overscheduled</td>
+                <td><code>make llamacpp-parity-perf</code>, <code>make test-gemv-comprehensive</code></td>
+            </tr>
+            <tr>
+                <td>Prompt/prefill is slow, standalone GEMM is fast</td>
+                <td>Model executor overhead: quantization, transposes, per-op boundaries</td>
+                <td>v8 op-level profiling and lowered prefill call inspection</td>
+            </tr>
+            <tr>
+                <td>Large shapes improve, small shapes regress</td>
+                <td>Thread split or tiled kernel not shape-gated</td>
+                <td><code>make test-q6k-prefill-dispatch-sweep-quick</code></td>
+            </tr>
+            <tr>
+                <td>CK matches parity but trails llama.cpp</td>
+                <td>Packed/interleaved layout or graph scheduling gap</td>
+                <td>Compare against llama.cpp repacked paths and kernel-level speed lanes</td>
+            </tr>
+        </table>
+
+        <p>
+            The practical rule is simple: first prove the kernel is mathematically correct, then prove it wins for the exact shapes, formats, thread counts, and hardware where dispatch will select it.
+        </p>
 
         <!-- Inspiration Section -->
         <h2>Standing on the Shoulders of Giants</h2>
@@ -2406,8 +2548,8 @@ gemm_microkernel_packed(A, B, C, M, N, K);</code></pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-bump.html
+++ b/docs/site/gguf-bump.html
@@ -6,11 +6,11 @@
     <title>GGUF to Bump  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/gguf-bump.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html">
     <meta property="og:title" content="GGUF to Bump  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/gguf-bump.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1830,8 +1830,8 @@ make gguf-to-bump GGUF=models/qwen2.5-3b-instruct-q4_k_m.gguf
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-conversion.html
+++ b/docs/site/gguf-conversion.html
@@ -6,11 +6,11 @@
     <title>GGUF Conversion Deep Dive  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/gguf-conversion.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html">
     <meta property="og:title" content="GGUF Conversion Deep Dive  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/gguf-conversion.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2178,8 +2178,8 @@ with open(output_path, "w+b") as f:
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -6,11 +6,11 @@
     <title>C-Kernel-Engine: CPU-Native AI Runtime and Training Engine | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine is a CPU-native AI runtime and code generation system for training and inference in pure C, with auditable IR, kernel parity, and Linux-first deployment.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/">
     <meta property="og:title" content="C-Kernel-Engine: CPU-Native AI Runtime and Training Engine | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine is a CPU-native AI runtime and code generation system for training and inference in pure C, with auditable IR, kernel parity, and Linux-first deployment.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1546,7 +1546,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-06-21 12:25</span>
+        <span class="folder-updated">Updated: 2026-06-24 11:49</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1916,7 +1916,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-21</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1147,6 +1147,13 @@
 
 <p>The intended deployment model is dependency-light execution, not dependency-free development. The generated runtime can be compiled with GCC or Clang, but the preferred path is to use the strongest native CPU toolchain for the target machine: Intel oneAPI/ICX on Intel CPUs, tuned GCC/Clang on AMD CPUs, ARM toolchains on ARM systems, and standard systems libraries for cluster execution.</p>
 
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Generated C, Planned Memory</h3>
+    <p>C-Kernel-Engine uses C as an <strong>auditable compiler target</strong>, not as a large hand-written pointer maze. The model graph, tensor shapes, lifetimes, kernel contracts, and memory sections are resolved before code emission. The generated C then reads and writes deterministic offsets from planned buffers instead of allocating or guessing inside the hot path.</p>
+    <p>This is the memory-safety model: avoid most ordinary C mistakes by not hand-authoring the model body in C in the first place. The compiler pipeline emits explicit offsets, optional bounds/canary checks, cache-aligned sections, and reproducible layout reports; ASAN, Valgrind, PyTorch parity, llama.cpp parity, perf, VTune, and Advisor validate the artifact from correctness down to memory behavior.</p>
+    <p style="margin-bottom: 0;">The result is still native C, but the important contract is visible: <code>IR op -> tensor lifetime -> byte offset -> generated pointer -> kernel call</code>. That makes the execution path deterministic, inspectable, and measurable for applications where memory layout is the application.</p>
+</div>
+
 <p>The north star is distributed CPU inference and training: model/layer ownership across CPU nodes, explicit activation and gradient movement, MPI/RDMA-style communication where available, and pipeline parallelism over hardware that can be bought, powered, audited, and scaled incrementally.</p>
 
 <p>The first version of C-Kernel-Engine tried to drive generation from HuggingFace <code>config.json</code> alone. That was not enough: config metadata does not fully capture quantized weight packing/layout details, nor all runtime stitching constraints needed for reliable kernel binding.</p>

--- a/docs/site/ir-pipeline.html
+++ b/docs/site/ir-pipeline.html
@@ -6,11 +6,11 @@
     <title>IR Pipeline v6.6  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/ir-pipeline.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html">
     <meta property="og:title" content="IR Pipeline v6.6  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/ir-pipeline.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2259,8 +2259,8 @@ python version/v6.6/tools/open_ir_visualizer.py Qwen--Qwen3-0.6B-GGUF</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-v2.html
+++ b/docs/site/ir-v2.html
@@ -6,11 +6,11 @@
     <title>IR v2 Format  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/ir-v2.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html">
     <meta property="og:title" content="IR v2 Format  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/ir-v2.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1655,8 +1655,8 @@ Page 2 (2-3GB)   → DRAM Bank 2 (Layer 12-17)
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/iteration-philosophy.html
+++ b/docs/site/iteration-philosophy.html
@@ -6,11 +6,11 @@
     <title>Documentation | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/iteration-philosophy.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html">
     <meta property="og:title" content="Documentation | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/iteration-philosophy.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2573,8 +2573,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernels.html
+++ b/docs/site/kernels.html
@@ -6,11 +6,11 @@
     <title>Kernel Catalog  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/kernels.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html">
     <meta property="og:title" content="Kernel Catalog  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/kernels.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1399,8 +1399,8 @@ out     = S_new^T * q_hat</code></pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/mega_fusion.html
+++ b/docs/site/mega_fusion.html
@@ -6,11 +6,11 @@
     <title>Mega-Fused Attention  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/mega_fusion.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html">
     <meta property="og:title" content="Mega-Fused Attention  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/mega_fusion.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1939,8 +1939,8 @@ mega_fused_attention_decode():
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-reality.html
+++ b/docs/site/memory-reality.html
@@ -6,11 +6,11 @@
     <title>Memory Reality  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/memory-reality.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html">
     <meta property="og:title" content="Memory Reality  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/memory-reality.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1711,8 +1711,8 @@ CPU (2TB server): FITS with 1.8TB headroom
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-safety.html
+++ b/docs/site/memory-safety.html
@@ -6,11 +6,11 @@
     <title>Memory Safety  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/memory-safety.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html">
     <meta property="og:title" content="Memory Safety  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/memory-safety.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1918,8 +1918,8 @@ echo "=== All memory safety checks passed ==="</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -972,6 +972,8 @@
     .model-card.mc-qwen3::before  { background: var(--green); }
     .model-card.mc-qwen35::before { background: #1abc9c; }
     .model-card.mc-qwen3vl::before { background: #00bcd4; }
+    .model-card.mc-gemma4v::before { background: #ff6f91; }
+    .model-card.mc-siglip::before  { background: #a78bfa; }
     .model-card.mc-qwen::before   { background: #16a085; }
     .model-card.mc-gemma3::before { background: var(--blue); }
     .model-card.mc-gemma4::before { background: #f39c12; }
@@ -1255,6 +1257,135 @@
   <div class="runner-callout">
     <strong>Recommended runner track:</strong> this model page points to the latest hardened v8 command path for hands-on smoke tests. Version pages remain historical snapshots of each engine generation; the cards below show the current practical command to convert, compile, run, and optionally emit the IR visualizer for that family. Large cards such as Gemma4, Nemotron, GLM4, and vision models assume a high-memory CPU host.
   </div>
+
+  <h2 style="color: var(--orange); margin-top: 2rem;">One Pipeline, Every Model</h2>
+  <p class="lead" style="margin-top: 0;">
+    Every supported family enters through the same deterministic compile path. The artifact (GGUF) carries the numbers,
+    the template carries the structure, and lowering turns both into a concrete C runtime with a fixed memory plan.
+    Vision families add a second lane that produces an encoder prefix and bridges it into the decoder.
+  </p>
+
+  <svg viewBox="0 0 1180 520" width="100%" role="img"
+       aria-label="C-Kernel-Engine model compilation pipeline: GGUF and template lower to IR, memory plan, codegen and runtime, with a vision encoder lane bridging into the decoder."
+       style="max-width: 1180px; margin: 0.5rem auto 1.75rem; display: block; font-family: 'Inter', system-ui, sans-serif;">
+    <defs>
+      <linearGradient id="mk-text" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#ffb400"/><stop offset="1" stop-color="#e5a200"/>
+      </linearGradient>
+      <linearGradient id="mk-vision" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#07adf8"/><stop offset="1" stop-color="#00bcd4"/>
+      </linearGradient>
+      <linearGradient id="mk-run" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#47b475"/><stop offset="1" stop-color="#2f8d59"/>
+      </linearGradient>
+      <marker id="mk-arrow" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+        <path d="M0,0 L7,3 L0,6 Z" fill="#8aa0b4"/>
+      </marker>
+      <marker id="mk-arrow-v" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+        <path d="M0,0 L7,3 L0,6 Z" fill="#07adf8"/>
+      </marker>
+      <style>
+        .mk-stage{fill:#323232;stroke:#454545;stroke-width:1.4;rx:12;}
+        .mk-title{fill:#f5f5f5;font-size:18px;font-weight:700;}
+        .mk-sub{fill:#b0b0b0;font-size:12.5px;font-family:'JetBrains Mono',monospace;}
+        .mk-band{fill:#9aa7b4;font-size:13px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;}
+        .mk-chip{fill:#0f151c;stroke:#263242;stroke-width:1;rx:6;}
+        .mk-chip-t{fill:#9ed6ff;font-size:12px;font-family:'JetBrains Mono',monospace;}
+      </style>
+    </defs>
+
+    <!-- band labels -->
+    <text x="24" y="40" class="mk-band">Source of truth</text>
+    <text x="24" y="250" class="mk-band">Deterministic compile</text>
+    <text x="24" y="430" class="mk-band">Vision lane (multimodal families)</text>
+
+    <!-- Row 1: sources -->
+    <g>
+      <rect class="mk-stage" x="24"  y="58" width="250" height="92" rx="12"/>
+      <text x="44" y="92"  class="mk-title">GGUF artifact</text>
+      <text x="44" y="116" class="mk-sub">tensors · dtypes · shapes</text>
+      <text x="44" y="134" class="mk-sub">tokenizer · vision metadata</text>
+
+      <rect class="mk-stage" x="320" y="58" width="250" height="92" rx="12"/>
+      <text x="340" y="92"  class="mk-title">Template <tspan class="mk-sub">.json</tspan></text>
+      <text x="340" y="116" class="mk-sub">header / body / footer graph</text>
+      <text x="340" y="134" class="mk-sub">kernel ids · contracts</text>
+    </g>
+    <!-- supported template chips -->
+    <g>
+      <rect class="mk-chip" x="616" y="58"  width="120" height="26" rx="6"/><text x="676" y="76" text-anchor="middle" class="mk-chip-t">qwen2/3/3.5</text>
+      <rect class="mk-chip" x="746" y="58"  width="120" height="26" rx="6"/><text x="806" y="76" text-anchor="middle" class="mk-chip-t">gemma3/4</text>
+      <rect class="mk-chip" x="876" y="58"  width="120" height="26" rx="6"/><text x="936" y="76" text-anchor="middle" class="mk-chip-t">glm4</text>
+      <rect class="mk-chip" x="1006" y="58" width="150" height="26" rx="6"/><text x="1081" y="76" text-anchor="middle" class="mk-chip-t">nemotron_h</text>
+      <rect class="mk-chip" x="616" y="92"  width="120" height="26" rx="6"/><text x="676" y="110" text-anchor="middle" class="mk-chip-t">llama</text>
+      <rect class="mk-chip" x="746" y="92"  width="120" height="26" rx="6"/><text x="806" y="110" text-anchor="middle" class="mk-chip-t">qwen3vl</text>
+      <rect class="mk-chip" x="876" y="92"  width="160" height="26" rx="6"/><text x="956" y="110" text-anchor="middle" class="mk-chip-t" fill="#9ed6ff">gemma4_vision</text>
+      <rect class="mk-chip" x="1046" y="92" width="110" height="26" rx="6"/><text x="1101" y="110" text-anchor="middle" class="mk-chip-t" fill="#cbb6ff">siglip_vit</text>
+      <text x="616" y="140" class="mk-sub" fill="#808080">11 templates resolve into the same lowering passes</text>
+    </g>
+
+    <!-- arrows sources -> compile -->
+    <path d="M149,150 L149,200" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+    <path d="M445,150 L445,200" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+
+    <!-- Row 2: compile pipeline -->
+    <g>
+      <rect class="mk-stage" x="24"   y="266" width="200" height="86" rx="12"/>
+      <text x="44" y="300" class="mk-title">IR lowering</text>
+      <text x="44" y="324" class="mk-sub">build_ir_v8.py</text>
+      <text x="44" y="342" class="mk-sub">template → kernel calls</text>
+
+      <rect class="mk-stage" x="264" y="266" width="200" height="86" rx="12"/>
+      <text x="284" y="300" class="mk-title">Memory plan</text>
+      <text x="284" y="324" class="mk-sub">bump offsets</text>
+      <text x="284" y="342" class="mk-sub">no malloc at runtime</text>
+
+      <rect class="mk-stage" x="504" y="266" width="200" height="86" rx="12"/>
+      <text x="524" y="300" class="mk-title">C codegen</text>
+      <text x="524" y="324" class="mk-sub">kernel dispatch</text>
+      <text x="524" y="342" class="mk-sub">SIMD tier select</text>
+
+      <rect x="744" y="266" width="220" height="86" rx="12" fill="url(#mk-run)" opacity="0.16" stroke="#47b475" stroke-width="1.6"/>
+      <text x="764" y="300" class="mk-title">Runtime</text>
+      <text x="764" y="324" class="mk-sub" fill="#a7e0bf">native C · deterministic</text>
+      <text x="764" y="342" class="mk-sub" fill="#a7e0bf">GEMM/GEMV · attention</text>
+    </g>
+    <path d="M224,309 L260,309" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+    <path d="M464,309 L500,309" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+    <path d="M704,309 L740,309" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#mk-arrow)"/>
+
+    <!-- text decoder feeds runtime token stream -->
+    <rect class="mk-stage" x="994" y="266" width="162" height="86" rx="12"/>
+    <text x="1014" y="300" class="mk-title">Decoder</text>
+    <text x="1014" y="324" class="mk-sub">prefill + decode</text>
+    <text x="1014" y="342" class="mk-sub">token stream out</text>
+    <path d="M964,309 L990,309" fill="none" stroke="#47b475" stroke-width="1.8" marker-end="url(#mk-arrow)"/>
+
+    <!-- Row 3: vision lane -->
+    <g>
+      <rect x="24"  y="446" width="190" height="58" rx="12" fill="url(#mk-vision)" opacity="0.14" stroke="#07adf8" stroke-width="1.5"/>
+      <text x="44" y="472" class="mk-title" font-size="16">Image in</text>
+      <text x="44" y="492" class="mk-sub" fill="#9ed6ff">resize · normalize</text>
+
+      <rect x="244" y="446" width="210" height="58" rx="12" fill="url(#mk-vision)" opacity="0.14" stroke="#07adf8" stroke-width="1.5"/>
+      <text x="264" y="472" class="mk-title" font-size="16">Patch frontend</text>
+      <text x="264" y="492" class="mk-sub" fill="#9ed6ff">im2patch · pos · merge</text>
+
+      <rect x="484" y="446" width="210" height="58" rx="12" fill="url(#mk-vision)" opacity="0.14" stroke="#07adf8" stroke-width="1.5"/>
+      <text x="504" y="472" class="mk-title" font-size="16">ViT encoder</text>
+      <text x="504" y="492" class="mk-sub" fill="#9ed6ff">attn · MLP · deepstack</text>
+
+      <rect x="724" y="446" width="210" height="58" rx="12" fill="url(#mk-vision)" opacity="0.22" stroke="#00bcd4" stroke-width="1.8"/>
+      <text x="744" y="472" class="mk-title" font-size="16">Bridge prefix</text>
+      <text x="744" y="492" class="mk-sub" fill="#9ed6ff">projector rows → decoder</text>
+    </g>
+    <path d="M214,475 L240,475" fill="none" stroke="#07adf8" stroke-width="1.6" marker-end="url(#mk-arrow-v)"/>
+    <path d="M454,475 L480,475" fill="none" stroke="#07adf8" stroke-width="1.6" marker-end="url(#mk-arrow-v)"/>
+    <path d="M694,475 L720,475" fill="none" stroke="#07adf8" stroke-width="1.6" marker-end="url(#mk-arrow-v)"/>
+    <!-- bridge climbs into decoder -->
+    <path d="M934,460 C1010,440 1060,400 1070,354" fill="none" stroke="#00bcd4" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#mk-arrow-v)"/>
+    <text x="750" y="400" class="mk-sub" fill="#7fd8ec">prefix rows stitch in before text tokens</text>
+  </svg>
 
   <div class="matrix-hero">
 
@@ -1562,6 +1693,55 @@
         <span class="mq-chip">Q5_0</span>
         <span class="mq-chip">Q8_0</span>
         <span class="mq-chip">FP32</span>
+      </div>
+    </div>
+
+    <!-- Gemma4 Vision -->
+    <div class="model-card mc-gemma4v">
+      <span class="model-badge">template: gemma4_vision.json</span>
+      <div class="model-title">Gemma4 Vision</div>
+      <div class="model-arch">SigLIP-style ViT encoder · XY position embeddings · average-pool merge<br>projector prep → Gemma4 decoder bridge · deterministic patch frontend</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 multimodal inference — patch frontend, encoder graph, projector bridge</span></div>
+        <div class="mp-row"><span class="mp-dot no"></span><span class="mp-text dim">Bring-up lane — staged behind the promoted Qwen3-VL baseline</span></div>
+      </div>
+      <div class="source-note">
+        Vision lane scope: shares the same lowering + memory-planning stack as Qwen3-VL. Uses <code>position_embeddings_add_gemma4v_xy</code> and <code>spatial_average_pool_contiguous</code> for the Gemma4 merge path instead of Qwen3-VL's 2×2 spatial merge.
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">gemma4v_xy_posemb</span>
+        <span class="tag learned">avgpool_merge</span>
+        <span class="tag learned">projector_bridge</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip preferred">Q4_K_M decoder ★</span>
+        <span class="mq-chip">Q8_0 mmproj</span>
+        <span class="mq-chip">FP32 encoder</span>
+        <span class="mq-chip">image bridge</span>
+      </div>
+    </div>
+
+    <!-- SigLIP ViT -->
+    <div class="model-card mc-siglip">
+      <span class="model-badge">template: siglip_vit.json</span>
+      <div class="model-title">SigLIP ViT (encoder)</div>
+      <div class="model-arch">Standalone vision tower · im2patch → patch embed · LayerNorm · full attention<br>learned position embeddings · GELU MLP · reusable encoder contract</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 encoder graph — patch frontend, transformer body, projector footer</span></div>
+        <div class="mp-row"><span class="mp-dot no"></span><span class="mp-text dim">Encoder-only — pairs with a decoder template via the bridge contract</span></div>
+      </div>
+      <div class="source-note">
+        Why it exists: SigLIP is the shared ViT backbone behind several vision-language families. Templating it on its own keeps the encoder reusable, so a new VLM can be brought up by swapping the decoder + projector instead of rewriting the vision tower.
+      </div>
+      <div class="model-tags">
+        <span class="tag learned">reusable_vit</span>
+        <span class="tag learned">im2patch</span>
+        <span class="tag learned">encoder_contract</span>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip">FP32</span>
+        <span class="mq-chip">BF16</span>
+        <span class="mq-chip">encoder prefix</span>
       </div>
     </div>
 

--- a/docs/site/prefill-performance-roadmap.html
+++ b/docs/site/prefill-performance-roadmap.html
@@ -1008,9 +1008,9 @@
       </tr>
       <tr>
         <td>Token-tile x output-tile GEMM</td>
-        <td>Extend x8 into a true <code>token_tile x output_tile</code> microkernel.</td>
-        <td>This should reuse both activation rows and weight metadata across a two-dimensional tile, not just eight output rows for one token row.</td>
-        <td>Next target</td>
+        <td>Add an opt-in <code>x8mt</code> lane that schedules small token tiles against eight-row output tiles.</td>
+        <td>This reuses the same packed Q4_K group across multiple Q8_K token rows and is the first step toward a true register-blocked GEMM microkernel.</td>
+        <td>Experimental benchmark/runtime lane</td>
       </tr>
       <tr>
         <td>Fused MLP kernels</td>
@@ -1063,6 +1063,21 @@
   <pre><code>for token_tile:
   for output_tile:
     compute multiple tokens x multiple output rows together</code></pre>
+
+  <p>
+    The current experimental <code>x8mt</code> path takes the first step:
+  </p>
+  <pre><code>CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL=1 \
+CK_Q4K_PACKED_META_X8MT_TILE_M=2 \
+make profile-v8-prefill-perf-stat</code></pre>
+
+  <p>
+    In the local dispatch matrix, <code>x8mt</code> with <code>tile_m=2</code> edged out plain x8 on the measured
+    Q4_K shapes, including the longer <code>M=128,N=896,K=4864</code> compact-down shape. It remains opt-in because
+    end-to-end Qwen2 timings on the laptop were noisy and not yet a stable promotion signal. The next real kernel
+    improvement is to keep the tile accumulators in registers across the token tile instead of using x8mt mostly as
+    a scheduling/data-reuse step.
+  </p>
 
   <h2>Why 2D Scheduling Was Not Enough</h2>
   <p>

--- a/docs/site/prefill-performance-roadmap.html
+++ b/docs/site/prefill-performance-roadmap.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Profiling  | C-Kernel-Engine</title>
+    <title>Prefill Performance Roadmap  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html">
-    <meta property="og:title" content="Profiling  | C-Kernel-Engine">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html">
+    <meta property="og:title" content="Prefill Performance Roadmap  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -940,459 +940,177 @@
     </header>
     <main>
 
-<h1>Profiling Guide</h1>
+<div class="container">
+  <h1>Prefill Performance Roadmap</h1>
+  <p class="lead">
+    The current CK prefill path is correct and auditable, but the Q4_K_M gap against llama.cpp is now mostly a layout and microkernel problem.
+  </p>
 
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Measure, Don't Guess</strong><br>
-        This page covers memory and compute profiling for C-Kernel-Engine. Always profile before optimizing.
-    </div>
-</div>
+  <div class="alert alert-info">
+    <strong>Current signal:</strong>
+    Qwen3.5 0.8B Q4_K_M decode is close enough to be useful for model bring-up. The first safe perf lane showed
+    canonical CK prefill around <code>31 tok/s</code> while llama.cpp was around <code>78 tok/s</code> on the local i7.
+    After x8 testing, the dispatch matrix showed x8 winning for short/medium prefill shapes and losing for the
+    longer <code>M=128,N=896,K=4864</code> compact-down shape. Treat the exact numbers as host-local; the durable
+    signal is that layout and shape-gated dispatch, not math, are the bottlenecks.
+  </div>
 
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Working on v7 Training Performance?</h3>
-    <p style="margin: 0;">Use the dedicated <a href="v7-profiling.html"><code>v7-profiling.html</code></a> runbook for VTune (<code>hotspots</code>/<code>memory-access</code>/<code>uarch-exploration</code>), Advisor roofline, perf/flamegraph capture, and run-dir artifact flow.</p>
-</div>
+  <h2>Why Prefill Is Different</h2>
+  <p>
+    Decode is mostly GEMV: one activation vector times many weight rows. Prefill is GEMM: many token rows times many output rows.
+    A fast decode kernel can still leave prefill slow because prefill needs to reuse both activation rows and weight blocks across a two-dimensional tile.
+  </p>
+  <p>
+    The key mistake is to treat prefill as many independent GEMV calls. That preserves correctness, but it reloads metadata and activation blocks too often.
+    llama.cpp's faster path uses repacked/interleaved layouts so the hot loop computes a block of rows and columns together.
+  </p>
 
-<div class="alert alert-warning">
-    <strong>Intel VTune / Advisor host-driver warning:</strong>
-    VTune and Advisor are useful for CK-vs-llama.cpp hotspot, memory, uarch, and roofline work, but some collection modes load Intel out-of-tree kernel drivers
-    such as <code>sep5</code>, <code>vtsspp</code>, <code>socwatch2_16</code>, and <code>pax</code>. On the local ThinkPad i7 / Linux 6.14 profiling host, a deeper
-    collection triggered repeated <code>BUG: scheduling while atomic</code> traces in <code>sep5</code>, followed by unrelated <code>runc</code>/<code>nmcli</code>
-    core dumps and an unclean reboot. That signature points to the profiler driver path, not CK user-space math.
-    Prefer <code>perf stat</code>, <code>perf record</code>, flamegraphs, and CK-vs-llama timing gates for routine iteration; run VTune/Advisor deep collections only on a
-    disposable profiling boot, server host, or after accepting that the whole machine may need a reboot.
-</div>
+  <h2>Optimization Ladder</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Step</th>
+        <th>What Changed</th>
+        <th>Why It Matters</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Q8 activation contract</td>
+        <td>Quantize prefill activations to <code>Q8_K</code> before mixed-quant GEMM.</td>
+        <td>Stops repeatedly feeding FP32 into quantized weights and aligns CK with llama-style quantized dot products.</td>
+        <td>Active</td>
+      </tr>
+      <tr>
+        <td>Persistent threadpool</td>
+        <td>Use CK's pthread pool instead of creating OpenMP regions around every kernel.</td>
+        <td>Reduces launch overhead and gives the runtime explicit control over active threads, row splitting, and phase-specific dispatch.</td>
+        <td>Active</td>
+      </tr>
+      <tr>
+        <td>Shape-gated dispatch</td>
+        <td>Choose serial, row-split, N-split, or 2D dispatch based on <code>M,N,K</code> and thread count.</td>
+        <td>Small shapes can regress when parallel overhead or activation rereads dominate; wide shapes need more jobs to fill cores.</td>
+        <td>Active for Q6; experimental for Q4</td>
+      </tr>
+      <tr>
+        <td>Packed Q4_K metadata</td>
+        <td>Pre-unpack Q4_K scales/mins into a cached packed-meta layout.</td>
+        <td>Moves repeated metadata decoding out of the hottest dot-product path.</td>
+        <td>Active, but not enough</td>
+      </tr>
+      <tr>
+        <td>Q4_K 8x8 repacked GEMM</td>
+        <td>Pack eight Q4_K output rows together and compute an output-row tile for each Q8_K token row.</td>
+        <td>This captures the first llama.cpp-style layout win: each Q8 activation load is reused across multiple output lanes instead of one row at a time.</td>
+        <td>Shape-gated default for measured short/medium Q4_K prefill shapes</td>
+      </tr>
+      <tr>
+        <td>Token-tile x output-tile GEMM</td>
+        <td>Extend x8 into a true <code>token_tile x output_tile</code> microkernel.</td>
+        <td>This should reuse both activation rows and weight metadata across a two-dimensional tile, not just eight output rows for one token row.</td>
+        <td>Next target</td>
+      </tr>
+      <tr>
+        <td>Fused MLP kernels</td>
+        <td>Fuse norm/projection/SwiGLU/down or similar sequences after the base GEMM is competitive.</td>
+        <td>Useful, but premature while the Q4_K prefill GEMM itself is still the dominant gap.</td>
+        <td>Later</td>
+      </tr>
+    </tbody>
+  </table>
 
-<h2>Safe v8 Prefill Counter Lane</h2>
+  <h2>The Q4_K Repack Target</h2>
+  <p>
+    The current CK packed-meta path is shaped like this:
+  </p>
+  <pre><code>for each token m:
+  for each output row n:
+    for each Q4_K block b:
+      dot_one_q4k_block_with_one_q8k_block()</code></pre>
 
-<p>For CK-vs-llama.cpp prefill work, start with the safe <code>perf stat</code> lane instead of VTune deep counters:</p>
+  <p>
+    That is simple and auditable, but it is still scalar at the tile level. The next target is shaped more like this:
+  </p>
+  <pre><code>for token tile Mx4 or Mx8:
+  pack Q8_K activations into an interleaved tile
+  for output tile Nx8:
+    read one interleaved Q4_K weight tile
+    accumulate an MxN output tile in registers
+    apply Q4_K scale/min metadata once per tile lane</code></pre>
 
-<pre><code>make profile-v8-prefill-perf-stat</code></pre>
+  <p>
+    This mirrors the idea behind llama.cpp's <code>ggml_gemm_q4_K_8x8_q8_K</code>: the math is the same, but the memory layout changes so the CPU hot loop does less bookkeeping per useful multiply.
+    The important part is not copying llama.cpp blindly; the important part is matching the dataflow: interleave weights, interleave activations, compute a small output tile, and keep metadata close to the SIMD lanes.
+  </p>
+  <p>
+    CK keeps the canonical <code>for token -> for output row -> dot()</code> kernel as the reliable fallback.
+    The <code>packed-x8</code> lane groups eight Q4_K output rows per K block and uses a SIMD tile accumulator that loads each Q8 activation chunk once, then reuses it across the active output lanes.
+    It is now the default for measured short/medium Qwen/Nemotron-family Q4_K prefill shapes, with
+    <code>CK_DISABLE_Q4K_PACKED_META_X8_PREFILL=1</code> as the escape hatch and
+    <code>CK_FORCE_Q4K_PACKED_META_X8_PREFILL=1</code> for new hardware sweeps.
+  </p>
+  <p>
+    The current x8 shape is still closer to:
+  </p>
+  <pre><code>for token:
+  for output_row_group_of_8:
+    compute 8 output rows for one Q8_K token row</code></pre>
+  <p>
+    The stronger target remains:
+  </p>
+  <pre><code>for token_tile:
+  for output_tile:
+    compute multiple tokens x multiple output rows together</code></pre>
 
-<p>The target compares the cached v8 Qwen3.5 Q4_K_M runtime against the local llama.cpp build with a fixed-token
-128-token prefill and one decode token. It writes a timestamped Markdown and JSON report under
-<code>profile_results/v8_prefill_perf_stat/</code> with prefill/decode tok/s, milliseconds, cycles, instructions, IPC,
-cache misses, cache miss rate, and context switches.</p>
-
-<p>The Q4_K packed-meta x8 prefill kernel is shape-gated on by default for measured short/medium
-Qwen/Nemotron-family prefill shapes. Use this escape hatch when validating a new CPU or bisecting a regression:</p>
-
-<pre><code>CK_DISABLE_Q4K_PACKED_META_X8_PREFILL=1 \
-CK_V8_PREFILL_PERF_ENGINE=ck \
-make profile-v8-prefill-perf-stat</code></pre>
-
-<p>On the local ThinkPad i7, the dispatch matrix showed the x8 layout winning at <code>M=32</code> and
-<code>M=64</code> Q4_K prefill shapes, while the longer <code>M=128,N=896,K=4864</code> compact-down shape
-lost to the canonical pool path. That is why the default gate has both a minimum and maximum token tile size.
-Treat these as host-local engineering numbers, not a universal benchmark: the llama lane uses <code>llama-bench</code>,
-run-to-run variance exists, and the important signal is the shape-gated layout win.</p>
-
-<p>Use these environment knobs when testing the older Q4_K packed-meta 2D scheduler without changing the default dispatcher:</p>
-
-<pre><code>CK_ENABLE_Q4K_PACKED_META_2D_PREFILL=1 \
+  <h2>Why 2D Scheduling Was Not Enough</h2>
+  <p>
+    CK now has an opt-in Q4_K packed-meta 2D scheduler:
+  </p>
+  <pre><code>CK_ENABLE_Q4K_PACKED_META_2D_PREFILL=1 \
 CK_FORCE_Q4K_PACKED_META_2D_PREFILL=1 \
 CK_Q4K_PACKED_META_TILE_M=8 \
 CK_Q4K_PACKED_META_TILE_N=512 \
 CK_V8_PREFILL_PERF_ENGINE=ck \
 make profile-v8-prefill-perf-stat</code></pre>
 
-<p>The local ThinkPad i7 data showed only a small win from 2D packed-meta scheduling. The stronger win came from
-the x8 packed-meta layout, which groups eight Q4_K output rows per K block so the hot loop reuses each Q8 activation
-load across multiple output lanes. Force it explicitly for new sweeps with
-<code>CK_FORCE_Q4K_PACKED_META_X8_PREFILL=1</code>. See
-<a href="prefill-performance-roadmap.html">Prefill Performance Roadmap</a> for the optimization ladder and promotion rules.</p>
+  <p>
+    Local tests showed only a small and noisy improvement. That is expected: 2D scheduling creates better work distribution, but the hot loop still computes one output value at a time.
+    The x8 layout fixed the more important part first: reuse one activation chunk across multiple output lanes.
+    The next step is a true token-tile/output-tile microkernel.
+  </p>
 
-<nav class="toc">
-    <h3>Contents</h3>
-    <ul>
-        <li><a href="#memory-profiling">Memory Profiling (Valgrind)</a></li>
-        <li><a href="#heap-profiling">Heap Profiling (Massif)</a></li>
-        <li><a href="#cpu-profiling">CPU Profiling (perf)</a></li>
-        <li><a href="#flamegraphs">Flamegraphs</a></li>
-        <li><a href="#cache-profiling">Cache Profiling (Cachegrind)</a></li>
-        <li><a href="#quick-reference">Quick Reference</a></li>
-    </ul>
-</nav>
+  <h2>Measurement Contract</h2>
+  <p>
+    Use the safe perf lane for routine iteration:
+  </p>
+  <pre><code>make profile-v8-prefill-perf-stat</code></pre>
 
-<h2 id="memory-profiling">Memory Profiling with Valgrind</h2>
+  <p>
+    The report records prefill/decode tok/s, milliseconds, cycles, instructions, IPC, cache misses, cache miss rate, and context switches.
+    This is the default lane because VTune/Advisor deep collection can load kernel drivers that destabilized the local Linux profiling host.
+  </p>
 
-<p>Valgrind's <code>memcheck</code> tool detects memory errors: leaks, use-after-free, uninitialized reads, and buffer overflows.</p>
+  <h2>Promotion Rule</h2>
+  <ol>
+    <li>Keep every new layout behind a shape gate and an escape hatch.</li>
+    <li>Prove parity against canonical CK for synthetic Q4_K/Q8_K blocks.</li>
+    <li>Benchmark micro-shapes: Qwen3.5 gate/up, down, qkv/out, compact MLP, and wider MLP shapes.</li>
+    <li>Benchmark end-to-end Qwen3.5 v8 prefill against llama.cpp with the same cached GGUF.</li>
+    <li>Promote only the shapes where the sweep wins; keep canonical dispatch as the fallback.</li>
+  </ol>
 
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Install Valgrind</h3>
-    <pre># Ubuntu/Debian
-sudo apt install valgrind
-
-# Fedora/RHEL
-sudo dnf install valgrind
-
-# Arch
-sudo pacman -S valgrind</pre>
+  <h2>Related Files</h2>
+  <ul>
+    <li><code>src/kernels/gemm_kernels_q4k_q8k_vnni.c</code> - Q4_K x Q8_K packed-meta kernels.</li>
+    <li><code>version/v8/src/ck_parallel_prefill_v8.c</code> - v8 prefill dispatch policy.</li>
+    <li><code>scripts/perf_stat_v8_prefill_compare.py</code> - safe CK-vs-llama perf counter lane.</li>
+    <li><code>benchmarks/compare_ck_llama_v8.py</code> - standardized v8 model-family comparison.</li>
+    <li><a href="q6-prefill-roofline.html">Q6_K Prefill Roofline Notes</a> - shape-gating precedent for Q6_K.</li>
+    <li><a href="profiling.html">Profiling Guide</a> - safe profiling commands and VTune/Advisor warning.</li>
+  </ul>
 </div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Basic Memory Check</h3>
-    <pre># Build with debug symbols (required for line numbers)
-make clean
-CFLAGS="-O0 -g" make
-
-# Run memcheck on the tiny model
-valgrind --leak-check=full \
-         --show-leak-kinds=all \
-         --track-origins=yes \
-         ./build/tiny_model \
-           --model-weights build/tiny_weights.bin \
-           --tokens build/tiny_tokens.bin \
-           --out-logits build/tiny_logits.bin</pre>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Actual Output from C-Kernel-Engine</h3>
-    <pre># Real output from: make profile-memory
-==537520== HEAP SUMMARY:
-==537520==     in use at exit: 8 bytes in 1 blocks
-==537520==   total heap usage: 11 allocs, 10 frees, 2,144,864 bytes allocated
-
-==537520== LEAK SUMMARY:
-==537520==    definitely lost: 0 bytes in 0 blocks
-==537520==    indirectly lost: 0 bytes in 0 blocks
-==537520==      possibly lost: 0 bytes in 0 blocks
-==537520==    still reachable: 0 bytes in 0 blocks
-==537520==         suppressed: 8 bytes in 1 blocks  # OpenMP internal
-
-==537520== ERROR SUMMARY: 0 errors from 0 contexts</pre>
-    <p><strong>Key observations:</strong></p>
-    <ul>
-        <li><strong>11 allocs, 10 frees</strong> - The 1 remaining is OpenMP internal (suppressed)</li>
-        <li><strong>2MB allocated</strong> - Our bump allocator buffer, properly freed</li>
-        <li><strong>0 definitely lost</strong> - No memory leaks!</li>
-    </ul>
-    <p><strong>Red flags:</strong> "definitely lost", "Invalid read/write", "Conditional jump depends on uninitialised value"</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Valgrind Options Explained</h3>
-    <table class="table">
-        <thead>
-            <tr><th>Option</th><th>Purpose</th></tr>
-        </thead>
-        <tbody>
-            <tr><td><code>--leak-check=full</code></td><td>Show where each leak was allocated</td></tr>
-            <tr><td><code>--show-leak-kinds=all</code></td><td>Include "still reachable" (our bump buffer)</td></tr>
-            <tr><td><code>--track-origins=yes</code></td><td>Track where uninitialized values came from</td></tr>
-            <tr><td><code>--error-exitcode=1</code></td><td>Exit with 1 if errors found (for CI)</td></tr>
-            <tr><td><code>--suppressions=file</code></td><td>Ignore known false positives</td></tr>
-        </tbody>
-    </table>
-</div>
-
-<h2 id="heap-profiling">Heap Profiling with Massif</h2>
-
-<p>Massif tracks memory usage over time, showing allocation patterns and peak usage.</p>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Capture Heap Profile</h3>
-    <pre># Run with massif
-valgrind --tool=massif \
-         --pages-as-heap=yes \
-         --massif-out-file=massif.out \
-         ./build/tiny_model \
-           --model-weights build/tiny_weights.bin \
-           --tokens build/tiny_tokens.bin \
-           --out-logits build/tiny_logits.bin
-
-# Visualize with ms_print
-ms_print massif.out</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Example Massif Output</h3>
-    <pre>    MB
-4.194^                                                       #
-     |                                                       #
-     |                                                       #
-     |                                                       #
-     |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@#
-     |@                                                     @#
-     |@                                                     @#
-     |@                                                     @#
-   0 +------------------------------------------------------->
-     0                                                   100ms
-
-# With bump allocator: one flat line (single allocation at startup)
-# Bad pattern: sawtooth (repeated malloc/free) or stairs (leaks)</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">GUI Visualization with Massif-Visualizer</h3>
-    <pre># Install
-sudo apt install massif-visualizer
-
-# Open profile
-massif-visualizer massif.out</pre>
-    <p>Shows interactive graphs with allocation call stacks.</p>
-</div>
-
-<h2 id="cpu-profiling">CPU Profiling with perf</h2>
-
-<p><code>perf</code> is the Linux profiler. It samples the CPU to find where time is spent.</p>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Install perf</h3>
-    <pre># Ubuntu/Debian
-sudo apt install linux-tools-common linux-tools-$(uname -r)
-
-# Fedora/RHEL
-sudo dnf install perf
-
-# Enable for non-root users
-echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Record and Report</h3>
-    <pre># Build with frame pointers for accurate call stacks
-CFLAGS="-O3 -fno-omit-frame-pointer -g" make clean all
-
-# Record profile (run your workload)
-perf record -g -F 99 ./build/tiny_model \
-  --model-weights build/tiny_weights.bin \
-  --tokens build/tiny_tokens.bin \
-  --out-logits build/tiny_logits.bin
-
-# View top functions
-perf report --stdio --sort=overhead
-
-# Interactive TUI
-perf report</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Example perf report Output</h3>
-    <pre># Overhead  Command    Shared Object       Symbol
-# ........  .........  ..................  ............................
-    42.15%  tiny_model libckernel_engine   [.] gemm_forward
-    18.23%  tiny_model libckernel_engine   [.] attention_forward_...
-    12.07%  tiny_model libckernel_engine   [.] rmsnorm_forward
-     8.45%  tiny_model libckernel_engine   [.] swiglu_forward
-     6.21%  tiny_model libc.so.6           [.] __memcpy_avx512
-     ...</pre>
-    <p><strong>What to look for:</strong> GEMM should dominate. If other kernels are high, they may need optimization.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Useful perf Commands</h3>
-    <pre># Count hardware events (cache misses, branch mispredicts)
-perf stat -e cache-misses,cache-references,branches,branch-misses \
-  ./build/tiny_model ...
-
-# Per-function stats
-perf annotate gemm_forward
-
-# Compare two runs
-perf diff perf.data.old perf.data</pre>
-</div>
-
-<h2 id="flamegraphs">Flamegraphs</h2>
-
-<p>Flamegraphs visualize profiling data as interactive SVGs. Width = time spent.</p>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Install FlameGraph Tools</h3>
-    <pre># Clone Brendan Gregg's FlameGraph repo
-git clone https://github.com/brendangregg/FlameGraph.git
-export PATH=$PATH:$(pwd)/FlameGraph</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Generate CPU Flamegraph</h3>
-    <pre># Record with perf
-perf record -g -F 99 ./build/tiny_model \
-  --model-weights build/tiny_weights.bin \
-  --tokens build/tiny_tokens.bin \
-  --out-logits build/tiny_logits.bin
-
-# Convert to flamegraph
-perf script | stackcollapse-perf.pl | flamegraph.pl > cpu_flame.svg
-
-# Open in browser
-firefox cpu_flame.svg</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Reading Flamegraphs</h3>
-    <ul>
-        <li><strong>Y-axis:</strong> Call stack depth (bottom = entry point, top = leaf functions)</li>
-        <li><strong>X-axis:</strong> Time spent (wider = more time)</li>
-        <li><strong>Colors:</strong> Random, just for visual distinction</li>
-        <li><strong>Click:</strong> Zoom into a function</li>
-        <li><strong>Search:</strong> Ctrl+F to highlight functions</li>
-    </ul>
-    <p><strong>What to look for:</strong> Wide plateaus at the top indicate hot functions to optimize.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Memory Allocation Flamegraph</h3>
-    <pre># Record malloc/free calls
-perf record -e 'probe:malloc' -e 'probe:free' -g ./build/tiny_model ...
-
-# With bump allocator, this should be nearly empty!
-# (Just one mmap at startup)</pre>
-</div>
-
-<h2 id="cache-profiling">Cache Profiling with Cachegrind</h2>
-
-<p>Cachegrind simulates CPU cache behavior to find cache-unfriendly code.</p>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Run Cachegrind</h3>
-    <pre># Profile cache behavior
-valgrind --tool=cachegrind \
-         --cachegrind-out-file=cachegrind.out \
-         ./build/tiny_model \
-           --model-weights build/tiny_weights.bin \
-           --tokens build/tiny_tokens.bin \
-           --out-logits build/tiny_logits.bin
-
-# Annotate source code with cache stats
-cg_annotate cachegrind.out src/kernels/gemm_kernels.c</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Understanding Cache Stats</h3>
-    <pre>--------------------------------------------------------------------------------
-I1 cache:         32,768 B, 64 B, 8-way associative
-D1 cache:         32,768 B, 64 B, 8-way associative
-LL cache:         8,388,608 B, 64 B, 16-way associative
---------------------------------------------------------------------------------
-        Ir          I1mr        ILmr          Dr          D1mr        DLmr
---------------------------------------------------------------------------------
- 1,234,567,890      12,345       1,234   456,789,012     2,345,678     123,456
-
-# Key metrics:
-# D1mr = L1 data cache read misses
-# DLmr = Last-level cache read misses (goes to RAM - expensive!)
-# Lower is better</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Per-Function Cache Analysis</h3>
-    <pre># Sort by L1 data misses
-cg_annotate --sort=D1mr cachegrind.out
-
-# Annotate specific source file
-cg_annotate cachegrind.out --auto=yes src/kernels/gemm_kernels.c</pre>
-    <p><strong>What to look for:</strong> High cache miss rates in inner loops indicate poor memory access patterns (consider tiling, prefetching).</p>
-</div>
-
-<h2 id="quick-reference">Quick Reference</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Makefile Targets</h3>
-    <pre># Add these to your workflow
-make profile-memory   # Valgrind memcheck
-make profile-heap     # Massif heap profile
-make profile-cpu      # perf record + report
-make flamegraph       # Generate SVG flamegraph</pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Profiling Cheatsheet</h3>
-    <table class="table">
-        <thead>
-            <tr><th>Goal</th><th>Tool</th><th>Command</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>Find memory leaks</td>
-                <td>Valgrind</td>
-                <td><code>valgrind --leak-check=full ./binary</code></td>
-            </tr>
-            <tr>
-                <td>Track heap over time</td>
-                <td>Massif</td>
-                <td><code>valgrind --tool=massif ./binary</code></td>
-            </tr>
-            <tr>
-                <td>Find hot functions</td>
-                <td>perf</td>
-                <td><code>perf record -g ./binary && perf report</code></td>
-            </tr>
-            <tr>
-                <td>Visualize call stacks</td>
-                <td>Flamegraph</td>
-                <td><code>perf script | stackcollapse-perf.pl | flamegraph.pl</code></td>
-            </tr>
-            <tr>
-                <td>Find cache misses</td>
-                <td>Cachegrind</td>
-                <td><code>valgrind --tool=cachegrind ./binary</code></td>
-            </tr>
-            <tr>
-                <td>Count CPU events</td>
-                <td>perf stat</td>
-                <td><code>perf stat -e cache-misses,cycles ./binary</code></td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Build Flags for Profiling</h3>
-    <table class="table">
-        <thead>
-            <tr><th>Purpose</th><th>CFLAGS</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>Valgrind (accurate line numbers)</td>
-                <td><code>-O0 -g</code></td>
-            </tr>
-            <tr>
-                <td>perf (with frame pointers)</td>
-                <td><code>-O3 -fno-omit-frame-pointer -g</code></td>
-            </tr>
-            <tr>
-                <td>Production + debug symbols</td>
-                <td><code>-O3 -g</code></td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">C-Kernel-Engine Profiling Tips</h3>
-    <ul>
-        <li><strong>Bump allocator:</strong> Valgrind should show one "still reachable" block (our mmap'd buffer)</li>
-        <li><strong>No mallocs in hot path:</strong> Memory allocation flamegraph should be nearly empty</li>
-        <li><strong>GEMM dominates:</strong> In perf, <code>gemm_forward</code> should be 40-60% of time</li>
-        <li><strong>Low cache misses:</strong> Cachegrind DLmr should be < 1% for well-tiled GEMM</li>
-        <li><strong>Huge pages:</strong> Check <code>/proc/PID/smaps</code> for <code>AnonHugePages</code> usage</li>
-    </ul>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">CI Integration</h3>
-    <pre># .github/workflows/profiling.yml
-- name: Memory check
-  run: |
-    make CFLAGS="-O0 -g"
-    valgrind --error-exitcode=1 --leak-check=full \
-      ./build/tiny_model --model-weights ... --tokens ...</pre>
-</div>
-
-<h2>Further Reading</h2>
-
-<ul>
-    <li><a href="https://valgrind.org/docs/manual/manual.html" target="_blank">Valgrind Manual</a></li>
-    <li><a href="https://www.brendangregg.com/flamegraphs.html" target="_blank">Brendan Gregg's Flamegraph Page</a></li>
-    <li><a href="https://perf.wiki.kernel.org/index.php/Tutorial" target="_blank">perf Wiki Tutorial</a></li>
-    <li><a href="memory-safety.html">Memory Safety</a> - Our bump allocator design</li>
-</ul>
     </main>
 
     <!-- SVG Viewer Overlay (shared across all pages) -->

--- a/docs/site/profiling.html
+++ b/docs/site/profiling.html
@@ -1006,6 +1006,16 @@ load across multiple output lanes. Force it explicitly for new sweeps with
 <code>CK_FORCE_Q4K_PACKED_META_X8_PREFILL=1</code>. See
 <a href="prefill-performance-roadmap.html">Prefill Performance Roadmap</a> for the optimization ladder and promotion rules.</p>
 
+<p>The token-tile/output-tile experiment is separate from the default x8 path:</p>
+
+<pre><code>CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL=1 \
+CK_Q4K_PACKED_META_X8MT_TILE_M=2 \
+CK_V8_PREFILL_PERF_ENGINE=ck \
+make profile-v8-prefill-perf-stat</code></pre>
+
+<p>Use this to test the first two-dimensional Q4_K prefill path. It is intentionally opt-in until model-level
+timings are stable across hardware and prompt lengths.</p>
+
 <nav class="toc">
     <h3>Contents</h3>
     <ul>

--- a/docs/site/pytorch-parity.html
+++ b/docs/site/pytorch-parity.html
@@ -6,11 +6,11 @@
     <title>PyTorch Parity and Numerical Validation | C-Kernel-Engine</title>
     <meta name="description" content="How C-Kernel-Engine validates kernel and training behavior against PyTorch with deterministic parity gates and numerical checks.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/pytorch-parity.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html">
     <meta property="og:title" content="PyTorch Parity and Numerical Validation | C-Kernel-Engine">
     <meta property="og:description" content="How C-Kernel-Engine validates kernel and training behavior against PyTorch with deterministic parity gates and numerical checks.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/pytorch-parity.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1332,8 +1332,8 @@ make litmus</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/q6-prefill-roofline.html
+++ b/docs/site/q6-prefill-roofline.html
@@ -6,11 +6,11 @@
     <title>Documentation | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/q6-prefill-roofline.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html">
     <meta property="og:title" content="Documentation | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/q6-prefill-roofline.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1290,8 +1290,8 @@ CK_NUM_THREADS=12 OMP_NUM_THREADS=1 CK_Q6K_Q8K_SIMD=1 \
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-19</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quant-formats.html
+++ b/docs/site/quant-formats.html
@@ -6,11 +6,11 @@
     <title>Quantization Formats Visual Guide  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/quant-formats.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html">
     <meta property="og:title" content="Quantization Formats Visual Guide  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/quant-formats.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1612,8 +1612,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-math-temp.html
+++ b/docs/site/quantization-math-temp.html
@@ -6,11 +6,11 @@
     <title>Quantization Math Deep Dive | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="noindex,nofollow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/quantization-math-temp.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-math-temp.html">
     <meta property="og:title" content="Quantization Math Deep Dive | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/quantization-math-temp.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-math-temp.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1376,8 +1376,8 @@ for (int ib = 0; ib < nb; ib++) {
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-visuals.html
+++ b/docs/site/quantization-visuals.html
@@ -6,11 +6,11 @@
     <title>Quantization Bit Manipulation Visuals  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/quantization-visuals.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html">
     <meta property="og:title" content="Quantization Bit Manipulation Visuals  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/quantization-visuals.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1508,8 +1508,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization.html
+++ b/docs/site/quantization.html
@@ -6,11 +6,11 @@
     <title>Quantization Deep Dive  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/quantization.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html">
     <meta property="og:title" content="Quantization Deep Dive  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/quantization.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2386,8 +2386,8 @@ void matmul_q4(float* out, const float* x, const tensor* W) {
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -6,11 +6,11 @@
     <title>Getting Started | C-Kernel-Engine</title>
     <meta name="description" content="Quickstart guide for building and running C-Kernel-Engine, including the current v7 runtime path plus the v8 text-inference and Qwen3-VL multimodal bring-up surfaces.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/quickstart.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html">
     <meta property="og:title" content="Getting Started | C-Kernel-Engine">
     <meta property="og:description" content="Quickstart guide for building and running C-Kernel-Engine, including the current v7 runtime path plus the v8 text-inference and Qwen3-VL multimodal bring-up surfaces.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/quickstart.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1092,7 +1092,7 @@ make v7-demo-runtime \
     <pre>version/v8/scripts/cks-v8-run run \
   hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
   --mmproj ./mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
-  --image-path version/v8/test_assets/v8_vision_doc_card_72.png \
+  --image-path version/v8/test_assets/v8_vision_doc_card_72.ppm \
   --prompt "Explain this image." \
   --context-len 1024 \
   --force-convert --force-compile \
@@ -1676,8 +1676,8 @@ firefox build/flamegraph.svg</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/research.html
+++ b/docs/site/research.html
@@ -6,11 +6,11 @@
     <title>Research Tracker  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/research.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/research.html">
     <meta property="og:title" content="Research Tracker  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/research.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/research.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1624,8 +1624,8 @@ K = [K_rope (with position), K_nope (from latent)]</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -6,11 +6,11 @@
     <title>Scaling Philosophy for CPU-Only AI Systems | C-Kernel-Engine</title>
     <meta name="description" content="Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/scaling.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html">
     <meta property="og:title" content="Scaling Philosophy for CPU-Only AI Systems | C-Kernel-Engine">
     <meta property="og:description" content="Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/scaling.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -3379,8 +3379,8 @@ That's it. For any model size.
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sentencepiece.html
+++ b/docs/site/sentencepiece.html
@@ -6,11 +6,11 @@
     <title>SentencePiece Deep Dive  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/sentencepiece.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html">
     <meta property="og:title" content="SentencePiece Deep Dive  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/sentencepiece.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1868,8 +1868,8 @@ ck_tokenizer_free(tok);</code></pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/simd-architecture.html
+++ b/docs/site/simd-architecture.html
@@ -6,11 +6,11 @@
     <title>Documentation | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/simd-architecture.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html">
     <meta property="og:title" content="Documentation | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/simd-architecture.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2361,8 +2361,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,254 +2,254 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-06-24</lastmod>
   </url>
 </urlset>

--- a/docs/site/spec-training-method.html
+++ b/docs/site/spec-training-method.html
@@ -6,11 +6,11 @@
     <title>Spec Training Method and Run Discipline | C-Kernel-Engine</title>
     <meta name="description" content="The spec[x] and run[y] method used by C-Kernel-Engine to build training intuition through controlled contracts, canaries, eval gates, and repair runs.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/spec-training-method.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html">
     <meta property="og:title" content="Spec Training Method and Run Discipline | C-Kernel-Engine">
     <meta property="og:description" content="The spec[x] and run[y] method used by C-Kernel-Engine to build training intuition through controlled contracts, canaries, eval gates, and repair runs.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/spec-training-method.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -3770,8 +3770,8 @@ Next run:</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -6,11 +6,11 @@
     <title>Spec Training Results and Run History | C-Kernel-Engine</title>
     <meta name="description" content="Manifest-driven run history for C-Kernel-Engine specs, including best rungs, recent results, and the archive split between stable docs and raw run artifacts.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/spec-training-results.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html">
     <meta property="og:title" content="Spec Training Results and Run History | C-Kernel-Engine">
     <meta property="og:description" content="Manifest-driven run history for C-Kernel-Engine specs, including best rungs, recent results, and the archive split between stable docs and raw run artifacts.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/spec-training-results.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1095,7 +1095,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-05 05:12 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-24 18:49 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>
@@ -1412,8 +1412,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec17-curriculum-blueprint.html
+++ b/docs/site/spec17-curriculum-blueprint.html
@@ -6,11 +6,11 @@
     <title>Spec17 Curriculum Blueprint  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html">
     <meta property="og:title" content="Spec17 Curriculum Blueprint  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1468,8 +1468,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec19-textbook-routing-mixture.html
+++ b/docs/site/spec19-textbook-routing-mixture.html
@@ -6,11 +6,11 @@
     <title>Spec19 Textbook Routing Mixture  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html">
     <meta property="og:title" content="Spec19 Textbook Routing Mixture  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1581,8 +1581,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spectrum.html
+++ b/docs/site/spectrum.html
@@ -6,11 +6,11 @@
     <title>OperatorSpectrum  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/spectrum.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html">
     <meta property="og:title" content="OperatorSpectrum  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/spectrum.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1759,8 +1759,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-viewer.html
+++ b/docs/site/test-viewer.html
@@ -6,11 +6,11 @@
     <title>SVG Viewer Test | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="noindex,nofollow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/test-viewer.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/test-viewer.html">
     <meta property="og:title" content="SVG Viewer Test | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/test-viewer.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/test-viewer.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1382,8 +1382,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -6,11 +6,11 @@
     <title>Documentation | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/testing.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html">
     <meta property="og:title" content="Documentation | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/testing.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1877,7 +1877,7 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/threadpool.html
+++ b/docs/site/threadpool.html
@@ -6,11 +6,11 @@
     <title>Thread Pool  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/threadpool.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html">
     <meta property="og:title" content="Thread Pool  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/threadpool.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2823,8 +2823,8 @@ make test-threadpool-parity-verbose
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/tokenizer.html
+++ b/docs/site/tokenizer.html
@@ -6,11 +6,11 @@
     <title>Tokenizer  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/tokenizer.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html">
     <meta property="og:title" content="Tokenizer  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/tokenizer.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2310,8 +2310,8 @@ True BPE (merge rules applied in order):
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-curriculum.html
+++ b/docs/site/training-curriculum.html
@@ -6,11 +6,11 @@
     <title>Training Curriculum and Capability Roadmap | C-Kernel-Engine</title>
     <meta name="description" content="A practical curriculum for growing C-Kernel-Engine from compiler-backed DSL training toward broader coding, tool use, and scientific reasoning.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/training-curriculum.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html">
     <meta property="og:title" content="Training Curriculum and Capability Roadmap | C-Kernel-Engine">
     <meta property="og:description" content="A practical curriculum for growing C-Kernel-Engine from compiler-backed DSL training toward broader coding, tool use, and scientific reasoning.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/training-curriculum.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1843,8 +1843,8 @@
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-intuition.html
+++ b/docs/site/training-intuition.html
@@ -6,11 +6,11 @@
     <title>Deep Training Intuition  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/training-intuition.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html">
     <meta property="og:title" content="Deep Training Intuition  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/training-intuition.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2250,8 +2250,8 @@ report:    version/v7/tools/ir_visualizer.html (or generated ir_report*.html)</c
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-lessons-learned.html
+++ b/docs/site/training-lessons-learned.html
@@ -6,11 +6,11 @@
     <title>Training Lessons Learned: Spec02 Through Spec19 | C-Kernel-Engine</title>
     <meta name="description" content="Full arc analysis of the CKE visual-DSL training journey from spec02 through spec19, including root cause analysis, research paper connections, and the working thesis for future training.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/training-lessons-learned.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html">
     <meta property="og:title" content="Training Lessons Learned: Spec02 Through Spec19 | C-Kernel-Engine">
     <meta property="og:description" content="Full arc analysis of the CKE visual-DSL training journey from spec02 through spec19, including root cause analysis, research paper connections, and the working thesis for future training.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/training-lessons-learned.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1836,8 +1836,8 @@ AFTER TRAINING:
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-backprop-ir.html
+++ b/docs/site/v7-backprop-ir.html
@@ -6,11 +6,11 @@
     <title>v7 Backprop IR  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-backprop-ir.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html">
     <meta property="og:title" content="v7 Backprop IR  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-backprop-ir.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2005,8 +2005,8 @@ version/v7/scripts/cks-v7-run init \
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-cross-entropy-parity.html
+++ b/docs/site/v7-cross-entropy-parity.html
@@ -6,11 +6,11 @@
     <title>v7 Cross-Entropy Parity  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html">
     <meta property="og:title" content="v7 Cross-Entropy Parity  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1392,8 +1392,8 @@ CK_NUM_THREADS=8 python version/v7/scripts/train_parity_epochs_v7.py \
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-grad-accum-windows.html
+++ b/docs/site/v7-grad-accum-windows.html
@@ -6,11 +6,11 @@
     <title>v7 Grad Accum Windows  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-grad-accum-windows.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html">
     <meta property="og:title" content="v7 Grad Accum Windows  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-grad-accum-windows.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1322,8 +1322,8 @@ at accumulation boundary:
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-parity-checklist.html
+++ b/docs/site/v7-parity-checklist.html
@@ -6,11 +6,11 @@
     <title>v7 Training Parity Checklist  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-parity-checklist.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html">
     <meta property="og:title" content="v7 Training Parity Checklist  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-parity-checklist.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1521,8 +1521,8 @@ PY</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-profiling.html
+++ b/docs/site/v7-profiling.html
@@ -6,11 +6,11 @@
     <title>v7 Profiling  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-profiling.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html">
     <meta property="og:title" content="v7 Profiling  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-profiling.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1440,8 +1440,8 @@ python3 version/v7/tools/open_ir_visualizer.py --generate --run /tmp/v7_ht_threa
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-python-authoring.html
+++ b/docs/site/v7-python-authoring.html
@@ -6,11 +6,11 @@
     <title>v7 Python Authoring Guide | C-Kernel-Engine</title>
     <meta name="description" content="Step-by-step guide to the C-Kernel-Engine v7 Python authoring layer, including notebook order, TrainingProject syntax, the ck.nn compile adapter, and the v7 handoff boundary.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-python-authoring.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html">
     <meta property="og:title" content="v7 Python Authoring Guide | C-Kernel-Engine">
     <meta property="og:description" content="Step-by-step guide to the C-Kernel-Engine v7 Python authoring layer, including notebook order, TrainingProject syntax, the ck.nn compile adapter, and the v7 handoff boundary.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-python-authoring.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1593,8 +1593,8 @@ python3 version/v7/examples/python_module_api_tiny_lm_v7.py --run-name py-module
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-runbook.html
+++ b/docs/site/v7-runbook.html
@@ -6,11 +6,11 @@
     <title>v7 Inference and Training Runbook | C-Kernel-Engine</title>
     <meta name="description" content="Operator runbook for C-Kernel-Engine v7 covering parity gates, training flow, canaries, probes, and cache-backed run artifacts.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-runbook.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html">
     <meta property="og:title" content="v7 Inference and Training Runbook | C-Kernel-Engine">
     <meta property="og:description" content="Operator runbook for C-Kernel-Engine v7 covering parity gates, training flow, canaries, probes, and cache-backed run artifacts.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-runbook.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -5603,8 +5603,8 @@ python3 scripts/ck_chat.py --help</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-svg-dataset-runbook.html
+++ b/docs/site/v7-svg-dataset-runbook.html
@@ -6,11 +6,11 @@
     <title>v7 SVG Dataset Runbook  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html">
     <meta property="og:title" content="v7 SVG Dataset Runbook  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1651,8 +1651,8 @@ tail -n 20 "$RUN/autopilot/summary.jsonl"</pre>
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-training-progression-playbook.html
+++ b/docs/site/v7-training-progression-playbook.html
@@ -6,11 +6,11 @@
     <title>v7 Training Progression Playbook  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-training-progression-playbook.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html">
     <meta property="og:title" content="v7 Training Progression Playbook  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-training-progression-playbook.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1571,8 +1571,8 @@ jq -r '.status, (.stages // [])' "$RUN/training_parity_regimen_latest.json" 2>/d
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-visualizer-test-runbook.html
+++ b/docs/site/v7-visualizer-test-runbook.html
@@ -6,11 +6,11 @@
     <title>v7 Visualizer Test Runbook  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html">
     <meta property="og:title" content="v7 Visualizer Test Runbook  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1922,8 +1922,8 @@ document.querySelectorAll('.copy-btn').forEach(btn => {
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -6,11 +6,11 @@
     <title>v8 Vision Encoder Architecture | C-Kernel-Engine</title>
     <meta name="description" content="Architecture page for how C-Kernel-Engine v8 lowers and runs the Qwen3-VL vision encoder, bridges the prefix, and continues generation in the decoder.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/v8-vision-encoder.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html">
     <meta property="og:title" content="v8 Vision Encoder Architecture | C-Kernel-Engine">
     <meta property="og:description" content="Architecture page for how C-Kernel-Engine v8 lowers and runs the Qwen3-VL vision encoder, bridges the prefix, and continues generation in the decoder.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/v8-vision-encoder.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1188,6 +1188,129 @@
     </div>
 </div>
 
+<svg viewBox="0 0 1180 430" width="100%" role="img"
+     aria-label="Qwen3-VL vision pipeline: image to patch frontend to ViT encoder to projector bridge prefix, stitched into the Qwen3 decoder prefill and decode."
+     style="max-width:1180px;margin:0.5rem auto 1.5rem;display:block;font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <linearGradient id="vp-enc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#07adf8"/><stop offset="1" stop-color="#00bcd4"/>
+    </linearGradient>
+    <linearGradient id="vp-dec" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffb400"/><stop offset="1" stop-color="#e5a200"/>
+    </linearGradient>
+    <linearGradient id="vp-bridge" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00bcd4"/><stop offset="1" stop-color="#ffb400"/>
+    </linearGradient>
+    <marker id="vp-a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#8aa0b4"/>
+    </marker>
+    <style>
+      .vp-card{fill:#2f2f2f;stroke:#454545;stroke-width:1.4;}
+      .vp-t{fill:#f5f5f5;font-size:15px;font-weight:700;}
+      .vp-s{fill:#b0b0b0;font-size:11.5px;font-family:'JetBrains Mono',monospace;}
+      .vp-band{fill:#9aa7b4;font-size:12px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;}
+    </style>
+  </defs>
+
+  <!-- ENCODER LANE -->
+  <rect x="14" y="34" width="690" height="170" rx="14" fill="rgba(7,173,248,0.06)" stroke="#1d4a5e" stroke-width="1.2"/>
+  <text x="34" y="58" class="vp-band" fill="#56c7f5">Vision encoder graph · template-driven</text>
+
+  <rect class="vp-card" x="34"  y="74" width="120" height="110" rx="11"/>
+  <text x="94" y="104" text-anchor="middle" class="vp-t">Image</text>
+  <text x="94" y="126" text-anchor="middle" class="vp-s">RGB · resize</text>
+  <text x="94" y="142" text-anchor="middle" class="vp-s">normalize</text>
+  <text x="94" y="166" text-anchor="middle" class="vp-s" fill="#56c7f5">[C,H,W]</text>
+
+  <rect class="vp-card" x="178" y="74" width="150" height="110" rx="11" stroke="#07adf8"/>
+  <text x="253" y="104" text-anchor="middle" class="vp-t">Patch frontend</text>
+  <text x="253" y="126" text-anchor="middle" class="vp-s">im2patch · dual proj</text>
+  <text x="253" y="142" text-anchor="middle" class="vp-s">merge · bias</text>
+  <text x="253" y="158" text-anchor="middle" class="vp-s">tiled 2D pos + RoPE</text>
+  <text x="253" y="176" text-anchor="middle" class="vp-s" fill="#56c7f5">[patches, d]</text>
+
+  <rect class="vp-card" x="352" y="74" width="150" height="110" rx="11" stroke="#07adf8"/>
+  <text x="427" y="104" text-anchor="middle" class="vp-t">Transformer body</text>
+  <text x="427" y="126" text-anchor="middle" class="vp-s">LN · packed QKV</text>
+  <text x="427" y="142" text-anchor="middle" class="vp-s">full attn · out proj</text>
+  <text x="427" y="158" text-anchor="middle" class="vp-s">residual · MLP</text>
+  <text x="427" y="176" text-anchor="middle" class="vp-s" fill="#56c7f5">× N layers</text>
+
+  <rect class="vp-card" x="526" y="74" width="158" height="110" rx="11" stroke="#07adf8"/>
+  <text x="605" y="104" text-anchor="middle" class="vp-t">Deepstack + proj</text>
+  <text x="605" y="126" text-anchor="middle" class="vp-s">layer taps merged</text>
+  <text x="605" y="142" text-anchor="middle" class="vp-s">branch MLP blocks</text>
+  <text x="605" y="158" text-anchor="middle" class="vp-s">projector footer</text>
+  <text x="605" y="176" text-anchor="middle" class="vp-s" fill="#56c7f5">[rows, d_model]</text>
+
+  <path d="M154,129 L176,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+  <path d="M328,129 L350,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+  <path d="M502,129 L524,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+
+  <!-- BRIDGE -->
+  <rect x="724" y="74" width="120" height="110" rx="11" fill="url(#vp-bridge)" opacity="0.9"/>
+  <text x="784" y="120" text-anchor="middle" fill="#101317" font-size="15" font-weight="800">BRIDGE</text>
+  <text x="784" y="142" text-anchor="middle" fill="#1a1f24" font-size="11" font-family="'JetBrains Mono',monospace">named activation</text>
+  <text x="784" y="158" text-anchor="middle" fill="#1a1f24" font-size="11" font-family="'JetBrains Mono',monospace">prefix rows + grid</text>
+  <path d="M684,129 L722,129" fill="none" stroke="#8aa0b4" stroke-width="1.8" marker-end="url(#vp-a)"/>
+
+  <!-- DECODER LANE -->
+  <rect x="864" y="34" width="302" height="170" rx="14" fill="rgba(255,180,0,0.06)" stroke="#5e4d1d" stroke-width="1.2"/>
+  <text x="884" y="58" class="vp-band" fill="#ffce5a">Qwen3 decoder · decode-layout runtime</text>
+
+  <rect class="vp-card" x="884" y="74" width="124" height="110" rx="11" stroke="#ffb400"/>
+  <text x="946" y="108" text-anchor="middle" class="vp-t">Mixed prefill</text>
+  <text x="946" y="130" text-anchor="middle" class="vp-s">vision rows</text>
+  <text x="946" y="146" text-anchor="middle" class="vp-s">+ text tokens</text>
+  <text x="946" y="170" text-anchor="middle" class="vp-s" fill="#ffce5a">staged prefix</text>
+
+  <rect class="vp-card" x="1024" y="74" width="124" height="110" rx="11" stroke="#ffb400"/>
+  <text x="1086" y="108" text-anchor="middle" class="vp-t">Decode</text>
+  <text x="1086" y="130" text-anchor="middle" class="vp-s">KV cache</text>
+  <text x="1086" y="146" text-anchor="middle" class="vp-s">token stream</text>
+  <text x="1086" y="170" text-anchor="middle" class="vp-s" fill="#ffce5a">caption out</text>
+
+  <path d="M844,129 L882,129" fill="none" stroke="#8aa0b4" stroke-width="1.8" marker-end="url(#vp-a)"/>
+  <path d="M1008,129 L1022,129" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#vp-a)"/>
+
+  <!-- COMPILE SUBSTRATE -->
+  <rect x="14" y="248" width="1152" height="150" rx="14" fill="#262626" stroke="#3a3a3a" stroke-width="1.2"/>
+  <text x="34" y="276" class="vp-band">One deterministic stack underneath both lanes</text>
+  <g>
+    <rect class="vp-card" x="34"   y="294" width="206" height="84" rx="10"/>
+    <text x="54" y="324" class="vp-t" font-size="14">GGUF intake</text>
+    <text x="54" y="346" class="vp-s">tensors · vision metadata</text>
+    <text x="54" y="364" class="vp-s">convert_gguf_to_bump_v8</text>
+
+    <rect class="vp-card" x="262" y="294" width="206" height="84" rx="10"/>
+    <text x="282" y="324" class="vp-t" font-size="14">Template resolve</text>
+    <text x="282" y="346" class="vp-s">qwen3_vl_vision.json</text>
+    <text x="282" y="364" class="vp-s">graph order + kernel ids</text>
+
+    <rect class="vp-card" x="490" y="294" width="206" height="84" rx="10"/>
+    <text x="510" y="324" class="vp-t" font-size="14">IR + memory plan</text>
+    <text x="510" y="346" class="vp-s">build_ir_v8.py</text>
+    <text x="510" y="364" class="vp-s">offsets · buffers · no malloc</text>
+
+    <rect class="vp-card" x="718" y="294" width="206" height="84" rx="10"/>
+    <text x="738" y="324" class="vp-t" font-size="14">Codegen</text>
+    <text x="738" y="346" class="vp-s">encoder_v8.c</text>
+    <text x="738" y="364" class="vp-s">kernel dispatch · SIMD tier</text>
+
+    <rect x="946" y="294" width="206" height="84" rx="10" fill="rgba(71,180,117,0.14)" stroke="#47b475" stroke-width="1.5"/>
+    <text x="966" y="324" class="vp-t" font-size="14" fill="#a7e0bf">Bridge host</text>
+    <text x="966" y="346" class="vp-s" fill="#a7e0bf">run_multimodal_bridge_v8</text>
+    <text x="966" y="364" class="vp-s" fill="#a7e0bf">maps rows → decoder prefix</text>
+  </g>
+  <path d="M240,336 L260,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <path d="M468,336 L488,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <path d="M696,336 L716,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <path d="M924,336 L944,336" fill="none" stroke="#8aa0b4" stroke-width="1.4" marker-end="url(#vp-a)"/>
+  <!-- substrate feeds both lanes -->
+  <path d="M340,294 L340,210 L340,206" fill="none" stroke="#5a6b78" stroke-width="1.3" stroke-dasharray="4 4" marker-end="url(#vp-a)"/>
+  <path d="M1049,294 L1049,210 L1049,206" fill="none" stroke="#5a6b78" stroke-width="1.3" stroke-dasharray="4 4" marker-end="url(#vp-a)"/>
+</svg>
+
 <h2>Source of Truth Stack</h2>
 
 <div class="v8-vision-contracts">
@@ -1286,6 +1409,103 @@
         That matters because the engine is not “calling an external encoder.” It is lowering and running the encoder as part of the same system.
     </p>
 </div>
+
+<h2>Inside the Patch Frontend</h2>
+
+<p>
+    The patch frontend is where a raw image becomes encoder tokens. These steps map directly to kernels in
+    <code>src/kernels/vision_kernels.c</code> &mdash; there is no hidden Python preprocessing doing the heavy lifting.
+</p>
+
+<svg viewBox="0 0 1180 360" width="100%" role="img"
+     aria-label="Vision patch embedding: im2patch slices the image into a patch grid, each patch is flattened and projected, then 2x2 spatial merge groups patches and tiled 2D position ids are added."
+     style="max-width:1180px;margin:0.5rem auto 1.25rem;display:block;font-family:'Inter',system-ui,sans-serif;">
+  <defs>
+    <marker id="pf-a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#8aa0b4"/>
+    </marker>
+    <style>
+      .pf-t{fill:#f5f5f5;font-size:14px;font-weight:700;}
+      .pf-s{fill:#b0b0b0;font-size:11px;font-family:'JetBrains Mono',monospace;}
+      .pf-k{fill:#56c7f5;font-size:10.5px;font-family:'JetBrains Mono',monospace;}
+      .pf-step{fill:#9aa7b4;font-size:11px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;}
+    </style>
+  </defs>
+
+  <!-- Step 1: image grid -->
+  <text x="20" y="32" class="pf-step">1 · im2patch</text>
+  <g stroke="#3a6072" stroke-width="1.2" fill="rgba(7,173,248,0.08)">
+    <rect x="20" y="44" width="40" height="40"/><rect x="60" y="44" width="40" height="40"/><rect x="100" y="44" width="40" height="40"/><rect x="140" y="44" width="40" height="40"/>
+    <rect x="20" y="84" width="40" height="40"/><rect x="60" y="84" width="40" height="40"/><rect x="100" y="84" width="40" height="40"/><rect x="140" y="84" width="40" height="40"/>
+    <rect x="20" y="124" width="40" height="40"/><rect x="60" y="124" width="40" height="40"/><rect x="100" y="124" width="40" height="40"/><rect x="140" y="124" width="40" height="40"/>
+    <rect x="20" y="164" width="40" height="40"/><rect x="60" y="164" width="40" height="40"/><rect x="100" y="164" width="40" height="40"/><rect x="140" y="164" width="40" height="40"/>
+  </g>
+  <rect x="20" y="44" width="80" height="80" fill="none" stroke="#ffb400" stroke-width="2.4"/>
+  <text x="20" y="224" class="pf-s">image [C,H,W]</text>
+  <text x="20" y="240" class="pf-k">patch P×P · grid (H/P)×(W/P)</text>
+
+  <path d="M188,124 L228,124" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 2: flattened patch rows -->
+  <text x="244" y="32" class="pf-step">2 · flatten</text>
+  <g>
+    <rect x="244" y="44" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#ffb400" stroke-width="1.6"/>
+    <rect x="244" y="68" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#454545"/>
+    <rect x="244" y="92" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#454545"/>
+    <rect x="244" y="116" width="150" height="20" rx="3" fill="#2f2f2f" stroke="#454545"/>
+    <text x="319" y="148" text-anchor="middle" class="pf-s">⋮</text>
+  </g>
+  <text x="244" y="224" class="pf-s">patches</text>
+  <text x="244" y="240" class="pf-k">[num_patches, C·P·P]</text>
+
+  <path d="M402,100 L442,100" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 3: dual patch projection -->
+  <text x="458" y="32" class="pf-step">3 · patch embed</text>
+  <rect x="458" y="44" width="180" height="120" rx="11" fill="#2f2f2f" stroke="#07adf8" stroke-width="1.5"/>
+  <text x="548" y="78" text-anchor="middle" class="pf-t">Dual patch proj</text>
+  <text x="548" y="100" text-anchor="middle" class="pf-s">GEMM W_patch</text>
+  <text x="548" y="118" text-anchor="middle" class="pf-s">+ stream merge</text>
+  <text x="548" y="136" text-anchor="middle" class="pf-s">+ patch bias</text>
+  <text x="458" y="224" class="pf-s">embedded</text>
+  <text x="458" y="240" class="pf-k">[num_patches, d]</text>
+
+  <path d="M646,104 L686,104" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 4: 2x2 spatial merge -->
+  <text x="702" y="32" class="pf-step">4 · spatial_merge_2x2</text>
+  <g stroke="#454545" stroke-width="1.1" fill="#2f2f2f">
+    <rect x="702" y="44" width="22" height="22"/><rect x="724" y="44" width="22" height="22"/>
+    <rect x="702" y="66" width="22" height="22"/><rect x="724" y="66" width="22" height="22"/>
+  </g>
+  <rect x="702" y="44" width="44" height="44" fill="none" stroke="#00bcd4" stroke-width="2.2"/>
+  <path d="M756,66 L792,66" fill="none" stroke="#00bcd4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+  <rect x="794" y="50" width="64" height="34" rx="6" fill="rgba(0,188,212,0.16)" stroke="#00bcd4" stroke-width="1.4"/>
+  <text x="826" y="72" text-anchor="middle" class="pf-k" fill="#7fe6f5">merged tok</text>
+  <text x="702" y="116" class="pf-s">4 patches → 1 row</text>
+  <text x="702" y="132" class="pf-k">tile_order_index_2d</text>
+  <text x="702" y="148" class="pf-k">(merge_size = 2)</text>
+  <text x="702" y="224" class="pf-s">merged grid</text>
+  <text x="702" y="240" class="pf-k">[rows, 4·d]</text>
+
+  <path d="M870,90 L908,120" fill="none" stroke="#8aa0b4" stroke-width="1.6" marker-end="url(#pf-a)"/>
+
+  <!-- Step 5: tiled 2D position -->
+  <text x="924" y="32" class="pf-step">5 · +2D position</text>
+  <rect x="924" y="44" width="236" height="120" rx="11" fill="#2f2f2f" stroke="#07adf8" stroke-width="1.5"/>
+  <text x="1042" y="76" text-anchor="middle" class="pf-t">Tiled 2D pos + RoPE</text>
+  <text x="1042" y="98" text-anchor="middle" class="pf-s">position_embeddings_add_tiled_2d</text>
+  <text x="1042" y="116" text-anchor="middle" class="pf-s">vision_position_ids_2d_merge</text>
+  <text x="1042" y="134" text-anchor="middle" class="pf-s">multi-section RoPE</text>
+  <text x="1042" y="152" text-anchor="middle" class="pf-k" fill="#56c7f5">→ ready for transformer body</text>
+
+  <!-- footer note -->
+  <text x="20" y="300" class="pf-s" fill="#808080">Gemma4 vision swaps step 4/5 for </text>
+  <text x="320" y="300" class="pf-k">spatial_average_pool_contiguous</text>
+  <text x="600" y="300" class="pf-s" fill="#808080"> + </text>
+  <text x="624" y="300" class="pf-k">position_embeddings_add_gemma4v_xy</text>
+  <text x="20" y="322" class="pf-s" fill="#808080">All steps are pure, bump-allocated kernels — deterministic and reproducible across runs.</text>
+</svg>
 
 <h2>Important Artifacts</h2>
 
@@ -1578,7 +1798,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-23</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/version-history.html
+++ b/docs/site/version-history.html
@@ -6,11 +6,11 @@
     <title>Version History and Roadmap | C-Kernel-Engine</title>
     <meta name="description" content="Version-by-version roadmap for C-Kernel-Engine, including inference, training, parity, distributed systems, and future capability milestones.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/version-history.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html">
     <meta property="og:title" content="Version History and Roadmap | C-Kernel-Engine">
     <meta property="og:description" content="Version-by-version roadmap for C-Kernel-Engine, including inference, training, parity, distributed systems, and future capability milestones.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/version-history.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -2676,8 +2676,8 @@ console.log('Roadmap: ' + versionData.roadmap.map(v => 'v' + v.major).join(' →
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -6,11 +6,11 @@
     <title>Documentation | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://antshiv.github.io/C-Kernel-Engine/vision-encoder-parity.html">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html">
     <meta property="og:title" content="Documentation | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://antshiv.github.io/C-Kernel-Engine/vision-encoder-parity.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -1323,8 +1323,8 @@ permalink: /vision-encoder-parity/
                 </ul>
             </div>
             <div style="text-align: right;">
-                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Built with zero dependencies</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
             </div>
         </div>
     </footer>

--- a/scripts/perf_stat_v8_prefill_compare.py
+++ b/scripts/perf_stat_v8_prefill_compare.py
@@ -239,6 +239,10 @@ def main() -> int:
                 "CK_ENABLE_Q4K_PACKED_META_X8_PREFILL": env.get("CK_ENABLE_Q4K_PACKED_META_X8_PREFILL", ""),
                 "CK_FORCE_Q4K_PACKED_META_X8_PREFILL": env.get("CK_FORCE_Q4K_PACKED_META_X8_PREFILL", ""),
                 "CK_DISABLE_Q4K_PACKED_META_X8_PREFILL": env.get("CK_DISABLE_Q4K_PACKED_META_X8_PREFILL", ""),
+                "CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL": env.get("CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL", ""),
+                "CK_FORCE_Q4K_PACKED_META_X8MT_PREFILL": env.get("CK_FORCE_Q4K_PACKED_META_X8MT_PREFILL", ""),
+                "CK_DISABLE_Q4K_PACKED_META_X8MT_PREFILL": env.get("CK_DISABLE_Q4K_PACKED_META_X8MT_PREFILL", ""),
+                "CK_Q4K_PACKED_META_X8MT_TILE_M": env.get("CK_Q4K_PACKED_META_X8MT_TILE_M", ""),
             },
         },
         "runs": {},
@@ -277,6 +281,10 @@ def main() -> int:
         f"- CK Q4 packed-x8: `{env.get('CK_ENABLE_Q4K_PACKED_META_X8_PREFILL', '')}` "
         f"force=`{env.get('CK_FORCE_Q4K_PACKED_META_X8_PREFILL', '')}` "
         f"disabled=`{env.get('CK_DISABLE_Q4K_PACKED_META_X8_PREFILL', '')}`",
+        f"- CK Q4 packed-x8mt: `{env.get('CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL', '')}` "
+        f"force=`{env.get('CK_FORCE_Q4K_PACKED_META_X8MT_PREFILL', '')}` "
+        f"disabled=`{env.get('CK_DISABLE_Q4K_PACKED_META_X8MT_PREFILL', '')}` "
+        f"tile_m=`{env.get('CK_Q4K_PACKED_META_X8MT_TILE_M', '') or 'default'}`",
         "",
         "| Engine | prefill tok/s | prefill ms | decode tok/s | decode ms | cycles | instructions | IPC | cache misses | cache miss rate | ctx switches |",
         "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",

--- a/scripts/perf_stat_v8_prefill_compare.py
+++ b/scripts/perf_stat_v8_prefill_compare.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Collect perf stat counters for CK v8 and llama.cpp prefill/decode.
+
+This is the safe profiling lane for machines where VTune/Advisor kernel-driver
+collections are too risky. It intentionally uses the same fixed-token workload
+shape as benchmarks/compare_ck_llama_v8.py so timing and counters can be read
+together.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MODEL_DIR = Path.home() / ".cache/ck-engine-v8/models/unsloth--Qwen3.5-0.8B-GGUF"
+DEFAULT_GGUF = DEFAULT_MODEL_DIR / "Qwen3.5-0.8B-Q4_K_M.gguf"
+DEFAULT_OUT = ROOT / "profile_results" / "v8_prefill_perf_stat"
+
+EVENTS = [
+    "cycles",
+    "instructions",
+    "cache-references",
+    "cache-misses",
+    "branches",
+    "branch-misses",
+    "context-switches",
+    "cpu-migrations",
+    "page-faults",
+]
+
+PERF_LINE_RE = re.compile(
+    r"^\s*(?P<value>[0-9][0-9,\.]*|<not counted>|<not supported>)\s+"
+    r"(?P<event>[A-Za-z0-9_./:-]+)"
+)
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+CK_TIMING_RE = re.compile(
+    r"prefill\s+(?P<prompt_tokens>\d+)\s+tok.*?"
+    r"(?P<prompt_ms>[0-9.]+)\s+ms\s+(?P<prompt_tok_s>[0-9.]+)\s+tok/s.*?"
+    r"decode\s+(?P<decode_tokens>\d+)\s+tok\s+"
+    r"(?P<decode_ms>[0-9.]+)\s+ms\s+(?P<decode_tok_s>[0-9.]+)\s+tok/s",
+    re.S,
+)
+
+
+def run(cmd: list[str], *, env: dict[str, str], timeout: int | None = None) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(shlex.quote(part) for part in cmd), flush=True)
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_perf_stat(text: str) -> dict[str, Any]:
+    counters: dict[str, Any] = {}
+    for line in text.splitlines():
+        if "," in line:
+            fields = line.split(",")
+            if len(fields) < 3:
+                continue
+            raw_value = fields[0].strip()
+            event = fields[2].strip()
+        else:
+            match = PERF_LINE_RE.match(line)
+            if not match:
+                continue
+            raw_value = match.group("value")
+            event = match.group("event")
+        if event.startswith("cpu_atom/") and event.endswith("/"):
+            event = event[len("cpu_atom/"):-1]
+        elif event.startswith("cpu_core/") and event.endswith("/"):
+            event = event[len("cpu_core/"):-1]
+        if raw_value.startswith("<"):
+            counters[event] = raw_value
+            continue
+        try:
+            parsed: Any = int(raw_value.replace(",", ""))
+        except ValueError:
+            try:
+                parsed = float(raw_value.replace(",", ""))
+            except ValueError:
+                parsed = raw_value
+        if isinstance(parsed, (int, float)) and isinstance(counters.get(event), (int, float)):
+            counters[event] += parsed
+        else:
+            counters[event] = parsed
+    cycles = counters.get("cycles")
+    instructions = counters.get("instructions")
+    cache_refs = counters.get("cache-references")
+    cache_misses = counters.get("cache-misses")
+    if isinstance(cycles, int) and cycles > 0 and isinstance(instructions, int):
+        counters["ipc"] = instructions / cycles
+    if isinstance(cache_refs, int) and cache_refs > 0 and isinstance(cache_misses, int):
+        counters["cache_miss_rate"] = cache_misses / cache_refs
+    return counters
+
+
+def parse_ck_timing(text: str) -> dict[str, Any]:
+    clean = ANSI_RE.sub("", text).replace("\r", "")
+    match = CK_TIMING_RE.search(clean)
+    if not match:
+        return {}
+    return {
+        "prompt_tokens": int(match.group("prompt_tokens")),
+        "decode_tokens": int(match.group("decode_tokens")),
+        "prompt_ms": float(match.group("prompt_ms")),
+        "decode_ms": float(match.group("decode_ms")),
+        "prompt_tok_s": float(match.group("prompt_tok_s")),
+        "decode_tok_s": float(match.group("decode_tok_s")),
+    }
+
+
+def parse_llama_bench_timing(text: str) -> dict[str, Any]:
+    try:
+        rows = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(rows, list):
+        return {}
+    prompt = next((row for row in rows if int(row.get("n_prompt", 0)) > 0), None)
+    decode = next((row for row in rows if int(row.get("n_gen", 0)) > 0), None)
+    timing: dict[str, Any] = {}
+    if prompt:
+        timing.update(
+            {
+                "prompt_tokens": int(prompt.get("n_prompt", 0)),
+                "prompt_ms": float(prompt.get("avg_ns", 0.0)) / 1_000_000.0,
+                "prompt_tok_s": float(prompt.get("avg_ts", 0.0)),
+            }
+        )
+    if decode:
+        timing.update(
+            {
+                "decode_tokens": int(decode.get("n_gen", 0)),
+                "decode_ms": float(decode.get("avg_ns", 0.0)) / 1_000_000.0,
+                "decode_tok_s": float(decode.get("avg_ts", 0.0)),
+            }
+        )
+    return timing
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", choices=["ck", "llama", "both"], default="both")
+    parser.add_argument("--gguf", type=Path, default=DEFAULT_GGUF)
+    parser.add_argument("--ck-lib", type=Path, default=DEFAULT_MODEL_DIR / "libmodel.so")
+    parser.add_argument("--ck-weights", type=Path, default=DEFAULT_MODEL_DIR / "weights.bump")
+    parser.add_argument("--prompt", type=int, default=128)
+    parser.add_argument("--decode", type=int, default=1)
+    parser.add_argument("--threads", type=int, default=12)
+    parser.add_argument("--token-id", type=int, default=100)
+    parser.add_argument("--events", default=",".join(EVENTS))
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--timeout", type=int, default=600)
+    args = parser.parse_args()
+
+    timestamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    out_dir = args.out / timestamp
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(args.threads)
+    env["OMP_NUM_THREADS"] = env.get("OMP_NUM_THREADS", "1")
+    env["LD_LIBRARY_PATH"] = f"{ROOT / 'build'}:{ROOT / 'llama.cpp'}:{env.get('LD_LIBRARY_PATH', '')}"
+
+    token_csv = ",".join([str(args.token_id)] * args.prompt)
+    context = max(args.prompt + args.decode + 16, 128)
+    event_arg = args.events
+
+    commands: dict[str, list[str]] = {
+        "ck": [
+            "perf", "stat", "-x", ",", "-e", event_arg,
+            str(ROOT / "build/ck-cli-v8"),
+            str(args.ck_lib),
+            str(args.ck_weights),
+            "--prompt-tokens", token_csv,
+            "--max-tokens", str(args.decode + 1),
+            "--context", str(context),
+            "--temperature", "0",
+            "--ignore-eos",
+            "--quiet-output",
+            "--no-chat-template",
+            "--no-stream",
+            "--timing",
+        ],
+        "llama": [
+            "perf", "stat", "-x", ",", "-e", event_arg,
+            str(ROOT / "llama.cpp/build/bin/llama-bench"),
+            "-m", str(args.gguf),
+            "-p", str(args.prompt),
+            "-n", str(args.decode),
+            "-t", str(args.threads),
+            "-ngl", "0",
+            "-r", "1",
+            "-o", "json",
+        ],
+    }
+
+    engines = ["ck", "llama"] if args.engine == "both" else [args.engine]
+    report: dict[str, Any] = {
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "config": {
+            "prompt": args.prompt,
+            "decode": args.decode,
+            "threads": args.threads,
+            "events": event_arg.split(","),
+            "gguf": str(args.gguf),
+            "ck_lib": str(args.ck_lib),
+            "ck_weights": str(args.ck_weights),
+            "ck_env": {
+                "CK_ENABLE_Q4K_PACKED_META_2D_PREFILL": env.get("CK_ENABLE_Q4K_PACKED_META_2D_PREFILL", ""),
+                "CK_FORCE_Q4K_PACKED_META_2D_PREFILL": env.get("CK_FORCE_Q4K_PACKED_META_2D_PREFILL", ""),
+                "CK_Q4K_PACKED_META_TILE_M": env.get("CK_Q4K_PACKED_META_TILE_M", ""),
+                "CK_Q4K_PACKED_META_TILE_N": env.get("CK_Q4K_PACKED_META_TILE_N", ""),
+                "CK_DISABLE_Q4K_PACKED_META_PREFILL": env.get("CK_DISABLE_Q4K_PACKED_META_PREFILL", ""),
+                "CK_FORCE_Q4K_PACKED_META_PREFILL": env.get("CK_FORCE_Q4K_PACKED_META_PREFILL", ""),
+                "CK_ENABLE_Q4K_PACKED_META_X8_PREFILL": env.get("CK_ENABLE_Q4K_PACKED_META_X8_PREFILL", ""),
+                "CK_FORCE_Q4K_PACKED_META_X8_PREFILL": env.get("CK_FORCE_Q4K_PACKED_META_X8_PREFILL", ""),
+                "CK_DISABLE_Q4K_PACKED_META_X8_PREFILL": env.get("CK_DISABLE_Q4K_PACKED_META_X8_PREFILL", ""),
+            },
+        },
+        "runs": {},
+    }
+
+    for engine in engines:
+        proc = run(commands[engine], env=env, timeout=args.timeout)
+        stdout_path = out_dir / f"{engine}.stdout.txt"
+        stderr_path = out_dir / f"{engine}.stderr.txt"
+        write_text(stdout_path, proc.stdout)
+        write_text(stderr_path, proc.stderr)
+        report["runs"][engine] = {
+            "returncode": proc.returncode,
+            "cmd": commands[engine],
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "perf": parse_perf_stat(proc.stderr),
+            "timing": parse_ck_timing(proc.stdout)
+            if engine == "ck"
+            else parse_llama_bench_timing(proc.stdout),
+        }
+
+    json_path = out_dir / "perf_stat_v8_prefill_compare.json"
+    md_path = out_dir / "perf_stat_v8_prefill_compare.md"
+    write_text(json_path, json.dumps(report, indent=2))
+
+    lines = [
+        "# v8 Prefill perf stat",
+        "",
+        f"- Prompt/decode: `{args.prompt}` / `{args.decode}`",
+        f"- Threads: `{args.threads}`",
+        f"- CK Q4 packed 2D: `{env.get('CK_ENABLE_Q4K_PACKED_META_2D_PREFILL', '')}` "
+        f"force=`{env.get('CK_FORCE_Q4K_PACKED_META_2D_PREFILL', '')}` "
+        f"tile=`{env.get('CK_Q4K_PACKED_META_TILE_M', '') or 'default'}x"
+        f"{env.get('CK_Q4K_PACKED_META_TILE_N', '') or 'default'}`",
+        f"- CK Q4 packed-x8: `{env.get('CK_ENABLE_Q4K_PACKED_META_X8_PREFILL', '')}` "
+        f"force=`{env.get('CK_FORCE_Q4K_PACKED_META_X8_PREFILL', '')}` "
+        f"disabled=`{env.get('CK_DISABLE_Q4K_PACKED_META_X8_PREFILL', '')}`",
+        "",
+        "| Engine | prefill tok/s | prefill ms | decode tok/s | decode ms | cycles | instructions | IPC | cache misses | cache miss rate | ctx switches |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for engine in engines:
+        perf = report["runs"][engine]["perf"]
+        timing = report["runs"][engine].get("timing", {})
+        lines.append(
+            f"| {engine} | {timing.get('prompt_tok_s', '-')} | {timing.get('prompt_ms', '-')} | "
+            f"{timing.get('decode_tok_s', '-')} | {timing.get('decode_ms', '-')} | "
+            f"{perf.get('cycles', '-')} | {perf.get('instructions', '-')} | "
+            f"{perf.get('ipc', 0.0):.3f} | {perf.get('cache-misses', '-')} | "
+            f"{perf.get('cache_miss_rate', 0.0):.3%} | {perf.get('context-switches', '-')} |"
+        )
+    lines += ["", f"JSON: `{json_path}`", ""]
+    write_text(md_path, "\n".join(lines))
+
+    print(f"wrote {json_path}")
+    print(f"wrote {md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/profile_v8_prefill_roofline.sh
+++ b/scripts/profile_v8_prefill_roofline.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Profile CK v8 and llama.cpp prefill with Intel Advisor/VTune.
+#
+# Default target is Qwen3.5 0.8B Q4_K_M because CK's v8 op profiler shows
+# prefill time is dominated by mlp_gate_up -> gemm_nt_q4_k_q8_k on this model.
+#
+# Examples:
+#   scripts/profile_v8_prefill_roofline.sh --tool advisor --engine both --prompt 128
+#   scripts/profile_v8_prefill_roofline.sh --tool vtune-hotspots --engine ck --prompt 512
+#   scripts/profile_v8_prefill_roofline.sh --tool all --engine both --prompt 128
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/profile_results/v8_prefill_roofline}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+ENGINE="both"
+TOOL="advisor"
+PROMPT_TOKENS="${CK_PROFILE_PROMPT_TOKENS:-128}"
+DECODE_TOKENS="${CK_PROFILE_DECODE_TOKENS:-1}"
+THREADS="${CK_NUM_THREADS:-12}"
+TOKEN_ID="${CK_PROFILE_TOKEN_ID:-100}"
+MODEL_KEY="qwen35"
+
+QWEN35_DIR="${CK_QWEN35_DIR:-$HOME/.cache/ck-engine-v8/models/unsloth--Qwen3.5-0.8B-GGUF}"
+CK_CLI="${CK_CLI:-$ROOT_DIR/build/ck-cli-v8}"
+CK_LIB="${CK_LIB:-$QWEN35_DIR/libmodel.so}"
+CK_WEIGHTS="${CK_WEIGHTS:-$QWEN35_DIR/weights.bump}"
+GGUF="${GGUF:-$QWEN35_DIR/Qwen3.5-0.8B-Q4_K_M.gguf}"
+LLAMA_BENCH="${LLAMA_BENCH:-$ROOT_DIR/llama.cpp/build/bin/llama-bench}"
+
+usage() {
+    sed -n '1,24p' "$0"
+    echo
+    echo "Options:"
+    echo "  --engine ck|llama|both        default: $ENGINE"
+    echo "  --tool advisor|vtune-hotspots|vtune-memory|vtune-uarch|all"
+    echo "                                default: $TOOL"
+    echo "  --prompt N                    prompt tokens, default: $PROMPT_TOKENS"
+    echo "  --decode N                    decode tokens, default: $DECODE_TOKENS"
+    echo "  --threads N                   CPU threads, default: $THREADS"
+    echo "  --token-id N                  repeated CK prompt token id, default: $TOKEN_ID"
+    echo "  --out DIR                     output root, default: $OUT_ROOT"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --engine) ENGINE="$2"; shift 2 ;;
+        --tool) TOOL="$2"; shift 2 ;;
+        --prompt) PROMPT_TOKENS="$2"; shift 2 ;;
+        --decode) DECODE_TOKENS="$2"; shift 2 ;;
+        --threads) THREADS="$2"; shift 2 ;;
+        --token-id) TOKEN_ID="$2"; shift 2 ;;
+        --out) OUT_ROOT="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+case "$ENGINE" in
+    ck|llama|both) ;;
+    *) echo "invalid --engine: $ENGINE" >&2; exit 2 ;;
+esac
+
+case "$TOOL" in
+    advisor|vtune-hotspots|vtune-memory|vtune-uarch|all) ;;
+    *) echo "invalid --tool: $TOOL" >&2; exit 2 ;;
+esac
+
+require_file() {
+    if [ ! -e "$1" ]; then
+        echo "missing required file: $1" >&2
+        exit 1
+    fi
+}
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "missing required tool: $1" >&2
+        echo "try: source /opt/intel/oneapi/setvars.sh" >&2
+        exit 1
+    fi
+}
+
+repeat_token_csv() {
+    local n="$1"
+    local tok="$2"
+    local out="$tok"
+    local i=1
+    while [ "$i" -lt "$n" ]; do
+        out="$out,$tok"
+        i=$((i + 1))
+    done
+    printf '%s' "$out"
+}
+
+require_file "$CK_CLI"
+require_file "$CK_LIB"
+require_file "$CK_WEIGHTS"
+require_file "$GGUF"
+require_file "$LLAMA_BENCH"
+
+if [ "$TOOL" = "advisor" ] || [ "$TOOL" = "all" ]; then
+    require_tool advisor
+fi
+if [ "$TOOL" = "vtune-hotspots" ] || [ "$TOOL" = "vtune-memory" ] || [ "$TOOL" = "vtune-uarch" ] || [ "$TOOL" = "all" ]; then
+    require_tool vtune
+fi
+
+RUN_ROOT="$OUT_ROOT/$STAMP"
+mkdir -p "$RUN_ROOT"
+
+TOKEN_CSV="$(repeat_token_csv "$PROMPT_TOKENS" "$TOKEN_ID")"
+CONTEXT=$((PROMPT_TOKENS + DECODE_TOKENS + 16))
+CK_DECODE=$((DECODE_TOKENS + 1))
+
+export CK_NUM_THREADS="$THREADS"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+export LD_LIBRARY_PATH="$ROOT_DIR/build:$QWEN35_DIR:${LD_LIBRARY_PATH:-}"
+
+CK_CMD=(
+    "$CK_CLI" "$CK_LIB" "$CK_WEIGHTS"
+    --prompt-tokens "$TOKEN_CSV"
+    --max-tokens "$CK_DECODE"
+    --context "$CONTEXT"
+    --temperature 0
+    --ignore-eos
+    --quiet-output
+    --no-chat-template
+    --no-stream
+    --timing
+)
+
+LLAMA_CMD=(
+    "$LLAMA_BENCH"
+    -m "$GGUF"
+    -p "$PROMPT_TOKENS"
+    -n "$DECODE_TOKENS"
+    -t "$THREADS"
+    -ngl 0
+    -r 1
+    -o json
+)
+
+write_command_file() {
+    {
+        echo "model_key=$MODEL_KEY"
+        echo "threads=$THREADS"
+        echo "prompt_tokens=$PROMPT_TOKENS"
+        echo "decode_tokens=$DECODE_TOKENS"
+        echo "ck_cli=$CK_CLI"
+        echo "ck_lib=$CK_LIB"
+        echo "ck_weights=$CK_WEIGHTS"
+        echo "gguf=$GGUF"
+        echo
+        printf 'CK_CMD='
+        printf '%q ' "${CK_CMD[@]}"
+        echo
+        printf 'LLAMA_CMD='
+        printf '%q ' "${LLAMA_CMD[@]}"
+        echo
+    } > "$RUN_ROOT/commands.txt"
+}
+
+run_advisor_one() {
+    local name="$1"
+    shift
+    local project="$RUN_ROOT/advisor_${name}"
+    echo "Advisor roofline: $name -> $project"
+    advisor --collect=roofline \
+        --project-dir="$project" \
+        --search-dir "src:r=$ROOT_DIR" \
+        -- "$@"
+    advisor --report=roofline --project-dir="$project" \
+        --report-output="$RUN_ROOT/advisor_${name}_roofline.txt" \
+        --format=text >/dev/null 2>&1 || true
+    advisor --report=survey --project-dir="$project" \
+        --report-output="$RUN_ROOT/advisor_${name}_survey.txt" \
+        --format=text >/dev/null 2>&1 || true
+}
+
+run_vtune_one() {
+    local kind="$1"
+    local name="$2"
+    shift 2
+    local result="$RUN_ROOT/vtune_${kind}_${name}"
+    local collect="$kind"
+    if [ "$kind" = "vtune-hotspots" ]; then
+        collect="hotspots"
+    elif [ "$kind" = "vtune-memory" ]; then
+        collect="memory-access"
+    elif [ "$kind" = "vtune-uarch" ]; then
+        collect="uarch-exploration"
+    fi
+    echo "VTune $collect: $name -> $result"
+    vtune -collect "$collect" -result-dir "$result" -quiet -- "$@"
+    vtune -report summary -result-dir "$result" \
+        -report-output="$RUN_ROOT/${kind}_${name}_summary.txt" \
+        -format=text >/dev/null 2>&1 || true
+    vtune -report hotspots -result-dir "$result" \
+        -report-output="$RUN_ROOT/${kind}_${name}_hotspots.txt" \
+        -format=text >/dev/null 2>&1 || true
+}
+
+run_for_engine() {
+    local which="$1"
+    local cmd_ref="$2"
+    shift 2
+    if [ "$TOOL" = "advisor" ] || [ "$TOOL" = "all" ]; then
+        run_advisor_one "$which" "$@"
+    fi
+    if [ "$TOOL" = "vtune-hotspots" ] || [ "$TOOL" = "all" ]; then
+        run_vtune_one "vtune-hotspots" "$which" "$@"
+    fi
+    if [ "$TOOL" = "vtune-memory" ] || [ "$TOOL" = "all" ]; then
+        run_vtune_one "vtune-memory" "$which" "$@"
+    fi
+    if [ "$TOOL" = "vtune-uarch" ] || [ "$TOOL" = "all" ]; then
+        run_vtune_one "vtune-uarch" "$which" "$@"
+    fi
+}
+
+write_command_file
+
+echo "Output: $RUN_ROOT"
+echo "Threads: $THREADS, prompt=$PROMPT_TOKENS, decode=$DECODE_TOKENS"
+
+if [ "$ENGINE" = "ck" ] || [ "$ENGINE" = "both" ]; then
+    run_for_engine "ck" CK_CMD "${CK_CMD[@]}"
+fi
+
+if [ "$ENGINE" = "llama" ] || [ "$ENGINE" = "both" ]; then
+    run_for_engine "llama" LLAMA_CMD "${LLAMA_CMD[@]}"
+fi
+
+echo
+echo "Done. Commands and reports: $RUN_ROOT"

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -33,7 +33,7 @@
 #include "ck_threadpool.h"
 #include "ckernel_quant.h"
 
-#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+#if (defined(__AVX512VNNI__) && defined(__AVX512VL__)) || defined(__AVX2__)
 #include <immintrin.h>
 #endif
 
@@ -47,7 +47,7 @@ void gemv_q4_k_q8_k_avx2(float *y,
                          const void *x_q8,
                          int M, int K);
 
-#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+#if (defined(__AVX512VNNI__) && defined(__AVX512VL__)) || defined(__AVX2__)
 static inline int32_t hsum256_epi32(__m256i v) {
     __m128i lo = _mm256_castsi256_si128(v);
     __m128i hi = _mm256_extracti128_si256(v, 1);
@@ -56,16 +56,31 @@ static inline int32_t hsum256_epi32(__m256i v) {
     sum = _mm_hadd_epi32(sum, sum);
     return _mm_cvtsi128_si32(sum);
 }
+#endif
 
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
 static inline int32_t dot_q4_k_q8_k_32_vnni(const uint8_t *q4_packed_32,
                                             const int8_t *q8_32,
                                             int high_nibble) {
+    const __m256i q8_bytes = _mm256_loadu_si256((const __m256i *)q8_32);
     const __m256i packed = _mm256_loadu_si256((const __m256i *)q4_packed_32);
     const __m256i mask4 = _mm256_set1_epi8(0x0F);
     const __m256i q4_bytes = high_nibble
         ? _mm256_and_si256(_mm256_srli_epi16(packed, 4), mask4)
         : _mm256_and_si256(packed, mask4);
-    const __m256i q8_bytes = _mm256_loadu_si256((const __m256i *)q8_32);
+    __m256i acc = _mm256_setzero_si256();
+    acc = _mm256_dpbusd_epi32(acc, q4_bytes, q8_bytes);
+    return hsum256_epi32(acc);
+}
+
+static inline int32_t dot_q4_k_q8_k_32_vnni_q8v(const uint8_t *q4_packed_32,
+                                                 __m256i q8_bytes,
+                                                 int high_nibble) {
+    const __m256i packed = _mm256_loadu_si256((const __m256i *)q4_packed_32);
+    const __m256i mask4 = _mm256_set1_epi8(0x0F);
+    const __m256i q4_bytes = high_nibble
+        ? _mm256_and_si256(_mm256_srli_epi16(packed, 4), mask4)
+        : _mm256_and_si256(packed, mask4);
     __m256i acc = _mm256_setzero_si256();
     acc = _mm256_dpbusd_epi32(acc, q4_bytes, q8_bytes);
     return hsum256_epi32(acc);
@@ -106,6 +121,22 @@ static inline float dot_q4_k_q8_k_vnni_block(const block_q4_K *w,
 }
 #endif
 
+#if defined(__AVX2__) && !(defined(__AVX512VNNI__) && defined(__AVX512VL__))
+static inline int32_t dot_q4_k_q8_k_32_avx2_q8v(const uint8_t *q4_packed_32,
+                                                 __m256i q8_bytes,
+                                                 int high_nibble) {
+    const __m256i packed = _mm256_loadu_si256((const __m256i *)q4_packed_32);
+    const __m256i mask4 = _mm256_set1_epi8(0x0F);
+    const __m256i q4_bytes = high_nibble
+        ? _mm256_and_si256(_mm256_srli_epi16(packed, 4), mask4)
+        : _mm256_and_si256(packed, mask4);
+    const __m256i pair_sums_i16 = _mm256_maddubs_epi16(q4_bytes, q8_bytes);
+    const __m256i ones = _mm256_set1_epi16(1);
+    const __m256i sums_i32 = _mm256_madd_epi16(pair_sums_i16, ones);
+    return hsum256_epi32(sums_i32);
+}
+#endif
+
 
 typedef struct {
     ck_half d;
@@ -123,6 +154,16 @@ typedef struct {
     uint8_t qs[QK_K / 2];
 } block_q4_K_packed_meta;
 
+typedef struct {
+    ck_half d[8];
+    ck_half dmin[8];
+    uint8_t sc[8][8];
+    uint8_t m[8][8];
+    uint8_t qs[8][QK_K / 2];
+    uint8_t active;
+    uint8_t reserved[7];
+} block_q4_K_packed_meta_x8;
+
 size_t q4_k_packed_u8_block_size(void)
 {
     return sizeof(block_q4_K_packed_u8);
@@ -131,6 +172,11 @@ size_t q4_k_packed_u8_block_size(void)
 size_t q4_k_packed_meta_block_size(void)
 {
     return sizeof(block_q4_K_packed_meta);
+}
+
+size_t q4_k_packed_meta_x8_block_size(void)
+{
+    return sizeof(block_q4_K_packed_meta_x8);
 }
 
 void pack_q4_k_to_packed_u8(const void *src, void *dst, int N, int K)
@@ -175,6 +221,34 @@ void pack_q4_k_to_packed_meta(const void *src, void *dst, int N, int K)
             pb->dmin = sb->dmin;
             unpack_q4_k_scales(sb->scales, pb->sc, pb->m);
             memcpy(pb->qs, sb->qs, sizeof(pb->qs));
+        }
+    }
+}
+
+void pack_q4_k_to_packed_meta_x8(const void *src, void *dst, int N, int K)
+{
+    if (!src || !dst || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    const block_q4_K *in = (const block_q4_K *)src;
+    block_q4_K_packed_meta_x8 *out = (block_q4_K_packed_meta_x8 *)dst;
+    const int blocks_per_row = K / QK_K;
+    const int groups = (N + 7) / 8;
+    memset(out, 0, (size_t)groups * (size_t)blocks_per_row * sizeof(*out));
+
+    for (int g = 0; g < groups; ++g) {
+        const int n0 = g * 8;
+        const int active = (n0 + 8 <= N) ? 8 : (N - n0);
+        for (int b = 0; b < blocks_per_row; ++b) {
+            block_q4_K_packed_meta_x8 *pb = out + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+            pb->active = (uint8_t)active;
+            for (int lane = 0; lane < active; ++lane) {
+                const block_q4_K *sb = in + (size_t)(n0 + lane) * (size_t)blocks_per_row + (size_t)b;
+                pb->d[lane] = sb->d;
+                pb->dmin[lane] = sb->dmin;
+                unpack_q4_k_scales(sb->scales, pb->sc[lane], pb->m[lane]);
+                memcpy(pb->qs[lane], sb->qs, sizeof(pb->qs[lane]));
+            }
         }
     }
 }
@@ -258,6 +332,54 @@ static inline float dot_q4_k_packed_meta_q8_k_block(const block_q4_K_packed_meta
     return sumf;
 }
 
+static inline void accum_q4_k_packed_meta_x8_q8_k_block(float acc[8],
+                                                         const block_q4_K_packed_meta_x8 *w,
+                                                         int active,
+                                                         const block_q8_K *x)
+{
+    const float xd = x->d;
+    for (int j = 0, is = 0, q_offset = 0; j < QK_K; j += 64, is += 2, q_offset += 32) {
+        const int8_t *q8_lo_ptr = &x->qs[j];
+        const int8_t *q8_hi_ptr = &x->qs[j + 32];
+        const int32_t bsum_lo = (int32_t)x->bsums[j / 16] +
+                                (int32_t)x->bsums[j / 16 + 1];
+        const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
+                                (int32_t)x->bsums[(j + 32) / 16 + 1];
+
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#elif defined(__AVX2__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#endif
+
+        for (int lane = 0; lane < active; ++lane) {
+            const uint8_t *qs = &w->qs[lane][q_offset];
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+            const int32_t sum_lo = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_lo, 0);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_hi, 1);
+#elif defined(__AVX2__)
+            const int32_t sum_lo = dot_q4_k_q8_k_32_avx2_q8v(qs, q8_lo, 0);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_avx2_q8v(qs, q8_hi, 1);
+#else
+            int32_t sum_lo = 0;
+            int32_t sum_hi = 0;
+            for (int l = 0; l < 32; ++l) {
+                sum_lo += (int32_t)(qs[l] & 0x0F) * (int32_t)q8_lo_ptr[l];
+                sum_hi += (int32_t)(qs[l] >> 4) * (int32_t)q8_hi_ptr[l];
+            }
+#endif
+            const float d = CK_FP16_TO_FP32(w->d[lane]) * xd;
+            const float dmin = CK_FP16_TO_FP32(w->dmin[lane]) * xd;
+            acc[lane] += d * (float)w->sc[lane][is] * (float)sum_lo;
+            acc[lane] -= dmin * (float)w->m[lane][is] * (float)bsum_lo;
+            acc[lane] += d * (float)w->sc[lane][is + 1] * (float)sum_hi;
+            acc[lane] -= dmin * (float)w->m[lane][is + 1] * (float)bsum_hi;
+        }
+    }
+}
+
 void gemm_nt_q4_k_packed_u8_q8_k(const void *A_q8,
                                   const void *B_packed,
                                   const float *bias,
@@ -313,6 +435,80 @@ void gemm_nt_q4_k_packed_meta_q8_k(const void *A_q8,
     }
 }
 
+void gemm_nt_q4_k_packed_meta_q8_k_tile(const void *A_q8,
+                                         const void *B_packed,
+                                         const float *bias,
+                                         float *C,
+                                         int M, int N, int K,
+                                         int m0, int m1, int n0, int n1)
+{
+    if (!A_q8 || !B_packed || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    if (m0 < 0) m0 = 0;
+    if (n0 < 0) n0 = 0;
+    if (m1 > M) m1 = M;
+    if (n1 > N) n1 = N;
+    if (m0 >= m1 || n0 >= n1) {
+        return;
+    }
+
+    const block_q8_K *A = (const block_q8_K *)A_q8;
+    const block_q4_K_packed_meta *W = (const block_q4_K_packed_meta *)B_packed;
+    const int blocks_per_vec = K / QK_K;
+    const int blocks_per_row = K / QK_K;
+
+    for (int m = m0; m < m1; ++m) {
+        const block_q8_K *a_row = A + (size_t)m * (size_t)blocks_per_vec;
+        float *c_row = C + (size_t)m * (size_t)N;
+        for (int n = n0; n < n1; ++n) {
+            const block_q4_K_packed_meta *w_row = W + (size_t)n * (size_t)blocks_per_row;
+            float sum = bias ? bias[n] : 0.0f;
+            for (int b = 0; b < blocks_per_row; ++b) {
+                sum += dot_q4_k_packed_meta_q8_k_block(&w_row[b], &a_row[b]);
+            }
+            c_row[n] = sum;
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_meta_x8_q8_k(const void *A_q8,
+                                       const void *B_packed_x8,
+                                       const float *bias,
+                                       float *C,
+                                       int M, int N, int K)
+{
+    if (!A_q8 || !B_packed_x8 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    const block_q8_K *A = (const block_q8_K *)A_q8;
+    const block_q4_K_packed_meta_x8 *W = (const block_q4_K_packed_meta_x8 *)B_packed_x8;
+    const int blocks_per_vec = K / QK_K;
+    const int blocks_per_row = K / QK_K;
+    const int groups = (N + 7) / 8;
+
+    for (int m = 0; m < M; ++m) {
+        const block_q8_K *a_row = A + (size_t)m * (size_t)blocks_per_vec;
+        float *c_row = C + (size_t)m * (size_t)N;
+        for (int g = 0; g < groups; ++g) {
+            const int n0 = g * 8;
+            const int active = (n0 + 8 <= N) ? 8 : (N - n0);
+            float acc[8];
+            for (int lane = 0; lane < active; ++lane) {
+                acc[lane] = bias ? bias[n0 + lane] : 0.0f;
+            }
+            for (int b = 0; b < blocks_per_row; ++b) {
+                const block_q4_K_packed_meta_x8 *w_group =
+                    W + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+                accum_q4_k_packed_meta_x8_q8_k_block(acc, w_group, active, &a_row[b]);
+            }
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[n0 + lane] = acc[lane];
+            }
+        }
+    }
+}
+
 
 typedef struct {
     const block_q8_K *A;
@@ -325,6 +521,19 @@ typedef struct {
     int blocks_per_vec;
     int blocks_per_row;
 } gemm_q4_packed_meta_thread_work_t;
+
+typedef struct {
+    const block_q8_K *A;
+    const block_q4_K_packed_meta_x8 *W;
+    const float *bias;
+    float *C;
+    int M;
+    int N;
+    int K;
+    int blocks_per_vec;
+    int blocks_per_row;
+    int groups;
+} gemm_q4_packed_meta_x8_thread_work_t;
 
 static void gemm_q4_packed_meta_thread_fn(int ith, int nth, void *args)
 {
@@ -449,6 +658,79 @@ void gemm_nt_q4_k_packed_meta_q8_k_threaded_nsplit(const void *A_q8,
         .blocks_per_row = K / QK_K,
     };
     ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_packed_meta_nsplit_thread_fn, &work);
+}
+
+static void gemm_q4_packed_meta_x8_nsplit_thread_fn(int ith, int nth, void *args)
+{
+    gemm_q4_packed_meta_x8_thread_work_t *a = (gemm_q4_packed_meta_x8_thread_work_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) {
+        return;
+    }
+    const int dg = (a->groups + nth - 1) / nth;
+    const int g0 = dg * ith;
+    const int g1 = (g0 + dg < a->groups) ? (g0 + dg) : a->groups;
+    if (g0 >= a->groups) {
+        return;
+    }
+
+    for (int m = 0; m < a->M; ++m) {
+        const block_q8_K *a_row = a->A + (size_t)m * (size_t)a->blocks_per_vec;
+        float *c_row = a->C + (size_t)m * (size_t)a->N;
+        for (int g = g0; g < g1; ++g) {
+            const int n0 = g * 8;
+            const int active = (n0 + 8 <= a->N) ? 8 : (a->N - n0);
+            float acc[8];
+            for (int lane = 0; lane < active; ++lane) {
+                acc[lane] = a->bias ? a->bias[n0 + lane] : 0.0f;
+            }
+            for (int b = 0; b < a->blocks_per_row; ++b) {
+                const block_q4_K_packed_meta_x8 *w_group =
+                    a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
+                accum_q4_k_packed_meta_x8_q8_k_block(acc, w_group, active, &a_row[b]);
+            }
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[n0 + lane] = acc[lane];
+            }
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(const void *A_q8,
+                                                       const void *B_packed_x8,
+                                                       const float *bias,
+                                                       float *C,
+                                                       int M, int N, int K,
+                                                       int active_threads)
+{
+    if (!A_q8 || !B_packed_x8 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int pool_threads = pool ? ck_threadpool_n_threads(pool) : 1;
+    const int groups = (N + 7) / 8;
+    if (active_threads <= 0 || active_threads > pool_threads) {
+        active_threads = pool_threads;
+    }
+    if (active_threads > groups) {
+        active_threads = groups;
+    }
+    if (active_threads <= 1) {
+        gemm_nt_q4_k_packed_meta_x8_q8_k(A_q8, B_packed_x8, bias, C, M, N, K);
+        return;
+    }
+    gemm_q4_packed_meta_x8_thread_work_t work = {
+        .A = (const block_q8_K *)A_q8,
+        .W = (const block_q4_K_packed_meta_x8 *)B_packed_x8,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .N = N,
+        .K = K,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+        .groups = groups,
+    };
+    ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_packed_meta_x8_nsplit_thread_fn, &work);
 }
 
 

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -533,6 +533,8 @@ typedef struct {
     int blocks_per_vec;
     int blocks_per_row;
     int groups;
+    int tile_m;
+    int jobs;
 } gemm_q4_packed_meta_x8_thread_work_t;
 
 static void gemm_q4_packed_meta_thread_fn(int ith, int nth, void *args)
@@ -731,6 +733,98 @@ void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(const void *A_q8,
         .groups = groups,
     };
     ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_packed_meta_x8_nsplit_thread_fn, &work);
+}
+
+static void gemm_q4_packed_meta_x8_mtile_thread_fn(int ith, int nth, void *args)
+{
+    gemm_q4_packed_meta_x8_thread_work_t *a = (gemm_q4_packed_meta_x8_thread_work_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) {
+        return;
+    }
+    int tile_m = a->tile_m > 0 ? a->tile_m : 4;
+    if (tile_m > 8) tile_m = 8;
+    const int mt = (a->M + tile_m - 1) / tile_m;
+    const int total = mt * a->groups;
+
+    for (int job = ith; job < total; job += nth) {
+        const int g = job / mt;
+        const int tm = job - g * mt;
+        const int m0 = tm * tile_m;
+        const int m1 = (m0 + tile_m < a->M) ? (m0 + tile_m) : a->M;
+        const int n0 = g * 8;
+        const int active = (n0 + 8 <= a->N) ? 8 : (a->N - n0);
+        if (m0 >= a->M || g >= a->groups) {
+            continue;
+        }
+
+        float acc[8][8];
+        for (int mt_lane = 0; mt_lane < m1 - m0; ++mt_lane) {
+            for (int lane = 0; lane < active; ++lane) {
+                acc[mt_lane][lane] = a->bias ? a->bias[n0 + lane] : 0.0f;
+            }
+        }
+
+        for (int b = 0; b < a->blocks_per_row; ++b) {
+            const block_q4_K_packed_meta_x8 *w_group =
+                a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
+            for (int m = m0; m < m1; ++m) {
+                const block_q8_K *a_row = a->A + (size_t)m * (size_t)a->blocks_per_vec;
+                accum_q4_k_packed_meta_x8_q8_k_block(acc[m - m0], w_group, active, &a_row[b]);
+            }
+        }
+
+        for (int m = m0; m < m1; ++m) {
+            float *c_row = a->C + (size_t)m * (size_t)a->N;
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[n0 + lane] = acc[m - m0][lane];
+            }
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(const void *A_q8,
+                                                      const void *B_packed_x8,
+                                                      const float *bias,
+                                                      float *C,
+                                                      int M, int N, int K,
+                                                      int tile_m,
+                                                      int active_threads)
+{
+    if (!A_q8 || !B_packed_x8 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int pool_threads = pool ? ck_threadpool_n_threads(pool) : 1;
+    const int groups = (N + 7) / 8;
+    int tm = tile_m > 0 ? tile_m : 4;
+    if (tm > 8) tm = 8;
+    const int mt = (M + tm - 1) / tm;
+    const int jobs = mt * groups;
+    if (active_threads <= 0 || active_threads > pool_threads) {
+        active_threads = pool_threads;
+    }
+    if (active_threads > jobs) {
+        active_threads = jobs;
+    }
+    if (active_threads <= 1) {
+        gemm_nt_q4_k_packed_meta_x8_q8_k(A_q8, B_packed_x8, bias, C, M, N, K);
+        return;
+    }
+    gemm_q4_packed_meta_x8_thread_work_t work = {
+        .A = (const block_q8_K *)A_q8,
+        .W = (const block_q4_K_packed_meta_x8 *)B_packed_x8,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .N = N,
+        .K = K,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+        .groups = groups,
+        .tile_m = tm,
+        .jobs = jobs,
+    };
+    ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_packed_meta_x8_mtile_thread_fn, &work);
 }
 
 

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -52,7 +52,9 @@ extern void gemm_nt_q4_k_q8_k(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemv_q4_k_q8_k(float *y, const void *W, const void *x_q8, int M, int K);
 extern size_t q4_k_packed_meta_block_size(void);
+extern size_t q4_k_packed_meta_x8_block_size(void);
 extern void pack_q4_k_to_packed_meta(const void *src, void *dst, int N, int K);
+extern void pack_q4_k_to_packed_meta_x8(const void *src, void *dst, int N, int K);
 extern void gemm_nt_q4_k_packed_meta_q8_k_threaded(const void *A_q8,
                                                     const void *B_packed,
                                                     const float *bias,
@@ -65,6 +67,18 @@ extern void gemm_nt_q4_k_packed_meta_q8_k_threaded_nsplit(const void *A_q8,
                                                           float *C,
                                                           int M, int N, int K,
                                                           int threads);
+extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(const void *A_q8,
+                                                             const void *B_packed_x8,
+                                                             const float *bias,
+                                                             float *C,
+                                                             int M, int N, int K,
+                                                             int threads);
+extern void gemm_nt_q4_k_packed_meta_q8_k_tile(const void *A_q8,
+                                               const void *B_packed,
+                                               const float *bias,
+                                               float *C,
+                                               int M, int N, int K,
+                                               int m0, int m1, int n0, int n1);
 extern void gemm_nt_q6_k_q8_k(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemm_nt_q6_k_q8_k_tile(const void *A, const void *B, const float *bias,
@@ -154,6 +168,17 @@ typedef struct ck_q4k_packed_meta_cache_entry {
 static pthread_mutex_t ck_q4k_packed_meta_cache_mu = PTHREAD_MUTEX_INITIALIZER;
 static ck_q4k_packed_meta_cache_entry_t *ck_q4k_packed_meta_cache_head = NULL;
 
+typedef struct ck_q4k_packed_meta_x8_cache_entry {
+    const void *src;
+    int N;
+    int K;
+    void *packed;
+    struct ck_q4k_packed_meta_x8_cache_entry *next;
+} ck_q4k_packed_meta_x8_cache_entry_t;
+
+static pthread_mutex_t ck_q4k_packed_meta_x8_cache_mu = PTHREAD_MUTEX_INITIALIZER;
+static ck_q4k_packed_meta_x8_cache_entry_t *ck_q4k_packed_meta_x8_cache_head = NULL;
+
 /* Q4_K packed-meta prefill experiment
  * -----------------------------------
  * This is intentionally kept in the v8 prefill dispatcher for now instead of
@@ -233,6 +258,43 @@ static void *ck_get_q4k_packed_meta_cached(const void *B, int N, int K)
     return packed;
 }
 
+static void *ck_get_q4k_packed_meta_x8_cached(const void *B, int N, int K)
+{
+    if (!B || N <= 0 || K <= 0 || (K % QK_K) != 0) return NULL;
+
+    pthread_mutex_lock(&ck_q4k_packed_meta_x8_cache_mu);
+    for (ck_q4k_packed_meta_x8_cache_entry_t *e = ck_q4k_packed_meta_x8_cache_head; e; e = e->next) {
+        if (e->src == B && e->N == N && e->K == K) {
+            void *packed = e->packed;
+            pthread_mutex_unlock(&ck_q4k_packed_meta_x8_cache_mu);
+            return packed;
+        }
+    }
+
+    const size_t groups = (size_t)((N + 7) / 8);
+    const size_t blocks = groups * (size_t)(K / QK_K);
+    const size_t bytes = blocks * q4_k_packed_meta_x8_block_size();
+    void *packed = malloc(bytes);
+    ck_q4k_packed_meta_x8_cache_entry_t *entry =
+        (ck_q4k_packed_meta_x8_cache_entry_t *)malloc(sizeof(*entry));
+    if (!packed || !entry) {
+        free(packed);
+        free(entry);
+        pthread_mutex_unlock(&ck_q4k_packed_meta_x8_cache_mu);
+        return NULL;
+    }
+
+    pack_q4_k_to_packed_meta_x8(B, packed, N, K);
+    entry->src = B;
+    entry->N = N;
+    entry->K = K;
+    entry->packed = packed;
+    entry->next = ck_q4k_packed_meta_x8_cache_head;
+    ck_q4k_packed_meta_x8_cache_head = entry;
+    pthread_mutex_unlock(&ck_q4k_packed_meta_x8_cache_mu);
+    return packed;
+}
+
 static int ck_should_use_q4k_packed_meta_prefill(int M, int N, int K)
 {
     if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_META_PREFILL")) return 0;
@@ -254,8 +316,62 @@ static int ck_should_use_q4k_packed_meta_prefill(int M, int N, int K)
      * Keep decode on GEMV. This gate is prefill-only because M > 1 and is
      * still shape-gated; use CK_DISABLE_Q4K_PACKED_META_PREFILL=1 to force
      * canonical Q4_K while validating a new CPU. */
-    if (N >= 768 && K >= 1024) return 1;
+    /* Local i7 sweeps show that narrow output projections do not reliably
+     * recover the packed-meta scheduling cost:
+     *   - N=512,K=1024 regresses/slightly loses at M=128.
+     *   - N=896,K=4864 was slower than canonical pool in the dispatch matrix.
+     * Keep packed-meta on the wider Qwen3.5 gate/up style shapes that win, and
+     * let force/env tuning override this when collecting new hardware data. */
+    if (N >= 1024 && K >= 1024) return 1;
     if (K <= 2048 && N >= 1024 && N <= 8192) return 1;
+    return 0;
+}
+
+static int ck_should_use_q4k_packed_meta_x8_prefill(int M, int N, int K)
+{
+    if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_META_X8_PREFILL")) return 0;
+    if (M <= 1 || N <= 0 || K <= 0 || (K % QK_K) != 0) return 0;
+
+    const int min_m = ck_env_int_or2("CK_Q4K_PACKED_META_X8_MIN_M", NULL, 16);
+    if (M < min_m) return 0;
+    if (getenv("CK_FORCE_Q4K_PACKED_META_X8_PREFILL")) return 1;
+    const int max_m = ck_env_int_or2("CK_Q4K_PACKED_META_X8_MAX_M", NULL, 64);
+    if (max_m > 0 && M > max_m) return 0;
+
+    /* Experimental x8 prefill gate, derived from the dispatch matrix:
+     *   small:        M=8,  N=256,  K=256   -> useful microbench, not model-critical
+     *   qwen35_qkv:   M=32, N=1024, K=1024  -> x8 wins over packed-N locally
+     *   qwen35_down:  M=32, N=896,  K=4864  -> x8 wins over packed-N locally
+     *   wide:         M=64, N=1024, K=2560  -> x8 wins over packed-N locally
+     *   prefill128:   M=128,N=896,  K=4864  -> x8 loses locally; use canonical pool
+     *
+     * Keep the gate on measured short/medium Qwen/Nemotron-family prefill shapes and retain
+     * CK_DISABLE_Q4K_PACKED_META_X8_PREFILL as the production escape hatch. */
+    if (N >= 768 && K >= 1024) return 1;
+    return 0;
+}
+
+static int ck_should_use_q4k_packed_meta_2d_prefill(const ck_threadpool_t *pool,
+                                                     int M, int N, int K,
+                                                     int tile_m, int tile_n)
+{
+    if (!ck_env_enabled("CK_ENABLE_Q4K_PACKED_META_2D_PREFILL")) return 0;
+    if (!pool || ck_threadpool_n_threads(pool) <= 1) return 0;
+    if (M <= 1 || N <= 0 || K <= 0 || (K % QK_K) != 0) return 0;
+
+    const int tm = tile_m > 0 ? tile_m : 16;
+    const int tn = tile_n > 0 ? tile_n : 256;
+    const int mt = ck_ceil_div_int(M, tm);
+    const int nt = ck_ceil_div_int(N, tn);
+    const int jobs = mt * nt;
+    const int active = ck_select_gemm_active_threads(pool, M, N, K);
+
+    if (jobs < active * 2) return 0;
+    if (getenv("CK_FORCE_Q4K_PACKED_META_2D_PREFILL")) return 1;
+
+    /* Experimental path: measure before promotion. The current packed-meta dot
+     * loop still computes one output at a time, so 2D scheduling improves job
+     * balance but can reread activation tiles. */
     return 0;
 }
 
@@ -433,6 +549,29 @@ static void work_gemm_nt_q6_k_q8_k_2d(int ith, int nth, void *args)
     }
 }
 
+static void work_gemm_nt_q4_k_packed_meta_q8_k_2d(int ith, int nth, void *args)
+{
+    const gemm_args_t *a = (const gemm_args_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) return;
+
+    const int tile_m = a->tile_m > 0 ? a->tile_m : 16;
+    const int tile_n = a->tile_n > 0 ? a->tile_n : 256;
+    const int mt = ck_ceil_div_int(a->M, tile_m);
+    const int nt = ck_ceil_div_int(a->N, tile_n);
+    const int total = mt * nt;
+
+    for (int job = ith; job < total; job += nth) {
+        const int jm = job % mt;
+        const int jn = job / mt;
+        const int m0 = jm * tile_m;
+        const int m1 = ck_min_int(m0 + tile_m, a->M);
+        const int n0 = jn * tile_n;
+        const int n1 = ck_min_int(n0 + tile_n, a->N);
+        gemm_nt_q4_k_packed_meta_q8_k_tile(a->A, a->B, a->bias, a->C,
+                                           a->M, a->N, a->K, m0, m1, n0, n1);
+    }
+}
+
 static void work_gemm_nt_q5_1_q8_1(int ith, int nth, void *args)
 {
     const gemm_args_t *a = (const gemm_args_t *)args;
@@ -521,12 +660,36 @@ void gemm_nt_q4_k_q8_k_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
+    if (pool && ck_should_use_q4k_packed_meta_x8_prefill(M, N, K)) {
+        void *packed_x8 = ck_get_q4k_packed_meta_x8_cached(B, N, K);
+        if (packed_x8) {
+            const int active = ck_select_gemm_active_threads(pool, M, N, K);
+            gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(
+                A, packed_x8, bias, C, M, N, K,
+                active
+            );
+            return;
+        }
+    }
+
     if (pool && ck_should_use_q4k_packed_meta_prefill(M, N, K)) {
         void *packed = ck_get_q4k_packed_meta_cached(B, N, K);
         if (packed) {
+            const int active = ck_select_gemm_active_threads(pool, M, N, K);
+            gemm_args_t args = {
+                .A = A, .B = packed, .bias = bias, .C = C,
+                .M = M, .N = N, .K = K,
+                .A_row_bytes = (size_t)(K / QK_K) * sizeof(block_q8_K),
+                .tile_m = ck_env_int_or2("CK_Q4K_PACKED_META_TILE_M", "CK_PREFILL_TILE_M", 16),
+                .tile_n = ck_env_int_or2("CK_Q4K_PACKED_META_TILE_N", "CK_PREFILL_TILE_N", 256)
+            };
+            if (ck_should_use_q4k_packed_meta_2d_prefill(pool, M, N, K, args.tile_m, args.tile_n)) {
+                ck_threadpool_dispatch_n(pool, active, work_gemm_nt_q4_k_packed_meta_q8_k_2d, &args);
+                return;
+            }
             gemm_nt_q4_k_packed_meta_q8_k_threaded_nsplit(
                 A, packed, bias, C, M, N, K,
-                ck_select_gemm_active_threads(pool, M, N, K)
+                active
             );
             return;
         }

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -73,6 +73,13 @@ extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(const void *A_q8,
                                                              float *C,
                                                              int M, int N, int K,
                                                              int threads);
+extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(const void *A_q8,
+                                                            const void *B_packed_x8,
+                                                            const float *bias,
+                                                            float *C,
+                                                            int M, int N, int K,
+                                                            int tile_m,
+                                                            int threads);
 extern void gemm_nt_q4_k_packed_meta_q8_k_tile(const void *A_q8,
                                                const void *B_packed,
                                                const float *bias,
@@ -347,6 +354,23 @@ static int ck_should_use_q4k_packed_meta_x8_prefill(int M, int N, int K)
      *
      * Keep the gate on measured short/medium Qwen/Nemotron-family prefill shapes and retain
      * CK_DISABLE_Q4K_PACKED_META_X8_PREFILL as the production escape hatch. */
+    if (N >= 768 && K >= 1024) return 1;
+    return 0;
+}
+
+static int ck_should_use_q4k_packed_meta_x8mt_prefill(int M, int N, int K)
+{
+    if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_META_X8MT_PREFILL")) return 0;
+    if (!ck_env_enabled("CK_ENABLE_Q4K_PACKED_META_X8MT_PREFILL") &&
+        !ck_env_enabled("CK_FORCE_Q4K_PACKED_META_X8MT_PREFILL")) return 0;
+    if (M <= 1 || N <= 0 || K <= 0 || (K % QK_K) != 0) return 0;
+
+    const int min_m = ck_env_int_or2("CK_Q4K_PACKED_META_X8MT_MIN_M", NULL, 16);
+    if (M < min_m) return 0;
+    if (ck_env_enabled("CK_FORCE_Q4K_PACKED_META_X8MT_PREFILL")) return 1;
+
+    /* Token-tile x output-tile path is still experimental. It is measured via
+     * the dispatch matrix and model perf-stat lane before shape promotion. */
     if (N >= 768 && K >= 1024) return 1;
     return 0;
 }
@@ -660,6 +684,20 @@ void gemm_nt_q4_k_q8_k_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
+    if (pool && ck_should_use_q4k_packed_meta_x8mt_prefill(M, N, K)) {
+        void *packed_x8 = ck_get_q4k_packed_meta_x8_cached(B, N, K);
+        if (packed_x8) {
+            const int active = ck_select_gemm_active_threads(pool, M, N, K);
+            const int tile_m = ck_env_int_or2("CK_Q4K_PACKED_META_X8MT_TILE_M", "CK_PREFILL_TILE_M", 2);
+            gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(
+                A, packed_x8, bias, C, M, N, K,
+                tile_m,
+                active
+            );
+            return;
+        }
+    }
+
     if (pool && ck_should_use_q4k_packed_meta_x8_prefill(M, N, K)) {
         void *packed_x8 = ck_get_q4k_packed_meta_x8_cached(B, N, K);
         if (packed_x8) {


### PR DESCRIPTION
## Summary
- add a packed-meta x8 Q4_K x Q8_K prefill kernel that groups eight output rows per Q8 activation load
- wire it into v8 prefill behind conservative shape gates plus force/disable env knobs
- add CK-vs-llama perf-stat tooling, an optional VTune/Advisor roofline script, and a prefill performance roadmap page

## Performance notes
- Direct dispatch matrix shows x8 wins on short/medium Q4_K shapes such as qwen35_qkv, qwen35_down, and wide_mlp.
- The same sweep shows x8 loses on the longer M=128 compact-down shape, so the default gate caps x8 at M<=64 unless CK_FORCE_Q4K_PACKED_META_X8_PREFILL=1 is set.
- The next target is a true token-tile x output-tile GEMM microkernel; this commit only promotes the safer output-row x8 layout.

## Tests
- make bench-q4k-dispatch-matrix
- CK_V8_PREFILL_PERF_ENGINE=ck make profile-v8-prefill-perf-stat
- .venv/bin/python -m py_compile scripts/perf_stat_v8_prefill_compare.py benchmarks/compare_ck_llama_v8.py
- bash -n scripts/profile_v8_prefill_roofline.sh
- bash docs/site/build.sh
- pre-commit hook: v7-regression-fast, v8-regression-fast
- pre-push hook: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training smoke, v7/v8 fast regression, v7 training-kernel parity