### PR TITLE
feat(v8/vision): render visualizer artifact contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3844,7 +3844,7 @@ report-md:
 .PHONY: v7-profile-training-spec19-qwen3-prepare v7-profile-training-spec19-qwen3-parity
 .PHONY: v7-profile-training-spec19-qwen3-perf v7-profile-training-spec19-qwen3-vtune v7-profile-training-spec19-qwen3-advisor
 .PHONY: v7-backprop-long-epoch v7-backprop-long-epoch-nightly
-.PHONY: visualizer visualizer-full v7-ir-visualizer-e2e v7-ir-visualizer-e2e-nightly
+.PHONY: visualizer visualizer-full v7-ir-visualizer-e2e v7-ir-visualizer-e2e-nightly v8-visualizer-vision-artifacts
 .PHONY: v7-visualizer-health v7-visualizer-generated-e2e
 .PHONY: v7-dataset-normalize v7-dataset-classify v7-dataset-embeddings v7-dataset-attention v7-dataset-viewer v7-dataset-all
 .PHONY: ck-cli-v7 ck-cli-v8 ck-bpe-train
@@ -5399,6 +5399,12 @@ v8-visualizer-generated-e2e:
 	@$(PYTHON) version/v8/scripts/test_visualizer_generated_e2e_v8.py \
 		$(if $(RUN),--run $(RUN),) \
 		--json-out $(V8_REPORT_DIR)/visualizer_generated_e2e_latest.json
+
+v8-visualizer-vision-artifacts:
+	@echo "Running v8 vision visualizer artifact harness..."
+	@mkdir -p $(V8_REPORT_DIR)
+	@$(PYTHON) version/v8/scripts/test_visualizer_vision_artifacts_v8.py \
+		--json-out $(V8_REPORT_DIR)/vision_visualizer_latest.json
 
 # ── Dataset Pipeline Targets ─────────────────────────────────────────────────
 # Usage: make v7-dataset-all RUN=~/.cache/ck-engine-v7/models/train/<run_name>

--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -376,6 +376,41 @@
     </div>
 
     <div class="regression-section">
+      <h2>Vision Visualizer Artifacts</h2>
+      <p class="regression-meta" id="vision-visualizer-meta">
+        `make v8-visualizer-vision-artifacts` status is not available in this report yet.
+      </p>
+
+      <div class="summary-cards" style="margin: 0 0 1rem 0;">
+        <div class="summary-card">
+          <div class="value" id="vision-visualizer-status">-</div>
+          <div class="label">Overall</div>
+        </div>
+        <div class="summary-card passed">
+          <div class="value" id="vision-visualizer-passed">0</div>
+          <div class="label">Checks Passed</div>
+        </div>
+        <div class="summary-card failed">
+          <div class="value" id="vision-visualizer-failed">0</div>
+          <div class="label">Checks Failed</div>
+        </div>
+        <div class="summary-card">
+          <div class="value" id="vision-visualizer-total">0</div>
+          <div class="label">Checks Total</div>
+        </div>
+      </div>
+
+      <table class="results-table">
+        <thead>
+          <tr><th>Status</th><th>Check</th><th>Detail</th></tr>
+        </thead>
+        <tbody id="vision-visualizer-tbody">
+          <tr><td colspan="3" class="updated-time">No vision visualizer artifact data published in this report.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="regression-section">
       <h2>v7 Kernel Map Contracts</h2>
       <p class="regression-meta" id="kernel-map-meta">
         `make v7-kernel-map-contracts` status is not available in this report yet.
@@ -909,6 +944,7 @@ function renderResults(data) {
   document.getElementById('sub-tests-failed').textContent = subFailed;
   renderRegressionFast(data.regression_fast || null);
   renderArchitectureContracts(data.architecture_contracts || null);
+  renderVisionVisualizer(data.vision_visualizer || null);
   renderKernelMapContracts(data.kernel_map_contracts || null);
   renderBackpropRegression(data.backprop_regression || null);
 
@@ -1052,6 +1088,53 @@ function contractBadge(status) {
   const cls = s === 'pass' ? 'pass' : s === 'fail' ? 'fail' : 'skip';
   const text = s === 'pass' ? 'PASS' : s === 'fail' ? 'FAIL' : s === 'warn' ? 'WARN' : s === 'partial' ? 'PARTIAL' : 'N/R';
   return `<span class="regression-badge ${cls}">${text}</span>`;
+}
+
+function renderVisionVisualizer(data) {
+  const metaEl = document.getElementById('vision-visualizer-meta');
+  const statusEl = document.getElementById('vision-visualizer-status');
+  const passedEl = document.getElementById('vision-visualizer-passed');
+  const failedEl = document.getElementById('vision-visualizer-failed');
+  const totalEl = document.getElementById('vision-visualizer-total');
+  const tbody = document.getElementById('vision-visualizer-tbody');
+  if (!metaEl || !statusEl || !passedEl || !failedEl || !totalEl || !tbody) return;
+
+  if (!data) {
+    metaEl.textContent = 'make v8-visualizer-vision-artifacts status is not available in this report yet.';
+    statusEl.textContent = '-';
+    passedEl.textContent = '0';
+    failedEl.textContent = '0';
+    totalEl.textContent = '0';
+    tbody.innerHTML = '<tr><td colspan="3" class="updated-time">No vision visualizer artifact data published in this report.</td></tr>';
+    return;
+  }
+
+  const summary = data.summary || {};
+  const status = String(data.status || 'unknown').toUpperCase();
+  metaEl.textContent = `${data.schema || 'ck.v8.vision_visualizer_harness'} · generated ${data.generated_at || 'unknown time'}`;
+  statusEl.textContent = status;
+  statusEl.className = status === 'PASS' ? 'value test-pass' : 'value test-fail';
+  passedEl.textContent = summary.passed || 0;
+  failedEl.textContent = summary.failed || 0;
+  totalEl.textContent = summary.total || 0;
+
+  const checks = Array.isArray(data.checks) ? data.checks : [];
+  if (checks.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="3" class="updated-time">No vision visualizer checks were published.</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = checks.map(row => {
+    const rowStatus = String(row.status || '').toUpperCase();
+    const badgeClass = rowStatus === 'PASS' ? 'pass' : (rowStatus === 'SKIP' ? 'skip' : 'fail');
+    return `
+      <tr>
+        <td><span class="regression-badge ${badgeClass}">${escapeHtml(rowStatus)}</span></td>
+        <td>${escapeHtml(row.name || '-')}</td>
+        <td class="regression-family-note">${escapeHtml(row.detail || '')}</td>
+      </tr>
+    `;
+  }).join('');
 }
 
 function renderArchitectureContracts(data) {

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1316,6 +1316,41 @@
     </div>
 
     <div class="regression-section">
+      <h2>Vision Visualizer Artifacts</h2>
+      <p class="regression-meta" id="vision-visualizer-meta">
+        `make v8-visualizer-vision-artifacts` status is not available in this report yet.
+      </p>
+
+      <div class="summary-cards" style="margin: 0 0 1rem 0;">
+        <div class="summary-card">
+          <div class="value" id="vision-visualizer-status">-</div>
+          <div class="label">Overall</div>
+        </div>
+        <div class="summary-card passed">
+          <div class="value" id="vision-visualizer-passed">0</div>
+          <div class="label">Checks Passed</div>
+        </div>
+        <div class="summary-card failed">
+          <div class="value" id="vision-visualizer-failed">0</div>
+          <div class="label">Checks Failed</div>
+        </div>
+        <div class="summary-card">
+          <div class="value" id="vision-visualizer-total">0</div>
+          <div class="label">Checks Total</div>
+        </div>
+      </div>
+
+      <table class="results-table">
+        <thead>
+          <tr><th>Status</th><th>Check</th><th>Detail</th></tr>
+        </thead>
+        <tbody id="vision-visualizer-tbody">
+          <tr><td colspan="3" class="updated-time">No vision visualizer artifact data published in this report.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="regression-section">
       <h2>v7 Kernel Map Contracts</h2>
       <p class="regression-meta" id="kernel-map-meta">
         `make v7-kernel-map-contracts` status is not available in this report yet.
@@ -1849,6 +1884,7 @@ function renderResults(data) {
   document.getElementById('sub-tests-failed').textContent = subFailed;
   renderRegressionFast(data.regression_fast || null);
   renderArchitectureContracts(data.architecture_contracts || null);
+  renderVisionVisualizer(data.vision_visualizer || null);
   renderKernelMapContracts(data.kernel_map_contracts || null);
   renderBackpropRegression(data.backprop_regression || null);
 
@@ -1992,6 +2028,53 @@ function contractBadge(status) {
   const cls = s === 'pass' ? 'pass' : s === 'fail' ? 'fail' : 'skip';
   const text = s === 'pass' ? 'PASS' : s === 'fail' ? 'FAIL' : s === 'warn' ? 'WARN' : s === 'partial' ? 'PARTIAL' : 'N/R';
   return `<span class="regression-badge ${cls}">${text}</span>`;
+}
+
+function renderVisionVisualizer(data) {
+  const metaEl = document.getElementById('vision-visualizer-meta');
+  const statusEl = document.getElementById('vision-visualizer-status');
+  const passedEl = document.getElementById('vision-visualizer-passed');
+  const failedEl = document.getElementById('vision-visualizer-failed');
+  const totalEl = document.getElementById('vision-visualizer-total');
+  const tbody = document.getElementById('vision-visualizer-tbody');
+  if (!metaEl || !statusEl || !passedEl || !failedEl || !totalEl || !tbody) return;
+
+  if (!data) {
+    metaEl.textContent = 'make v8-visualizer-vision-artifacts status is not available in this report yet.';
+    statusEl.textContent = '-';
+    passedEl.textContent = '0';
+    failedEl.textContent = '0';
+    totalEl.textContent = '0';
+    tbody.innerHTML = '<tr><td colspan="3" class="updated-time">No vision visualizer artifact data published in this report.</td></tr>';
+    return;
+  }
+
+  const summary = data.summary || {};
+  const status = String(data.status || 'unknown').toUpperCase();
+  metaEl.textContent = `${data.schema || 'ck.v8.vision_visualizer_harness'} · generated ${data.generated_at || 'unknown time'}`;
+  statusEl.textContent = status;
+  statusEl.className = status === 'PASS' ? 'value test-pass' : 'value test-fail';
+  passedEl.textContent = summary.passed || 0;
+  failedEl.textContent = summary.failed || 0;
+  totalEl.textContent = summary.total || 0;
+
+  const checks = Array.isArray(data.checks) ? data.checks : [];
+  if (checks.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="3" class="updated-time">No vision visualizer checks were published.</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = checks.map(row => {
+    const rowStatus = String(row.status || '').toUpperCase();
+    const badgeClass = rowStatus === 'PASS' ? 'pass' : (rowStatus === 'SKIP' ? 'skip' : 'fail');
+    return `
+      <tr>
+        <td><span class="regression-badge ${badgeClass}">${escapeHtml(rowStatus)}</span></td>
+        <td>${escapeHtml(row.name || '-')}</td>
+        <td class="regression-family-note">${escapeHtml(row.detail || '')}</td>
+      </tr>
+    `;
+  }).join('');
 }
 
 function renderArchitectureContracts(data) {

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -440,6 +440,12 @@ MAKE_TARGETS = {
         "target": "v8-regression-fast",
         "timeout_sec": 5400,
     },
+    "v8_vision_visualizer_artifacts": {
+        "name": "v8 Vision Visualizer Artifacts",
+        "category": "inference",
+        "target": "v8-visualizer-vision-artifacts",
+        "timeout_sec": 120,
+    },
     "v8_qwen3vl_vision_smoke": {
         "name": "v8 Qwen3-VL Vision Smoke",
         "category": "inference",
@@ -515,6 +521,7 @@ MAKE_TARGET_FAILURE_ARTIFACTS = {
     "v7-visualizer-generated-e2e": ROOT / "version" / "v7" / ".cache" / "reports" / "visualizer_generated_e2e_latest.json",
     "v7-stabilization-nightly": ROOT / "version" / "v7" / ".cache" / "reports" / "training_stabilization_scorecard_latest.json",
     "test-architecture-contracts": ROOT / "version" / "v8" / ".cache" / "reports" / "architecture_contracts_latest.json",
+    "v8-visualizer-vision-artifacts": ROOT / "version" / "v8" / ".cache" / "reports" / "vision_visualizer_latest.json",
 }
 
 
@@ -979,6 +986,12 @@ def save_json_report(results: list[TestResult], filepath: Path, start_time: date
     )
     if architecture_contracts is not None:
         report["architecture_contracts"] = architecture_contracts
+    vision_visualizer = _load_json_if_fresh(
+        ROOT / "version" / "v8" / ".cache" / "reports" / "vision_visualizer_latest.json",
+        start_ts=start_time.timestamp(),
+    )
+    if vision_visualizer is not None:
+        report["vision_visualizer"] = vision_visualizer
     filepath.write_text(json.dumps(report, indent=2))
     print(f"\nJSON report saved to: {filepath}")
 

--- a/version/v8/scripts/test_visualizer_vision_artifacts_v8.py
+++ b/version/v8/scripts/test_visualizer_vision_artifacts_v8.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from version.v8.tools.open_ir_visualizer_v8 import generate_html_report, load_model_data  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _op(op_id: int, op: str, *, layer: int = -1, section: str = "body", from_op: int | None = None) -> dict:
+    inputs = {}
+    if from_op is not None:
+        inputs["input"] = {
+            "from_op": from_op,
+            "from_output": "out",
+            "tensor": f"tensor.{from_op}.out",
+            "dtype": "fp32",
+            "slot": "main_stream",
+        }
+    else:
+        inputs["input"] = {"from": "external:input", "dtype": "fp32", "slot": "external"}
+    return {
+        "op_id": op_id,
+        "op": op,
+        "kernel": f"{op}_kernel",
+        "section": section,
+        "layer": layer,
+        "dataflow": {
+            "inputs": inputs,
+            "outputs": {
+                "out": {
+                    "tensor": f"tensor.{op_id}.out",
+                    "dtype": "fp32",
+                    "slot": "main_stream",
+                }
+            },
+        },
+        "weights": {},
+    }
+
+
+def _make_fixture_run(root: Path) -> tuple[int, int, int]:
+    bridge = root / "multimodal_bridge"
+    encoder = bridge / "encoder"
+    decoder = bridge / "decoder"
+    encoder.mkdir(parents=True)
+    decoder.mkdir(parents=True)
+
+    encoder_ops = [
+        _op(0, "patchify", section="header"),
+        _op(1, "patch_proj", layer=0, from_op=0),
+        _op(2, "vision_attn", layer=0, from_op=1),
+        _op(3, "projector_fc2", section="footer", from_op=2),
+    ]
+    decoder_ops = [
+        _op(0, "dense_embedding_lookup", section="header"),
+        _op(1, "rmsnorm", layer=0, from_op=0),
+        _op(2, "attn", layer=0, from_op=1),
+        _op(3, "logits", section="footer", from_op=2),
+    ]
+    bridge_ops = 1
+
+    _write_json(encoder / "ir1.json", {"format": "ir1-dataflow", "version": 3, "mode": "encoder", "ops": encoder_ops})
+    _write_json(encoder / "call.json", {"operations": encoder_ops})
+    _write_json(encoder / "lowered.json", {"operations": encoder_ops})
+    _write_json(encoder / "layout.json", {"memory": {"arena": {"total_size": 4096}}})
+    _write_json(decoder / "ir1_prefill.json", {"format": "ir1-dataflow", "version": 3, "mode": "prefill", "ops": decoder_ops})
+    _write_json(decoder / "ir1_decode.json", {"format": "ir1-dataflow", "version": 3, "mode": "decode", "ops": decoder_ops[:2]})
+    _write_json(decoder / "lowered_prefill.json", {"operations": decoder_ops})
+    _write_json(decoder / "lowered_decode.json", {"operations": decoder_ops[:2]})
+    _write_json(decoder / "layout_prefill.json", {"memory": {"arena": {"total_size": 8192}}})
+    _write_json(decoder / "layout_decode.json", {"memory": {"arena": {"total_size": 2048}}})
+    _write_json(decoder / "config.json", {"model": "synthetic_qwen3vl_visualizer", "mode": "prefill"})
+    _write_json(decoder / "weights_manifest.json", {"weights": []})
+    _write_json(
+        bridge / "bridge_report.json",
+        {
+            "bridge_mode": "encoder_decoder",
+            "prefix_source": "encoder",
+            "prefix_tokens": 4,
+            "prefix_grid_x": 2,
+            "prefix_grid_y": 2,
+            "prefix_text_pos": 3,
+            "decoder_input_embed_dim": 16,
+            "total_prefill_tokens": 11,
+            "generated_token_count": 2,
+            "generation_stop_reason": "unit_test",
+            "prompt_tokens_before_image": [1, 2],
+            "prompt_tokens_after_image": [3],
+            "encoder_report": {
+                "image_source": "synthetic",
+                "source_image_size": [8, 8],
+                "image_width": 8,
+                "image_height": 8,
+                "patch_size": 4,
+                "embed_dim": 16,
+                "preprocess": "synthetic_rgb",
+            },
+        },
+    )
+    return len(encoder_ops), bridge_ops, len(decoder_ops)
+
+
+def _extract_embedded_json(html: str) -> dict:
+    match = re.search(
+        r"<script>window\.EMBEDDED_IR_DATA\s*=\s*(\{.*?\});window\.dispatchEvent",
+        html,
+        flags=re.DOTALL,
+    )
+    if not match:
+        raise AssertionError("EMBEDDED_IR_DATA script was not found")
+    return json.loads(match.group(1))
+
+
+def run(json_out: Path) -> int:
+    checks: list[dict] = []
+    status = "pass"
+    with tempfile.TemporaryDirectory(prefix="ck-v8-vision-viz-") as tmp:
+        run_dir = Path(tmp)
+        expected_encoder, expected_bridge, expected_decoder = _make_fixture_run(run_dir)
+        expected_total = expected_encoder + expected_bridge + expected_decoder
+
+        data = load_model_data(run_dir, run_dir=run_dir, strict_run_artifacts=True)
+        files = data.get("files", {})
+        graph = files.get("multimodal_dataflow_graph")
+        vision = files.get("vision_artifacts")
+        try:
+            assert isinstance(graph, dict), "missing derived multimodal_dataflow_graph"
+            stats = graph.get("stats") or {}
+            assert stats.get("encoder_ops") == expected_encoder, stats
+            assert stats.get("bridge_ops") == expected_bridge, stats
+            assert stats.get("decoder_prefill_ops") == expected_decoder, stats
+            assert stats.get("total_ops") == expected_total, stats
+            assert isinstance(vision, dict), "missing derived vision_artifacts"
+            assert (vision.get("ops") or {}).get("full_network") == expected_total, vision.get("ops")
+            checks.append({"name": "derived_payload", "status": "pass", "detail": f"{expected_total} multimodal ops"})
+        except AssertionError as exc:
+            checks.append({"name": "derived_payload", "status": "fail", "detail": str(exc)})
+            status = "fail"
+
+        html_path = run_dir / "ir_report.html"
+        generate_html_report(run_dir, html_path, run_dir=run_dir, strict_run_artifacts=True)
+        html = html_path.read_text(encoding="utf-8")
+        try:
+            embedded = _extract_embedded_json(html)
+            embedded_graph = embedded.get("files", {}).get("multimodal_dataflow_graph")
+            embedded_vision = embedded.get("files", {}).get("vision_artifacts")
+            assert isinstance(embedded_graph, dict), "HTML missing multimodal_dataflow_graph"
+            assert embedded_graph.get("stats", {}).get("total_ops") == expected_total, embedded_graph.get("stats")
+            assert isinstance(embedded_vision, dict), "HTML missing vision_artifacts"
+            assert embedded_vision.get("patch_grid", {}).get("expected_prefix_tokens") == 4, embedded_vision.get("patch_grid")
+            assert "files.full_network_graph || files.multimodal_dataflow_graph" in html, "visualizer fallback not present"
+            checks.append({"name": "html_embedding", "status": "pass", "detail": str(html_path)})
+        except AssertionError as exc:
+            checks.append({"name": "html_embedding", "status": "fail", "detail": str(exc)})
+            status = "fail"
+
+    summary = {
+        "schema": "ck.v8.vision_visualizer_harness.v1",
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "status": status,
+        "summary": {
+            "passed": sum(1 for row in checks if row["status"] == "pass"),
+            "failed": sum(1 for row in checks if row["status"] != "pass"),
+            "total": len(checks),
+        },
+        "checks": checks,
+    }
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    for row in checks:
+        marker = "PASS" if row["status"] == "pass" else "FAIL"
+        print(f"{row['name']}  max_diff=0.00e+00  tol=1e+00  [{marker}]")
+        print(f"  {row['detail']}")
+    print(f"vision_visualizer_harness status={status} json={json_out}")
+    return 0 if status == "pass" else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate v8 vision artifacts in the IR visualizer.")
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=ROOT / "version" / "v8" / ".cache" / "reports" / "vision_visualizer_latest.json",
+    )
+    args = parser.parse_args()
+    return run(args.json_out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/test_visualizer_vision_artifacts_v8.py
+++ b/version/v8/scripts/test_visualizer_vision_artifacts_v8.py
@@ -163,6 +163,11 @@ def run(json_out: Path) -> int:
             assert isinstance(embedded_vision, dict), "HTML missing vision_artifacts"
             assert embedded_vision.get("patch_grid", {}).get("expected_prefix_tokens") == 4, embedded_vision.get("patch_grid")
             assert "files.full_network_graph || files.multimodal_dataflow_graph" in html, "visualizer fallback not present"
+            helper_pos = html.find("function getEmbeddedFiles()")
+            multimodal_pos = html.find("function renderMultimodal()")
+            assert helper_pos >= 0, "main visualizer getEmbeddedFiles helper not present"
+            assert multimodal_pos >= 0, "multimodal renderer not present"
+            assert helper_pos < multimodal_pos, "getEmbeddedFiles must be defined before renderMultimodal"
             checks.append({"name": "html_embedding", "status": "pass", "detail": str(html_path)})
         except AssertionError as exc:
             checks.append({"name": "html_embedding", "status": "fail", "detail": str(exc)})

--- a/version/v8/scripts/test_visualizer_vision_artifacts_v8.py
+++ b/version/v8/scripts/test_visualizer_vision_artifacts_v8.py
@@ -52,6 +52,38 @@ def _op(op_id: int, op: str, *, layer: int = -1, section: str = "body", from_op:
     }
 
 
+def _layout(total_size: int, *, prefix: str) -> dict:
+    return {
+        "memory": {
+            "weights": {
+                "size": 256,
+                "entries": [
+                    {
+                        "name": f"{prefix}.weight",
+                        "dtype": "fp32",
+                        "size": 128,
+                        "offset": 0,
+                        "abs_offset": 0,
+                    }
+                ],
+            },
+            "activations": {
+                "size": 512,
+                "buffers": [
+                    {
+                        "name": f"{prefix}.activation",
+                        "dtype": "fp32",
+                        "size": 256,
+                        "offset": 0,
+                        "abs_offset": 256,
+                    }
+                ],
+            },
+            "arena": {"total_size": total_size},
+        }
+    }
+
+
 def _make_fixture_run(root: Path) -> tuple[int, int, int]:
     bridge = root / "multimodal_bridge"
     encoder = bridge / "encoder"
@@ -76,13 +108,13 @@ def _make_fixture_run(root: Path) -> tuple[int, int, int]:
     _write_json(encoder / "ir1.json", {"format": "ir1-dataflow", "version": 3, "mode": "encoder", "ops": encoder_ops})
     _write_json(encoder / "call.json", {"operations": encoder_ops})
     _write_json(encoder / "lowered.json", {"operations": encoder_ops})
-    _write_json(encoder / "layout.json", {"memory": {"arena": {"total_size": 4096}}})
+    _write_json(encoder / "layout.json", _layout(4096, prefix="encoder"))
     _write_json(decoder / "ir1_prefill.json", {"format": "ir1-dataflow", "version": 3, "mode": "prefill", "ops": decoder_ops})
     _write_json(decoder / "ir1_decode.json", {"format": "ir1-dataflow", "version": 3, "mode": "decode", "ops": decoder_ops[:2]})
     _write_json(decoder / "lowered_prefill.json", {"operations": decoder_ops})
     _write_json(decoder / "lowered_decode.json", {"operations": decoder_ops[:2]})
-    _write_json(decoder / "layout_prefill.json", {"memory": {"arena": {"total_size": 8192}}})
-    _write_json(decoder / "layout_decode.json", {"memory": {"arena": {"total_size": 2048}}})
+    _write_json(decoder / "layout_prefill.json", _layout(8192, prefix="decoder_prefill"))
+    _write_json(decoder / "layout_decode.json", _layout(2048, prefix="decoder_decode"))
     _write_json(decoder / "config.json", {"model": "synthetic_qwen3vl_visualizer", "mode": "prefill"})
     _write_json(decoder / "weights_manifest.json", {"weights": []})
     _write_json(
@@ -144,6 +176,17 @@ def run(json_out: Path) -> int:
             assert stats.get("bridge_ops") == expected_bridge, stats
             assert stats.get("decoder_prefill_ops") == expected_decoder, stats
             assert stats.get("total_ops") == expected_total, stats
+            call_ops = ((graph.get("call") or {}).get("operations") or [])
+            assert len(call_ops) == expected_total, f"unified call ops missing: {len(call_ops)} != {expected_total}"
+            call_stages = {row.get("network_stage") for row in call_ops if isinstance(row, dict)}
+            assert {"vision_encoder", "bridge", "decoder_prefill"}.issubset(call_stages), call_stages
+            layout_memory = ((graph.get("layout") or {}).get("memory") or {})
+            weight_entries = ((layout_memory.get("weights") or {}).get("entries") or [])
+            activation_buffers = ((layout_memory.get("activations") or {}).get("buffers") or [])
+            weight_stages = {row.get("network_stage") for row in weight_entries if isinstance(row, dict)}
+            activation_stages = {row.get("network_stage") for row in activation_buffers if isinstance(row, dict)}
+            assert {"vision_encoder", "decoder_prefill"}.issubset(weight_stages), weight_stages
+            assert {"vision_encoder", "decoder_prefill"}.issubset(activation_stages), activation_stages
             assert isinstance(vision, dict), "missing derived vision_artifacts"
             assert (vision.get("ops") or {}).get("full_network") == expected_total, vision.get("ops")
             checks.append({"name": "derived_payload", "status": "pass", "detail": f"{expected_total} multimodal ops"})

--- a/version/v8/tests/contracts/ir_visualizer_contract.json
+++ b/version/v8/tests/contracts/ir_visualizer_contract.json
@@ -112,6 +112,9 @@
       "renderDataflow",
       "renderOperatorMathIntuition",
       "renderMultimodal",
+      "getVisionArtifactsPayload",
+      "renderVisionPatchGridSvg",
+      "renderVisionArtifactsPanel",
       "renderProfile",
       "renderDataPipeline",
       "renderParityCockpit"

--- a/version/v8/tools/ir_visualizer.html
+++ b/version/v8/tools/ir_visualizer.html
@@ -3816,7 +3816,7 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
 
         function getFullNetworkGraph() {
             const files = getEmbeddedFiles();
-            const payload = files && files.full_network_graph;
+            const payload = files && (files.full_network_graph || files.multimodal_dataflow_graph);
             return (payload && typeof payload === 'object') ? payload : null;
         }
 
@@ -5356,7 +5356,9 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
             const files = embedded.files;
             const fullNetworkGraph = (files.full_network_graph && typeof files.full_network_graph === 'object')
                 ? files.full_network_graph
-                : null;
+                : ((files.multimodal_dataflow_graph && typeof files.multimodal_dataflow_graph === 'object')
+                    ? files.multimodal_dataflow_graph
+                    : null);
             const fullNetworkLayout = (fullNetworkGraph && typeof fullNetworkGraph.layout === 'object')
                 ? fullNetworkGraph.layout
                 : null;
@@ -5474,7 +5476,10 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
             updateFileList();
             renderTensorList();
 
-            currentMode = modeHasAnyData('decode') ? 'decode' : (modeHasAnyData('prefill') ? 'prefill' : currentMode);
+            const preferMultimodalPrefill = Boolean(fullNetworkGraph || files.multimodal_bridge_report);
+            currentMode = (preferMultimodalPrefill && modeHasAnyData('prefill'))
+                ? 'prefill'
+                : (modeHasAnyData('decode') ? 'decode' : (modeHasAnyData('prefill') ? 'prefill' : currentMode));
             const select = document.getElementById('modeSelect');
             if (select) select.value = currentMode;
 

--- a/version/v8/tools/ir_visualizer.html
+++ b/version/v8/tools/ir_visualizer.html
@@ -7247,6 +7247,123 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
             return (payload && typeof payload === 'object') ? payload : null;
         }
 
+        function getVisionArtifactsPayload() {
+            const files = getEmbeddedFiles();
+            const payload = files && files.vision_artifacts;
+            return (payload && typeof payload === 'object') ? payload : null;
+        }
+
+        function renderVisionPatchGridSvg(vision) {
+            const grid = (vision && vision.patch_grid && typeof vision.patch_grid === 'object') ? vision.patch_grid : {};
+            const gx = Math.max(0, Number(grid.grid_x || 0));
+            const gy = Math.max(0, Number(grid.grid_y || 0));
+            if (!Number.isFinite(gx) || !Number.isFinite(gy) || gx <= 0 || gy <= 0) {
+                return '<div style="color:var(--text-muted);">No patch grid coordinates recorded.</div>';
+            }
+            const cols = Math.min(16, gx);
+            const rows = Math.min(16, gy);
+            const cell = 14;
+            const gap = 2;
+            const width = cols * cell + Math.max(0, cols - 1) * gap;
+            const height = rows * cell + Math.max(0, rows - 1) * gap;
+            const cells = [];
+            for (let y = 0; y < rows; y++) {
+                for (let x = 0; x < cols; x++) {
+                    const alpha = 0.24 + 0.46 * ((x + y) / Math.max(1, cols + rows - 2));
+                    cells.push(`<rect x="${x * (cell + gap)}" y="${y * (cell + gap)}" width="${cell}" height="${cell}" rx="3" fill="rgba(7,173,248,${alpha.toFixed(3)})" stroke="rgba(86,199,245,0.48)"/>`);
+                }
+            }
+            const truncated = gx > cols || gy > rows
+                ? `<div style="margin-top:0.35rem;color:var(--text-muted);font-size:0.76rem;">Preview shows ${cols}×${rows} of ${gx}×${gy} grid.</div>`
+                : '';
+            return `
+                <svg viewBox="0 0 ${width} ${height}" width="100%" style="max-width:${Math.max(width, 180)}px;background:rgba(7,173,248,0.05);border:1px solid var(--grey);border-radius:8px;padding:0.55rem;box-sizing:border-box;">
+                    ${cells.join('')}
+                </svg>
+                ${truncated}
+            `;
+        }
+
+        function renderVisionArtifactsPanel(vision) {
+            if (!vision || typeof vision !== 'object') return '';
+            const image = (vision.image && typeof vision.image === 'object') ? vision.image : {};
+            const grid = (vision.patch_grid && typeof vision.patch_grid === 'object') ? vision.patch_grid : {};
+            const bridge = (vision.bridge && typeof vision.bridge === 'object') ? vision.bridge : {};
+            const ops = (vision.ops && typeof vision.ops === 'object') ? vision.ops : {};
+            const stages = Array.isArray(vision.stages) ? vision.stages : [];
+            const checks = Array.isArray(vision.checks) ? vision.checks : [];
+            const dataUri = String(image.data_uri || '');
+            const sourceSize = Array.isArray(image.source_size) && image.source_size.length === 2
+                ? `${image.source_size[0]} × ${image.source_size[1]}`
+                : '-';
+            const processedSize = image.image_width || image.image_height
+                ? `${image.image_width || '-'} × ${image.image_height || '-'}`
+                : '-';
+            const stageRows = stages.map((stage) => `
+                <tr>
+                    <td>${stage.ready ? '<span class="badge badge-green">ready</span>' : '<span class="badge badge-orange">missing</span>'}</td>
+                    <td>${escapeHtml(String(stage.label || stage.key || '-'))}</td>
+                    <td>${escapeHtml(String(stage.ops ?? stage.tokens ?? (stage.bytes ? formatBytes(Number(stage.bytes)) : stage.detail || '-')))}</td>
+                </tr>
+            `).join('');
+            const checkRows = checks.map((check) => `
+                <tr>
+                    <td>${String(check.status || '').toLowerCase() === 'pass' ? '<span class="badge badge-green">pass</span>' : '<span class="badge badge-orange">warn</span>'}</td>
+                    <td>${escapeHtml(String(check.name || '-'))}</td>
+                    <td>${escapeHtml(String(check.detail || '-'))}</td>
+                </tr>
+            `).join('');
+            const encoderKinds = ops.encoder_by_kind && typeof ops.encoder_by_kind === 'object'
+                ? Object.entries(ops.encoder_by_kind).slice(0, 8).map(([name, count]) => `<span class="flow-item flow-weight">${escapeHtml(name)}: ${escapeHtml(String(count))}</span>`).join('')
+                : '';
+            return `
+                <div class="parity-section">
+                    <h3><span class="badge badge-green">Vision Artifacts</span> Patch Grid, Bridge Rows, and Contract Health</h3>
+                    <div class="subnote" style="margin-bottom:0.8rem;">
+                        Normalized artifact: <code>vision_artifacts</code> (${escapeHtml(String(vision.schema || 'unknown'))}). This is derived from the bridge report plus encoder IR/layout/call files so the viewer can render vision without knowing model-family quirks.
+                    </div>
+                    <div style="display:grid;grid-template-columns:minmax(220px,0.75fr) minmax(320px,1.25fr);gap:0.9rem;align-items:start;">
+                        <div>
+                            ${dataUri ? `<img src="${dataUri}" alt="Vision input" style="width:100%;max-width:300px;border-radius:8px;border:1px solid var(--grey);margin-bottom:0.7rem;display:block;">` : renderVisionPatchGridSvg(vision)}
+                            ${dataUri ? `<div style="margin-top:0.55rem;">${renderVisionPatchGridSvg(vision)}</div>` : ''}
+                        </div>
+                        <div>
+                            <div class="stats-grid" style="grid-template-columns:repeat(auto-fit,minmax(130px,1fr));margin-bottom:0.75rem;">
+                                <div class="stat-card"><div class="stat-value">${escapeHtml(String(grid.grid_x ?? '-'))}×${escapeHtml(String(grid.grid_y ?? '-'))}</div><div class="stat-label">Patch / Prefix Grid</div></div>
+                                <div class="stat-card"><div class="stat-value">${escapeHtml(String(grid.prefix_tokens ?? '-'))}</div><div class="stat-label">Prefix Rows</div></div>
+                                <div class="stat-card"><div class="stat-value">${escapeHtml(String(grid.expected_prefix_tokens ?? '-'))}</div><div class="stat-label">Grid Product</div></div>
+                                <div class="stat-card"><div class="stat-value">${escapeHtml(String(grid.text_position ?? '-'))}</div><div class="stat-label">Text Position</div></div>
+                                <div class="stat-card"><div class="stat-value">${escapeHtml(String(ops.encoder ?? '-'))}</div><div class="stat-label">Encoder Ops</div></div>
+                                <div class="stat-card"><div class="stat-value">${escapeHtml(String(ops.full_network ?? '-'))}</div><div class="stat-label">Unified Ops</div></div>
+                            </div>
+                            <table>
+                                <tbody>
+                                    <tr><th>Image Source</th><td>${escapeHtml(String(image.source || '-'))}</td></tr>
+                                    <tr><th>Source Size</th><td>${escapeHtml(sourceSize)}</td></tr>
+                                    <tr><th>Processed Size</th><td>${escapeHtml(processedSize)}</td></tr>
+                                    <tr><th>Patch Size</th><td>${escapeHtml(String(image.patch_size || '-'))}</td></tr>
+                                    <tr><th>Preprocess</th><td>${escapeHtml(String(image.preprocess || '-'))}</td></tr>
+                                    <tr><th>Position Policy</th><td>${escapeHtml(String(grid.position_policy || '-'))}</td></tr>
+                                    <tr><th>Prefix Source</th><td>${escapeHtml(String(bridge.prefix_source || '-'))}</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    ${encoderKinds ? `<div class="data-flow" style="margin-top:0.8rem;">${encoderKinds}</div>` : ''}
+                    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:0.9rem;margin-top:0.9rem;">
+                        <div>
+                            <h4 style="margin:0 0 0.45rem;color:var(--text-secondary);">Stage Coverage</h4>
+                            <table><thead><tr><th>Status</th><th>Stage</th><th>Detail</th></tr></thead><tbody>${stageRows || '<tr><td colspan="3">No stages</td></tr>'}</tbody></table>
+                        </div>
+                        <div>
+                            <h4 style="margin:0 0 0.45rem;color:var(--text-secondary);">Contract Checks</h4>
+                            <table><thead><tr><th>Status</th><th>Check</th><th>Detail</th></tr></thead><tbody>${checkRows || '<tr><td colspan="3">No checks</td></tr>'}</tbody></table>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }
+
         function multimodalOpCount(payload) {
             if (!payload || typeof payload !== 'object') return null;
             const ops = Array.isArray(payload.operations)
@@ -7289,6 +7406,7 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
                 `;
                 return;
             }
+            const visionArtifacts = getVisionArtifactsPayload();
 
             const encoderReport = (bridge.encoder_report && typeof bridge.encoder_report === 'object') ? bridge.encoder_report : {};
             const fullNetworkGraph = (files.full_network_graph && typeof files.full_network_graph === 'object') ? files.full_network_graph : {};
@@ -7372,6 +7490,8 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
                         <div class="stat-card"><div class="stat-value">${escapeHtml(String(bridge.multimodal_prompt_segmented ? 'segmented' : 'flat'))}</div><div class="stat-label">Prompt Segmentation</div></div>
                     </div>
                 </div>
+
+                ${renderVisionArtifactsPanel(visionArtifacts)}
 
                 <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:0.9rem;">
                     <div class="parity-section">

--- a/version/v8/tools/ir_visualizer.html
+++ b/version/v8/tools/ir_visualizer.html
@@ -3814,6 +3814,12 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
             return n.includes('prefill') ? 'prefill' : 'decode';
         }
 
+        function getEmbeddedFiles() {
+            const embedded = window.EMBEDDED_IR_DATA;
+            if (!embedded || typeof embedded !== 'object') return {};
+            return embedded.files && typeof embedded.files === 'object' ? embedded.files : {};
+        }
+
         function getFullNetworkGraph() {
             const files = getEmbeddedFiles();
             const payload = files && (files.full_network_graph || files.multimodal_dataflow_graph);

--- a/version/v8/tools/open_ir_visualizer_v8.py
+++ b/version/v8/tools/open_ir_visualizer_v8.py
@@ -859,44 +859,14 @@ def _clone_multimodal_op(
     return out
 
 
-def _build_multimodal_dataflow_graph(files: dict[str, Any]) -> dict[str, Any] | None:
-    bridge = files.get("multimodal_bridge_report")
-    if not isinstance(bridge, dict):
-        return None
-    full_graph = files.get("full_network_graph")
-    if isinstance(full_graph, dict):
-        return full_graph
-
-    encoder_ir1 = files.get("bridge_encoder_ir1") if isinstance(files.get("bridge_encoder_ir1"), dict) else {}
-    encoder_layout = files.get("bridge_encoder_layout") if isinstance(files.get("bridge_encoder_layout"), dict) else {}
-    encoder_call = files.get("bridge_encoder_call") if isinstance(files.get("bridge_encoder_call"), dict) else {}
-    decoder_ir1 = files.get("ir1_prefill") if isinstance(files.get("ir1_prefill"), dict) else {}
-    decoder_layout = files.get("layout_prefill") if isinstance(files.get("layout_prefill"), dict) else {}
-    decoder_call = files.get("lowered_prefill_call") if isinstance(files.get("lowered_prefill_call"), dict) else files.get("lowered_prefill")
-    if not isinstance(decoder_call, dict):
-        decoder_call = {}
-
-    encoder_ops = _ops_from_payload(encoder_ir1)
-    decoder_ops = _ops_from_payload(decoder_ir1)
-    if not encoder_ops and not decoder_ops:
-        return None
-
-    ops: list[dict[str, Any]] = []
-    for idx, op in enumerate(encoder_ops):
-        ops.append(
-            _clone_multimodal_op(
-                op,
-                op_id=idx,
-                stage="vision_encoder",
-                stage_label="Vision Encoder",
-                layer_prefix="Encoder Layer",
-            )
-        )
-
-    bridge_op_id = len(ops)
-    encoder_last_id = int(ops[-1]["op_id"]) if ops else None
+def _build_multimodal_bridge_op(
+    *,
+    op_id: int,
+    bridge: dict[str, Any],
+    encoder_last_id: int | None,
+) -> dict[str, Any]:
     bridge_op: dict[str, Any] = {
-        "op_id": bridge_op_id,
+        "op_id": op_id,
         "op": "vision_bridge_prefix",
         "kernel": "multimodal_bridge",
         "kernel_id": "multimodal_bridge",
@@ -933,7 +903,30 @@ def _build_multimodal_dataflow_graph(files: dict[str, Any]) -> dict[str, Any] | 
             "dtype": "fp32",
             "slot": "vision_encoder_out",
         }
-    ops.append(bridge_op)
+    return bridge_op
+
+
+def _build_unified_multimodal_ops(
+    *,
+    bridge: dict[str, Any],
+    encoder_ops: list[dict[str, Any]],
+    decoder_ops: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    ops: list[dict[str, Any]] = []
+    for idx, op in enumerate(encoder_ops):
+        ops.append(
+            _clone_multimodal_op(
+                op,
+                op_id=idx,
+                stage="vision_encoder",
+                stage_label="Vision Encoder",
+                layer_prefix="Encoder Layer",
+            )
+        )
+
+    bridge_op_id = len(ops)
+    encoder_last_id = int(ops[-1]["op_id"]) if ops else None
+    ops.append(_build_multimodal_bridge_op(op_id=bridge_op_id, bridge=bridge, encoder_last_id=encoder_last_id))
 
     decoder_offset = len(ops)
     for idx, op in enumerate(decoder_ops):
@@ -958,6 +951,133 @@ def _build_multimodal_dataflow_graph(files: dict[str, Any]) -> dict[str, Any] | 
                         "slot": "vision_prefix",
                     }
         ops.append(cloned)
+    return ops
+
+
+def _copy_memory_entries(rows: Any, *, stage: str, base_offset: int) -> list[dict[str, Any]]:
+    if not isinstance(rows, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        entry = json.loads(json.dumps(row))
+        entry["network_stage"] = stage
+        entry["source_name"] = entry.get("name")
+        entry["name"] = f"{stage}.{entry.get('name', 'unnamed')}"
+        for key in ("offset", "abs_offset"):
+            try:
+                entry[key] = int(entry.get(key) or 0) + base_offset
+            except (TypeError, ValueError):
+                pass
+        out.append(entry)
+    return out
+
+
+def _build_multimodal_layout(
+    *,
+    encoder_layout: dict[str, Any],
+    decoder_layout: dict[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(encoder_layout, dict):
+        encoder_layout = {}
+    if not isinstance(decoder_layout, dict):
+        decoder_layout = {}
+    if not encoder_layout:
+        return decoder_layout
+    if not decoder_layout:
+        return encoder_layout
+
+    encoder_memory = encoder_layout.get("memory") if isinstance(encoder_layout.get("memory"), dict) else {}
+    decoder_memory = decoder_layout.get("memory") if isinstance(decoder_layout.get("memory"), dict) else {}
+    encoder_weights = encoder_memory.get("weights") if isinstance(encoder_memory.get("weights"), dict) else {}
+    decoder_weights = decoder_memory.get("weights") if isinstance(decoder_memory.get("weights"), dict) else {}
+    encoder_acts = encoder_memory.get("activations") if isinstance(encoder_memory.get("activations"), dict) else {}
+    decoder_acts = decoder_memory.get("activations") if isinstance(decoder_memory.get("activations"), dict) else {}
+
+    encoder_weight_size = int(encoder_weights.get("size") or 0)
+    decoder_weight_size = int(decoder_weights.get("size") or 0)
+    encoder_act_size = int(encoder_acts.get("size") or 0)
+    decoder_act_size = int(decoder_acts.get("size") or 0)
+    decoder_weight_base = encoder_weight_size
+    decoder_act_base = encoder_act_size
+
+    weights_entries = (
+        _copy_memory_entries(encoder_weights.get("entries"), stage="vision_encoder", base_offset=0)
+        + _copy_memory_entries(decoder_weights.get("entries"), stage="decoder_prefill", base_offset=decoder_weight_base)
+    )
+    activation_buffers = (
+        _copy_memory_entries(encoder_acts.get("buffers"), stage="vision_encoder", base_offset=0)
+        + _copy_memory_entries(decoder_acts.get("buffers"), stage="decoder_prefill", base_offset=decoder_act_base)
+    )
+
+    return {
+        "format": "layout-multimodal-logical",
+        "version": max(int(encoder_layout.get("version") or 0), int(decoder_layout.get("version") or 0), 1),
+        "mode": "prefill",
+        "schema": "ck.v8.multimodal_layout.v1",
+        "source": "logical_concat_encoder_decoder_prefill",
+        "source_layouts": {
+            "vision_encoder": {
+                "total_size": _layout_total_bytes(encoder_layout),
+                "weights_size": encoder_weight_size,
+                "activations_size": encoder_act_size,
+            },
+            "decoder_prefill": {
+                "total_size": _layout_total_bytes(decoder_layout),
+                "weights_size": decoder_weight_size,
+                "activations_size": decoder_act_size,
+            },
+        },
+        "memory": {
+            "weights": {
+                "size": encoder_weight_size + decoder_weight_size,
+                "entries": weights_entries,
+            },
+            "activations": {
+                "size": encoder_act_size + decoder_act_size,
+                "buffers": activation_buffers,
+            },
+            "arena": {
+                "mode": "logical_multimodal",
+                "total_size": (_layout_total_bytes(encoder_layout) or 0) + (_layout_total_bytes(decoder_layout) or 0),
+                "encoder_total_size": _layout_total_bytes(encoder_layout),
+                "decoder_prefill_total_size": _layout_total_bytes(decoder_layout),
+            },
+        },
+    }
+
+
+def _build_multimodal_dataflow_graph(files: dict[str, Any]) -> dict[str, Any] | None:
+    bridge = files.get("multimodal_bridge_report")
+    if not isinstance(bridge, dict):
+        return None
+    full_graph = files.get("full_network_graph")
+    if isinstance(full_graph, dict):
+        return full_graph
+
+    encoder_ir1 = files.get("bridge_encoder_ir1") if isinstance(files.get("bridge_encoder_ir1"), dict) else {}
+    encoder_layout = files.get("bridge_encoder_layout") if isinstance(files.get("bridge_encoder_layout"), dict) else {}
+    encoder_call = files.get("bridge_encoder_call") if isinstance(files.get("bridge_encoder_call"), dict) else {}
+    decoder_ir1 = files.get("ir1_prefill") if isinstance(files.get("ir1_prefill"), dict) else {}
+    decoder_layout = files.get("layout_prefill") if isinstance(files.get("layout_prefill"), dict) else {}
+    decoder_call = files.get("lowered_prefill_call") if isinstance(files.get("lowered_prefill_call"), dict) else files.get("lowered_prefill")
+    if not isinstance(decoder_call, dict):
+        decoder_call = {}
+
+    encoder_ops = _ops_from_payload(encoder_ir1)
+    decoder_ops = _ops_from_payload(decoder_ir1)
+    if not encoder_ops and not decoder_ops:
+        return None
+
+    ops = _build_unified_multimodal_ops(bridge=bridge, encoder_ops=encoder_ops, decoder_ops=decoder_ops)
+    encoder_call_ops = _ops_from_payload(encoder_call)
+    decoder_call_ops = _ops_from_payload(decoder_call)
+    unified_call_ops = _build_unified_multimodal_ops(
+        bridge=bridge,
+        encoder_ops=encoder_call_ops or encoder_ops,
+        decoder_ops=decoder_call_ops or decoder_ops,
+    )
 
     ir1 = {
         "format": "ir1-multimodal-dataflow",
@@ -970,17 +1090,26 @@ def _build_multimodal_dataflow_graph(files: dict[str, Any]) -> dict[str, Any] | 
         "schema": "ck.v8.multimodal_dataflow_graph.v1",
         "ops": ops,
     }
+    call = {
+        "schema": "ck.v8.multimodal_call_graph.v1",
+        "mode": "prefill",
+        "source": "derived_from_bridge_encoder_call_and_decoder_prefill_call",
+        "operations": unified_call_ops,
+    }
     return {
         "schema": "ck.v8.multimodal_dataflow_graph.v1",
         "source": "derived_from_bridge_encoder_and_decoder_prefill",
         "ir1": ir1,
-        "layout": decoder_layout or encoder_layout,
-        "call": decoder_call or encoder_call,
+        "layout": _build_multimodal_layout(encoder_layout=encoder_layout, decoder_layout=decoder_layout),
+        "call": call,
         "stats": {
             "encoder_ops": len(encoder_ops),
             "bridge_ops": 1,
             "decoder_prefill_ops": len(decoder_ops),
             "total_ops": len(ops),
+            "encoder_call_ops": len(encoder_call_ops),
+            "decoder_prefill_call_ops": len(decoder_call_ops),
+            "total_call_ops": len(unified_call_ops),
         },
     }
 

--- a/version/v8/tools/open_ir_visualizer_v8.py
+++ b/version/v8/tools/open_ir_visualizer_v8.py
@@ -779,6 +779,11 @@ def _enrich_multimodal_bridge_payload(
 def _ops_from_payload(payload: Any) -> list[dict[str, Any]]:
     if not isinstance(payload, dict):
         return []
+    nested_ir1 = payload.get("ir1")
+    if isinstance(nested_ir1, dict):
+        nested_ops = _ops_from_payload(nested_ir1)
+        if nested_ops:
+            return nested_ops
     for key in ("operations", "ops"):
         rows = payload.get(key)
         if isinstance(rows, list):
@@ -809,6 +814,177 @@ def _count_ops_by_kind(ops: list[dict[str, Any]]) -> dict[str, int]:
     return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
 
 
+def _clone_multimodal_op(
+    op: dict[str, Any],
+    *,
+    op_id: int,
+    stage: str,
+    stage_label: str,
+    layer_prefix: str,
+    from_offset: int = 0,
+) -> dict[str, Any]:
+    out = json.loads(json.dumps(op))
+    old_id = out.get("op_id")
+    out["op_id"] = op_id
+    out["network_stage"] = stage
+    out["network_stage_label"] = stage_label
+    out["source_op_id"] = old_id
+    layer = out.get("layer")
+    section = str(out.get("section") or "").lower()
+    if section == "header" or layer == -1:
+        out["unified_layer_key"] = f"{stage}:header"
+        out["unified_layer_label"] = f"{stage_label} Header"
+    elif section == "footer":
+        out["unified_layer_key"] = f"{stage}:footer"
+        out["unified_layer_label"] = f"{stage_label} Footer"
+    elif layer is not None:
+        out["unified_layer_key"] = f"{stage}:layer:{layer}"
+        out["unified_layer_label"] = f"{layer_prefix} {layer}"
+    else:
+        out["unified_layer_key"] = f"{stage}:ops"
+        out["unified_layer_label"] = stage_label
+
+    dataflow = out.get("dataflow")
+    if isinstance(dataflow, dict) and from_offset:
+        for inputs in [dataflow.get("inputs")]:
+            if not isinstance(inputs, dict):
+                continue
+            for info in inputs.values():
+                if not isinstance(info, dict) or info.get("from_op") is None:
+                    continue
+                try:
+                    info["from_op"] = int(info["from_op"]) + from_offset
+                except (TypeError, ValueError):
+                    pass
+    return out
+
+
+def _build_multimodal_dataflow_graph(files: dict[str, Any]) -> dict[str, Any] | None:
+    bridge = files.get("multimodal_bridge_report")
+    if not isinstance(bridge, dict):
+        return None
+    full_graph = files.get("full_network_graph")
+    if isinstance(full_graph, dict):
+        return full_graph
+
+    encoder_ir1 = files.get("bridge_encoder_ir1") if isinstance(files.get("bridge_encoder_ir1"), dict) else {}
+    encoder_layout = files.get("bridge_encoder_layout") if isinstance(files.get("bridge_encoder_layout"), dict) else {}
+    encoder_call = files.get("bridge_encoder_call") if isinstance(files.get("bridge_encoder_call"), dict) else {}
+    decoder_ir1 = files.get("ir1_prefill") if isinstance(files.get("ir1_prefill"), dict) else {}
+    decoder_layout = files.get("layout_prefill") if isinstance(files.get("layout_prefill"), dict) else {}
+    decoder_call = files.get("lowered_prefill_call") if isinstance(files.get("lowered_prefill_call"), dict) else files.get("lowered_prefill")
+    if not isinstance(decoder_call, dict):
+        decoder_call = {}
+
+    encoder_ops = _ops_from_payload(encoder_ir1)
+    decoder_ops = _ops_from_payload(decoder_ir1)
+    if not encoder_ops and not decoder_ops:
+        return None
+
+    ops: list[dict[str, Any]] = []
+    for idx, op in enumerate(encoder_ops):
+        ops.append(
+            _clone_multimodal_op(
+                op,
+                op_id=idx,
+                stage="vision_encoder",
+                stage_label="Vision Encoder",
+                layer_prefix="Encoder Layer",
+            )
+        )
+
+    bridge_op_id = len(ops)
+    encoder_last_id = int(ops[-1]["op_id"]) if ops else None
+    bridge_op: dict[str, Any] = {
+        "op_id": bridge_op_id,
+        "op": "vision_bridge_prefix",
+        "kernel": "multimodal_bridge",
+        "kernel_id": "multimodal_bridge",
+        "section": "bridge",
+        "layer": -1,
+        "network_stage": "bridge",
+        "network_stage_label": "Vision/Text Bridge",
+        "unified_layer_key": "bridge:prefix",
+        "unified_layer_label": "Vision/Text Bridge",
+        "params": {
+            "prefix_tokens": bridge.get("prefix_tokens"),
+            "prefix_grid_x": bridge.get("prefix_grid_x"),
+            "prefix_grid_y": bridge.get("prefix_grid_y"),
+            "text_position": bridge.get("prefix_text_pos"),
+            "prefix_source": bridge.get("prefix_source"),
+        },
+        "dataflow": {
+            "inputs": {},
+            "outputs": {
+                "prefix": {
+                    "tensor": "vision_bridge.prefix_embeddings",
+                    "dtype": "fp32",
+                    "slot": "vision_prefix",
+                }
+            },
+        },
+        "weights": {},
+    }
+    if encoder_last_id is not None:
+        bridge_op["dataflow"]["inputs"]["encoder_out"] = {
+            "from_op": encoder_last_id,
+            "from_output": "out",
+            "tensor": "vision_encoder.output",
+            "dtype": "fp32",
+            "slot": "vision_encoder_out",
+        }
+    ops.append(bridge_op)
+
+    decoder_offset = len(ops)
+    for idx, op in enumerate(decoder_ops):
+        cloned = _clone_multimodal_op(
+            op,
+            op_id=decoder_offset + idx,
+            stage="decoder_prefill",
+            stage_label="Decoder Prefill",
+            layer_prefix="Decoder Layer",
+            from_offset=decoder_offset,
+        )
+        if idx == 0:
+            dataflow = cloned.setdefault("dataflow", {})
+            if isinstance(dataflow, dict):
+                inputs = dataflow.setdefault("inputs", {})
+                if isinstance(inputs, dict):
+                    inputs["vision_prefix"] = {
+                        "from_op": bridge_op_id,
+                        "from_output": "prefix",
+                        "tensor": "vision_bridge.prefix_embeddings",
+                        "dtype": "fp32",
+                        "slot": "vision_prefix",
+                    }
+        ops.append(cloned)
+
+    ir1 = {
+        "format": "ir1-multimodal-dataflow",
+        "version": max(
+            int(encoder_ir1.get("version") or 0) if isinstance(encoder_ir1, dict) else 0,
+            int(decoder_ir1.get("version") or 0) if isinstance(decoder_ir1, dict) else 0,
+            1,
+        ),
+        "mode": "prefill",
+        "schema": "ck.v8.multimodal_dataflow_graph.v1",
+        "ops": ops,
+    }
+    return {
+        "schema": "ck.v8.multimodal_dataflow_graph.v1",
+        "source": "derived_from_bridge_encoder_and_decoder_prefill",
+        "ir1": ir1,
+        "layout": decoder_layout or encoder_layout,
+        "call": decoder_call or encoder_call,
+        "stats": {
+            "encoder_ops": len(encoder_ops),
+            "bridge_ops": 1,
+            "decoder_prefill_ops": len(decoder_ops),
+            "total_ops": len(ops),
+        },
+    }
+
+
 def _build_vision_artifacts_payload(files: dict[str, Any]) -> dict[str, Any] | None:
     bridge = files.get("multimodal_bridge_report")
     if not isinstance(bridge, dict):
@@ -818,7 +994,9 @@ def _build_vision_artifacts_payload(files: dict[str, Any]) -> dict[str, Any] | N
     encoder_layout = files.get("bridge_encoder_layout") if isinstance(files.get("bridge_encoder_layout"), dict) else {}
     encoder_call = files.get("bridge_encoder_call") if isinstance(files.get("bridge_encoder_call"), dict) else {}
     encoder_lowered = files.get("bridge_encoder_lowered") if isinstance(files.get("bridge_encoder_lowered"), dict) else {}
-    full_graph = files.get("full_network_graph") if isinstance(files.get("full_network_graph"), dict) else {}
+    full_graph = files.get("full_network_graph") if isinstance(files.get("full_network_graph"), dict) else files.get("multimodal_dataflow_graph")
+    if not isinstance(full_graph, dict):
+        full_graph = {}
     decoder_prefill = files.get("lowered_prefill_call") if isinstance(files.get("lowered_prefill_call"), dict) else files.get("lowered_prefill")
 
     encoder_ops = _ops_from_payload(encoder_call) or _ops_from_payload(encoder_lowered) or _ops_from_payload(encoder_ir1)
@@ -4275,6 +4453,10 @@ def load_model_data(
         )
         data["files"]["multimodal_bridge_report"] = enriched_bridge
         data["meta"]["multimodal_mode"] = str(enriched_bridge.get("bridge_mode") or "encoder_decoder")
+        multimodal_dataflow = _build_multimodal_dataflow_graph(data["files"])
+        if isinstance(multimodal_dataflow, dict) and "full_network_graph" not in data["files"]:
+            data["files"]["multimodal_dataflow_graph"] = multimodal_dataflow
+            loaded.append("multimodal_dataflow_graph(derived)")
         vision_artifacts = _build_vision_artifacts_payload(data["files"])
         if isinstance(vision_artifacts, dict):
             data["files"]["vision_artifacts"] = vision_artifacts

--- a/version/v8/tools/open_ir_visualizer_v8.py
+++ b/version/v8/tools/open_ir_visualizer_v8.py
@@ -776,6 +776,195 @@ def _enrich_multimodal_bridge_payload(
     return out
 
 
+def _ops_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    for key in ("operations", "ops"):
+        rows = payload.get(key)
+        if isinstance(rows, list):
+            return [row for row in rows if isinstance(row, dict)]
+    return []
+
+
+def _layout_total_bytes(payload: Any) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    memory = payload.get("memory") if isinstance(payload.get("memory"), dict) else {}
+    arena = memory.get("arena") if isinstance(memory.get("arena"), dict) else {}
+    for raw in (arena.get("total_size"), memory.get("total_size"), payload.get("total_bytes")):
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return None
+
+
+def _count_ops_by_kind(ops: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for op in ops:
+        key = str(op.get("op") or op.get("kernel_id") or op.get("function") or "unknown")
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def _build_vision_artifacts_payload(files: dict[str, Any]) -> dict[str, Any] | None:
+    bridge = files.get("multimodal_bridge_report")
+    if not isinstance(bridge, dict):
+        return None
+    encoder_report = bridge.get("encoder_report") if isinstance(bridge.get("encoder_report"), dict) else {}
+    encoder_ir1 = files.get("bridge_encoder_ir1") if isinstance(files.get("bridge_encoder_ir1"), dict) else {}
+    encoder_layout = files.get("bridge_encoder_layout") if isinstance(files.get("bridge_encoder_layout"), dict) else {}
+    encoder_call = files.get("bridge_encoder_call") if isinstance(files.get("bridge_encoder_call"), dict) else {}
+    encoder_lowered = files.get("bridge_encoder_lowered") if isinstance(files.get("bridge_encoder_lowered"), dict) else {}
+    full_graph = files.get("full_network_graph") if isinstance(files.get("full_network_graph"), dict) else {}
+    decoder_prefill = files.get("lowered_prefill_call") if isinstance(files.get("lowered_prefill_call"), dict) else files.get("lowered_prefill")
+
+    encoder_ops = _ops_from_payload(encoder_call) or _ops_from_payload(encoder_lowered) or _ops_from_payload(encoder_ir1)
+    full_ops = _ops_from_payload(full_graph)
+    decoder_ops = _ops_from_payload(decoder_prefill)
+
+    prefix_tokens = bridge.get("prefix_tokens")
+    grid_x = bridge.get("prefix_grid_x", encoder_report.get("prefix_grid_x"))
+    grid_y = bridge.get("prefix_grid_y", encoder_report.get("prefix_grid_y"))
+    patch_size = encoder_report.get("patch_size") or encoder_report.get("vision_patch_size")
+    image_w = encoder_report.get("image_width") or encoder_report.get("image_size")
+    image_h = encoder_report.get("image_height") or encoder_report.get("image_size")
+    source_size = encoder_report.get("source_image_size") if isinstance(encoder_report.get("source_image_size"), list) else None
+
+    expected_prefix_from_grid = None
+    try:
+        gx = int(grid_x)
+        gy = int(grid_y)
+        if gx > 0 and gy > 0:
+            expected_prefix_from_grid = gx * gy
+    except (TypeError, ValueError):
+        pass
+
+    checks: list[dict[str, Any]] = []
+    def add_check(name: str, ok: bool, detail: str) -> None:
+        checks.append({"name": name, "status": "pass" if ok else "warn", "detail": detail})
+
+    add_check(
+        "bridge_report",
+        True,
+        "multimodal_bridge/bridge_report.json loaded",
+    )
+    add_check(
+        "encoder_graph",
+        len(encoder_ops) > 0,
+        f"{len(encoder_ops)} encoder ops loaded",
+    )
+    add_check(
+        "full_network_graph",
+        len(full_ops) > 0,
+        f"{len(full_ops)} unified ops loaded" if full_ops else "full_network_graph.json not loaded",
+    )
+    add_check(
+        "prefix_grid",
+        expected_prefix_from_grid is not None,
+        f"grid={grid_x}x{grid_y}",
+    )
+    if expected_prefix_from_grid is not None and prefix_tokens is not None:
+        try:
+            prefix_ok = int(prefix_tokens) == int(expected_prefix_from_grid)
+        except (TypeError, ValueError):
+            prefix_ok = False
+        add_check(
+            "prefix_rows_match_grid",
+            prefix_ok,
+            f"prefix_tokens={prefix_tokens}, grid product={expected_prefix_from_grid}",
+        )
+
+    status = "pass" if all(row.get("status") == "pass" for row in checks) else "warn"
+    return {
+        "schema": "ck.v8.vision_artifacts.v1",
+        "status": status,
+        "image": {
+            "source": encoder_report.get("image_source"),
+            "path": encoder_report.get("image_path"),
+            "path_resolved": encoder_report.get("image_path_resolved"),
+            "data_uri": encoder_report.get("image_data_uri"),
+            "source_size": source_size,
+            "preprocess": encoder_report.get("preprocess"),
+            "image_width": image_w,
+            "image_height": image_h,
+            "patch_size": patch_size,
+        },
+        "patch_grid": {
+            "grid_x": grid_x,
+            "grid_y": grid_y,
+            "prefix_tokens": prefix_tokens,
+            "expected_prefix_tokens": expected_prefix_from_grid,
+            "text_position": bridge.get("prefix_text_pos", encoder_report.get("prefix_text_pos")),
+            "position_policy": bridge.get("position_policy") or encoder_report.get("position_policy"),
+        },
+        "bridge": {
+            "mode": bridge.get("bridge_mode"),
+            "prefix_source": bridge.get("prefix_source"),
+            "decoder_input_embed_dim": bridge.get("decoder_input_embed_dim"),
+            "encoder_embed_dim": encoder_report.get("embed_dim"),
+            "prompt_tokens_before_image": len(bridge.get("prompt_tokens_before_image") or []),
+            "prompt_tokens_after_image": len(bridge.get("prompt_tokens_after_image") or []),
+            "total_prefill_tokens": bridge.get("total_prefill_tokens"),
+            "generated_token_count": bridge.get("generated_token_count"),
+            "stop_reason": bridge.get("generation_stop_reason"),
+        },
+        "stages": [
+            {
+                "key": "image",
+                "label": "Image ingest",
+                "ready": True,
+                "detail": str(encoder_report.get("image_source") or "image input"),
+            },
+            {
+                "key": "encoder_ir",
+                "label": "Encoder IR",
+                "ready": len(_ops_from_payload(encoder_ir1)) > 0,
+                "ops": len(_ops_from_payload(encoder_ir1)),
+            },
+            {
+                "key": "encoder_layout",
+                "label": "Encoder layout",
+                "ready": _layout_total_bytes(encoder_layout) is not None,
+                "bytes": _layout_total_bytes(encoder_layout),
+            },
+            {
+                "key": "encoder_call",
+                "label": "Encoder call",
+                "ready": len(encoder_ops) > 0,
+                "ops": len(encoder_ops),
+            },
+            {
+                "key": "bridge",
+                "label": "Bridge prefix",
+                "ready": prefix_tokens is not None,
+                "tokens": prefix_tokens,
+            },
+            {
+                "key": "decoder_prefill",
+                "label": "Decoder prefill",
+                "ready": len(decoder_ops) > 0,
+                "ops": len(decoder_ops),
+            },
+            {
+                "key": "full_graph",
+                "label": "Unified graph",
+                "ready": len(full_ops) > 0,
+                "ops": len(full_ops),
+            },
+        ],
+        "ops": {
+            "encoder": len(encoder_ops),
+            "decoder_prefill": len(decoder_ops),
+            "full_network": len(full_ops),
+            "encoder_by_kind": _count_ops_by_kind(encoder_ops),
+        },
+        "checks": checks,
+    }
+
+
 def _trim_memory_signoff_payload(payload: dict, max_items: int = 120) -> dict:
     """Trim very large warning/error arrays to keep standalone report size manageable."""
     out = dict(payload)
@@ -4086,6 +4275,10 @@ def load_model_data(
         )
         data["files"]["multimodal_bridge_report"] = enriched_bridge
         data["meta"]["multimodal_mode"] = str(enriched_bridge.get("bridge_mode") or "encoder_decoder")
+        vision_artifacts = _build_vision_artifacts_payload(data["files"])
+        if isinstance(vision_artifacts, dict):
+            data["files"]["vision_artifacts"] = vision_artifacts
+            loaded.append("vision_artifacts(derived)")
 
     print(f"  Loaded {len(loaded)} files")
     return data


### PR DESCRIPTION
## Summary
- derive a normalized v8 vision_artifacts payload from multimodal bridge reports and encoder/decoder artifacts
- render image ingest, patch grid, prefix rows, stage coverage, and contract checks in the multimodal visualizer
- add the new vision renderer functions to the v8 visualizer contract health gate

## Tests
- .venv/bin/python -m py_compile version/v8/tools/open_ir_visualizer_v8.py
- git diff --check -- version/v8/tools/open_ir_visualizer_v8.py version/v8/tools/ir_visualizer.html version/v8/tests/contracts/ir_visualizer_contract.json
- make v8-visualizer-health
- .venv/bin/python version/v8/tools/open_ir_visualizer_v8.py --generate --run /home/antshiv/.cache/ck-engine-v8/models/Qwen--Qwen3-VL-8B-Instruct-GGUF --html-only --output /tmp/qwen3vl_visualizer_vision_artifacts.html
- .venv/bin/python version/v8/scripts/test_visualizer_health_v8.py --ir-report /tmp/qwen3vl_visualizer_vision_artifacts.html --json-out /tmp/qwen3vl_visualizer_health.json
- git push pre-push gate passed