### PR TITLE
feat(v8/kimi): add VL MoE MLA guardrails

### DIFF
--- a/src/kernels/axpy_kernels.c
+++ b/src/kernels/axpy_kernels.c
@@ -378,6 +378,292 @@ void moe_relu2_expert_forward_f32(const float *hidden,
 }
 
 
+
+static inline float ck_moe_sigmoid_f32(float x)
+{
+    return 1.0f / (1.0f + expf(-x));
+}
+
+static inline float ck_moe_silu_f32(float x)
+{
+    return x * ck_moe_sigmoid_f32(x);
+}
+
+static inline float ck_moe_dsilu_f32(float x)
+{
+    const float sig = ck_moe_sigmoid_f32(x);
+    return sig + x * sig * (1.0f - sig);
+}
+
+void moe_swiglu_expert_forward_f32(const float *hidden,
+                                   const int *indices,
+                                   const float *routing_weights,
+                                   const float *expert_gate,
+                                   const float *expert_up,
+                                   const float *expert_down,
+                                   float *output,
+                                   int rows,
+                                   int hidden_dim,
+                                   int intermediate_dim,
+                                   int n_experts,
+                                   int top_k)
+{
+    if (!hidden || !indices || !routing_weights || !expert_gate || !expert_up || !expert_down || !output ||
+        rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0 || n_experts <= 0 || top_k <= 0) {
+        return;
+    }
+
+    for (size_t p = 0; p < (size_t)rows * (size_t)hidden_dim; ++p) output[p] = 0.0f;
+
+    float gate[intermediate_dim];
+    float up[intermediate_dim];
+    float act[intermediate_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        float *y = output + (size_t)r * (size_t)hidden_dim;
+        for (int slot = 0; slot < top_k; ++slot) {
+            const int e = indices[(size_t)r * (size_t)top_k + (size_t)slot];
+            if (e < 0 || e >= n_experts) continue;
+            const float route_w = routing_weights[(size_t)r * (size_t)top_k + (size_t)slot];
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                float gv = 0.0f;
+                float uv = 0.0f;
+                for (int h = 0; h < hidden_dim; ++h) {
+                    gv += expert_gate[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] * x[h];
+                    uv += expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] * x[h];
+                }
+                gate[i] = gv;
+                up[i] = uv;
+                act[i] = ck_moe_silu_f32(gv) * uv;
+            }
+
+            for (int h = 0; h < hidden_dim; ++h) {
+                float v = 0.0f;
+                for (int i = 0; i < intermediate_dim; ++i) {
+                    v += expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)] * act[i];
+                }
+                y[h] += route_w * v;
+            }
+        }
+    }
+}
+
+void moe_swiglu_expert_backward_f32(const float *d_output,
+                                    const float *hidden,
+                                    const int *indices,
+                                    const float *routing_weights,
+                                    const float *expert_gate,
+                                    const float *expert_up,
+                                    const float *expert_down,
+                                    float *d_hidden,
+                                    float *d_routing_weights,
+                                    float *d_expert_gate,
+                                    float *d_expert_up,
+                                    float *d_expert_down,
+                                    int rows,
+                                    int hidden_dim,
+                                    int intermediate_dim,
+                                    int n_experts,
+                                    int top_k)
+{
+    if (!d_output || !hidden || !indices || !routing_weights || !expert_gate || !expert_up || !expert_down ||
+        !d_hidden || !d_routing_weights || !d_expert_gate || !d_expert_up || !d_expert_down ||
+        rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0 || n_experts <= 0 || top_k <= 0) {
+        return;
+    }
+
+    for (size_t p = 0; p < (size_t)rows * (size_t)hidden_dim; ++p) d_hidden[p] = 0.0f;
+    for (size_t p = 0; p < (size_t)rows * (size_t)top_k; ++p) d_routing_weights[p] = 0.0f;
+    for (size_t p = 0; p < (size_t)n_experts * (size_t)intermediate_dim * (size_t)hidden_dim; ++p) {
+        d_expert_gate[p] = 0.0f;
+        d_expert_up[p] = 0.0f;
+    }
+    for (size_t p = 0; p < (size_t)n_experts * (size_t)hidden_dim * (size_t)intermediate_dim; ++p) d_expert_down[p] = 0.0f;
+
+    float gate[intermediate_dim];
+    float up[intermediate_dim];
+    float silu_gate[intermediate_dim];
+    float act[intermediate_dim];
+    float d_act[intermediate_dim];
+    float expert_out[hidden_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        const float *dy = d_output + (size_t)r * (size_t)hidden_dim;
+        float *dx = d_hidden + (size_t)r * (size_t)hidden_dim;
+
+        for (int slot = 0; slot < top_k; ++slot) {
+            const int e = indices[(size_t)r * (size_t)top_k + (size_t)slot];
+            if (e < 0 || e >= n_experts) continue;
+            const float route_w = routing_weights[(size_t)r * (size_t)top_k + (size_t)slot];
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                float gv = 0.0f;
+                float uv = 0.0f;
+                for (int h = 0; h < hidden_dim; ++h) {
+                    gv += expert_gate[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] * x[h];
+                    uv += expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] * x[h];
+                }
+                gate[i] = gv;
+                up[i] = uv;
+                silu_gate[i] = ck_moe_silu_f32(gv);
+                act[i] = silu_gate[i] * uv;
+                d_act[i] = 0.0f;
+            }
+
+            for (int h = 0; h < hidden_dim; ++h) {
+                float v = 0.0f;
+                for (int i = 0; i < intermediate_dim; ++i) {
+                    v += expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)] * act[i];
+                }
+                expert_out[h] = v;
+            }
+
+            float d_route = 0.0f;
+            for (int h = 0; h < hidden_dim; ++h) {
+                const float d_expert_out = dy[h] * route_w;
+                d_route += dy[h] * expert_out[h];
+                for (int i = 0; i < intermediate_dim; ++i) {
+                    d_expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)] += d_expert_out * act[i];
+                    d_act[i] += d_expert_out * expert_down[ck_moe_down_idx(e, h, i, hidden_dim, intermediate_dim)];
+                }
+            }
+            d_routing_weights[(size_t)r * (size_t)top_k + (size_t)slot] += d_route;
+
+            for (int i = 0; i < intermediate_dim; ++i) {
+                const float d_up = d_act[i] * silu_gate[i];
+                const float d_gate = d_act[i] * up[i] * ck_moe_dsilu_f32(gate[i]);
+                for (int h = 0; h < hidden_dim; ++h) {
+                    d_expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] += d_up * x[h];
+                    d_expert_gate[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] += d_gate * x[h];
+                    dx[h] += d_up * expert_up[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)] +
+                             d_gate * expert_gate[ck_moe_up_idx(e, i, h, intermediate_dim, hidden_dim)];
+                }
+            }
+        }
+    }
+}
+
+void moe_swiglu_shared_forward_f32(const float *hidden,
+                                   const float *routed,
+                                   const float *shared_gate,
+                                   const float *shared_up,
+                                   const float *shared_down,
+                                   float *output,
+                                   int rows,
+                                   int hidden_dim,
+                                   int intermediate_dim)
+{
+    if (!hidden || !shared_gate || !shared_up || !shared_down || !output || rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0) {
+        return;
+    }
+
+    float gate[intermediate_dim];
+    float up[intermediate_dim];
+    float act[intermediate_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        const float *route = routed ? (routed + (size_t)r * (size_t)hidden_dim) : NULL;
+        float *y = output + (size_t)r * (size_t)hidden_dim;
+        for (int i = 0; i < intermediate_dim; ++i) {
+            float gv = 0.0f;
+            float uv = 0.0f;
+            for (int h = 0; h < hidden_dim; ++h) {
+                gv += shared_gate[(size_t)i * (size_t)hidden_dim + (size_t)h] * x[h];
+                uv += shared_up[(size_t)i * (size_t)hidden_dim + (size_t)h] * x[h];
+            }
+            gate[i] = gv;
+            up[i] = uv;
+            act[i] = ck_moe_silu_f32(gv) * uv;
+        }
+        for (int h = 0; h < hidden_dim; ++h) {
+            float v = route ? route[h] : 0.0f;
+            for (int i = 0; i < intermediate_dim; ++i) {
+                v += shared_down[(size_t)h * (size_t)intermediate_dim + (size_t)i] * act[i];
+            }
+            y[h] = v;
+        }
+    }
+}
+
+void moe_swiglu_shared_backward_f32(const float *d_output,
+                                    const float *hidden,
+                                    const float *shared_gate,
+                                    const float *shared_up,
+                                    const float *shared_down,
+                                    float *d_hidden,
+                                    float *d_routed,
+                                    float *d_shared_gate,
+                                    float *d_shared_up,
+                                    float *d_shared_down,
+                                    int rows,
+                                    int hidden_dim,
+                                    int intermediate_dim)
+{
+    if (!d_output || !hidden || !shared_gate || !shared_up || !shared_down ||
+        !d_hidden || !d_routed || !d_shared_gate || !d_shared_up || !d_shared_down ||
+        rows <= 0 || hidden_dim <= 0 || intermediate_dim <= 0) {
+        return;
+    }
+
+    for (size_t p = 0; p < (size_t)rows * (size_t)hidden_dim; ++p) {
+        d_hidden[p] = 0.0f;
+        d_routed[p] = d_output[p];
+    }
+    for (size_t p = 0; p < (size_t)intermediate_dim * (size_t)hidden_dim; ++p) {
+        d_shared_gate[p] = 0.0f;
+        d_shared_up[p] = 0.0f;
+    }
+    for (size_t p = 0; p < (size_t)hidden_dim * (size_t)intermediate_dim; ++p) d_shared_down[p] = 0.0f;
+
+    float gate[intermediate_dim];
+    float up[intermediate_dim];
+    float silu_gate[intermediate_dim];
+    float act[intermediate_dim];
+    float d_act[intermediate_dim];
+
+    for (int r = 0; r < rows; ++r) {
+        const float *x = hidden + (size_t)r * (size_t)hidden_dim;
+        const float *dy = d_output + (size_t)r * (size_t)hidden_dim;
+        float *dx = d_hidden + (size_t)r * (size_t)hidden_dim;
+
+        for (int i = 0; i < intermediate_dim; ++i) {
+            float gv = 0.0f;
+            float uv = 0.0f;
+            for (int h = 0; h < hidden_dim; ++h) {
+                gv += shared_gate[(size_t)i * (size_t)hidden_dim + (size_t)h] * x[h];
+                uv += shared_up[(size_t)i * (size_t)hidden_dim + (size_t)h] * x[h];
+            }
+            gate[i] = gv;
+            up[i] = uv;
+            silu_gate[i] = ck_moe_silu_f32(gv);
+            act[i] = silu_gate[i] * uv;
+            d_act[i] = 0.0f;
+        }
+
+        for (int h = 0; h < hidden_dim; ++h) {
+            for (int i = 0; i < intermediate_dim; ++i) {
+                d_shared_down[(size_t)h * (size_t)intermediate_dim + (size_t)i] += dy[h] * act[i];
+                d_act[i] += dy[h] * shared_down[(size_t)h * (size_t)intermediate_dim + (size_t)i];
+            }
+        }
+
+        for (int i = 0; i < intermediate_dim; ++i) {
+            const float d_up = d_act[i] * silu_gate[i];
+            const float d_gate = d_act[i] * up[i] * ck_moe_dsilu_f32(gate[i]);
+            for (int h = 0; h < hidden_dim; ++h) {
+                d_shared_up[(size_t)i * (size_t)hidden_dim + (size_t)h] += d_up * x[h];
+                d_shared_gate[(size_t)i * (size_t)hidden_dim + (size_t)h] += d_gate * x[h];
+                dx[h] += d_up * shared_up[(size_t)i * (size_t)hidden_dim + (size_t)h] +
+                         d_gate * shared_gate[(size_t)i * (size_t)hidden_dim + (size_t)h];
+            }
+        }
+    }
+}
+
 void moe_relu2_expert_forward_q5_0_q8_0(const float *hidden,
                                         const int *indices,
                                         const float *routing_weights,

--- a/src/kernels/deepseek_kernels.c
+++ b/src/kernels/deepseek_kernels.c
@@ -165,6 +165,113 @@ void deepseek_dsa_topk_softmax_backward_f32(const int *indices,
                               top_k);
 }
 
+
+static inline size_t ds_mla_tok_idx(int t, int d, int dim)
+{
+    return (size_t)t * (size_t)dim + (size_t)d;
+}
+
+static inline size_t ds_mla_thd_idx(int t, int h, int d, int heads, int dim)
+{
+    return ((size_t)t * (size_t)heads + (size_t)h) * (size_t)dim + (size_t)d;
+}
+
+void deepseek_mla_kv_decompress_f32(const float *compressed_kv,
+                                    const float *kv_b_proj,
+                                    float *k_nope,
+                                    float *value,
+                                    int tokens,
+                                    int heads,
+                                    int kv_lora_rank,
+                                    int qk_nope_dim,
+                                    int v_dim)
+{
+    if (!compressed_kv || !kv_b_proj || !k_nope || !value ||
+        tokens <= 0 || heads <= 0 || kv_lora_rank <= 0 || qk_nope_dim <= 0 || v_dim <= 0) {
+        return;
+    }
+
+    const int out_per_head = qk_nope_dim + v_dim;
+    for (int t = 0; t < tokens; ++t) {
+        for (int h = 0; h < heads; ++h) {
+            for (int d = 0; d < qk_nope_dim; ++d) {
+                const int out_col = h * out_per_head + d;
+                float acc = 0.0f;
+                for (int r = 0; r < kv_lora_rank; ++r) {
+                    acc += kv_b_proj[(size_t)out_col * (size_t)kv_lora_rank + (size_t)r] *
+                           compressed_kv[ds_mla_tok_idx(t, r, kv_lora_rank)];
+                }
+                k_nope[ds_mla_thd_idx(t, h, d, heads, qk_nope_dim)] = acc;
+            }
+            for (int d = 0; d < v_dim; ++d) {
+                const int out_col = h * out_per_head + qk_nope_dim + d;
+                float acc = 0.0f;
+                for (int r = 0; r < kv_lora_rank; ++r) {
+                    acc += kv_b_proj[(size_t)out_col * (size_t)kv_lora_rank + (size_t)r] *
+                           compressed_kv[ds_mla_tok_idx(t, r, kv_lora_rank)];
+                }
+                value[ds_mla_thd_idx(t, h, d, heads, v_dim)] = acc;
+            }
+        }
+    }
+}
+
+static void ds_mla_apply_kimi_rope(const float *src,
+                                   float *dst,
+                                   const float *cos_row,
+                                   const float *sin_row,
+                                   int dim)
+{
+    const int half = dim / 2;
+    for (int i = 0; i < half; ++i) {
+        const float x_first = src[2 * i];
+        const float x_second = src[2 * i + 1];
+        const float c = cos_row[i];
+        const float s = sin_row[i];
+        dst[i] = x_first * c - x_second * s;
+        dst[half + i] = x_second * c + x_first * s;
+    }
+}
+
+void deepseek_mla_partial_rope_concat_f32(const float *q_nope,
+                                          const float *q_pe,
+                                          const float *k_nope,
+                                          const float *k_pe,
+                                          const float *cos,
+                                          const float *sin,
+                                          float *query,
+                                          float *key,
+                                          int tokens,
+                                          int heads,
+                                          int qk_nope_dim,
+                                          int qk_rope_dim)
+{
+    if (!q_nope || !q_pe || !k_nope || !k_pe || !cos || !sin || !query || !key ||
+        tokens <= 0 || heads <= 0 || qk_nope_dim <= 0 || qk_rope_dim <= 0 || (qk_rope_dim % 2) != 0) {
+        return;
+    }
+
+    const int q_head_dim = qk_nope_dim + qk_rope_dim;
+    for (int t = 0; t < tokens; ++t) {
+        const float *cos_row = cos + (size_t)t * (size_t)(qk_rope_dim / 2);
+        const float *sin_row = sin + (size_t)t * (size_t)(qk_rope_dim / 2);
+        for (int h = 0; h < heads; ++h) {
+            float *q_out = query + ds_mla_thd_idx(t, h, 0, heads, q_head_dim);
+            float *k_out = key + ds_mla_thd_idx(t, h, 0, heads, q_head_dim);
+            const float *qn = q_nope + ds_mla_thd_idx(t, h, 0, heads, qk_nope_dim);
+            const float *qp = q_pe + ds_mla_thd_idx(t, h, 0, heads, qk_rope_dim);
+            const float *kn = k_nope + ds_mla_thd_idx(t, h, 0, heads, qk_nope_dim);
+            const float *kp = k_pe + ds_mla_tok_idx(t, 0, qk_rope_dim);
+            for (int d = 0; d < qk_nope_dim; ++d) {
+                q_out[d] = qn[d];
+                k_out[d] = kn[d];
+            }
+            ds_mla_apply_kimi_rope(qp, q_out + qk_nope_dim, cos_row, sin_row, qk_rope_dim);
+            ds_mla_apply_kimi_rope(kp, k_out + qk_nope_dim, cos_row, sin_row, qk_rope_dim);
+        }
+    }
+}
+
 static inline size_t ds_qkv_idx(int token, int head, int d, int heads, int dim)
 {
     return ((size_t)token * (size_t)heads + (size_t)head) * (size_t)dim + (size_t)d;

--- a/tests/test_v8_model_contract_inspector.py
+++ b/tests/test_v8_model_contract_inspector.py
@@ -99,6 +99,131 @@ class ModelContractInspectorTests(unittest.TestCase):
         self.assertEqual(report["families"]["moe_shared_expert"], 2)
         self.assertEqual(report["layers"]["2"]["expert_count"], 1)
 
+
+    def test_kimi_vl_reports_mla_moe_bringup_contract(self) -> None:
+        cfg = {
+            "architectures": ["KimiVLForConditionalGeneration"],
+            "model_type": "kimi_vl",
+            "vision_config": {
+                "model_type": "moonvit",
+                "patch_size": 14,
+                "num_attention_heads": 16,
+                "num_hidden_layers": 27,
+                "hidden_size": 1152,
+                "intermediate_size": 4304,
+                "merge_kernel_size": [2, 2],
+            },
+            "text_config": {
+                "vocab_size": 163840,
+                "max_position_embeddings": 131072,
+                "hidden_size": 2048,
+                "intermediate_size": 11264,
+                "moe_intermediate_size": 1408,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 16,
+                "n_shared_experts": 2,
+                "n_routed_experts": 64,
+                "kv_lora_rank": 512,
+                "q_lora_rank": None,
+                "qk_rope_head_dim": 64,
+                "v_head_dim": 128,
+                "qk_nope_head_dim": 128,
+                "topk_method": "noaux_tc",
+                "n_group": 1,
+                "topk_group": 1,
+                "num_experts_per_tok": 6,
+                "moe_layer_freq": 1,
+                "first_k_dense_replace": 1,
+                "norm_topk_prob": True,
+                "scoring_func": "sigmoid",
+                "routed_scaling_factor": 2.446,
+                "hidden_act": "silu",
+                "rope_theta": 800000.0,
+            },
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "config.json"
+            path.write_text(json.dumps(cfg), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), str(path)],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["arch"], "kimi_vl")
+        self.assertEqual(report["status"], "bringup_required")
+        self.assertEqual(report["layer_kind_counts"], {"mla_dense_mlp": 1, "mla_moe": 3})
+        for op in (
+            "mla_attention",
+            "kv_lora_decompress",
+            "group_limited_topk_router",
+            "moe_swiglu_expert_mlp",
+            "shared_swiglu_expert_mlp",
+            "moonvit_encoder",
+            "tiktoken_tokenizer",
+        ):
+            self.assertIn(op, report["required_ops"])
+        for missing in (
+            "kimi_vl_safetensors_to_bump_mapping",
+            "mla_attention_contract",
+            "tiktoken_tokenizer_contract",
+            "moonvit_bridge_contract",
+        ):
+            self.assertIn(missing, report["missing_ops"])
+        self.assertNotIn("moe_swiglu_expert_mlp", report["missing_ops"])
+        self.assertNotIn("shared_swiglu_expert_mlp", report["missing_ops"])
+        self.assertNotIn("kv_lora_decompress_contract", report["missing_ops"])
+        self.assertNotIn("kimi_vl_template_contract", report["missing_ops"])
+        self.assertNotIn("v8_template_contract", report["missing_ops"])
+
+    def test_safetensors_index_audit_classifies_kimi_mla_moe_families(self) -> None:
+        index = {
+            "metadata": {"total_parameters": 123, "total_size": 456},
+            "weight_map": {
+                "language_model.lm_head.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.embed_tokens.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.input_layernorm.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_layernorm.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_proj_with_mqa.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_b_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.mlp.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.mlp.up_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.mlp.down_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.gate.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.gate.e_score_correction_bias": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.experts.0.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.experts.0.up_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.experts.0.down_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.shared_experts.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.shared_experts.up_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.shared_experts.down_proj.weight": "model-00001-of-00001.safetensors",
+                "vision_tower.encoder.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "multi_modal_projector.linear_1.weight": "model-00001-of-00001.safetensors",
+            },
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "model.safetensors.index.json"
+            path.write_text(json.dumps(index), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(AUDIT_SCRIPT), str(path)],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+            )
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["families"]["mla_attention"], 3)
+        self.assertEqual(report["families"]["moe_router"], 2)
+        self.assertEqual(report["families"]["moe_expert"], 3)
+        self.assertEqual(report["families"]["moe_shared_expert"], 3)
+        self.assertEqual(report["families"]["vision_tower"], 1)
+        self.assertEqual(report["families"]["multimodal_projector"], 1)
+        self.assertEqual(report["layers"]["1"]["expert_count"], 1)
+
     def test_qwen3_dense_config_is_supported_at_contract_level(self) -> None:
         cfg = {
             "architectures": ["Qwen3ForCausalLM"],

--- a/tests/test_v8_template_circuit_audit.py
+++ b/tests/test_v8_template_circuit_audit.py
@@ -96,6 +96,54 @@ class TemplateCircuitAuditTests(unittest.TestCase):
         self.assertEqual(report["missing"], [])
 
 
+    def test_kimi_vl_template_declares_mla_and_moe_edges(self) -> None:
+        audit = _load_module()
+        template = json.loads((REPO / "version/v8/templates/kimi_vl.json").read_text(encoding="utf-8"))
+        report = audit.audit_template_explicit_edges(template)
+        explicit = set(report["explicit"])
+        self.assertIn("decoder.body:mla_dense_mlp[2].q_proj.x=layer_input", explicit)
+        self.assertIn("decoder.body:mla_dense_mlp[3].kv_a_proj.x=layer_input", explicit)
+        self.assertIn("decoder.body:mla_dense_mlp[5].kv_lora_decompress.compressed_kv=compressed_kv_normed", explicit)
+        self.assertIn("decoder.body:mla_dense_mlp[6].partial_rope_concat.q_pe=q_pe", explicit)
+        self.assertIn("decoder.body:mla_dense_mlp[7].mla_attention.query=mla_query", explicit)
+        self.assertIn("decoder.body:mla_moe[14].moe_swiglu_expert_mlp.routing_weights=router_weights", explicit)
+        self.assertIn("decoder.body:mla_moe[15].shared_swiglu_expert_mlp.routed=moe_routed", explicit)
+        self.assertIn("decoder.footer[2].logits.x=main_stream", explicit)
+        self.assertEqual(report["missing"], [])
+
+    def test_mla_dataflow_must_consume_normed_compressed_kv(self) -> None:
+        audit = _load_module()
+        ir = {
+            "ops": [
+                _op(0, -1, "dense_embedding_lookup", {}, {"out": {"slot": "main_stream", "dtype": "fp32"}}),
+                _op(1, 0, "residual_save", {"src": {"from_op": 0, "slot": "main_stream"}}, {"dst": {"slot": "residual", "dtype": "fp32"}}),
+                _op(2, 0, "block_rmsnorm", {"input": {"from_op": 0, "slot": "main_stream"}}, {"output": {"slot": "layer_input", "dtype": "fp32"}}),
+                _op(3, 0, "q_proj", {"x": {"from_op": 2, "slot": "layer_input"}}, {"y": {"slot": "q_proj", "dtype": "fp32"}}),
+                _op(4, 0, "kv_a_proj", {"x": {"from_op": 2, "slot": "layer_input"}}, {"y": {"slot": "compressed_kv", "dtype": "fp32"}}),
+                _op(5, 0, "kv_a_layernorm", {"x": {"from_op": 4, "slot": "compressed_kv"}}, {"y": {"slot": "compressed_kv_normed", "dtype": "fp32"}}),
+                _op(6, 0, "kv_lora_decompress", {"compressed_kv": {"from_op": 4, "slot": "compressed_kv"}}, {"k_nope": {"slot": "k_nope"}, "value": {"slot": "mla_value"}}),
+            ]
+        }
+        errors = audit.audit_ir1(ir)
+        self.assertTrue(any("kv_lora_decompress.compressed_kv" in e and "expected kv_a_layernorm" in e for e in errors), errors)
+
+    def test_mla_dataflow_passes_for_normed_kv_and_partial_rope(self) -> None:
+        audit = _load_module()
+        ir = {
+            "ops": [
+                _op(0, -1, "dense_embedding_lookup", {}, {"out": {"slot": "main_stream", "dtype": "fp32"}}),
+                _op(1, 0, "residual_save", {"src": {"from_op": 0, "slot": "main_stream"}}, {"dst": {"slot": "residual", "dtype": "fp32"}}),
+                _op(2, 0, "block_rmsnorm", {"input": {"from_op": 0, "slot": "main_stream"}}, {"output": {"slot": "layer_input", "dtype": "fp32"}}),
+                _op(3, 0, "q_proj", {"x": {"from_op": 2, "slot": "layer_input"}}, {"y": {"slot": "q_proj", "dtype": "fp32"}}),
+                _op(4, 0, "kv_a_proj", {"x": {"from_op": 2, "slot": "layer_input"}}, {"y": {"slot": "compressed_kv", "dtype": "fp32"}}),
+                _op(5, 0, "kv_a_layernorm", {"x": {"from_op": 4, "slot": "compressed_kv"}}, {"y": {"slot": "compressed_kv_normed", "dtype": "fp32"}}),
+                _op(6, 0, "kv_lora_decompress", {"compressed_kv": {"from_op": 5, "slot": "compressed_kv_normed"}}, {"k_nope": {"slot": "k_nope"}, "value": {"slot": "mla_value"}}),
+                _op(7, 0, "partial_rope_concat", {"q_nope": {"from_op": 3, "slot": "q_nope"}, "q_pe": {"from_op": 3, "slot": "q_pe"}, "k_nope": {"from_op": 6, "slot": "k_nope"}}, {"query": {"slot": "mla_query"}, "key": {"slot": "mla_key"}}),
+                _op(8, 0, "mla_attention", {"query": {"from_op": 7, "slot": "mla_query"}, "key": {"from_op": 7, "slot": "mla_key"}, "value": {"from_op": 6, "slot": "mla_value"}}, {"out": {"slot": "attn_scratch"}}),
+            ]
+        }
+        self.assertEqual(audit.audit_ir1(ir), [])
+
     def test_lowered_rejects_quantized_activation_bound_to_fp32_stream(self) -> None:
         audit = _load_module()
         lowered = {

--- a/unittest/test_deepseek_reference_kernels.py
+++ b/unittest/test_deepseek_reference_kernels.py
@@ -32,6 +32,10 @@ lib.deepseek_csa_attention_backward_f32.argtypes = [fptr, fptr, fptr, fptr, iptr
 lib.deepseek_csa_attention_backward_f32.restype = None
 lib.deepseek_hybrid_attention_f32.argtypes = [fptr, fptr, fptr, iptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_float, ctypes.c_int]
 lib.deepseek_hybrid_attention_f32.restype = None
+lib.deepseek_mla_kv_decompress_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.deepseek_mla_kv_decompress_f32.restype = None
+lib.deepseek_mla_partial_rope_concat_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.deepseek_mla_partial_rope_concat_f32.restype = None
 
 
 def ptr(a):
@@ -110,6 +114,68 @@ class TestDeepSeekReferenceKernels(unittest.TestCase):
         d_scores = np.empty((tokens, heads, keys), dtype=np.float32)
         lib.deepseek_dsa_topk_softmax_backward_f32(iptr_np(idx_np), ptr(weights_np), ptr(d_weights_np), ptr(d_scores), tokens, heads, keys, top_k)
         np.testing.assert_allclose(d_scores, scores.grad.numpy(), rtol=1e-6, atol=1e-6)
+
+
+    def test_mla_kv_decompress_matches_pytorch(self):
+        torch.manual_seed(19)
+        tokens, heads, rank, nope_dim, v_dim = 3, 4, 5, 6, 7
+        compressed = torch.randn(tokens, rank, dtype=torch.float32)
+        kv_b = torch.randn(heads * (nope_dim + v_dim), rank, dtype=torch.float32)
+        kv = torch.matmul(compressed, kv_b.T).view(tokens, heads, nope_dim + v_dim)
+        ref_k = kv[:, :, :nope_dim].contiguous()
+        ref_v = kv[:, :, nope_dim:].contiguous()
+
+        compressed_np = np.ascontiguousarray(compressed.numpy())
+        kv_b_np = np.ascontiguousarray(kv_b.numpy())
+        k_np = np.empty((tokens, heads, nope_dim), dtype=np.float32)
+        v_np = np.empty((tokens, heads, v_dim), dtype=np.float32)
+        lib.deepseek_mla_kv_decompress_f32(ptr(compressed_np), ptr(kv_b_np), ptr(k_np), ptr(v_np), tokens, heads, rank, nope_dim, v_dim)
+        np.testing.assert_allclose(k_np, ref_k.numpy(), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(v_np, ref_v.numpy(), rtol=1e-6, atol=1e-6)
+
+    def test_mla_partial_rope_concat_matches_kimi_layout(self):
+        torch.manual_seed(23)
+        tokens, heads, nope_dim, rope_dim = 3, 2, 5, 6
+        q_nope = torch.randn(tokens, heads, nope_dim, dtype=torch.float32)
+        q_pe = torch.randn(tokens, heads, rope_dim, dtype=torch.float32)
+        k_nope = torch.randn(tokens, heads, nope_dim, dtype=torch.float32)
+        k_pe = torch.randn(tokens, rope_dim, dtype=torch.float32)
+        base = torch.randn(tokens, rope_dim // 2, dtype=torch.float32)
+        cos_half = base.cos()
+        sin_half = base.sin()
+        cos = torch.cat([cos_half, cos_half], dim=-1)
+        sin = torch.cat([sin_half, sin_half], dim=-1)
+
+        def apply_kimi_rope(x):
+            b = x.reshape(*x.shape[:-1], rope_dim // 2, 2).transpose(-1, -2).reshape(*x.shape[:-1], rope_dim)
+            first, second = b[..., : rope_dim // 2], b[..., rope_dim // 2 :]
+            rotated = torch.cat([-second, first], dim=-1)
+            c = cos.reshape(tokens, 1, rope_dim)
+            ss = sin.reshape(tokens, 1, rope_dim)
+            return b * c + rotated * ss
+
+        q_ref = torch.cat([q_nope, apply_kimi_rope(q_pe)], dim=-1)
+        k_pe_heads = k_pe[:, None, :].expand(tokens, heads, rope_dim).contiguous()
+        k_ref = torch.cat([k_nope, apply_kimi_rope(k_pe_heads)], dim=-1)
+
+        query = np.empty((tokens, heads, nope_dim + rope_dim), dtype=np.float32)
+        key = np.empty_like(query)
+        lib.deepseek_mla_partial_rope_concat_f32(
+            ptr(np.ascontiguousarray(q_nope.numpy())),
+            ptr(np.ascontiguousarray(q_pe.numpy())),
+            ptr(np.ascontiguousarray(k_nope.numpy())),
+            ptr(np.ascontiguousarray(k_pe.numpy())),
+            ptr(np.ascontiguousarray(cos_half.numpy())),
+            ptr(np.ascontiguousarray(sin_half.numpy())),
+            ptr(query),
+            ptr(key),
+            tokens,
+            heads,
+            nope_dim,
+            rope_dim,
+        )
+        np.testing.assert_allclose(query, q_ref.numpy(), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(key, k_ref.numpy(), rtol=1e-6, atol=1e-6)
 
     def test_csa_attention_forward_backward(self):
         torch.manual_seed(13)

--- a/unittest/test_moe_swiglu_expert.py
+++ b/unittest/test_moe_swiglu_expert.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""PyTorch parity test for routed/shared SwiGLU MoE expert MLPs."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import sys
+import time
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import torch
+except Exception as exc:  # pragma: no cover
+    print(f"[SKIP] torch not available: {exc}")
+    sys.exit(0)
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB_PATH = ROOT / "build" / "libckernel_engine.so"
+if not LIB_PATH.exists():  # pragma: no cover
+    print("[SKIP] libckernel_engine.so not found")
+    sys.exit(0)
+
+LIB = ctypes.CDLL(str(LIB_PATH))
+fptr = ctypes.POINTER(ctypes.c_float)
+iptr = ctypes.POINTER(ctypes.c_int)
+
+LIB.moe_swiglu_expert_forward_f32.argtypes = [fptr, iptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.moe_swiglu_expert_forward_f32.restype = None
+LIB.moe_swiglu_expert_backward_f32.argtypes = [fptr, fptr, iptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.moe_swiglu_expert_backward_f32.restype = None
+LIB.moe_swiglu_shared_forward_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.moe_swiglu_shared_forward_f32.restype = None
+LIB.moe_swiglu_shared_backward_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+LIB.moe_swiglu_shared_backward_f32.restype = None
+
+
+def _fptr(a: np.ndarray) -> ctypes.POINTER(ctypes.c_float):
+    return a.ctypes.data_as(fptr)
+
+
+def _iptr(a: np.ndarray) -> ctypes.POINTER(ctypes.c_int):
+    return a.ctypes.data_as(iptr)
+
+
+def torch_routed(hidden, indices, weights, gate, up, down):
+    rows, hidden_dim = hidden.shape
+    top_k = indices.shape[1]
+    out = torch.zeros_like(hidden)
+    for r in range(rows):
+        for s in range(top_k):
+            e = int(indices[r, s])
+            g = torch.matmul(gate[e], hidden[r])
+            u = torch.matmul(up[e], hidden[r])
+            act = torch.nn.functional.silu(g) * u
+            expert_out = torch.matmul(down[e], act)
+            out[r] = out[r] + weights[r, s] * expert_out
+    return out
+
+
+def torch_shared(hidden, routed, gate, up, down):
+    act = torch.nn.functional.silu(hidden @ gate.T) * (hidden @ up.T)
+    out = act @ down.T
+    return out + routed
+
+
+class TestMoESwiGLUExpert(unittest.TestCase):
+    def test_routed_forward_backward(self) -> None:
+        rows, hidden_dim, intermediate_dim, n_experts, top_k = 4, 9, 7, 6, 3
+        rng = np.random.default_rng(101)
+        hidden_np = np.ascontiguousarray((0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32))
+        gate_np = np.ascontiguousarray((0.13 * rng.standard_normal((n_experts, intermediate_dim, hidden_dim))).astype(np.float32))
+        up_np = np.ascontiguousarray((0.11 * rng.standard_normal((n_experts, intermediate_dim, hidden_dim))).astype(np.float32))
+        down_np = np.ascontiguousarray((0.09 * rng.standard_normal((n_experts, hidden_dim, intermediate_dim))).astype(np.float32))
+        idx_np = np.empty((rows, top_k), dtype=np.int32)
+        for r in range(rows):
+            idx_np[r] = rng.choice(n_experts, size=top_k, replace=False).astype(np.int32)
+        w_raw = rng.random((rows, top_k)).astype(np.float32)
+        weights_np = np.ascontiguousarray(w_raw / w_raw.sum(axis=1, keepdims=True))
+        d_out_np = np.ascontiguousarray((0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32))
+
+        ck_out = np.empty_like(hidden_np)
+        LIB.moe_swiglu_expert_forward_f32(_fptr(hidden_np), _iptr(idx_np), _fptr(weights_np), _fptr(gate_np), _fptr(up_np), _fptr(down_np), _fptr(ck_out), rows, hidden_dim, intermediate_dim, n_experts, top_k)
+
+        ck_dh = np.empty_like(hidden_np)
+        ck_dw = np.empty_like(weights_np)
+        ck_dg = np.empty_like(gate_np)
+        ck_du = np.empty_like(up_np)
+        ck_dd = np.empty_like(down_np)
+        LIB.moe_swiglu_expert_backward_f32(_fptr(d_out_np), _fptr(hidden_np), _iptr(idx_np), _fptr(weights_np), _fptr(gate_np), _fptr(up_np), _fptr(down_np), _fptr(ck_dh), _fptr(ck_dw), _fptr(ck_dg), _fptr(ck_du), _fptr(ck_dd), rows, hidden_dim, intermediate_dim, n_experts, top_k)
+
+        hidden = torch.tensor(hidden_np, dtype=torch.float32, requires_grad=True)
+        gate = torch.tensor(gate_np, dtype=torch.float32, requires_grad=True)
+        up = torch.tensor(up_np, dtype=torch.float32, requires_grad=True)
+        down = torch.tensor(down_np, dtype=torch.float32, requires_grad=True)
+        weights = torch.tensor(weights_np, dtype=torch.float32, requires_grad=True)
+        indices = torch.tensor(idx_np, dtype=torch.long)
+        ref = torch_routed(hidden, indices, weights, gate, up, down)
+        ref.backward(torch.tensor(d_out_np, dtype=torch.float32))
+
+        np.testing.assert_allclose(ck_out, ref.detach().numpy(), atol=2e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dh, hidden.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dw, weights.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dg, gate.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_du, up.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dd, down.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+
+    def test_shared_forward_backward(self) -> None:
+        rows, hidden_dim, intermediate_dim = 5, 8, 11
+        rng = np.random.default_rng(103)
+        hidden_np = np.ascontiguousarray((0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32))
+        routed_np = np.ascontiguousarray((0.1 * rng.standard_normal((rows, hidden_dim))).astype(np.float32))
+        gate_np = np.ascontiguousarray((0.13 * rng.standard_normal((intermediate_dim, hidden_dim))).astype(np.float32))
+        up_np = np.ascontiguousarray((0.11 * rng.standard_normal((intermediate_dim, hidden_dim))).astype(np.float32))
+        down_np = np.ascontiguousarray((0.09 * rng.standard_normal((hidden_dim, intermediate_dim))).astype(np.float32))
+        d_out_np = np.ascontiguousarray((0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32))
+
+        ck_out = np.empty_like(hidden_np)
+        LIB.moe_swiglu_shared_forward_f32(_fptr(hidden_np), _fptr(routed_np), _fptr(gate_np), _fptr(up_np), _fptr(down_np), _fptr(ck_out), rows, hidden_dim, intermediate_dim)
+
+        ck_dh = np.empty_like(hidden_np)
+        ck_dr = np.empty_like(routed_np)
+        ck_dg = np.empty_like(gate_np)
+        ck_du = np.empty_like(up_np)
+        ck_dd = np.empty_like(down_np)
+        LIB.moe_swiglu_shared_backward_f32(_fptr(d_out_np), _fptr(hidden_np), _fptr(gate_np), _fptr(up_np), _fptr(down_np), _fptr(ck_dh), _fptr(ck_dr), _fptr(ck_dg), _fptr(ck_du), _fptr(ck_dd), rows, hidden_dim, intermediate_dim)
+
+        hidden = torch.tensor(hidden_np, dtype=torch.float32, requires_grad=True)
+        routed = torch.tensor(routed_np, dtype=torch.float32, requires_grad=True)
+        gate = torch.tensor(gate_np, dtype=torch.float32, requires_grad=True)
+        up = torch.tensor(up_np, dtype=torch.float32, requires_grad=True)
+        down = torch.tensor(down_np, dtype=torch.float32, requires_grad=True)
+        ref = torch_shared(hidden, routed, gate, up, down)
+        ref.backward(torch.tensor(d_out_np, dtype=torch.float32))
+
+        np.testing.assert_allclose(ck_out, ref.detach().numpy(), atol=2e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dh, hidden.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dr, routed.grad.detach().numpy(), atol=0.0, rtol=0.0)
+        np.testing.assert_allclose(ck_dg, gate.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_du, up.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+        np.testing.assert_allclose(ck_dd, down.grad.detach().numpy(), atol=3e-6, rtol=0.0)
+
+
+def _time_us(fn, iterations: int) -> float:
+    start = time.perf_counter()
+    for _ in range(iterations):
+        fn()
+    return (time.perf_counter() - start) * 1.0e6 / max(1, iterations)
+
+
+def run_benchmark() -> None:
+    rows, hidden_dim, intermediate_dim, n_experts, top_k = 8, 64, 48, 16, 4
+    rng = np.random.default_rng(107)
+    hidden = np.ascontiguousarray((0.2 * rng.standard_normal((rows, hidden_dim))).astype(np.float32))
+    gate = np.ascontiguousarray((0.13 * rng.standard_normal((n_experts, intermediate_dim, hidden_dim))).astype(np.float32))
+    up = np.ascontiguousarray((0.11 * rng.standard_normal((n_experts, intermediate_dim, hidden_dim))).astype(np.float32))
+    down = np.ascontiguousarray((0.09 * rng.standard_normal((n_experts, hidden_dim, intermediate_dim))).astype(np.float32))
+    idx = np.empty((rows, top_k), dtype=np.int32)
+    for r in range(rows):
+        idx[r] = rng.choice(n_experts, size=top_k, replace=False).astype(np.int32)
+    w = rng.random((rows, top_k)).astype(np.float32)
+    weights = np.ascontiguousarray(w / w.sum(axis=1, keepdims=True))
+    out = np.empty_like(hidden)
+
+    th = torch.tensor(hidden, dtype=torch.float32)
+    tg = torch.tensor(gate, dtype=torch.float32)
+    tu = torch.tensor(up, dtype=torch.float32)
+    td = torch.tensor(down, dtype=torch.float32)
+    tw = torch.tensor(weights, dtype=torch.float32)
+    ti = torch.tensor(idx, dtype=torch.long)
+
+    def ck_step() -> None:
+        LIB.moe_swiglu_expert_forward_f32(_fptr(hidden), _iptr(idx), _fptr(weights), _fptr(gate), _fptr(up), _fptr(down), _fptr(out), rows, hidden_dim, intermediate_dim, n_experts, top_k)
+
+    def torch_step() -> None:
+        torch_routed(th, ti, tw, tg, tu, td)
+
+    ck_step(); torch_step()
+    torch_us = _time_us(torch_step, 100)
+    ck_us = _time_us(ck_step, 100)
+    print("kernel                      pytorch_us      ck_us       speedup")
+    print(f"moe_swiglu_expert_forward {torch_us:12.3f} {ck_us:10.3f} {torch_us / max(ck_us, 1e-12):8.2f}x")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--benchmark", action="store_true")
+    args, remaining = ap.parse_known_args()
+    if args.benchmark:
+        run_benchmark()
+    else:
+        sys.argv = [sys.argv[0], *remaining]
+        unittest.main(verbosity=2)

--- a/unittest/test_nemotron_router.py
+++ b/unittest/test_nemotron_router.py
@@ -124,6 +124,9 @@ class TestNemotronRouter(unittest.TestCase):
     def test_no_norm_scaled_router(self) -> None:
         self._run_case(rows=5, n_experts=16, top_k=4, n_group=4, topk_group=2, norm=False, scale=0.7, seed=31)
 
+    def test_kimi_vl_like_router(self) -> None:
+        self._run_case(rows=9, n_experts=64, top_k=6, n_group=1, topk_group=1, norm=True, scale=2.446, seed=41)
+
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,7 +5,7 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 162,
+      "total": 173,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -27,13 +27,14 @@
         "gated_deltanet": 2,
         "geglu": 4,
         "gelu": 3,
-        "gemm": 15,
+        "gemm": 16,
         "gemm_backward": 1,
         "gemma4_per_layer_embed": 1,
         "gemma4_per_layer_prepare": 2,
         "gemv": 14,
         "group_limited_topk_router": 1,
         "kv_cache_store": 2,
+        "kv_lora_decompress": 1,
         "layernorm": 2,
         "logits_store_indexed": 1,
         "mamba_conv1d_state_update": 1,
@@ -43,9 +44,12 @@
         "mamba_selective_scan": 1,
         "mamba_selective_state_update_decode": 1,
         "moe_relu2_expert_mlp": 4,
+        "moe_swiglu_expert_mlp": 2,
         "optimizer": 4,
-        "position_embeddings": 2,
+        "partial_rope_concat": 1,
+        "position_embeddings": 3,
         "position_ids": 1,
+        "projector_prep": 1,
         "qk_norm": 1,
         "qk_norm_backward": 1,
         "qkv_projection": 1,
@@ -64,13 +68,14 @@
         "residual_add": 1,
         "residual_save": 1,
         "rmsnorm": 2,
-        "rope": 7,
+        "rope": 8,
         "rope_backward": 2,
         "rope_init": 2,
         "rowwise_bias_add": 1,
         "shared_relu2_expert_mlp": 1,
+        "shared_swiglu_expert_mlp": 2,
         "softmax": 1,
-        "spatial_merge": 2,
+        "spatial_merge": 3,
         "split_q_gate": 1,
         "split_q_gate_backward": 1,
         "split_qkv_packed_head_major": 1,
@@ -3391,6 +3396,220 @@
       "_source_file": "ck_residual_add_token_major.json"
     },
     {
+      "id": "deepseek_mla_kv_decompress_f32",
+      "op": "kv_lora_decompress",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "compressed_kv",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "R"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "kv_b_proj",
+          "dtype": "fp32",
+          "shape": [
+            "H*(Dk+Dv)",
+            "R"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "k_nope",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk"
+          ]
+        },
+        {
+          "name": "value",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dv"
+          ]
+        }
+      ],
+      "dims": [
+        "T",
+        "H",
+        "R",
+        "Dk",
+        "Dv"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "deepseek_mla_kv_decompress_f32",
+        "c_declaration": "void deepseek_mla_kv_decompress_f32(const float *compressed_kv, const float *kv_b_proj, float *k_nope, float *value, int tokens, int heads, int kv_lora_rank, int qk_nope_dim, int v_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_deepseek_reference_kernels.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+            "tolerance": "1e-5"
+          }
+        ]
+      },
+      "notes": "Scalar reference for DeepSeek/Kimi MLA KV LoRA decompress after kv_a_layernorm: kv_b_proj expands compressed KV, then splits into k_nope and value heads.",
+      "name": "deepseek_mla_kv_decompress_f32",
+      "_source_file": "deepseek_mla_kv_decompress_f32.json"
+    },
+    {
+      "id": "deepseek_mla_partial_rope_concat_f32",
+      "op": "partial_rope_concat",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q_nope",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk"
+          ]
+        },
+        {
+          "name": "q_pe",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dr"
+          ]
+        },
+        {
+          "name": "k_nope",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk"
+          ]
+        },
+        {
+          "name": "k_pe",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "Dr"
+          ]
+        },
+        {
+          "name": "cos",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "Dr/2"
+          ]
+        },
+        {
+          "name": "sin",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "Dr/2"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "query",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        },
+        {
+          "name": "key",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        }
+      ],
+      "dims": [
+        "T",
+        "H",
+        "Dk",
+        "Dr"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "deepseek_mla_partial_rope_concat_f32",
+        "c_declaration": "void deepseek_mla_partial_rope_concat_f32(const float *q_nope, const float *q_pe, const float *k_nope, const float *k_pe, const float *cos, const float *sin, float *query, float *key, int tokens, int heads, int qk_nope_dim, int qk_rope_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_deepseek_reference_kernels.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+            "tolerance": "1e-6"
+          }
+        ]
+      },
+      "notes": "Scalar reference for MLA partial RoPE assembly: copy q/k no-PE slices, apply Kimi/DeepSeek pair layout RoPE to q_pe and shared k_pe, then concatenate.",
+      "name": "deepseek_mla_partial_rope_concat_f32",
+      "_source_file": "deepseek_mla_partial_rope_concat_f32.json"
+    },
+    {
       "id": "dense_embedding_lookup",
       "kernel": "dense_embedding_lookup",
       "op": "embedding",
@@ -5901,6 +6120,107 @@
       "_source_file": "gemm_nt_f16.json"
     },
     {
+      "id": "gemm_nt_f16_clipped",
+      "op": "gemm",
+      "variant": "f16_w_fp32_a_fp32_out_clipped",
+      "quant": {
+        "weight": "fp16|f16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "A",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "K"
+          ],
+          "desc": "Activation matrix [M,K], clamped before FP16 rounding"
+        },
+        {
+          "name": "B",
+          "dtype": "fp16",
+          "shape": [
+            "N",
+            "K"
+          ],
+          "desc": "Weight matrix [N,K] FP16"
+        },
+        {
+          "name": "bias",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ],
+          "optional": true
+        },
+        {
+          "name": "input_min",
+          "dtype": "fp32",
+          "shape": [
+            1
+          ],
+          "optional": true
+        },
+        {
+          "name": "input_max",
+          "dtype": "fp32",
+          "shape": [
+            1
+          ],
+          "optional": true
+        },
+        {
+          "name": "output_min",
+          "dtype": "fp32",
+          "shape": [
+            1
+          ],
+          "optional": true
+        },
+        {
+          "name": "output_max",
+          "dtype": "fp32",
+          "shape": [
+            1
+          ],
+          "optional": true
+        }
+      ],
+      "outputs": [
+        {
+          "name": "C",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "N"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "M",
+        "N",
+        "K"
+      ],
+      "impl": {
+        "function": "gemm_nt_f16_clipped",
+        "c_declaration": "void gemm_nt_f16_clipped(const float *A, const void *B, const float *bias, const float *input_min, const float *input_max, const float *output_min, const float *output_max, float *C, int M, int N, int K);",
+        "sources": [
+          "src/kernels/gemm_kernels_f16.c"
+        ]
+      },
+      "tests": {
+        "unit": [
+          "tests/test_v8_native_bridge_host.py"
+        ]
+      },
+      "notes": "Gemma4V ClippableLinear: clamp input, F16 matmul, clamp output.",
+      "name": "gemm_nt_f16_clipped",
+      "_source_file": "gemm_nt_f16_clipped.json"
+    },
+    {
       "id": "gemm_nt_fp32_exact",
       "op": "gemm",
       "variant": "fp32_nt_exact",
@@ -7466,6 +7786,64 @@
       "notes": "Prepare Gemma4 per-layer input stream once from original token embedding stream.",
       "name": "gemma4_per_layer_prepare_forward",
       "_source_file": "gemma4_per_layer_prepare_forward.json"
+    },
+    {
+      "id": "gemma4_vision_projector_prep_forward",
+      "op": "projector_prep",
+      "variant": "fp32_scale_unit_rmsnorm",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Pooled Gemma4V visual tokens"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Scaled and unit-RMS-normalized projector input"
+        }
+      ],
+      "dims": [
+        "tokens",
+        "dim"
+      ],
+      "params": [
+        {
+          "name": "scale",
+          "dtype": "float32",
+          "desc": "Pre-RMS scale, usually sqrt(vision_embed_dim)"
+        },
+        {
+          "name": "eps",
+          "dtype": "float32",
+          "desc": "RMSNorm epsilon"
+        }
+      ],
+      "impl": {
+        "function": "gemma4_vision_projector_prep_forward",
+        "c_declaration": "void gemma4_vision_projector_prep_forward(const float *input, float *output, int tokens, int dim, float scale, float eps);",
+        "sources": [
+          "src/kernels/vision_kernels.c"
+        ]
+      },
+      "notes": "Gemma4V projector preparation: pool output is scaled by sqrt(embed_dim), then unit-gamma RMSNorm is applied before mm.input_projection.weight.",
+      "name": "gemma4_vision_projector_prep_forward",
+      "_source_file": "gemma4_vision_projector_prep_forward.json"
     },
     {
       "id": "gemv_bf16",
@@ -12233,6 +12611,520 @@
       "_source_file": "moe_relu2_shared_forward_q5_1_q8_0.json"
     },
     {
+      "id": "moe_swiglu_expert_backward_f32",
+      "op": "moe_swiglu_expert_mlp",
+      "variant": "fp32",
+      "modes": {
+        "inference": false,
+        "training": true,
+        "backward": true
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "d_output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "expert_gate",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_up",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_down",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "d_hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "d_routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "d_expert_gate",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "d_expert_up",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "d_expert_down",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I",
+        "E",
+        "K"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "moe_swiglu_expert_backward_f32",
+        "c_declaration": "void moe_swiglu_expert_backward_f32(const float *d_output, const float *hidden, const int *indices, const float *routing_weights, const float *expert_gate, const float *expert_up, const float *expert_down, float *d_hidden, float *d_routing_weights, float *d_expert_gate, float *d_expert_up, float *d_expert_down, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_swiglu_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+            "tolerance": "3e-6"
+          }
+        ]
+      },
+      "notes": "Backward pass for routed SwiGLU MoE expert reference kernel.",
+      "name": "moe_swiglu_expert_backward_f32",
+      "_source_file": "moe_swiglu_expert_backward_f32.json"
+    },
+    {
+      "id": "moe_swiglu_expert_forward_f32",
+      "op": "moe_swiglu_expert_mlp",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "expert_gate",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_up",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_down",
+          "dtype": "fp32",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I",
+        "E",
+        "K"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "moe_swiglu_expert_forward_f32",
+        "c_declaration": "void moe_swiglu_expert_forward_f32(const float *hidden, const int *indices, const float *routing_weights, const float *expert_gate, const float *expert_up, const float *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_swiglu_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+            "tolerance": "3e-6"
+          }
+        ]
+      },
+      "notes": "Routed SwiGLU MoE expert reference kernel for Kimi/DeepSeek-style experts: down(silu(gate(x))*up(x)), accumulated by routing weights.",
+      "name": "moe_swiglu_expert_forward_f32",
+      "_source_file": "moe_swiglu_expert_forward_f32.json"
+    },
+    {
+      "id": "moe_swiglu_shared_backward_f32",
+      "op": "shared_swiglu_expert_mlp",
+      "variant": "fp32",
+      "modes": {
+        "inference": false,
+        "training": true,
+        "backward": true
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "d_output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "shared_gate",
+          "dtype": "fp32",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "shared_up",
+          "dtype": "fp32",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "shared_down",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "d_hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "d_routed",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "d_shared_gate",
+          "dtype": "fp32",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "d_shared_up",
+          "dtype": "fp32",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "d_shared_down",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "moe_swiglu_shared_backward_f32",
+        "c_declaration": "void moe_swiglu_shared_backward_f32(const float *d_output, const float *hidden, const float *shared_gate, const float *shared_up, const float *shared_down, float *d_hidden, float *d_routed, float *d_shared_gate, float *d_shared_up, float *d_shared_down, int rows, int hidden_dim, int intermediate_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_swiglu_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+            "tolerance": "3e-6"
+          }
+        ]
+      },
+      "notes": "Backward pass for shared SwiGLU expert reference kernel.",
+      "name": "moe_swiglu_shared_backward_f32",
+      "_source_file": "moe_swiglu_shared_backward_f32.json"
+    },
+    {
+      "id": "moe_swiglu_shared_forward_f32",
+      "op": "shared_swiglu_expert_mlp",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "routed",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ],
+          "optional": true
+        }
+      ],
+      "weights": [
+        {
+          "name": "shared_gate",
+          "dtype": "fp32",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "shared_up",
+          "dtype": "fp32",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "shared_down",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "moe_swiglu_shared_forward_f32",
+        "c_declaration": "void moe_swiglu_shared_forward_f32(const float *hidden, const float *routed, const float *shared_gate, const float *shared_up, const float *shared_down, float *output, int rows, int hidden_dim, int intermediate_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_swiglu_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+            "tolerance": "3e-6"
+          }
+        ]
+      },
+      "notes": "Shared SwiGLU expert branch used by Kimi/DeepSeek-style MoE; output = routed + shared_down(silu(shared_gate(x))*shared_up(x)).",
+      "name": "moe_swiglu_shared_forward_f32",
+      "_source_file": "moe_swiglu_shared_forward_f32.json"
+    },
+    {
       "id": "mrope_qk_text",
       "op": "rope",
       "variant": "fp32_head_major_text_mrope",
@@ -12714,6 +13606,38 @@
       "notes": "Add learned absolute position embeddings in-place. Fixed-size first path for v8 vision bring-up.",
       "name": "position_embeddings_add",
       "_source_file": "position_embeddings_add.json"
+    },
+    {
+      "id": "position_embeddings_add_gemma4v_xy",
+      "op": "position_embeddings",
+      "family": "vision",
+      "description": "Add Gemma4V learned 2D x/y positional embeddings to patch embeddings.",
+      "inputs": [
+        {
+          "name": "x",
+          "type": "float*",
+          "shape": "[grid_h*grid_w, embed_dim]"
+        },
+        {
+          "name": "position_embd",
+          "type": "const float*",
+          "shape": "[2, source_grid_size, embed_dim]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "x",
+          "type": "float*",
+          "shape": "[grid_h*grid_w, embed_dim]"
+        }
+      ],
+      "c_function": {
+        "name": "position_embeddings_add_gemma4v_xy",
+        "header": "include/ckernel_engine.h",
+        "source": "src/kernels/vision_kernels.c"
+      },
+      "name": "position_embeddings_add_gemma4v_xy",
+      "_source_file": "position_embeddings_add_gemma4v_xy.json"
     },
     {
       "id": "position_embeddings_add_tiled_2d",
@@ -16487,6 +17411,77 @@
       "_source_file": "rope_forward_qk_gemma4.json"
     },
     {
+      "id": "rope_forward_qk_gemma4v_vision_xy",
+      "op": "rope",
+      "variant": "fp32_head_major_gemma4v_vision_xy_neox",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor rotated in-place"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ],
+          "desc": "Key tensor rotated in-place"
+        }
+      ],
+      "weights": [],
+      "outputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ]
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ]
+        }
+      ],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "D",
+        "grid_w",
+        "rotary_dim"
+      ],
+      "impl": {
+        "function": "rope_forward_qk_gemma4v_vision_xy",
+        "c_declaration": "void rope_forward_qk_gemma4v_vision_xy(float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int grid_w, int rotary_dim, float freq_base);",
+        "sources": [
+          "src/kernels/rope_kernels.c"
+        ]
+      },
+      "notes": "Gemma4V vision tower Q/K RoPE matching llama.cpp: x-position rotation on first half of the rotary span and y-position rotation on the second half, using NEOX split-half layout inside each half.",
+      "name": "rope_forward_qk_gemma4v_vision_xy",
+      "_source_file": "rope_forward_qk_gemma4v_vision_xy.json"
+    },
+    {
       "id": "rope_forward_qk_pairwise",
       "op": "rope",
       "variant": "fp32_head_major",
@@ -17343,6 +18338,54 @@
       "notes": "Softmax cross-entropy forward + dlogits kernel for v7 training (index-target mean reduction aligned to PyTorch ignore_index semantics).",
       "name": "softmax_cross_entropy_loss",
       "_source_file": "softmax_cross_entropy_loss.json"
+    },
+    {
+      "id": "spatial_average_pool_contiguous",
+      "op": "spatial_merge",
+      "variant": "fp32_spatial_average_pool",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Token-major activation stream arranged as a dense HxW patch grid"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T/(M*M)",
+            "E"
+          ],
+          "desc": "Pooled stream formed by averaging each merge_size x merge_size patch tile"
+        }
+      ],
+      "dims": [
+        "grid_h",
+        "grid_w",
+        "embed_dim",
+        "merge_size"
+      ],
+      "impl": {
+        "function": "spatial_average_pool_contiguous",
+        "c_declaration": "void spatial_average_pool_contiguous(const float *input, float *output, int grid_h, int grid_w, int embed_dim, int merge_size);",
+        "sources": [
+          "src/kernels/vision_kernels.c"
+        ]
+      },
+      "notes": "Average-pool merge_size x merge_size spatial tiles while preserving embedding width; used by Gemma4V before the projector.",
+      "name": "spatial_average_pool_contiguous",
+      "_source_file": "spatial_average_pool_contiguous.json"
     },
     {
       "id": "spatial_merge_2x2",
@@ -18535,112 +19578,6 @@
       "notes": "Build merged vision position IDs for 2D M-RoPE style encoders.",
       "name": "vision_position_ids_2d_merge",
       "_source_file": "vision_position_ids_2d_merge.json"
-    },
-    {
-      "id": "spatial_average_pool_contiguous",
-      "op": "spatial_merge",
-      "variant": "fp32_spatial_average_pool",
-      "quant": {
-        "weight": "none",
-        "activation": "fp32",
-        "output": "fp32"
-      },
-      "inputs": [
-        {
-          "name": "input",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "E"
-          ],
-          "desc": "Token-major activation stream arranged as a dense HxW patch grid"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "output",
-          "dtype": "fp32",
-          "shape": [
-            "T/(M*M)",
-            "E"
-          ],
-          "desc": "Pooled stream formed by averaging each merge_size x merge_size patch tile"
-        }
-      ],
-      "dims": [
-        "grid_h",
-        "grid_w",
-        "embed_dim",
-        "merge_size"
-      ],
-      "impl": {
-        "function": "spatial_average_pool_contiguous",
-        "c_declaration": "void spatial_average_pool_contiguous(const float *input, float *output, int grid_h, int grid_w, int embed_dim, int merge_size);",
-        "sources": [
-          "src/kernels/vision_kernels.c"
-        ]
-      },
-      "notes": "Average-pool merge_size x merge_size spatial tiles while preserving embedding width; used by Gemma4V before the projector.",
-      "name": "spatial_average_pool_contiguous",
-      "_source_file": "spatial_average_pool_contiguous.json"
-    },
-    {
-      "id": "gemma4_vision_projector_prep_forward",
-      "op": "projector_prep",
-      "variant": "fp32_scale_unit_rmsnorm",
-      "quant": {
-        "weight": "none",
-        "activation": "fp32",
-        "output": "fp32"
-      },
-      "inputs": [
-        {
-          "name": "input",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "E"
-          ],
-          "desc": "Pooled Gemma4V visual tokens"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "output",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "E"
-          ],
-          "desc": "Scaled and unit-RMS-normalized projector input"
-        }
-      ],
-      "dims": [
-        "tokens",
-        "dim"
-      ],
-      "params": [
-        {
-          "name": "scale",
-          "dtype": "float32",
-          "desc": "Pre-RMS scale, usually sqrt(vision_embed_dim)"
-        },
-        {
-          "name": "eps",
-          "dtype": "float32",
-          "desc": "RMSNorm epsilon"
-        }
-      ],
-      "impl": {
-        "function": "gemma4_vision_projector_prep_forward",
-        "c_declaration": "void gemma4_vision_projector_prep_forward(const float *input, float *output, int tokens, int dim, float scale, float eps);",
-        "sources": [
-          "src/kernels/vision_kernels.c"
-        ]
-      },
-      "notes": "Gemma4V projector preparation: pool output is scaled by sqrt(embed_dim), then unit-gamma RMSNorm is applied before mm.input_projection.weight.",
-      "name": "gemma4_vision_projector_prep_forward",
-      "_source_file": "gemma4_vision_projector_prep_forward.json"
     }
   ]
 }

--- a/version/v8/kernel_maps/deepseek_mla_kv_decompress_f32.json
+++ b/version/v8/kernel_maps/deepseek_mla_kv_decompress_f32.json
@@ -1,0 +1,89 @@
+{
+  "id": "deepseek_mla_kv_decompress_f32",
+  "op": "kv_lora_decompress",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "compressed_kv",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "R"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "kv_b_proj",
+      "dtype": "fp32",
+      "shape": [
+        "H*(Dk+Dv)",
+        "R"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "k_nope",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk"
+      ]
+    },
+    {
+      "name": "value",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dv"
+      ]
+    }
+  ],
+  "dims": [
+    "T",
+    "H",
+    "R",
+    "Dk",
+    "Dv"
+  ],
+  "impl": {
+    "sources": [
+      "src/kernels/deepseek_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ],
+    "function": "deepseek_mla_kv_decompress_f32",
+    "c_declaration": "void deepseek_mla_kv_decompress_f32(const float *compressed_kv, const float *kv_b_proj, float *k_nope, float *value, int tokens, int heads, int kv_lora_rank, int qk_nope_dim, int v_dim);"
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_deepseek_reference_kernels.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+        "tolerance": "1e-5"
+      }
+    ]
+  },
+  "notes": "Scalar reference for DeepSeek/Kimi MLA KV LoRA decompress after kv_a_layernorm: kv_b_proj expands compressed KV, then splits into k_nope and value heads."
+}

--- a/version/v8/kernel_maps/deepseek_mla_partial_rope_concat_f32.json
+++ b/version/v8/kernel_maps/deepseek_mla_partial_rope_concat_f32.json
@@ -1,0 +1,121 @@
+{
+  "id": "deepseek_mla_partial_rope_concat_f32",
+  "op": "partial_rope_concat",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q_nope",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk"
+      ]
+    },
+    {
+      "name": "q_pe",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dr"
+      ]
+    },
+    {
+      "name": "k_nope",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk"
+      ]
+    },
+    {
+      "name": "k_pe",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "Dr"
+      ]
+    },
+    {
+      "name": "cos",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "Dr/2"
+      ]
+    },
+    {
+      "name": "sin",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "Dr/2"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "query",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk+Dr"
+      ]
+    },
+    {
+      "name": "key",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk+Dr"
+      ]
+    }
+  ],
+  "dims": [
+    "T",
+    "H",
+    "Dk",
+    "Dr"
+  ],
+  "impl": {
+    "sources": [
+      "src/kernels/deepseek_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ],
+    "function": "deepseek_mla_partial_rope_concat_f32",
+    "c_declaration": "void deepseek_mla_partial_rope_concat_f32(const float *q_nope, const float *q_pe, const float *k_nope, const float *k_pe, const float *cos, const float *sin, float *query, float *key, int tokens, int heads, int qk_nope_dim, int qk_rope_dim);"
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_deepseek_reference_kernels.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+        "tolerance": "1e-6"
+      }
+    ]
+  },
+  "notes": "Scalar reference for MLA partial RoPE assembly: copy q/k no-PE slices, apply Kimi/DeepSeek pair layout RoPE to q_pe and shared k_pe, then concatenate."
+}

--- a/version/v8/kernel_maps/moe_swiglu_expert_backward_f32.json
+++ b/version/v8/kernel_maps/moe_swiglu_expert_backward_f32.json
@@ -1,0 +1,157 @@
+{
+  "id": "moe_swiglu_expert_backward_f32",
+  "op": "moe_swiglu_expert_mlp",
+  "variant": "fp32",
+  "modes": {
+    "inference": false,
+    "training": true,
+    "backward": true
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "d_output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "indices",
+      "dtype": "i32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "expert_gate",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_up",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_down",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "d_hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "d_routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "d_expert_gate",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "d_expert_up",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "d_expert_down",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "dims": [
+    "R",
+    "H",
+    "I",
+    "E",
+    "K"
+  ],
+  "impl": {
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ],
+    "function": "moe_swiglu_expert_backward_f32",
+    "c_declaration": "void moe_swiglu_expert_backward_f32(const float *d_output, const float *hidden, const int *indices, const float *routing_weights, const float *expert_gate, const float *expert_up, const float *expert_down, float *d_hidden, float *d_routing_weights, float *d_expert_gate, float *d_expert_up, float *d_expert_down, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);"
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_swiglu_expert.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+        "tolerance": "3e-6"
+      }
+    ]
+  },
+  "notes": "Backward pass for routed SwiGLU MoE expert reference kernel."
+}

--- a/version/v8/kernel_maps/moe_swiglu_expert_forward_f32.json
+++ b/version/v8/kernel_maps/moe_swiglu_expert_forward_f32.json
@@ -1,0 +1,114 @@
+{
+  "id": "moe_swiglu_expert_forward_f32",
+  "op": "moe_swiglu_expert_mlp",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "indices",
+      "dtype": "i32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    },
+    {
+      "name": "routing_weights",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "K"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "expert_gate",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_up",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "expert_down",
+      "dtype": "fp32",
+      "shape": [
+        "E",
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "dims": [
+    "R",
+    "H",
+    "I",
+    "E",
+    "K"
+  ],
+  "impl": {
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ],
+    "function": "moe_swiglu_expert_forward_f32",
+    "c_declaration": "void moe_swiglu_expert_forward_f32(const float *hidden, const int *indices, const float *routing_weights, const float *expert_gate, const float *expert_up, const float *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);"
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_swiglu_expert.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+        "tolerance": "3e-6"
+      }
+    ]
+  },
+  "notes": "Routed SwiGLU MoE expert reference kernel for Kimi/DeepSeek-style experts: down(silu(gate(x))*up(x)), accumulated by routing weights."
+}

--- a/version/v8/kernel_maps/moe_swiglu_shared_backward_f32.json
+++ b/version/v8/kernel_maps/moe_swiglu_shared_backward_f32.json
@@ -1,0 +1,133 @@
+{
+  "id": "moe_swiglu_shared_backward_f32",
+  "op": "shared_swiglu_expert_mlp",
+  "variant": "fp32",
+  "modes": {
+    "inference": false,
+    "training": true,
+    "backward": true
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "d_output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "weights": [
+    {
+      "name": "shared_gate",
+      "dtype": "fp32",
+      "shape": [
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "shared_up",
+      "dtype": "fp32",
+      "shape": [
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "shared_down",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "d_hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "d_routed",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "d_shared_gate",
+      "dtype": "fp32",
+      "shape": [
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "d_shared_up",
+      "dtype": "fp32",
+      "shape": [
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "d_shared_down",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "dims": [
+    "R",
+    "H",
+    "I"
+  ],
+  "impl": {
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ],
+    "function": "moe_swiglu_shared_backward_f32",
+    "c_declaration": "void moe_swiglu_shared_backward_f32(const float *d_output, const float *hidden, const float *shared_gate, const float *shared_up, const float *shared_down, float *d_hidden, float *d_routed, float *d_shared_gate, float *d_shared_up, float *d_shared_down, int rows, int hidden_dim, int intermediate_dim);"
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_swiglu_expert.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+        "tolerance": "3e-6"
+      }
+    ]
+  },
+  "notes": "Backward pass for shared SwiGLU expert reference kernel."
+}

--- a/version/v8/kernel_maps/moe_swiglu_shared_forward_f32.json
+++ b/version/v8/kernel_maps/moe_swiglu_shared_forward_f32.json
@@ -1,0 +1,102 @@
+{
+  "id": "moe_swiglu_shared_forward_f32",
+  "op": "shared_swiglu_expert_mlp",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    },
+    {
+      "name": "routed",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ],
+      "optional": true
+    }
+  ],
+  "weights": [
+    {
+      "name": "shared_gate",
+      "dtype": "fp32",
+      "shape": [
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "shared_up",
+      "dtype": "fp32",
+      "shape": [
+        "I",
+        "H"
+      ]
+    },
+    {
+      "name": "shared_down",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "I"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output",
+      "dtype": "fp32",
+      "shape": [
+        "R",
+        "H"
+      ]
+    }
+  ],
+  "dims": [
+    "R",
+    "H",
+    "I"
+  ],
+  "impl": {
+    "sources": [
+      "src/kernels/axpy_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ],
+    "function": "moe_swiglu_shared_forward_f32",
+    "c_declaration": "void moe_swiglu_shared_forward_f32(const float *hidden, const float *routed, const float *shared_gate, const float *shared_up, const float *shared_down, float *output, int rows, int hidden_dim, int intermediate_dim);"
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_moe_swiglu_expert.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+        "tolerance": "3e-6"
+      }
+    ]
+  },
+  "notes": "Shared SwiGLU expert branch used by Kimi/DeepSeek-style MoE; output = routed + shared_down(silu(shared_gate(x))*shared_up(x))."
+}

--- a/version/v8/model_maps/safetensors_ck_map.json
+++ b/version/v8/model_maps/safetensors_ck_map.json
@@ -179,6 +179,37 @@
           "optional": true
         }
       ]
+    },
+    "kimi_vl": {
+      "template": "kimi_vl",
+      "family": "kimi",
+      "aliases": [
+        "kimi_vl",
+        "KimiVLForConditionalGeneration"
+      ],
+      "status": "bringup_required",
+      "config": {
+        "model": "kimi_vl",
+        "arch": "kimi_vl",
+        "model_type": "kimi_vl",
+        "rope_layout": "partial_pairwise_concat",
+        "prefill_policy": "batched",
+        "attention_variant": "mla",
+        "moe_formula": "sigmoid_router_topk6_routed_and_shared_swiglu"
+      },
+      "required_tensor_families": [
+        "language_model.model.layers.{L}.self_attn.q_proj.weight",
+        "language_model.model.layers.{L}.self_attn.kv_a_proj_with_mqa.weight",
+        "language_model.model.layers.{L}.self_attn.kv_a_layernorm.weight",
+        "language_model.model.layers.{L}.self_attn.kv_b_proj.weight",
+        "language_model.model.layers.{L}.self_attn.o_proj.weight",
+        "language_model.model.layers.{L}.mlp.gate.weight",
+        "language_model.model.layers.{L}.mlp.experts.{E}.gate_proj.weight",
+        "language_model.model.layers.{L}.mlp.shared_experts.gate_proj.weight",
+        "vision_tower.*",
+        "multi_modal_projector.*"
+      ],
+      "notes": "Declared mapping contract only. Full tensor_refs are intentionally absent until Kimi MLA/MoE packing and MoonViT bridge lowering are implemented."
     }
   }
 }

--- a/version/v8/scripts/audit_safetensors_index_v8.py
+++ b/version/v8/scripts/audit_safetensors_index_v8.py
@@ -25,24 +25,51 @@ def _load_index(path: Path) -> dict[str, Any]:
 
 
 def _family(name: str) -> str:
-    if name in {"lm_head.weight", "backbone.embeddings.weight", "model.embed_tokens.weight"}:
+    if name in {
+        "lm_head.weight",
+        "language_model.lm_head.weight",
+        "backbone.embeddings.weight",
+        "model.embed_tokens.weight",
+        "language_model.model.embed_tokens.weight",
+    }:
         return name
-    if ".mixer." not in name:
-        return "other"
-    tail = name.split(".mixer.", 1)[1]
-    if tail.startswith("self_attn.") or tail in {"q_proj.weight", "k_proj.weight", "v_proj.weight", "o_proj.weight"}:
+    if name.startswith("vision_tower."):
+        return "vision_tower"
+    if name.startswith("multi_modal_projector."):
+        return "multimodal_projector"
+    if ".mixer." in name:
+        tail = name.split(".mixer.", 1)[1]
+        if tail.startswith("self_attn.") or tail in {"q_proj.weight", "k_proj.weight", "v_proj.weight", "o_proj.weight"}:
+            return "attention"
+        if tail.startswith("experts."):
+            return "moe_expert"
+        if tail.startswith("shared_experts."):
+            return "moe_shared_expert"
+        if tail.startswith("gate."):
+            return "moe_router"
+        if tail in {"up_proj.weight", "down_proj.weight"}:
+            return "dense_mlp"
+        if tail.startswith(("in_proj.", "out_proj.", "conv1d.", "dt_bias", "A_log", "D", "norm.")):
+            return "mamba"
+        return "mixer_other"
+    if ".self_attn." in name:
+        tail = name.split(".self_attn.", 1)[1]
+        if tail in {"q_proj.weight", "o_proj.weight", "rotary_emb.inv_freq"}:
+            return "attention"
+        if tail.startswith(("kv_a_proj_with_mqa.", "kv_a_layernorm.", "kv_b_proj.")):
+            return "mla_attention"
         return "attention"
-    if tail.startswith("experts."):
+    if ".mlp.experts." in name:
         return "moe_expert"
-    if tail.startswith("shared_experts."):
+    if ".mlp.shared_experts." in name:
         return "moe_shared_expert"
-    if tail.startswith("gate."):
+    if ".mlp.gate." in name:
         return "moe_router"
-    if tail in {"up_proj.weight", "down_proj.weight"}:
+    if ".mlp." in name:
         return "dense_mlp"
-    if tail.startswith(("in_proj.", "out_proj.", "conv1d.", "dt_bias", "A_log", "D", "norm.")):
-        return "mamba"
-    return "mixer_other"
+    if name.endswith(("input_layernorm.weight", "post_attention_layernorm.weight", "model.norm.weight")):
+        return "norm"
+    return "other"
 
 
 def audit_index(path: Path) -> dict[str, Any]:

--- a/version/v8/scripts/audit_template_circuit_v8.py
+++ b/version/v8/scripts/audit_template_circuit_v8.py
@@ -42,7 +42,14 @@ CRITICAL_TEMPLATE_INPUTS: dict[str, tuple[str, ...]] = {
     "q_gate_proj": ("x",),
     "k_proj": ("x",),
     "v_proj": ("x",),
+    "kv_a_proj": ("x",),
+    "kv_a_layernorm": ("x",),
+    "kv_lora_decompress": ("compressed_kv", "kv_b"),
+    "partial_rope_concat": ("q_nope", "q_pe", "k_nope", "k_pe"),
+    "mla_attention": ("query", "key", "value"),
     "mlp_gate_up": ("x",),
+    "moe_swiglu_expert_mlp": ("hidden", "indices", "routing_weights"),
+    "shared_swiglu_expert_mlp": ("hidden", "routed"),
     "mlp_up": ("x",),
     "mamba_in_proj": ("x",),
     "recurrent_qkv_proj": ("x",),
@@ -209,7 +216,7 @@ def audit_ir1(ir1: dict[str, Any]) -> list[str]:
         if norm is None:
             continue
         label = f"layer {layer}"
-        for proj_name in ("mamba_in_proj", "q_proj", "q_gate_proj", "k_proj", "v_proj", "mlp_up", "mlp_gate_up", "moe_router"):
+        for proj_name in ("mamba_in_proj", "q_proj", "q_gate_proj", "k_proj", "v_proj", "kv_a_proj", "mlp_up", "mlp_gate_up", "moe_router"):
             proj = by.get((layer, proj_name))
             if proj is not None:
                 _same_producer(errors, proj, "x", norm, f"{label} pre-norm projection")
@@ -248,13 +255,37 @@ def audit_ir1(ir1: dict[str, Any]) -> list[str]:
         if mlp_down is not None and relu2 is not None:
             _same_producer(errors, mlp_down, "x", relu2, f"{label} mlp down")
         q = by.get((layer, "q_proj")); k = by.get((layer, "k_proj")); v = by.get((layer, "v_proj"))
+        kv_a = by.get((layer, "kv_a_proj"))
+        kv_norm = by.get((layer, "kv_a_layernorm"))
+        kv_decomp = by.get((layer, "kv_lora_decompress"))
+        partial = by.get((layer, "partial_rope_concat"))
+        mla = by.get((layer, "mla_attention"))
+        if kv_a is not None:
+            _same_producer(errors, kv_a, "x", norm, f"{label} MLA kv_a")
+            _slot(errors, kv_a, "x", "layer_input", f"{label} MLA kv_a")
+        if kv_norm is not None and kv_a is not None:
+            _same_producer(errors, kv_norm, "x", kv_a, f"{label} MLA kv_a norm")
+        if kv_decomp is not None and kv_norm is not None:
+            _same_producer(errors, kv_decomp, "compressed_kv", kv_norm, f"{label} MLA kv decompress")
+        if partial is not None:
+            if q is not None:
+                for input_name in ("q_nope", "q_pe"):
+                    _same_producer(errors, partial, input_name, q, f"{label} MLA partial rope")
+            if kv_decomp is not None:
+                _same_producer(errors, partial, "k_nope", kv_decomp, f"{label} MLA partial rope")
+        if mla is not None:
+            if partial is not None:
+                _same_producer(errors, mla, "query", partial, f"{label} MLA attention")
+                _same_producer(errors, mla, "key", partial, f"{label} MLA attention")
+            if kv_decomp is not None:
+                _same_producer(errors, mla, "value", kv_decomp, f"{label} MLA attention")
         rope = by.get((layer, "rope_qk"))
         if rope is not None:
             if q is not None:
                 _same_producer(errors, rope, "q", q, f"{label} rope")
             if k is not None:
                 _same_producer(errors, rope, "k", k, f"{label} rope")
-        attn = by.get((layer, "attn")) or by.get((layer, "attn_sliding"))
+        attn = by.get((layer, "attn")) or by.get((layer, "attn_sliding")) or by.get((layer, "mla_attention"))
         if attn is not None:
             if rope is not None:
                 _same_producer(errors, attn, "q", rope, f"{label} attention")
@@ -287,7 +318,7 @@ def audit_lowered(lowered: dict[str, Any]) -> list[str]:
     layers = sorted({layer for layer, _ in by})
     for layer in layers:
         label = f"layer {layer}"
-        for proj_name in ("mamba_in_proj", "q_proj", "q_gate_proj", "k_proj", "v_proj", "mlp_up", "mlp_gate_up", "moe_router"):
+        for proj_name in ("mamba_in_proj", "q_proj", "q_gate_proj", "k_proj", "v_proj", "kv_a_proj", "mlp_up", "mlp_gate_up", "moe_router"):
             proj = by.get((layer, proj_name))
             if proj is not None:
                 buf = _input_buffer(proj, "x")

--- a/version/v8/scripts/collect_architecture_contracts_v8.py
+++ b/version/v8/scripts/collect_architecture_contracts_v8.py
@@ -32,6 +32,7 @@ PROMOTED_TEMPLATES = [
     "gemma4_vision",
     "glm4",
     "nemotron_h",
+    "kimi_vl",
     "llama",
 ]
 
@@ -74,6 +75,7 @@ MODEL_COVERAGE = [
     {"family": "gemma4", "template": "pass", "ir": "pass", "generated_c": "pass", "runtime": "partial", "model": "pass", "notes": "text coherent; vision bridge early"},
     {"family": "glm4", "template": "pass", "ir": "pass", "generated_c": "pass", "runtime": "partial", "model": "pass", "notes": "partial pairwise RoPE + GGUF smoke"},
     {"family": "nemotron-h", "template": "pass", "ir": "pass", "generated_c": "pass", "runtime": "partial", "model": "pass", "notes": "Mamba2 path equivalence monitored"},
+    {"family": "kimi-vl", "template": "pass", "ir": "partial", "generated_c": "partial", "runtime": "partial", "model": "partial", "notes": "MLA/MoE scalar contracts added; full template lowering/tokenizer/vision bridge in bring-up"},
     {"family": "llama/nanbeige", "template": "pass", "ir": "pass", "generated_c": "pass", "runtime": "partial", "model": "partial", "notes": "Nanbeige active bring-up lane"},
 ]
 

--- a/version/v8/scripts/inspect_model_contract_v8.py
+++ b/version/v8/scripts/inspect_model_contract_v8.py
@@ -18,7 +18,7 @@ from typing import Any
 
 
 SUPPORTED_DENSE_ARCHES = {"llama", "qwen2", "qwen3", "gemma3"}
-SUPPORTED_HYBRID_ARCHES = {"qwen35", "gemma4", "nemotron_h"}
+SUPPORTED_HYBRID_ARCHES = {"qwen35", "gemma4", "nemotron_h", "kimi_vl"}
 
 
 def _load_config(path: Path) -> dict[str, Any]:
@@ -42,6 +42,8 @@ def _infer_arch(config: dict[str, Any]) -> str:
         return "qwen35"
     if "nemotron_h" in model_type or "nemotronh" in architectures:
         return "nemotron_h"
+    if "kimi_vl" in model_type or "kimivl" in architectures or "kimi" in architectures:
+        return "kimi_vl"
     if "cohere" in model_type or "cohere" in architectures or "command" in model_type:
         return "cohere"
     if "gemma" in model_type and "4" in model_type:
@@ -98,6 +100,20 @@ def _gemma4_layers(config: dict[str, Any]) -> list[str]:
     return ["attention_or_sliding_attention"] * n
 
 
+def _kimi_vl_layers(config: dict[str, Any]) -> list[str]:
+    text = _text_config(config)
+    n = int(text.get("num_hidden_layers") or 0)
+    first_dense = int(text.get("first_k_dense_replace") or 0)
+    moe_freq = max(1, int(text.get("moe_layer_freq") or 1))
+    kinds: list[str] = []
+    for layer in range(n):
+        if layer < first_dense or (layer - first_dense) % moe_freq != 0:
+            kinds.append("mla_dense_mlp")
+        else:
+            kinds.append("mla_moe")
+    return kinds
+
+
 def _layer_kinds(arch: str, config: dict[str, Any]) -> list[str]:
     text = _text_config(config)
     if arch == "nemotron_h":
@@ -106,6 +122,8 @@ def _layer_kinds(arch: str, config: dict[str, Any]) -> list[str]:
         return _qwen35_layers(config)
     if arch == "gemma4":
         return _gemma4_layers(config)
+    if arch == "kimi_vl":
+        return _kimi_vl_layers(config)
     return _generic_dense_layers(config)
 
 
@@ -113,6 +131,13 @@ def _required_ops(arch: str, config: dict[str, Any], layer_kinds: list[str]) -> 
     ops = {"embedding", "rmsnorm", "matmul", "residual_add", "logits"}
     if any(kind in {"attention", "full_attention", "sliding_attention", "attention_or_sliding_attention"} for kind in layer_kinds):
         ops.update({"attention", "rope"})
+    if any(kind in {"mla_dense_mlp", "mla_moe"} for kind in layer_kinds):
+        ops.update({
+            "mla_attention",
+            "rope",
+            "kv_lora_decompress",
+            "partial_rope_concat",
+        })
     if any(kind == "deltanet" for kind in layer_kinds):
         ops.update({
             "recurrent_dt_gate",
@@ -137,6 +162,13 @@ def _required_ops(arch: str, config: dict[str, Any], layer_kinds: list[str]) -> 
             "moe_relu2_expert_mlp",
             "shared_expert_mlp",
         })
+    if any(kind == "mla_moe" for kind in layer_kinds):
+        ops.update({
+            "group_limited_topk_router",
+            "sigmoid_router_scores",
+            "moe_swiglu_expert_mlp",
+            "shared_swiglu_expert_mlp",
+        })
     act = str(_text_config(config).get("mlp_hidden_act") or _text_config(config).get("hidden_act") or "").lower()
     if act == "relu2":
         ops.add("relu2_mlp")
@@ -144,6 +176,8 @@ def _required_ops(arch: str, config: dict[str, Any], layer_kinds: list[str]) -> 
         ops.add("swiglu_or_geglu")
     if arch == "gemma4":
         ops.update({"gemma4_per_layer_embed", "gemma4_final_logit_softcap"})
+    if arch == "kimi_vl":
+        ops.update({"moonvit_encoder", "moonvit_projector", "media_placeholder_merge", "tiktoken_tokenizer"})
     return sorted(ops)
 
 
@@ -162,6 +196,13 @@ def _missing_ops(arch: str, required_ops: list[str]) -> list[str]:
             missing.append(op)
     if arch == "cohere":
         missing.append("cohere_tensor_name_mapping_audit")
+    if arch == "kimi_vl":
+        missing.extend([
+            "kimi_vl_safetensors_to_bump_mapping",
+            "mla_attention_contract",
+            "tiktoken_tokenizer_contract",
+            "moonvit_bridge_contract",
+        ])
     if arch not in SUPPORTED_DENSE_ARCHES | SUPPORTED_HYBRID_ARCHES:
         missing.append("v8_template_contract")
         missing.append("safetensors_to_bump_mapping")
@@ -210,6 +251,21 @@ def _notes(arch: str, config: dict[str, Any], layer_kinds: list[str], missing_op
     if arch == "cohere":
         notes.append("Cohere Command configs are gated in this environment; require config/weight access before mapping tensor names.")
         notes.append("Likely first target is dense decoder mapping/audit before any new math kernels.")
+    if arch == "kimi_vl":
+        notes.append("Kimi-VL text uses DeepSeek-V3-style MLA: q_proj plus compressed KV, kv_a_layernorm, kv_b_proj, qk_nope/qk_rope split, and RoPE only on the rope slice.")
+        notes.append(
+            f"MoE policy: first_k_dense_replace={text.get('first_k_dense_replace')} "
+            f"moe_layer_freq={text.get('moe_layer_freq')} routed_experts={text.get('n_routed_experts')} "
+            f"top_k={text.get('num_experts_per_tok')} shared_experts={text.get('n_shared_experts')} "
+            f"router={text.get('scoring_func')}/{text.get('topk_method')} scale={text.get('routed_scaling_factor')}."
+        )
+        notes.append("Existing group_limited_topk_router plus routed/shared SwiGLU expert kernels cover the scalar MoE math; scalar KV LoRA decompress and partial-RoPE concat helpers cover the first MLA sub-ops. Kimi still needs full MLA lowering, template wiring, tokenizer, and safetensors mapping.")
+        if isinstance(config.get("vision_config"), dict):
+            vision = config["vision_config"]
+            notes.append(
+                f"Vision path is MoonViT: layers={vision.get('num_hidden_layers')} hidden={vision.get('hidden_size')} "
+                f"patch={vision.get('patch_size')} merge={vision.get('merge_kernel_size')}; defer until text MLA+MoE parity is stamped."
+            )
     if not missing_ops:
         notes.append("Config-level contract has no known missing op, but weight-name audit and hidden parity are still required.")
     return notes

--- a/version/v8/templates/kimi_vl.json
+++ b/version/v8/templates/kimi_vl.json
@@ -1,0 +1,318 @@
+{
+  "version": 2,
+  "name": "kimi_vl",
+  "family": "kimi",
+  "flags": {
+    "use_qkv_bias": false,
+    "activation": "swiglu",
+    "rope": "partial_rope_concat",
+    "tokenizer": "tiktoken",
+    "prefill_policy": "batched",
+    "hybrid_block_pattern": "config.layer_kinds"
+  },
+  "contract": {
+    "tokenizer_contract": {
+      "tokenizer_type": "tiktoken",
+      "bos_policy": "model_defined",
+      "eos_policy": "model_defined",
+      "special_tokens": {
+        "source": "manifest_or_hf"
+      }
+    },
+    "chat_contract": {
+      "version": 1,
+      "name": "kimi_vl",
+      "raw_prompt_allowed": false,
+      "turn_prefix": "<|im_{role}|>",
+      "turn_suffix": "<|im_middle|>",
+      "assistant_generation_prefix": "<|im_assistant|>",
+      "role_labels": {
+        "system": "system",
+        "user": "user",
+        "assistant": "assistant"
+      },
+      "system_prompt_mode": "dedicated_turn",
+      "system_prompt_separator": "\n\n",
+      "default_system_prompt": "",
+      "inject_default_system_prompt": false,
+      "stop_text_markers": [
+        "<|im_user|>",
+        "<|im_system|>"
+      ],
+      "token_stop_markers": [
+        "<|im_user|>",
+        "<|im_system|>"
+      ],
+      "template_markers": [
+        "<|im_user|>",
+        "<|im_assistant|>",
+        "<|im_middle|>",
+        "<|media_start|>",
+        "<|media_content|>",
+        "<|media_pad|>",
+        "<|media_end|>"
+      ],
+      "min_response_tokens": 8
+    },
+    "attention_contract": {
+      "attn_variant": "mla",
+      "rope_layout": "partial_pairwise_concat",
+      "qk_norm": false,
+      "kv_layout": "compressed_kv_then_expanded_cache",
+      "layer_policy_config_key": "layer_kinds",
+      "kv_lora_rank_key": "kv_lora_rank",
+      "qk_nope_head_dim_key": "qk_nope_head_dim",
+      "qk_rope_head_dim_key": "qk_rope_head_dim",
+      "v_head_dim_key": "v_head_dim"
+    },
+    "block_contract": {
+      "norm_type": "rmsnorm",
+      "body_type": "mla_dense_mlp_or_moe",
+      "attention_formula": "q_proj + kv_a_proj_with_mqa -> kv_a_layernorm -> kv_b_proj split(k_nope,value); partial_rope(q_pe,k_pe); mla_attention -> o_proj",
+      "dense_mlp_formula": "gate_proj/up_proj -> silu_mul -> down_proj",
+      "moe_formula": "router(sigmoid) -> group_limited_topk -> routed_swiglu_experts + shared_swiglu_experts",
+      "qkv_bias": false
+    },
+    "vision_contract": {
+      "encoder": "moonvit",
+      "projector": "kimi_vl",
+      "placeholder_policy": "media_placeholder_merge"
+    },
+    "logits_contract": {
+      "final_norm": "rmsnorm",
+      "lm_head": "output_weight",
+      "logits_layout": "auto"
+    },
+    "quant_contract": {
+      "kernel_select": "weight_dtype_registry",
+      "activation_policy": "manifest_defined",
+      "per_tensor_mixed_quant": true
+    }
+  },
+  "kernels": {
+    "kv_lora_decompress": "deepseek_mla_kv_decompress_f32",
+    "partial_rope_concat": "deepseek_mla_partial_rope_concat_f32",
+    "router": "nemotron_group_limited_topk_router_f32",
+    "moe_swiglu_expert": "moe_swiglu_expert_forward_f32",
+    "moe_swiglu_shared": "moe_swiglu_shared_forward_f32"
+  },
+  "sequence": [
+    "decoder"
+  ],
+  "block_types": {
+    "decoder": {
+      "sequence": [
+        "header",
+        "body",
+        "footer"
+      ],
+      "header": [
+        "tiktoken_tokenizer",
+        "dense_embedding_lookup"
+      ],
+      "body": {
+        "type": "kimi_mla_moe",
+        "kind_config_key": "layer_kinds",
+        "ops_by_kind": {
+          "mla_dense_mlp": [
+            "residual_save",
+            "block_rmsnorm",
+            {
+              "op": "q_proj",
+              "graph_slots": {
+                "inputs": {
+                  "x": "layer_input"
+                }
+              }
+            },
+            {
+              "op": "kv_a_proj",
+              "graph_slots": {
+                "inputs": {
+                  "x": "layer_input"
+                }
+              }
+            },
+            {
+              "op": "kv_a_layernorm",
+              "graph_slots": {
+                "inputs": {
+                  "x": "compressed_kv"
+                }
+              }
+            },
+            {
+              "op": "kv_lora_decompress",
+              "graph_slots": {
+                "inputs": {
+                  "compressed_kv": "compressed_kv_normed",
+                  "kv_b": "layer_kv_b_proj"
+                }
+              }
+            },
+            {
+              "op": "partial_rope_concat",
+              "graph_slots": {
+                "inputs": {
+                  "q_nope": "q_nope",
+                  "q_pe": "q_pe",
+                  "k_nope": "k_nope",
+                  "k_pe": "k_pe"
+                }
+              }
+            },
+            {
+              "op": "mla_attention",
+              "graph_slots": {
+                "inputs": {
+                  "query": "mla_query",
+                  "key": "mla_key",
+                  "value": "mla_value"
+                }
+              }
+            },
+            {
+              "op": "out_proj",
+              "graph_slots": {
+                "inputs": {
+                  "x": "attn_scratch"
+                }
+              }
+            },
+            "residual_add",
+            "residual_save",
+            "block_rmsnorm",
+            {
+              "op": "mlp_gate_up",
+              "graph_slots": {
+                "inputs": {
+                  "x": "layer_input"
+                }
+              }
+            },
+            "silu_mul",
+            {
+              "op": "mlp_down",
+              "graph_slots": {
+                "inputs": {
+                  "x": "mlp_scratch"
+                }
+              }
+            },
+            "residual_add"
+          ],
+          "mla_moe": [
+            "residual_save",
+            "block_rmsnorm",
+            {
+              "op": "q_proj",
+              "graph_slots": {
+                "inputs": {
+                  "x": "layer_input"
+                }
+              }
+            },
+            {
+              "op": "kv_a_proj",
+              "graph_slots": {
+                "inputs": {
+                  "x": "layer_input"
+                }
+              }
+            },
+            {
+              "op": "kv_a_layernorm",
+              "graph_slots": {
+                "inputs": {
+                  "x": "compressed_kv"
+                }
+              }
+            },
+            {
+              "op": "kv_lora_decompress",
+              "graph_slots": {
+                "inputs": {
+                  "compressed_kv": "compressed_kv_normed",
+                  "kv_b": "layer_kv_b_proj"
+                }
+              }
+            },
+            {
+              "op": "partial_rope_concat",
+              "graph_slots": {
+                "inputs": {
+                  "q_nope": "q_nope",
+                  "q_pe": "q_pe",
+                  "k_nope": "k_nope",
+                  "k_pe": "k_pe"
+                }
+              }
+            },
+            {
+              "op": "mla_attention",
+              "graph_slots": {
+                "inputs": {
+                  "query": "mla_query",
+                  "key": "mla_key",
+                  "value": "mla_value"
+                }
+              }
+            },
+            {
+              "op": "out_proj",
+              "graph_slots": {
+                "inputs": {
+                  "x": "attn_scratch"
+                }
+              }
+            },
+            "residual_add",
+            "residual_save",
+            "block_rmsnorm",
+            {
+              "op": "moe_router",
+              "graph_slots": {
+                "inputs": {
+                  "x": "layer_input"
+                }
+              }
+            },
+            "group_limited_topk_router",
+            {
+              "op": "moe_swiglu_expert_mlp",
+              "graph_slots": {
+                "inputs": {
+                  "hidden": "layer_input",
+                  "indices": "router_indices",
+                  "routing_weights": "router_weights"
+                }
+              }
+            },
+            {
+              "op": "shared_swiglu_expert_mlp",
+              "graph_slots": {
+                "inputs": {
+                  "hidden": "layer_input",
+                  "routed": "moe_routed"
+                }
+              }
+            },
+            "residual_add"
+          ]
+        }
+      },
+      "footer": [
+        "final_rmsnorm",
+        "lm_head",
+        {
+          "op": "logits",
+          "graph_slots": {
+            "inputs": {
+              "x": "main_stream"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Kimi-VL v8 template and safetensors model-map contract
- add DeepSeek MLA reference kernels and kernel-map entries
- add MoE SwiGLU routed/shared expert forward/backward kernels and tests
- extend v8 template/model contract guardrails and regenerate the v8 kernel registry

## Validation
- .venv/bin/python -m py_compile touched v8 scripts/tests
- make build/libckernel_engine.so
- .venv/bin/python unittest/test_deepseek_reference_kernels.py
- .venv/bin/python unittest/test_moe_swiglu_expert.py
- .venv/bin/python -m unittest tests.test_v8_model_contract_inspector tests.test_v8_template_circuit_audit
- .venv/bin/python unittest/test_nemotron_router.py
- pre-commit hook: v7-regression-fast and v8-regression-fast passed
- pre-push hook: build, kernel parity, v8 E2E, v8 contracts, v7 training smoke, v7/v8 fast regression, and training-kernel parity passed