### PR TITLE
feat(v8): add Kimi-VL MLA/MoE decoder contracts

### DIFF
--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -2292,6 +2292,30 @@ void moe_relu2_shared_forward_q5_1_q8_0(const float *hidden,
                                         int hidden_dim,
                                         int intermediate_dim);
 
+// Routed MoE SwiGLU expert MLP: output += weight * down(silu(gate(hidden)) * up(hidden)).
+void moe_swiglu_expert_forward_f32(const float *hidden,
+                                   const int *indices,
+                                   const float *routing_weights,
+                                   const float *expert_gate,
+                                   const float *expert_up,
+                                   const float *expert_down,
+                                   float *output,
+                                   int rows,
+                                   int hidden_dim,
+                                   int intermediate_dim,
+                                   int n_experts,
+                                   int top_k);
+
+void moe_swiglu_shared_forward_f32(const float *hidden,
+                                   const float *routed,
+                                   const float *shared_gate,
+                                   const float *shared_up,
+                                   const float *shared_down,
+                                   float *output,
+                                   int rows,
+                                   int hidden_dim,
+                                   int intermediate_dim);
+
 void moe_relu2_expert_backward_f32(const float *d_output,
                                    const float *hidden,
                                    const int *indices,
@@ -2438,6 +2462,42 @@ void deepseek_hybrid_attention_f32(const float *q,
                                    int top_k,
                                    float scale,
                                    int mode);
+
+void deepseek_mla_kv_decompress_f32(const float *compressed_kv,
+                                    const float *kv_b_proj,
+                                    float *k_nope,
+                                    float *value,
+                                    int tokens,
+                                    int heads,
+                                    int kv_lora_rank,
+                                    int qk_nope_dim,
+                                    int v_dim);
+
+void deepseek_mla_partial_rope_concat_f32(const float *q_nope,
+                                          const float *q_pe,
+                                          const float *k_nope,
+                                          const float *k_pe,
+                                          const float *cos,
+                                          const float *sin,
+                                          float *query,
+                                          float *key,
+                                          int tokens,
+                                          int heads,
+                                          int qk_nope_dim,
+                                          int qk_rope_dim);
+
+void deepseek_mla_partial_rope_concat_packed_f32(const float *q_packed,
+                                             const float *k_nope,
+                                             const float *kv_a_packed,
+                                             const float *cos,
+                                             const float *sin,
+                                             float *query,
+                                             float *key,
+                                             int tokens,
+                                             int heads,
+                                             int kv_lora_rank,
+                                             int qk_nope_dim,
+                                             int qk_rope_dim);
 
 // Attention backward (GQA-aware): computes d_q, d_k, d_v.
 void attention_backward_causal_head_major_gqa(

--- a/src/kernels/deepseek_kernels.c
+++ b/src/kernels/deepseek_kernels.c
@@ -272,6 +272,60 @@ void deepseek_mla_partial_rope_concat_f32(const float *q_nope,
     }
 }
 
+void deepseek_mla_partial_rope_concat_packed_f32(const float *q_packed,
+                                             const float *k_nope,
+                                             const float *kv_a_packed,
+                                             const float *cos,
+                                             const float *sin,
+                                             float *query,
+                                             float *key,
+                                             int tokens,
+                                             int heads,
+                                             int kv_lora_rank,
+                                             int qk_nope_dim,
+                                             int qk_rope_dim)
+{
+    if (!q_packed || !k_nope || !kv_a_packed || !cos || !sin || !query || !key ||
+        tokens <= 0 || heads <= 0 || kv_lora_rank <= 0 || qk_nope_dim <= 0 ||
+        qk_rope_dim <= 0 || (qk_rope_dim % 2) != 0) {
+        return;
+    }
+
+    const int q_head_dim = qk_nope_dim + qk_rope_dim;
+    const int kv_a_dim = kv_lora_rank + qk_rope_dim;
+    const int half = qk_rope_dim / 2;
+    for (int t = 0; t < tokens; ++t) {
+        const float *cos_row = cos + (size_t)t * (size_t)half;
+        const float *sin_row = sin + (size_t)t * (size_t)half;
+        const float *kp = kv_a_packed + (size_t)t * (size_t)kv_a_dim + (size_t)kv_lora_rank;
+        for (int h = 0; h < heads; ++h) {
+            const float *q_in = q_packed + ds_mla_thd_idx(t, h, 0, heads, q_head_dim);
+            const float *kn = k_nope + ds_mla_thd_idx(t, h, 0, heads, qk_nope_dim);
+            float *q_out = query + ds_mla_thd_idx(t, h, 0, heads, q_head_dim);
+            float *k_out = key + ds_mla_thd_idx(t, h, 0, heads, q_head_dim);
+
+            for (int d = 0; d < qk_nope_dim; ++d) {
+                q_out[d] = q_in[d];
+                k_out[d] = kn[d];
+            }
+
+            const float *qp = q_in + qk_nope_dim;
+            for (int i = 0; i < half; ++i) {
+                const float q_first = qp[2 * i];
+                const float q_second = qp[2 * i + 1];
+                const float k_first = kp[2 * i];
+                const float k_second = kp[2 * i + 1];
+                const float c = cos_row[i];
+                const float ss = sin_row[i];
+                q_out[qk_nope_dim + i] = q_first * c - q_second * ss;
+                q_out[qk_nope_dim + half + i] = q_second * c + q_first * ss;
+                k_out[qk_nope_dim + i] = k_first * c - k_second * ss;
+                k_out[qk_nope_dim + half + i] = k_second * c + k_first * ss;
+            }
+        }
+    }
+}
+
 static inline size_t ds_qkv_idx(int token, int head, int d, int heads, int dim)
 {
     return ((size_t)token * (size_t)heads + (size_t)head) * (size_t)dim + (size_t)d;

--- a/tests/test_v8_kimi_template.py
+++ b/tests/test_v8_kimi_template.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+V8_BUILD_PATH = ROOT / "version" / "v8" / "scripts" / "build_ir_v8.py"
+
+
+def _load_module(name: str, path: Path):
+    if str(path.parent) not in sys.path:
+        sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+build_ir_v8 = _load_module("build_ir_v8_kimi_tests", V8_BUILD_PATH)
+
+
+def _entry(name: str, dtype: str, shape: list[int], offset: int) -> dict:
+    nbytes_per = {"fp32": 4, "bf16": 2, "fp16": 2, "q8_0": 1, "q5_0": 1, "q6_k": 1, "q4_k": 1}.get(dtype, 4)
+    size = 1
+    for dim in shape:
+        size *= int(dim)
+    return {"name": name, "dtype": dtype, "offset": offset, "shape": shape, "nbytes": size * nbytes_per}
+
+
+def _make_tiny_kimi_manifest() -> dict:
+    offset = 0
+    entries = []
+
+    def add(name: str, dtype: str, shape: list[int]) -> None:
+        nonlocal offset
+        item = _entry(name, dtype, shape, offset)
+        entries.append(item)
+        offset += int(item["nbytes"])
+
+    add("token_emb", "bf16", [32, 8])
+    add("final_ln_weight", "fp32", [8])
+    add("final_ln_bias", "fp32", [8])
+    add("output.weight", "bf16", [32, 8])
+    for layer in range(2):
+        add(f"layer.{layer}.block_norm", "fp32", [8])
+        add(f"layer.{layer}.post_attention_norm", "fp32", [8])
+        add(f"layer.{layer}.mla_q_proj", "bf16", [8, 8])
+        add(f"layer.{layer}.mla_kv_a_proj", "bf16", [6, 8])
+        add(f"layer.{layer}.mla_kv_a_norm", "fp32", [4])
+        add(f"layer.{layer}.mla_kv_b_proj", "bf16", [8, 4])
+        add(f"layer.{layer}.mla_out_proj", "bf16", [8, 8])
+    add("layer.0.mlp_gate", "bf16", [16, 8])
+    add("layer.0.mlp_up", "bf16", [16, 8])
+    add("layer.0.mlp_down", "bf16", [8, 16])
+    add("layer.1.moe_router", "fp32", [2, 8])
+    add("layer.1.moe_router_bias", "fp32", [2])
+    add("layer.1.moe_expert_gate", "bf16", [2, 4, 8])
+    add("layer.1.moe_expert_up", "bf16", [2, 4, 8])
+    add("layer.1.moe_expert_down", "bf16", [2, 8, 4])
+    add("layer.1.moe_shared_gate", "bf16", [4, 8])
+    add("layer.1.moe_shared_up", "bf16", [4, 8])
+    add("layer.1.moe_shared_down", "bf16", [8, 4])
+
+    return {
+        "config": {
+            "model": "kimi_vl",
+            "arch": "kimi_vl",
+            "model_type": "kimi_vl",
+            "num_layers": 2,
+            "embed_dim": 8,
+            "hidden_size": 8,
+            "num_heads": 2,
+            "num_kv_heads": 2,
+            "head_dim": 4,
+            "intermediate_size": 16,
+            "intermediate_dim": 16,
+            "moe_intermediate_size": 4,
+            "n_shared_experts": 1,
+            "n_routed_experts": 2,
+            "num_experts_per_tok": 1,
+            "kv_lora_rank": 4,
+            "qk_nope_head_dim": 2,
+            "qk_rope_head_dim": 2,
+            "v_head_dim": 2,
+            "vocab_size": 32,
+            "context_length": 16,
+            "layer_kinds": ["mla_dense_mlp", "mla_moe"],
+            "layer_attention_policy": ["mla", "mla"],
+            "layer_moe_policy": ["none", "routed_swiglu"],
+            "rope_layout": "partial_pairwise_concat",
+        },
+        "quant_summary": {
+            "token_emb": "bf16",
+            "lm_head": "bf16",
+            "final_ln_weight": "fp32",
+            "layer.0": {
+                "mla_q_proj": "bf16",
+                "mla_kv_a_proj": "bf16",
+                "mla_kv_a_norm": "fp32",
+                "mla_kv_b_proj": "bf16",
+                "mla_out_proj": "bf16",
+                "mlp_gate": "bf16",
+                "mlp_up": "bf16",
+                "mlp_down": "bf16",
+            },
+            "layer.1": {
+                "mla_q_proj": "bf16",
+                "mla_kv_a_proj": "bf16",
+                "mla_kv_a_norm": "fp32",
+                "mla_kv_b_proj": "bf16",
+                "mla_out_proj": "bf16",
+                "moe_router": "fp32",
+                "moe_router_bias": "fp32",
+                "moe_expert_gate": "bf16",
+                "moe_expert_up": "bf16",
+                "moe_expert_down": "bf16",
+                "moe_shared_gate": "bf16",
+                "moe_shared_up": "bf16",
+                "moe_shared_down": "bf16",
+            },
+        },
+        "entries": entries,
+        "template": build_ir_v8._load_builtin_template_doc("kimi_vl"),
+    }
+
+
+class V8KimiTemplateTests(unittest.TestCase):
+    def test_kimi_mla_moe_template_lowers_to_reference_kernels(self) -> None:
+        manifest = _make_tiny_kimi_manifest()
+        ops = build_ir_v8.build_ir1_direct(manifest, ROOT / "tests" / "kimi.synthetic.json", mode="decode")
+        by_layer_op = {(op.get("layer"), op.get("op"), op.get("instance", 0)): op for op in ops}
+
+        self.assertEqual([op["op"] for op in ops].count("residual_save"), 4)
+        self.assertEqual(by_layer_op[(0, "q_proj", 0)]["kernel"], "gemv_bf16")
+        self.assertEqual(by_layer_op[(0, "kv_a_proj", 0)]["kernel"], "gemv_bf16")
+        self.assertEqual(by_layer_op[(0, "kv_lora_decompress", 0)]["kernel"], "deepseek_mla_kv_decompress_f32")
+        self.assertEqual(by_layer_op[(0, "partial_rope_concat", 0)]["kernel"], "deepseek_mla_partial_rope_concat_packed_f32")
+        self.assertEqual(by_layer_op[(1, "moe_swiglu_expert_mlp", 0)]["kernel"], "moe_swiglu_expert_forward_f32")
+        self.assertEqual(by_layer_op[(1, "shared_swiglu_expert_mlp", 0)]["kernel"], "moe_swiglu_shared_forward_f32")
+
+        q_source = by_layer_op[(0, "q_proj", 0)]["dataflow"]["inputs"]["x"]
+        kv_source = by_layer_op[(0, "kv_a_proj", 0)]["dataflow"]["inputs"]["x"]
+        router_source = by_layer_op[(1, "moe_router", 0)]["dataflow"]["inputs"]["x"]
+        self.assertEqual(q_source["slot"], "layer_input")
+        self.assertEqual(q_source["from_op"], by_layer_op[(0, "block_rmsnorm", 0)]["op_id"])
+        self.assertEqual(kv_source["slot"], "layer_input")
+        self.assertEqual(router_source["slot"], "layer_input")
+        self.assertEqual(router_source["from_op"], by_layer_op[(1, "block_rmsnorm", 1)]["op_id"])
+
+        routed_weights = by_layer_op[(1, "moe_swiglu_expert_mlp", 0)]["weights"]
+        self.assertIn("moe_expert_gate", routed_weights)
+        self.assertIn("moe_expert_up", routed_weights)
+        self.assertIn("moe_expert_down", routed_weights)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v8_model_contract_inspector.py
+++ b/tests/test_v8_model_contract_inspector.py
@@ -224,6 +224,71 @@ class ModelContractInspectorTests(unittest.TestCase):
         self.assertEqual(report["families"]["multimodal_projector"], 1)
         self.assertEqual(report["layers"]["1"]["expert_count"], 1)
 
+
+    def test_kimi_safetensors_index_validates_required_model_map_patterns(self) -> None:
+        index = {
+            "metadata": {"total_parameters": 123, "total_size": 456},
+            "weight_map": {
+                "language_model.model.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_proj_with_mqa.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_layernorm.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_b_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.o_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.gate.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.experts.0.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.shared_experts.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "vision_tower.encoder.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "multi_modal_projector.linear_1.weight": "model-00001-of-00001.safetensors",
+            },
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "model.safetensors.index.json"
+            path.write_text(json.dumps(index), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(AUDIT_SCRIPT), str(path), "--arch", "kimi_vl"],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["model_map_status"], "known")
+        self.assertEqual(report["required_tensor_patterns"]["missing"], [])
+        expert_row = next(row for row in report["required_tensor_patterns"]["patterns"] if "experts.{E}.gate_proj" in row["pattern"])
+        self.assertEqual(expert_row["expert_counts"], {"1": 1})
+
+    def test_kimi_safetensors_index_fails_when_required_mla_tensor_missing(self) -> None:
+        index = {
+            "metadata": {"total_parameters": 123, "total_size": 456},
+            "weight_map": {
+                "language_model.model.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_proj_with_mqa.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_layernorm.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.o_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.gate.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.experts.0.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.shared_experts.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "vision_tower.encoder.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "multi_modal_projector.linear_1.weight": "model-00001-of-00001.safetensors",
+            },
+        }
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "model.safetensors.index.json"
+            path.write_text(json.dumps(index), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(AUDIT_SCRIPT), str(path), "--arch", "kimi_vl"],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["status"], "fail")
+        self.assertIn("language_model.model.layers.{L}.self_attn.kv_b_proj.weight", report["required_tensor_patterns"]["missing"])
+
     def test_qwen3_dense_config_is_supported_at_contract_level(self) -> None:
         cfg = {
             "architectures": ["Qwen3ForCausalLM"],

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -697,3 +697,145 @@ def test_glm4_safetensors_to_bump_uses_declarative_source_map(tmp_path: Path) ->
     assert entries["layer.0.w1"]["shape"] == [16, 8]
     assert entries["layer.0.b1"]["shape"] == [32]
     assert "output.weight" in names
+
+def test_kimi_vl_safetensors_to_bump_dry_run_maps_text_decoder(tmp_path: Path) -> None:
+    torch, st = _require_torch_safetensors()
+    checkpoint = tmp_path / "kimi_vl"
+    out = tmp_path / "out_kimi_vl"
+    checkpoint.mkdir()
+    out.mkdir()
+
+    config = {
+        "architectures": ["KimiVLForConditionalGeneration"],
+        "model_type": "kimi_vl",
+        "text_config": {
+            "num_hidden_layers": 2,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "moe_intermediate_size": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "vocab_size": 32,
+            "max_position_embeddings": 128,
+            "kv_lora_rank": 4,
+            "q_lora_rank": None,
+            "qk_nope_head_dim": 2,
+            "qk_rope_head_dim": 2,
+            "v_head_dim": 2,
+            "n_shared_experts": 1,
+            "n_routed_experts": 2,
+            "num_experts_per_tok": 1,
+            "first_k_dense_replace": 1,
+            "moe_layer_freq": 1,
+            "n_group": 1,
+            "topk_group": 1,
+            "norm_topk_prob": True,
+            "routed_scaling_factor": 2.446,
+            "scoring_func": "sigmoid",
+            "topk_method": "noaux_tc",
+            "rope_theta": 800000.0,
+            "tie_word_embeddings": False,
+        },
+        "vision_config": {
+            "model_type": "moonvit",
+            "hidden_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "patch_size": 14,
+        },
+    }
+    (checkpoint / "config.json").write_text(json.dumps(config) + "\n", encoding="utf-8")
+
+    tensors = {
+        "language_model.model.embed_tokens.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+        "language_model.model.norm.weight": torch.ones(8, dtype=torch.float32),
+        "language_model.lm_head.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+    }
+    for layer in range(2):
+        pfx = f"language_model.model.layers.{layer}"
+        tensors.update(
+            {
+                f"{pfx}.input_layernorm.weight": torch.ones(8, dtype=torch.float32),
+                f"{pfx}.post_attention_layernorm.weight": torch.ones(8, dtype=torch.float32),
+                f"{pfx}.self_attn.q_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+                f"{pfx}.self_attn.kv_a_proj_with_mqa.weight": torch.randn(6, 8, dtype=torch.bfloat16),
+                f"{pfx}.self_attn.kv_a_layernorm.weight": torch.ones(4, dtype=torch.float32),
+                f"{pfx}.self_attn.kv_b_proj.weight": torch.randn(8, 4, dtype=torch.bfloat16),
+                f"{pfx}.self_attn.o_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+            }
+        )
+    tensors.update(
+        {
+            "language_model.model.layers.0.mlp.gate_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+            "language_model.model.layers.0.mlp.up_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+            "language_model.model.layers.0.mlp.down_proj.weight": torch.randn(8, 16, dtype=torch.bfloat16),
+            "language_model.model.layers.1.mlp.gate.weight": torch.randn(2, 8, dtype=torch.float32),
+            "language_model.model.layers.1.mlp.gate.e_score_correction_bias": torch.randn(2, dtype=torch.float32),
+            "language_model.model.layers.1.mlp.shared_experts.gate_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+            "language_model.model.layers.1.mlp.shared_experts.up_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+            "language_model.model.layers.1.mlp.shared_experts.down_proj.weight": torch.randn(8, 4, dtype=torch.bfloat16),
+        }
+    )
+    for expert in range(2):
+        tensors.update(
+            {
+                f"language_model.model.layers.1.mlp.experts.{expert}.gate_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+                f"language_model.model.layers.1.mlp.experts.{expert}.up_proj.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+                f"language_model.model.layers.1.mlp.experts.{expert}.down_proj.weight": torch.randn(8, 4, dtype=torch.bfloat16),
+            }
+        )
+    st.save_file(tensors, checkpoint / "model.safetensors")
+
+    script = Path("version/v8/scripts/convert_safetensors_to_bump_v8.py")
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(out / "weights.bump"),
+            "--config-out",
+            str(out / "config.json"),
+            "--manifest-out",
+            str(out / "weights_manifest.json"),
+            "--arch",
+            "auto",
+            "--dry-run",
+        ],
+        check=True,
+    )
+
+    manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
+    audit = json.loads((out / "conversion_audit.json").read_text(encoding="utf-8"))
+    names = {entry["name"] for entry in manifest["entries"]}
+    entries = {entry["name"]: entry for entry in manifest["entries"]}
+
+    assert manifest["model"] == "kimi_vl"
+    assert manifest["template"]["name"] == "kimi_vl"
+    assert manifest["config"]["layer_kinds"] == ["mla_dense_mlp", "mla_moe"]
+    assert manifest["config"]["rotary_dim"] == 2
+    assert manifest["config"]["mla_q_head_dim"] == 4
+    assert manifest["config"]["layer_moe_policy"] == ["none", "routed_swiglu"]
+    assert audit["verdict"] == "pass"
+    assert audit["unmapped_source_tensors"] == []
+    assert entries["layer.1.moe_expert_gate"]["shape"] == [2, 4, 8]
+    assert entries["layer.1.moe_expert_up"]["shape"] == [2, 4, 8]
+    assert entries["layer.1.moe_expert_down"]["shape"] == [2, 8, 4]
+    assert {
+        "token_emb",
+        "layer.0.mla_q_proj",
+        "layer.0.mla_kv_a_proj",
+        "layer.0.mla_kv_a_norm",
+        "layer.0.mla_kv_b_proj",
+        "layer.0.mlp_gate",
+        "layer.1.moe_router",
+        "layer.1.moe_router_bias",
+        "layer.1.moe_expert_gate",
+        "layer.1.moe_expert_up",
+        "layer.1.moe_expert_down",
+        "layer.1.moe_shared_gate",
+        "final_ln_weight",
+        "final_ln_bias",
+        "output.weight",
+    }.issubset(names)

--- a/tests/test_v8_template_circuit_audit.py
+++ b/tests/test_v8_template_circuit_audit.py
@@ -104,10 +104,10 @@ class TemplateCircuitAuditTests(unittest.TestCase):
         self.assertIn("decoder.body:mla_dense_mlp[2].q_proj.x=layer_input", explicit)
         self.assertIn("decoder.body:mla_dense_mlp[3].kv_a_proj.x=layer_input", explicit)
         self.assertIn("decoder.body:mla_dense_mlp[5].kv_lora_decompress.compressed_kv=compressed_kv_normed", explicit)
-        self.assertIn("decoder.body:mla_dense_mlp[6].partial_rope_concat.q_pe=q_pe", explicit)
-        self.assertIn("decoder.body:mla_dense_mlp[7].mla_attention.query=mla_query", explicit)
-        self.assertIn("decoder.body:mla_moe[14].moe_swiglu_expert_mlp.routing_weights=router_weights", explicit)
-        self.assertIn("decoder.body:mla_moe[15].shared_swiglu_expert_mlp.routed=moe_routed", explicit)
+        self.assertIn("decoder.body:mla_dense_mlp[6].partial_rope_concat.q_packed=q_scratch", explicit)
+        self.assertIn("decoder.body:mla_dense_mlp[7].mla_attention.query=q_scratch", explicit)
+        self.assertIn("decoder.body:mla_moe[14].moe_swiglu_expert_mlp.routing_weights=k_scratch", explicit)
+        self.assertIn("decoder.body:mla_moe[15].shared_swiglu_expert_mlp.routed=mlp_scratch", explicit)
         self.assertIn("decoder.footer[2].logits.x=main_stream", explicit)
         self.assertEqual(report["missing"], [])
 
@@ -138,8 +138,8 @@ class TemplateCircuitAuditTests(unittest.TestCase):
                 _op(4, 0, "kv_a_proj", {"x": {"from_op": 2, "slot": "layer_input"}}, {"y": {"slot": "compressed_kv", "dtype": "fp32"}}),
                 _op(5, 0, "kv_a_layernorm", {"x": {"from_op": 4, "slot": "compressed_kv"}}, {"y": {"slot": "compressed_kv_normed", "dtype": "fp32"}}),
                 _op(6, 0, "kv_lora_decompress", {"compressed_kv": {"from_op": 5, "slot": "compressed_kv_normed"}}, {"k_nope": {"slot": "k_nope"}, "value": {"slot": "mla_value"}}),
-                _op(7, 0, "partial_rope_concat", {"q_nope": {"from_op": 3, "slot": "q_nope"}, "q_pe": {"from_op": 3, "slot": "q_pe"}, "k_nope": {"from_op": 6, "slot": "k_nope"}}, {"query": {"slot": "mla_query"}, "key": {"slot": "mla_key"}}),
-                _op(8, 0, "mla_attention", {"query": {"from_op": 7, "slot": "mla_query"}, "key": {"from_op": 7, "slot": "mla_key"}, "value": {"from_op": 6, "slot": "mla_value"}}, {"out": {"slot": "attn_scratch"}}),
+                _op(7, 0, "partial_rope_concat", {"q_packed": {"from_op": 3, "slot": "q_scratch"}, "k_nope": {"from_op": 6, "slot": "k_nope"}, "k_pe": {"from_op": 4, "slot": "compressed_kv"}}, {"query": {"slot": "q_scratch"}, "key": {"slot": "k_scratch"}}),
+                _op(8, 0, "mla_attention", {"query": {"from_op": 7, "slot": "q_scratch"}, "key": {"from_op": 7, "slot": "k_scratch"}, "value": {"from_op": 6, "slot": "v_scratch"}}, {"out": {"slot": "attn_scratch"}}),
             ]
         }
         self.assertEqual(audit.audit_ir1(ir), [])

--- a/unittest/test_deepseek_reference_kernels.py
+++ b/unittest/test_deepseek_reference_kernels.py
@@ -36,6 +36,8 @@ lib.deepseek_mla_kv_decompress_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_
 lib.deepseek_mla_kv_decompress_f32.restype = None
 lib.deepseek_mla_partial_rope_concat_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
 lib.deepseek_mla_partial_rope_concat_f32.restype = None
+lib.deepseek_mla_partial_rope_concat_packed_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.deepseek_mla_partial_rope_concat_packed_f32.restype = None
 
 
 def ptr(a):
@@ -171,6 +173,52 @@ class TestDeepSeekReferenceKernels(unittest.TestCase):
             ptr(key),
             tokens,
             heads,
+            nope_dim,
+            rope_dim,
+        )
+        np.testing.assert_allclose(query, q_ref.numpy(), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(key, k_ref.numpy(), rtol=1e-6, atol=1e-6)
+
+    def test_mla_partial_rope_concat_packed_q_matches_kimi_layout(self):
+        torch.manual_seed(29)
+        tokens, heads, rank, nope_dim, rope_dim = 3, 2, 4, 5, 6
+        q_packed = torch.randn(tokens, heads, nope_dim + rope_dim, dtype=torch.float32)
+        k_nope = torch.randn(tokens, heads, nope_dim, dtype=torch.float32)
+        k_pe = torch.randn(tokens, rope_dim, dtype=torch.float32)
+        kv_a_packed = torch.cat([torch.randn(tokens, rank, dtype=torch.float32), k_pe], dim=-1).contiguous()
+        base = torch.randn(tokens, rope_dim // 2, dtype=torch.float32)
+        cos_half = base.cos()
+        sin_half = base.sin()
+        cos = torch.cat([cos_half, cos_half], dim=-1)
+        sin = torch.cat([sin_half, sin_half], dim=-1)
+
+        def apply_kimi_rope(x):
+            b = x.reshape(*x.shape[:-1], rope_dim // 2, 2).transpose(-1, -2).reshape(*x.shape[:-1], rope_dim)
+            first, second = b[..., : rope_dim // 2], b[..., rope_dim // 2 :]
+            rotated = torch.cat([-second, first], dim=-1)
+            c = cos.reshape(tokens, 1, rope_dim)
+            ss = sin.reshape(tokens, 1, rope_dim)
+            return b * c + rotated * ss
+
+        q_nope = q_packed[:, :, :nope_dim].contiguous()
+        q_pe = q_packed[:, :, nope_dim:].contiguous()
+        q_ref = torch.cat([q_nope, apply_kimi_rope(q_pe)], dim=-1)
+        k_pe_heads = k_pe[:, None, :].expand(tokens, heads, rope_dim).contiguous()
+        k_ref = torch.cat([k_nope, apply_kimi_rope(k_pe_heads)], dim=-1)
+
+        query = np.empty((tokens, heads, nope_dim + rope_dim), dtype=np.float32)
+        key = np.empty_like(query)
+        lib.deepseek_mla_partial_rope_concat_packed_f32(
+            ptr(np.ascontiguousarray(q_packed.numpy())),
+            ptr(np.ascontiguousarray(k_nope.numpy())),
+            ptr(np.ascontiguousarray(kv_a_packed.numpy())),
+            ptr(np.ascontiguousarray(cos_half.numpy())),
+            ptr(np.ascontiguousarray(sin_half.numpy())),
+            ptr(query),
+            ptr(key),
+            tokens,
+            heads,
+            rank,
             nope_dim,
             rope_dim,
         )

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -19578,6 +19578,121 @@
       "notes": "Build merged vision position IDs for 2D M-RoPE style encoders.",
       "name": "vision_position_ids_2d_merge",
       "_source_file": "vision_position_ids_2d_merge.json"
+    },
+    {
+      "id": "deepseek_mla_partial_rope_concat_packed_f32",
+      "op": "partial_rope_concat",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q_packed",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        },
+        {
+          "name": "k_nope",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk"
+          ]
+        },
+        {
+          "name": "kv_a_packed",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "R+Dr"
+          ]
+        },
+        {
+          "name": "cos",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "Dr/2"
+          ]
+        },
+        {
+          "name": "sin",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "Dr/2"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "query",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        },
+        {
+          "name": "key",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        }
+      ],
+      "dims": [
+        "T",
+        "H",
+        "R",
+        "Dk",
+        "Dr"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "deepseek_mla_partial_rope_concat_packed_f32",
+        "c_declaration": "void deepseek_mla_partial_rope_concat_packed_f32(const float *q_packed, const float *k_nope, const float *kv_a_packed, const float *cos, const float *sin, float *query, float *key, int tokens, int heads, int kv_lora_rank, int qk_nope_dim, int qk_rope_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_deepseek_reference_kernels.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+            "tolerance": "1e-6"
+          }
+        ]
+      },
+      "notes": "Scalar reference for MLA partial RoPE assembly from packed q_proj [q_nope|q_pe] and packed kv_a_proj [compressed_kv|k_pe]. This preserves the Kimi/DeepSeek circuit without inventing compact q_pe/k_pe activation buffers.",
+      "name": "deepseek_mla_partial_rope_concat_packed_f32",
+      "_source_file": "deepseek_mla_partial_rope_concat_packed_f32.json"
     }
   ]
 }

--- a/version/v8/kernel_maps/deepseek_mla_partial_rope_concat_packed_f32.json
+++ b/version/v8/kernel_maps/deepseek_mla_partial_rope_concat_packed_f32.json
@@ -1,0 +1,113 @@
+{
+  "id": "deepseek_mla_partial_rope_concat_packed_f32",
+  "op": "partial_rope_concat",
+  "variant": "fp32",
+  "modes": {
+    "inference": true,
+    "training": true,
+    "backward": false
+  },
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q_packed",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk+Dr"
+      ]
+    },
+    {
+      "name": "k_nope",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk"
+      ]
+    },
+    {
+      "name": "kv_a_packed",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "R+Dr"
+      ]
+    },
+    {
+      "name": "cos",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "Dr/2"
+      ]
+    },
+    {
+      "name": "sin",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "Dr/2"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "query",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk+Dr"
+      ]
+    },
+    {
+      "name": "key",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "H",
+        "Dk+Dr"
+      ]
+    }
+  ],
+  "dims": [
+    "T",
+    "H",
+    "R",
+    "Dk",
+    "Dr"
+  ],
+  "impl": {
+    "sources": [
+      "src/kernels/deepseek_kernels.c"
+    ],
+    "variants": [
+      {
+        "name": "scalar_ref",
+        "requires": [],
+        "compile_flags": []
+      }
+    ],
+    "function": "deepseek_mla_partial_rope_concat_packed_f32",
+    "c_declaration": "void deepseek_mla_partial_rope_concat_packed_f32(const float *q_packed, const float *k_nope, const float *kv_a_packed, const float *cos, const float *sin, float *query, float *key, int tokens, int heads, int kv_lora_rank, int qk_nope_dim, int qk_rope_dim);"
+  },
+  "tests": {
+    "unit": [
+      "unittest/test_deepseek_reference_kernels.py"
+    ],
+    "parity": [
+      {
+        "kind": "pytorch",
+        "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+        "tolerance": "1e-6"
+      }
+    ]
+  },
+  "notes": "Scalar reference for MLA partial RoPE assembly from packed q_proj [q_nope|q_pe] and packed kv_a_proj [compressed_kv|k_pe]. This preserves the Kimi/DeepSeek circuit without inventing compact q_pe/k_pe activation buffers."
+}

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -2574,6 +2574,214 @@
           "source": "dim:_input_dim"
         }
       ]
+    },
+    "deepseek_mla_kv_decompress_f32": {
+      "params": [
+        {
+          "name": "compressed_kv",
+          "source": "activation:compressed_kv",
+          "cast": "const float*"
+        },
+        {
+          "name": "kv_b_proj",
+          "source": "weight:mla_kv_b_proj",
+          "cast": "const float*"
+        },
+        {
+          "name": "k_nope",
+          "source": "output:k_nope",
+          "cast": "float*"
+        },
+        {
+          "name": "value",
+          "source": "output:value",
+          "cast": "float*"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:_m"
+        },
+        {
+          "name": "heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "kv_lora_rank",
+          "source": "dim:kv_lora_rank"
+        },
+        {
+          "name": "qk_nope_dim",
+          "source": "dim:qk_nope_head_dim"
+        },
+        {
+          "name": "v_dim",
+          "source": "dim:v_head_dim"
+        }
+      ]
+    },
+    "deepseek_mla_partial_rope_concat_packed_f32": {
+      "params": [
+        {
+          "name": "q_packed",
+          "source": "activation:q_packed",
+          "cast": "const float*"
+        },
+        {
+          "name": "k_nope",
+          "source": "activation:k_nope",
+          "cast": "const float*"
+        },
+        {
+          "name": "kv_a_packed",
+          "source": "activation:kv_a_packed",
+          "cast": "const float*"
+        },
+        {
+          "name": "cos",
+          "source": "runtime:rope_cos",
+          "cast": "const float*"
+        },
+        {
+          "name": "sin",
+          "source": "runtime:rope_sin",
+          "cast": "const float*"
+        },
+        {
+          "name": "query",
+          "source": "output:query",
+          "cast": "float*"
+        },
+        {
+          "name": "key",
+          "source": "output:key",
+          "cast": "float*"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:_m"
+        },
+        {
+          "name": "heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "kv_lora_rank",
+          "source": "dim:kv_lora_rank"
+        },
+        {
+          "name": "qk_nope_dim",
+          "source": "dim:qk_nope_head_dim"
+        },
+        {
+          "name": "qk_rope_dim",
+          "source": "dim:qk_rope_head_dim"
+        }
+      ]
+    },
+    "moe_swiglu_expert_forward_f32": {
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "indices",
+          "source": "activation:indices",
+          "cast": "const int*"
+        },
+        {
+          "name": "routing_weights",
+          "source": "activation:routing_weights",
+          "cast": "const float*"
+        },
+        {
+          "name": "expert_gate",
+          "source": "weight:moe_expert_gate",
+          "cast": "const float*"
+        },
+        {
+          "name": "expert_up",
+          "source": "weight:moe_expert_up",
+          "cast": "const float*"
+        },
+        {
+          "name": "expert_down",
+          "source": "weight:moe_expert_down",
+          "cast": "const float*"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "hidden_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:moe_intermediate_size"
+        },
+        {
+          "name": "n_experts",
+          "source": "dim:n_routed_experts"
+        },
+        {
+          "name": "top_k",
+          "source": "dim:num_experts_per_tok"
+        }
+      ]
+    },
+    "moe_swiglu_shared_forward_f32": {
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "routed",
+          "source": "activation:routed",
+          "cast": "const float*"
+        },
+        {
+          "name": "shared_gate",
+          "source": "weight:moe_shared_gate",
+          "cast": "const float*"
+        },
+        {
+          "name": "shared_up",
+          "source": "weight:moe_shared_up",
+          "cast": "const float*"
+        },
+        {
+          "name": "shared_down",
+          "source": "weight:moe_shared_down",
+          "cast": "const float*"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "hidden_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:moe_intermediate_size"
+        }
+      ]
     }
   }
 }

--- a/version/v8/scripts/audit_safetensors_index_v8.py
+++ b/version/v8/scripts/audit_safetensors_index_v8.py
@@ -11,6 +11,10 @@ from pathlib import Path
 from typing import Any
 
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_SAFETENSORS_CK_MAP = SCRIPT_DIR.parent / "model_maps" / "safetensors_ck_map.json"
+
+
 LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
 EXPERT_RE = re.compile(r"\.experts\.(\d+)\.")
 
@@ -72,9 +76,88 @@ def _family(name: str) -> str:
     return "other"
 
 
-def audit_index(path: Path) -> dict[str, Any]:
+
+def _pattern_regex(pattern: str) -> re.Pattern[str]:
+    sentinel_star = "<<<STAR>>>"
+    text = re.escape(pattern.replace("*", sentinel_star))
+    text = text.replace(r"\{L\}", r"(?P<L>\d+)")
+    text = text.replace(r"\{E\}", r"(?P<E>\d+)")
+    text = text.replace(sentinel_star, r".*")
+    return re.compile(r"^" + text + r"$")
+
+
+def _load_model_map(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"architectures": {}}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {"architectures": {}}
+
+
+def _arch_contract(model_map: dict[str, Any], arch: str | None) -> dict[str, Any]:
+    if not arch:
+        return {}
+    contracts = model_map.get("architectures") if isinstance(model_map.get("architectures"), dict) else {}
+    key = str(arch).lower()
+    row = contracts.get(key)
+    if isinstance(row, dict):
+        return row
+    for candidate, contract in contracts.items():
+        if not isinstance(contract, dict):
+            continue
+        aliases = [str(candidate).lower()]
+        aliases.extend(str(x).lower() for x in contract.get("aliases", []) if isinstance(x, str))
+        if key in aliases:
+            return contract
+    return {}
+
+
+def _validate_required_patterns(weight_names: list[str], contract: dict[str, Any]) -> dict[str, Any]:
+    patterns = contract.get("required_tensor_patterns")
+    if patterns is None:
+        patterns = contract.get("required_tensor_families")
+    if not isinstance(patterns, list):
+        patterns = []
+    rows: list[dict[str, Any]] = []
+    missing: list[str] = []
+    for raw in patterns:
+        pattern = str(raw)
+        rx = _pattern_regex(pattern)
+        matched = []
+        layers: set[int] = set()
+        experts: dict[int, set[int]] = defaultdict(set)
+        for name in weight_names:
+            m = rx.match(name)
+            if not m:
+                continue
+            matched.append(name)
+            gd = m.groupdict()
+            if gd.get("L") is not None:
+                layer = int(gd["L"])
+                layers.add(layer)
+                if gd.get("E") is not None:
+                    experts[layer].add(int(gd["E"]))
+        if not matched:
+            missing.append(pattern)
+        row: dict[str, Any] = {
+            "pattern": pattern,
+            "count": len(matched),
+            "layers": sorted(layers),
+        }
+        if experts:
+            row["expert_counts"] = {str(layer): len(ids) for layer, ids in sorted(experts.items())}
+        rows.append(row)
+    return {
+        "status": "pass" if not missing else "fail",
+        "required_count": len(rows),
+        "missing_count": len(missing),
+        "missing": missing,
+        "patterns": rows,
+    }
+
+def audit_index(path: Path, arch: str | None = None, model_map_path: Path = DEFAULT_SAFETENSORS_CK_MAP) -> dict[str, Any]:
     data = _load_index(path)
     wm = data["weight_map"]
+    weight_names = sorted(str(name) for name in wm)
     families = Counter(_family(name) for name in wm)
     layers: dict[int, Counter[str]] = defaultdict(Counter)
     expert_ids: dict[int, set[int]] = defaultdict(set)
@@ -96,7 +179,10 @@ def audit_index(path: Path) -> dict[str, Any]:
         }
         for layer, counter in sorted(layers.items())
     }
-    return {
+    model_map = _load_model_map(model_map_path)
+    contract = _arch_contract(model_map, arch)
+    required = _validate_required_patterns(weight_names, contract) if contract else None
+    report = {
         "metadata": data.get("metadata", {}),
         "tensor_count": len(wm),
         "shard_count": len(shards),
@@ -105,20 +191,33 @@ def audit_index(path: Path) -> dict[str, Any]:
         "layer_count": len(layers),
         "layers": layer_summary,
     }
+    if arch:
+        report["arch"] = str(arch)
+        report["model_map_status"] = "known" if contract else "unknown"
+        if required is not None:
+            report["required_tensor_patterns"] = required
+            report["status"] = required["status"]
+        elif contract:
+            report["status"] = "pass"
+        else:
+            report["status"] = "fail"
+    return report
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Audit safetensors index tensor families without loading shards")
     ap.add_argument("index", type=Path, help="model.safetensors.index.json or directory")
+    ap.add_argument("--arch", help="optional CK architecture key or alias to validate against model_maps/safetensors_ck_map.json")
+    ap.add_argument("--model-map", type=Path, default=DEFAULT_SAFETENSORS_CK_MAP, help="safetensors CK model map JSON")
     ap.add_argument("--json-out", type=Path)
     args = ap.parse_args()
-    report = audit_index(args.index)
+    report = audit_index(args.index, arch=args.arch, model_map_path=args.model_map)
     text = json.dumps(report, indent=2, sort_keys=True) + "\n"
     if args.json_out:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(text, encoding="utf-8")
     print(text, end="")
-    return 0
+    return 0 if report.get("status", "pass") != "fail" else 2
 
 
 if __name__ == "__main__":

--- a/version/v8/scripts/audit_template_circuit_v8.py
+++ b/version/v8/scripts/audit_template_circuit_v8.py
@@ -43,9 +43,9 @@ CRITICAL_TEMPLATE_INPUTS: dict[str, tuple[str, ...]] = {
     "k_proj": ("x",),
     "v_proj": ("x",),
     "kv_a_proj": ("x",),
-    "kv_a_layernorm": ("x",),
-    "kv_lora_decompress": ("compressed_kv", "kv_b"),
-    "partial_rope_concat": ("q_nope", "q_pe", "k_nope", "k_pe"),
+    "kv_a_layernorm": ("input",),
+    "kv_lora_decompress": ("compressed_kv",),
+    "partial_rope_concat": ("q_packed", "k_nope", "k_pe"),
     "mla_attention": ("query", "key", "value"),
     "mlp_gate_up": ("x",),
     "moe_swiglu_expert_mlp": ("hidden", "indices", "routing_weights"),
@@ -269,10 +269,11 @@ def audit_ir1(ir1: dict[str, Any]) -> list[str]:
             _same_producer(errors, kv_decomp, "compressed_kv", kv_norm, f"{label} MLA kv decompress")
         if partial is not None:
             if q is not None:
-                for input_name in ("q_nope", "q_pe"):
-                    _same_producer(errors, partial, input_name, q, f"{label} MLA partial rope")
+                _same_producer(errors, partial, "q_packed", q, f"{label} MLA partial rope")
             if kv_decomp is not None:
                 _same_producer(errors, partial, "k_nope", kv_decomp, f"{label} MLA partial rope")
+            if kv_a is not None:
+                _same_producer(errors, partial, "k_pe", kv_a, f"{label} MLA partial rope")
         if mla is not None:
             if partial is not None:
                 _same_producer(errors, mla, "query", partial, f"{label} MLA attention")

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -675,6 +675,47 @@ OP_DATAFLOW = {
         },
         "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "kv_a_proj": {
+        "inputs": {"x": "main_stream_q8"},
+        "outputs": {"y": {"slot": "compressed_kv", "dtype": "fp32"}},
+    },
+    "kv_a_layernorm": {
+        "inputs": {"input": "compressed_kv"},
+        "outputs": {"output": {"slot": "compressed_kv_normed", "dtype": "fp32"}},
+    },
+    "kv_lora_decompress": {
+        "inputs": {"compressed_kv": "compressed_kv_normed"},
+        "outputs": {
+            "k_nope": {"slot": "k_nope", "dtype": "fp32"},
+            "value": {"slot": "v_scratch", "dtype": "fp32"},
+        },
+    },
+    "partial_rope_concat": {
+        "inputs": {"q_packed": "q_scratch", "k_nope": "k_nope", "k_pe": "compressed_kv"},
+        "outputs": {
+            "query": {"slot": "q_scratch", "dtype": "fp32"},
+            "key": {"slot": "k_scratch", "dtype": "fp32"},
+        },
+    },
+    "mla_attention": {
+        "inputs": {"q": "q_scratch", "k": "k_scratch", "v": "v_scratch"},
+        "outputs": {"out": {"slot": "attn_scratch", "dtype": "fp32"}},
+    },
+    "moe_swiglu_expert_mlp": {
+        "inputs": {
+            "hidden": "layer_input",
+            "indices": "q_scratch",
+            "routing_weights": "k_scratch",
+        },
+        "outputs": {"output": {"slot": "mlp_scratch", "dtype": "fp32"}},
+    },
+    "shared_swiglu_expert_mlp": {
+        "inputs": {
+            "hidden": "layer_input",
+            "routed": "mlp_scratch",
+        },
+        "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
+    },
 
     "mamba_in_proj": {
         "inputs": {"x": "main_stream_q8"},
@@ -1858,6 +1899,15 @@ def build_activation_specs(config: Dict[str, Any], mode: str, context_len: int, 
     add("attn_gate", attn_gate_size, f"[{seq_len}, {attn_gate_dim}]")
     add("attn_scratch", attn_out_size, f"[{num_heads}, {seq_len}, {max_q_head_dim}]")
 
+    kv_lora_rank = int(config.get("kv_lora_rank", 0) or 0)
+    qk_nope_dim = int(config.get("qk_nope_head_dim", 0) or 0)
+    qk_rope_dim = int(config.get("qk_rope_head_dim", 0) or 0)
+    if kv_lora_rank > 0 and qk_rope_dim > 0:
+        add("compressed_kv", seq_len * (kv_lora_rank + qk_rope_dim) * 4, f"[{seq_len}, {kv_lora_rank + qk_rope_dim}]")
+        add("compressed_kv_normed", seq_len * kv_lora_rank * 4, f"[{seq_len}, {kv_lora_rank}]")
+        if qk_nope_dim > 0:
+            add("k_nope", num_heads * seq_len * qk_nope_dim * 4, f"[{num_heads}, {seq_len}, {qk_nope_dim}]")
+
     if bool(config.get("gemma4_per_layer_embedding", False)):
         per_layer_dim = int(config.get("per_layer_dim", 0) or 0)
         if per_layer_dim > 0 and num_layers > 0:
@@ -1955,6 +2005,7 @@ TEMPLATE_TO_KERNEL_OP = {
     "tokenizer": None,  # Metadata op - no kernel (deprecated, use bpe_tokenizer)
     "bpe_tokenizer": None,  # BPE tokenizer - init handled separately
     "wordpiece_tokenizer": None,  # WordPiece tokenizer - init handled separately
+    "tiktoken_tokenizer": None,  # TikToken tokenizer - init handled separately
     "patch_embeddings": None,  # Vision model patches - init handled separately
     "patchify": "vision_patchify",
     "patch_proj": "matmul",
@@ -1965,6 +2016,7 @@ TEMPLATE_TO_KERNEL_OP = {
     "position_ids_2d": "position_ids",
     "patch_bias_add": "rowwise_bias_add",
     "dense_embedding_lookup": "embedding",  # Token embedding lookup
+    "residual_save": "residual_save",
     "embedding": "embedding",
 
     # Attention block
@@ -2013,6 +2065,13 @@ TEMPLATE_TO_KERNEL_OP = {
     "group_limited_topk_router": "group_limited_topk_router",
     "moe_relu2_expert_mlp": "moe_relu2_expert_mlp",
     "shared_relu2_expert_mlp": "shared_relu2_expert_mlp",
+    "moe_swiglu_expert_mlp": "moe_swiglu_expert_mlp",
+    "shared_swiglu_expert_mlp": "shared_swiglu_expert_mlp",
+    "kv_a_proj": "matmul",
+    "kv_a_layernorm": "rmsnorm",
+    "kv_lora_decompress": "kv_lora_decompress",
+    "partial_rope_concat": "partial_rope_concat",
+    "mla_attention": "attention",
     "rope_qk": "rope",
     "mrope_qk": "rope",
     "kv_cache_store": "kv_cache_store",  # Store K,V to KV cache at pos
@@ -2208,6 +2267,8 @@ def should_insert_residual_save(layer_ops: List[str], op_idx: int) -> bool:
     if layer_ops[op_idx] not in PRE_NORM_OP_NAMES:
         return False
     if op_idx + 1 >= len(layer_ops):
+        return False
+    if op_idx > 0 and layer_ops[op_idx - 1] == "residual_save":
         return False
     return layer_ops[op_idx + 1] in RESIDUAL_SOURCE_BRANCH_STARTERS
 
@@ -2796,10 +2857,20 @@ def _apply_layer_quant_aliases(
     # do not need brittle per-source alias variants just to preserve dtype
     # propagation.
     canonical_aliases = {
+        "wq": ("attn_q", "mla_q_proj"),
         "w1": ("ffn_gate", "mlp_gate"),
         "w2": ("ffn_down", "mlp_down"),
         "w3": ("ffn_up", "mlp_up"),
-        "wo": ("attn_o", "out_proj"),
+        "wo": ("attn_o", "out_proj", "mla_out_proj"),
+        "mla_kv_a_proj": ("kv_a_proj",),
+        "mla_kv_a_norm": ("kv_a_norm",),
+        "mla_kv_b_proj": ("kv_b_proj",),
+        "moe_expert_gate": ("expert_gate",),
+        "moe_expert_up": ("expert_up",),
+        "moe_expert_down": ("expert_down",),
+        "moe_shared_gate": ("shared_gate",),
+        "moe_shared_up": ("shared_up",),
+        "moe_shared_down": ("shared_down",),
     }
     for dst, candidates in canonical_aliases.items():
         if dst in effective:
@@ -2859,10 +2930,12 @@ def compute_matmul_dims(op_name: str, config: Dict) -> Tuple[Optional[int], Opti
         return embed, int(config.get("ssm_inner_size", config.get("mamba_intermediate_size", attn_out)) or attn_out)
     if op_name in ("moe_router",):
         return int(config.get("n_routed_experts", config.get("num_experts", 0)) or 0) or None, embed
-    if op_name in ("moe_relu2_expert_mlp",):
+    if op_name in ("kv_a_proj",):
+        return int(config.get("kv_lora_rank", 0) or 0) + int(config.get("qk_rope_head_dim", 0) or 0), embed
+    if op_name in ("moe_relu2_expert_mlp", "moe_swiglu_expert_mlp"):
         return int(config.get("moe_intermediate_size", inter) or inter), embed
-    if op_name in ("shared_relu2_expert_mlp",):
-        return int(config.get("moe_shared_expert_intermediate_size", inter) or inter), embed
+    if op_name in ("shared_relu2_expert_mlp", "shared_swiglu_expert_mlp"):
+        return int(config.get("moe_shared_expert_intermediate_size", config.get("moe_intermediate_size", inter)) or inter), embed
     if op_name in ("mlp_gate_up",):
         return inter * 2, embed
     if op_name in ("mlp_up",):
@@ -4583,6 +4656,13 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
     "group_limited_topk_router": ["moe_router_bias"],
     "moe_relu2_expert_mlp": ["moe_expert_up", "moe_expert_down"],
     "shared_relu2_expert_mlp": ["moe_shared_up", "moe_shared_down"],
+    "moe_swiglu_expert_mlp": ["moe_expert_gate", "moe_expert_up", "moe_expert_down"],
+    "shared_swiglu_expert_mlp": ["moe_shared_gate", "moe_shared_up", "moe_shared_down"],
+    "kv_a_proj": ["mla_kv_a_proj"],
+    "kv_a_layernorm": ["mla_kv_a_norm"],
+    "kv_lora_decompress": ["mla_kv_b_proj"],
+    "partial_rope_concat": [],
+    "mla_attention": [],
         "out_proj": ["wo"],
         "mlp_gate_up": ["w1"],
         "mlp_up": ["w3"],
@@ -4656,6 +4736,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "tokenizer": "metadata",  # Deprecated, use bpe_tokenizer
         "bpe_tokenizer": "metadata",  # BPE tokenizer init
         "wordpiece_tokenizer": "metadata",  # WordPiece tokenizer init
+        "tiktoken_tokenizer": "metadata",  # TikToken tokenizer init
         "patch_embeddings": "metadata",  # Vision model patches
         "weight_tying": "metadata",
         "lm_head": "metadata",  # Signals separate lm_head weight (not tied)
@@ -4723,7 +4804,11 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         # Explicit no-weight math ops. These are real kernels, but they must not
         # flow through the header/footer weighted path below, which would invent
         # a q8_0 weight requirement and fail to bind kernels such as Gemma4 V RMSNorm.
-        if op in {"v_norm", "projector_prep", "group_limited_topk_router", "mamba_in_proj_split"}:
+        if op == "residual_save":
+            return ["memcpy"]
+        if op == "partial_rope_concat":
+            return ["deepseek_mla_partial_rope_concat_packed_f32"]
+        if op in {"v_norm", "projector_prep", "group_limited_topk_router", "mamba_in_proj_split", "mla_attention"}:
             kernel_id = find_kernel(
                 registry,
                 op=kernel_op,
@@ -4749,6 +4834,13 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             # Gemma4 per-layer prepare is a structured header op, not a
             # dense projection. It owns BF16/quantized weights internally and
             # must stay on its dedicated kernel regardless of source dtype.
+            if op == "kv_lora_decompress":
+                return ["deepseek_mla_kv_decompress_f32"]
+            if op == "moe_swiglu_expert_mlp":
+                return ["moe_swiglu_expert_forward_f32"]
+            if op == "shared_swiglu_expert_mlp":
+                return ["moe_swiglu_shared_forward_f32"]
+
             if op == "gemma4_per_layer_prepare":
                 token_dtype = layer_quant.get("per_layer_token_emb", header_quant.get("per_layer_token_emb", ""))
                 if token_dtype == "bf16":
@@ -5371,7 +5463,14 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         # Keep the kernel ABI override last so explicit circuit slots cannot
         # accidentally wire a quantized kernel back to the FP32 stream.
         merged_input_override = dict(explicit_input_override or {})
-        merged_input_override.update(input_override or {})
+        kernel_act = str(kernel_act_dtype.get(kernel_id, "fp32") or "fp32").lower() if kernel_id else "fp32"
+        if input_override:
+            # Explicit template graph slots are the semantic edge. For FP32-activation
+            # kernels no physical view remap is needed, so preserve explicit sources
+            # such as Kimi's block_rmsnorm -> layer_input. Quantized kernels still
+            # override to the Q8 physical view produced by an inserted quantize op.
+            if not (explicit_input_override and kernel_act == "fp32"):
+                merged_input_override.update(input_override)
         dataflow_info = dataflow_tracker.record_op(
             op_id,
             op_type,
@@ -5403,6 +5502,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         ("layernorm", 1): ["ln2_gamma", "ln2_beta"],  # Pre-MLP norm
         ("attn_norm", 0): ["ln1_gamma"],    # Pre-attention norm (Gemma)
         ("block_rmsnorm", 0): ["ln1_gamma"], # Generic pre-block norm
+        ("block_rmsnorm", 1): ["post_attention_norm"], # Second Kimi MLA block norm before MLP/MoE
         ("ffn_norm", 0): ["ln2_gamma"],     # Pre-MLP norm (Gemma)
         ("post_attention_norm", 0): ["post_attention_norm"],
         ("post_ffn_norm", 0): ["post_ffn_norm"],
@@ -5582,6 +5682,7 @@ def _check_ir1_completeness(manifest: Dict, ir1_ops: List[Dict]) -> None:
     NON_KERNEL_OPS = {
         "bpe_tokenizer",
         "wordpiece_tokenizer",
+        "tiktoken_tokenizer",
         "tokenizer",
         "weight_tying",
         "lm_head",
@@ -6525,7 +6626,7 @@ def generate_ir_lower_1(
 # Maps: kernel weight ref → possible manifest entry patterns
 WEIGHT_PATTERNS = {
     # QKV projection weights and biases
-    "wq": ["layer.{L}.wq", "layers.{L}.attention.wq", "layer.{L}.attn_q_gate", "layer.{L}.attn_q"],
+    "wq": ["layer.{L}.wq", "layers.{L}.attention.wq", "layer.{L}.attn_q_gate", "layer.{L}.attn_q", "layer.{L}.mla_q_proj"],
     "wk": ["layer.{L}.wk", "layers.{L}.attention.wk", "layer.{L}.attn_k"],
     "wv": ["layer.{L}.wv", "layers.{L}.attention.wv", "layer.{L}.attn_v"],
     "bq": ["layer.{L}.bq", "layers.{L}.attention.bq"],
@@ -6555,19 +6656,24 @@ WEIGHT_PATTERNS = {
     "mamba_d": ["layer.{L}.mamba_d"],
     "mamba_norm": ["layer.{L}.mamba_norm"],
     "mamba_out_proj": ["layer.{L}.mamba_out_proj"],
+    "mla_kv_a_proj": ["layer.{L}.mla_kv_a_proj"],
+    "mla_kv_a_norm": ["layer.{L}.mla_kv_a_norm"],
+    "mla_kv_b_proj": ["layer.{L}.mla_kv_b_proj"],
     "moe_router": ["layer.{L}.moe_router"],
     "moe_router_bias": ["layer.{L}.moe_router_bias"],
+    "moe_expert_gate": ["layer.{L}.moe_expert_gate", "layer.{L}.moe_expert.{E}.gate"],
     "moe_expert_up": ["layer.{L}.moe_expert_up", "layer.{L}.moe_expert.{E}.up"],
     "moe_expert_down": ["layer.{L}.moe_expert_down", "layer.{L}.moe_expert.{E}.down"],
+    "moe_shared_gate": ["layer.{L}.moe_shared_gate"],
     "moe_shared_up": ["layer.{L}.moe_shared_up"],
     "moe_shared_down": ["layer.{L}.moe_shared_down"],
 
     # Output projection
-    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output", "layer.{L}.attn_o"],
+    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output", "layer.{L}.attn_o", "layer.{L}.mla_out_proj"],
     "bo": ["layer.{L}.bo", "layers.{L}.attention.bo"],
 
     # MLP weights and biases
-    "w1": ["layer.{L}.w1", "layers.{L}.feed_forward.w1", "layer.{L}.ffn_gate"],
+    "w1": ["layer.{L}.w1", "layers.{L}.feed_forward.w1", "layer.{L}.ffn_gate", "layer.{L}.mlp_gate"],
     "w2": ["layer.{L}.w2", "layers.{L}.feed_forward.w2", "layer.{L}.ffn_down", "layer.{L}.mlp_down"],
     "w3": ["layer.{L}.w3", "layers.{L}.feed_forward.w3", "layer.{L}.ffn_up", "layer.{L}.mlp_up"],
     "b1": ["layer.{L}.b1", "layers.{L}.feed_forward.b1", "v.blk.{L}.ffn_up.bias"],
@@ -6629,9 +6735,9 @@ WEIGHT_PATTERNS = {
     "ln2_gamma": ["layer.{L}.ln2_gamma", "layers.{L}.ffn_norm.weight", "layer.{L}.post_attention_norm", "v.blk.{L}.ln2.weight"],
     "ln1_beta": ["layer.{L}.ln1_beta", "layers.{L}.attention_norm.bias", "v.blk.{L}.ln1.bias"],
     "ln2_beta": ["layer.{L}.ln2_beta", "layers.{L}.ffn_norm.bias", "v.blk.{L}.ln2.bias"],
-    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output", "layer.{L}.attn_o", "v.blk.{L}.attn_out.weight"],
+    "wo": ["layer.{L}.wo", "layers.{L}.attention.wo", "layer.{L}.attn_output", "layer.{L}.attn_o", "layer.{L}.mla_out_proj", "v.blk.{L}.attn_out.weight"],
     "bo": ["layer.{L}.bo", "layers.{L}.attention.bo", "v.blk.{L}.attn_out.bias"],
-    "w1": ["layer.{L}.w1", "layers.{L}.feed_forward.w1", "layer.{L}.ffn_gate", "v.blk.{L}.ffn_gate.weight"],
+    "w1": ["layer.{L}.w1", "layers.{L}.feed_forward.w1", "layer.{L}.ffn_gate", "layer.{L}.mlp_gate", "v.blk.{L}.ffn_gate.weight"],
     "w2": ["layer.{L}.w2", "layers.{L}.feed_forward.w2", "layer.{L}.ffn_down", "layer.{L}.mlp_down", "v.blk.{L}.ffn_down.weight"],
     "w3": ["layer.{L}.w3", "layers.{L}.feed_forward.w3", "layer.{L}.ffn_up", "layer.{L}.mlp_up", "v.blk.{L}.ffn_up.weight"],
     "branch_norm_gamma": ["v.deepstack.{L}.norm.weight"],
@@ -6665,7 +6771,7 @@ TEMPLATE_OP_WEIGHTS = {
     "rmsnorm": ["ln1_gamma", "ln2_gamma", "final_ln_weight", "final_ln_bias"],
     "layernorm": ["ln1_gamma", "ln1_beta", "ln2_gamma", "ln2_beta", "final_ln_weight", "final_ln_bias"],
     "attn_norm": ["ln1_gamma"],
-    "block_rmsnorm": ["ln1_gamma"],
+    "block_rmsnorm": ["ln1_gamma", "post_attention_norm"],
     "post_attention_norm": ["post_attention_norm"],
     "ffn_norm": ["ln2_gamma"],
     "post_ffn_norm": ["post_ffn_norm"],
@@ -6717,6 +6823,13 @@ TEMPLATE_OP_WEIGHTS = {
     "group_limited_topk_router": ["moe_router_bias"],
     "moe_relu2_expert_mlp": ["moe_expert_up", "moe_expert_down"],
     "shared_relu2_expert_mlp": ["moe_shared_up", "moe_shared_down"],
+    "moe_swiglu_expert_mlp": ["moe_expert_gate", "moe_expert_up", "moe_expert_down"],
+    "shared_swiglu_expert_mlp": ["moe_shared_gate", "moe_shared_up", "moe_shared_down"],
+    "kv_a_proj": ["mla_kv_a_proj"],
+    "kv_a_layernorm": ["mla_kv_a_norm"],
+    "kv_lora_decompress": ["mla_kv_b_proj"],
+    "partial_rope_concat": [],
+    "mla_attention": [],
     "qk_norm": ["q_norm", "k_norm"],  # Per-head RMSNorm gamma weights for Q and K
     "rope_qk": [],  # No model weights (uses precomputed tables)
     "mrope_qk": [],  # No model weights (runtime positions + RoPE params)
@@ -7242,6 +7355,15 @@ def generate_memory_layout(
     add_buffer("attn_q_gate_packed", seq_len * q_gate_proj_dim * 4, f"[{seq_len}, {q_gate_proj_dim}]")
     add_buffer("attn_gate", seq_len * attn_gate_dim * 4, f"[{seq_len}, {attn_gate_dim}]")
     add_buffer("attn_scratch", attn_out_size, f"[{num_heads}, {seq_len}, {max_q_head_dim}]")
+
+    kv_lora_rank = int(config.get("kv_lora_rank", 0) or 0)
+    qk_nope_dim = int(config.get("qk_nope_head_dim", 0) or 0)
+    qk_rope_dim = int(config.get("qk_rope_head_dim", 0) or 0)
+    if kv_lora_rank > 0 and qk_rope_dim > 0:
+        add_buffer("compressed_kv", seq_len * (kv_lora_rank + qk_rope_dim) * 4, f"[{seq_len}, {kv_lora_rank + qk_rope_dim}]")
+        add_buffer("compressed_kv_normed", seq_len * kv_lora_rank * 4, f"[{seq_len}, {kv_lora_rank}]")
+        if qk_nope_dim > 0:
+            add_buffer("k_nope", num_heads * seq_len * qk_nope_dim * 4, f"[{num_heads}, {seq_len}, {qk_nope_dim}]")
 
     if bool(config.get("gemma4_per_layer_embedding", False)):
         per_layer_dim = int(config.get("per_layer_dim", 0) or 0)
@@ -7832,6 +7954,9 @@ def generate_ir_lower_2(
         "A_ATTN_SCRATCH": "attn_scratch",
         "A_ATTN_Q_GATE_PACKED": "attn_q_gate_packed",
         "A_ATTN_GATE": "attn_gate",
+        "A_COMPRESSED_KV": "compressed_kv",
+        "A_COMPRESSED_KV_NORMED": "compressed_kv_normed",
+        "A_K_NOPE": "k_nope",
         "A_MLP_SCRATCH": "mlp_scratch",
         "A_LAYER_OUTPUT": "layer_output",
         "A_BRANCH_STREAM": "branch_stream",
@@ -8056,12 +8181,22 @@ def generate_ir_lower_2(
                         "dtype": input_info.get("dtype", act_dtype),
                         "ptr_expr": f"activations + {buf['offset']}",
                     }
-            # Q writes to q_scratch
+            # Q writes to the template-declared output slot. Standard attention
+            # uses q_scratch; Kimi/DeepSeek MLA keeps packed [q_nope|q_pe]
+            # in q_scratch for the packed partial-RoPE helper.
             if op_type == "q_proj":
-                q_buf = activation_buffers.get("q_scratch")
                 for output_name, output_info in ir_op.get("outputs", {}).items():
+                    planned = get_planned_buffer(op_id, "outputs", output_name) or get_planned_buffer(op_id, "outputs", "y")
+                    declared_slot = _get_declared_dataflow_slot(ir_op, "outputs", output_name, "y")
+                    buf_name = _resolve_logical_buffer_name(
+                        planned.get("buffer", "q_scratch") if planned else "q_scratch",
+                        declared_slot or output_info.get("slot"),
+                        activation_buffers,
+                        buffer_name_map,
+                    )
+                    q_buf = activation_buffers.get(buf_name)
                     lowered_op["outputs"][output_name] = {
-                        "buffer": "q_scratch",
+                        "buffer": buf_name,
                         "activation_offset": q_buf["offset"] if q_buf else 0,
                         "dtype": output_info.get("dtype", "fp32"),
                         "ptr_expr": f"activations + {q_buf['offset'] if q_buf else 0}",
@@ -8535,6 +8670,7 @@ def generate_ir_lower_2(
                     "q_token": "q",
                     "k_cache": "k",
                     "v_cache": "v",
+                    "kv_a_packed": "k_pe",
                 }
                 dataflow_name = _resolve_planner_io_name(
                     input_name,

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -2645,7 +2645,19 @@ static int do_init(const char *weights_path) {{
     g_model->activations = (float*)(g_model->bump + BUMP_ACT_OFFSET);
     g_model->kv_cache = (float*)(g_model->bump + A_KV_CACHE);
     g_model->kv_cache_f16 = (uint16_t*)(g_model->bump + A_KV_CACHE);
+#ifdef A_ROPE_CACHE
     g_model->rope_cos = (float*)(g_model->bump + A_ROPE_CACHE);
+#else
+    size_t rope_cache_elems = (size_t)MAX_SEQ_LEN * (size_t)ROTARY_DIM;
+    g_model->rope_cos = (float*)calloc(rope_cache_elems, sizeof(float));
+    if (!g_model->rope_cos) {{
+        fprintf(stderr, "ck_model_init: failed to allocate RoPE cache (%zu floats)\\n", rope_cache_elems);
+        ck_bump_alloc_free(&g_model->bump_alloc);
+        free(g_model);
+        g_model = NULL;
+        return -1;
+    }}
+#endif
     g_model->rope_sin = g_model->rope_cos + MAX_SEQ_LEN * ROTARY_DIM / 2;
     g_model->logits = (float*)(g_model->bump + A_LOGITS);
     g_model->pos = 0;
@@ -2759,6 +2771,9 @@ CK_EXPORT void ck_model_free(void) {{
         ck_unload_manifest_map(g_manifest);
         g_manifest = NULL;
     }}
+#ifndef A_ROPE_CACHE
+    free(g_model->rope_cos);
+#endif
     ck_bump_alloc_free(&g_model->bump_alloc);
     free(g_model);
     g_model = NULL;

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -467,6 +467,96 @@ def _parse_nemotron_h_pattern(pattern: str, num_layers: int) -> list[str]:
 
 
 
+
+def _kimi_vl_text_refs(config: dict[str, Any], headers: dict[str, HeaderTensor]) -> list[TensorRef]:
+    text = config.get("text_config") if isinstance(config.get("text_config"), dict) else config
+    num_layers = int(text.get("num_hidden_layers") or config.get("num_layers") or 0)
+    hidden = int(text.get("hidden_size") or config.get("hidden_size") or 0)
+    intermediate = int(text.get("intermediate_size") or config.get("intermediate_size") or 0)
+    moe_intermediate = int(text.get("moe_intermediate_size") or config.get("moe_intermediate_size") or 0)
+    n_experts = int(text.get("n_routed_experts") or config.get("n_routed_experts") or 0)
+    n_shared = int(text.get("n_shared_experts") or config.get("n_shared_experts") or 0)
+    layer_kinds = list(config.get("layer_kinds") or [])
+    if not layer_kinds:
+        first_dense = int(text.get("first_k_dense_replace") or 0)
+        moe_freq = int(text.get("moe_layer_freq") or 1)
+        layer_kinds = ["mla_dense_mlp" if layer < first_dense or (moe_freq > 0 and layer % moe_freq != 0) else "mla_moe" for layer in range(num_layers)]
+    if num_layers <= 0 or hidden <= 0 or intermediate <= 0:
+        raise SystemExit("Kimi-VL config missing num_hidden_layers/hidden_size/intermediate_size")
+    if len(layer_kinds) != num_layers:
+        raise SystemExit(f"Kimi-VL layer_kinds length {len(layer_kinds)} != num_layers {num_layers}")
+
+    refs: list[TensorRef] = [
+        TensorRef("token_emb", (_require_existing(headers, ("language_model.model.embed_tokens.weight", "model.embed_tokens.weight"), "token_emb"),)),
+    ]
+
+    for layer, kind in enumerate(layer_kinds):
+        pfx = f"language_model.model.layers.{layer}"
+        refs.extend([
+            TensorRef(f"layer.{layer}.block_norm", (_require_existing(headers, (f"{pfx}.input_layernorm.weight",), f"layer {layer} input norm"),), dtype="fp32"),
+            TensorRef(f"layer.{layer}.post_attention_norm", (_require_existing(headers, (f"{pfx}.post_attention_layernorm.weight",), f"layer {layer} post attention norm"),), dtype="fp32"),
+            TensorRef(f"layer.{layer}.mla_q_proj", (_require_existing(headers, (f"{pfx}.self_attn.q_proj.weight",), f"layer {layer} MLA q_proj"),)),
+            TensorRef(f"layer.{layer}.mla_kv_a_proj", (_require_existing(headers, (f"{pfx}.self_attn.kv_a_proj_with_mqa.weight",), f"layer {layer} MLA kv_a_proj_with_mqa"),)),
+            TensorRef(f"layer.{layer}.mla_kv_a_norm", (_require_existing(headers, (f"{pfx}.self_attn.kv_a_layernorm.weight",), f"layer {layer} MLA kv_a_layernorm"),), dtype="fp32"),
+            TensorRef(f"layer.{layer}.mla_kv_b_proj", (_require_existing(headers, (f"{pfx}.self_attn.kv_b_proj.weight",), f"layer {layer} MLA kv_b_proj"),), dtype="fp32"),
+            TensorRef(f"layer.{layer}.mla_out_proj", (_require_existing(headers, (f"{pfx}.self_attn.o_proj.weight",), f"layer {layer} MLA o_proj"),)),
+        ])
+        mlp = f"{pfx}.mlp"
+        if kind == "mla_dense_mlp":
+            refs.extend([
+                TensorRef(f"layer.{layer}.mlp_gate", (_require_existing(headers, (f"{mlp}.gate_proj.weight",), f"layer {layer} dense gate_proj"),)),
+                TensorRef(f"layer.{layer}.mlp_up", (_require_existing(headers, (f"{mlp}.up_proj.weight",), f"layer {layer} dense up_proj"),)),
+                TensorRef(f"layer.{layer}.mlp_down", (_require_existing(headers, (f"{mlp}.down_proj.weight",), f"layer {layer} dense down_proj"),)),
+            ])
+        elif kind == "mla_moe":
+            if n_experts <= 0:
+                raise SystemExit("Kimi-VL MoE layer requires n_routed_experts")
+            refs.append(TensorRef(f"layer.{layer}.moe_router", (_require_existing(headers, (f"{mlp}.gate.weight",), f"layer {layer} moe router"),), dtype="fp32"))
+            correction = _maybe_tensor_ref(headers, f"layer.{layer}.moe_router_bias", (f"{mlp}.gate.e_score_correction_bias",), dtype="fp32")
+            if correction is not None:
+                refs.append(correction)
+            expert_gate_sources: list[str] = []
+            expert_up_sources: list[str] = []
+            expert_down_sources: list[str] = []
+            expert_gate_shape: tuple[int, ...] | None = None
+            expert_up_shape: tuple[int, ...] | None = None
+            expert_down_shape: tuple[int, ...] | None = None
+            for expert in range(n_experts):
+                ep = f"{mlp}.experts.{expert}"
+                gate = _require_existing(headers, (f"{ep}.gate_proj.weight",), f"layer {layer} expert {expert} gate_proj")
+                up = _require_existing(headers, (f"{ep}.up_proj.weight",), f"layer {layer} expert {expert} up_proj")
+                down = _require_existing(headers, (f"{ep}.down_proj.weight",), f"layer {layer} expert {expert} down_proj")
+                expert_gate_sources.append(gate)
+                expert_up_sources.append(up)
+                expert_down_sources.append(down)
+                if expert_gate_shape is None:
+                    expert_gate_shape = tuple([n_experts] + list(headers[gate].shape))
+                if expert_up_shape is None:
+                    expert_up_shape = tuple([n_experts] + list(headers[up].shape))
+                if expert_down_shape is None:
+                    expert_down_shape = tuple([n_experts] + list(headers[down].shape))
+            refs.extend([
+                TensorRef(f"layer.{layer}.moe_expert_gate", tuple(expert_gate_sources), dtype="fp32", shape=expert_gate_shape),
+                TensorRef(f"layer.{layer}.moe_expert_up", tuple(expert_up_sources), dtype="fp32", shape=expert_up_shape),
+                TensorRef(f"layer.{layer}.moe_expert_down", tuple(expert_down_sources), dtype="fp32", shape=expert_down_shape),
+            ])
+            sp = f"{mlp}.shared_experts"
+            refs.extend([
+                TensorRef(f"layer.{layer}.moe_shared_gate", (_require_existing(headers, (f"{sp}.gate_proj.weight",), f"layer {layer} shared gate_proj"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.moe_shared_up", (_require_existing(headers, (f"{sp}.up_proj.weight",), f"layer {layer} shared up_proj"),), dtype="fp32"),
+                TensorRef(f"layer.{layer}.moe_shared_down", (_require_existing(headers, (f"{sp}.down_proj.weight",), f"layer {layer} shared down_proj"),), dtype="fp32"),
+            ])
+        else:
+            raise SystemExit(f"Unsupported Kimi-VL layer kind at {layer}: {kind}")
+
+    refs.append(TensorRef("final_ln_weight", (_require_existing(headers, ("language_model.model.norm.weight", "model.norm.weight"), "final norm"),), dtype="fp32"))
+    refs.append(TensorRef("final_ln_bias", (), dtype="fp32", synth="zeros_fp32", shape=(hidden,)))
+    lm_head = _first_existing(headers, ("language_model.lm_head.weight", "lm_head.weight", "model.lm_head.weight"))
+    if lm_head is not None:
+        refs.append(TensorRef("output.weight", (lm_head,)))
+    return refs
+
+
 def _nemotron_dt_limit(config: dict[str, Any]) -> tuple[float, float]:
     """Return CK runtime dt clamp bounds for Nemotron-H.
 
@@ -699,6 +789,8 @@ def _refs_for_arch(arch: str, config: dict[str, Any], headers: dict[str, HeaderT
         return _qwen35_text_refs(config, headers)
     if arch == "nemotron_h":
         return _nemotron_h_text_refs(config, headers)
+    if arch == "kimi_vl":
+        return _kimi_vl_text_refs(config, headers)
     if arch in {"llama", "qwen2", "qwen3", "gemma3"}:
         return _llama_family_text_refs(config, headers)
     raise SystemExit(f"Unsupported safetensors arch for v8 importer: {arch}")
@@ -794,6 +886,61 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "rope_freq_base": float(text.get("rope_theta") or 10000.0),
             "use_rope_freq_factors": 0,
             "has_attention_biases": bool(text.get("attention_bias", False)),
+            "has_qk_norm": False,
+            "prefill_policy": "batched",
+        })
+
+    if arch == "kimi_vl":
+        first_dense = int(text.get("first_k_dense_replace") or 0)
+        moe_freq = int(text.get("moe_layer_freq") or 1)
+        num_layers = int(cfg.get("num_layers") or 0)
+        layer_kinds = []
+        for layer in range(num_layers):
+            if layer < first_dense or (moe_freq > 0 and layer % moe_freq != 0):
+                layer_kinds.append("mla_dense_mlp")
+            else:
+                layer_kinds.append("mla_moe")
+        qk_nope = int(text.get("qk_nope_head_dim") or 0)
+        qk_rope = int(text.get("qk_rope_head_dim") or 0)
+        v_head = int(text.get("v_head_dim") or 0)
+        cfg.update({
+            "model": "kimi_vl",
+            "arch": "kimi_vl",
+            "model_type": "kimi_vl",
+            "layer_kinds": layer_kinds,
+            "hybrid_block_pattern": layer_kinds[:],
+            "layer_attention_policy": ["mla" for _ in layer_kinds],
+            "layer_moe_policy": ["routed_swiglu" if k == "mla_moe" else "none" for k in layer_kinds],
+            "layer_mlp_policy": ["swiglu" if k == "mla_dense_mlp" else "none" for k in layer_kinds],
+            "layer_kv_policy": ["compressed_mla_kv" for _ in layer_kinds],
+            "intermediate_dim": int(text.get("intermediate_size") or cfg.get("intermediate_size") or 0),
+            "moe_intermediate_size": int(text.get("moe_intermediate_size") or 0),
+            "n_shared_experts": int(text.get("n_shared_experts") or 0),
+            "n_routed_experts": int(text.get("n_routed_experts") or 0),
+            "num_experts_per_tok": int(text.get("num_experts_per_tok") or 0),
+            "n_group": int(text.get("n_group") or 0),
+            "topk_group": int(text.get("topk_group") or 0),
+            "norm_topk_prob": bool(text.get("norm_topk_prob", True)),
+            "router_num_groups": int(text.get("n_group") or 0),
+            "router_topk_group": int(text.get("topk_group") or 0),
+            "router_norm_topk_prob": 1 if bool(text.get("norm_topk_prob", True)) else 0,
+            "routed_scaling_factor": float(text.get("routed_scaling_factor") or 1.0),
+            "scoring_func": str(text.get("scoring_func") or "sigmoid"),
+            "topk_method": str(text.get("topk_method") or "noaux_tc"),
+            "kv_lora_rank": int(text.get("kv_lora_rank") or 0),
+            "q_lora_rank": text.get("q_lora_rank"),
+            "qk_nope_head_dim": qk_nope,
+            "qk_rope_head_dim": qk_rope,
+            "v_head_dim": v_head,
+            "head_dim": qk_nope + qk_rope,
+            "rotary_dim": qk_rope,
+            "mla_q_head_dim": qk_nope + qk_rope,
+            "mla_k_head_dim": qk_nope + qk_rope,
+            "mla_v_head_dim": v_head,
+            "rope_layout": "partial_pairwise_concat",
+            "rope_theta": float(text.get("rope_theta") or 10000.0),
+            "rope_freq_base": float(text.get("rope_theta") or 10000.0),
+            "has_attention_biases": False,
             "has_qk_norm": False,
             "prefill_policy": "batched",
         })
@@ -926,6 +1073,8 @@ def _entry_size_from_header(ref: TensorRef, headers: dict[str, HeaderTensor], dt
         total += int(np.prod(shape, dtype=np.int64)) * elem
         out_dtype = out_dtype or dtype
         out_shape = shape if not out_shape else out_shape
+    if ref.shape is not None:
+        out_shape = [int(x) for x in ref.shape]
     return out_dtype or "fp32", total, out_shape
 
 
@@ -1026,6 +1175,8 @@ def _write_ref(w: HashingWriter, model_dir: Path, headers: dict[str, HeaderTenso
         total += len(data)
         out_dtype = out_dtype or dt
         out_shape = shape if not out_shape else out_shape
+    if ref.shape is not None:
+        out_shape = [int(x) for x in ref.shape]
     return out_dtype or "fp32", total, out_shape
 
 
@@ -1154,7 +1305,7 @@ def main() -> int:
     ap.add_argument("--ram-dir", type=Path, default=Path("/dev/shm"), help="tmpfs directory for --ram-output; default: /dev/shm")
     ap.add_argument("--config-out", required=True, type=Path)
     ap.add_argument("--manifest-out", required=True, type=Path)
-    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h", "glm4"])
+    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h", "glm4", "kimi_vl"])
     ap.add_argument("--config-template", type=Path, help="existing v8 config/manifest to reuse explicit runtime policy")
     ap.add_argument("--dtype", default="preserve", choices=["preserve", "bf16", "fp32"])
     ap.add_argument("--dry-run", action="store_true", help="validate mapping and write JSON reports only; do not write BUMP")

--- a/version/v8/templates/kimi_vl.json
+++ b/version/v8/templates/kimi_vl.json
@@ -91,7 +91,7 @@
   },
   "kernels": {
     "kv_lora_decompress": "deepseek_mla_kv_decompress_f32",
-    "partial_rope_concat": "deepseek_mla_partial_rope_concat_f32",
+    "partial_rope_concat": "deepseek_mla_partial_rope_concat_packed_f32",
     "router": "nemotron_group_limited_topk_router_f32",
     "moe_swiglu_expert": "moe_swiglu_expert_forward_f32",
     "moe_swiglu_shared": "moe_swiglu_shared_forward_f32"
@@ -122,6 +122,9 @@
               "graph_slots": {
                 "inputs": {
                   "x": "layer_input"
+                },
+                "outputs": {
+                  "y": "q_scratch"
                 }
               }
             },
@@ -130,6 +133,9 @@
               "graph_slots": {
                 "inputs": {
                   "x": "layer_input"
+                },
+                "outputs": {
+                  "y": "compressed_kv"
                 }
               }
             },
@@ -137,7 +143,11 @@
               "op": "kv_a_layernorm",
               "graph_slots": {
                 "inputs": {
-                  "x": "compressed_kv"
+                  "x": "compressed_kv",
+                  "input": "compressed_kv"
+                },
+                "outputs": {
+                  "output": "compressed_kv_normed"
                 }
               }
             },
@@ -145,8 +155,11 @@
               "op": "kv_lora_decompress",
               "graph_slots": {
                 "inputs": {
-                  "compressed_kv": "compressed_kv_normed",
-                  "kv_b": "layer_kv_b_proj"
+                  "compressed_kv": "compressed_kv_normed"
+                },
+                "outputs": {
+                  "k_nope": "k_nope",
+                  "value": "v_scratch"
                 }
               }
             },
@@ -154,10 +167,13 @@
               "op": "partial_rope_concat",
               "graph_slots": {
                 "inputs": {
-                  "q_nope": "q_nope",
-                  "q_pe": "q_pe",
+                  "q_packed": "q_scratch",
                   "k_nope": "k_nope",
-                  "k_pe": "k_pe"
+                  "k_pe": "compressed_kv"
+                },
+                "outputs": {
+                  "query": "q_scratch",
+                  "key": "k_scratch"
                 }
               }
             },
@@ -165,9 +181,9 @@
               "op": "mla_attention",
               "graph_slots": {
                 "inputs": {
-                  "query": "mla_query",
-                  "key": "mla_key",
-                  "value": "mla_value"
+                  "query": "q_scratch",
+                  "key": "k_scratch",
+                  "value": "v_scratch"
                 }
               }
             },
@@ -209,6 +225,9 @@
               "graph_slots": {
                 "inputs": {
                   "x": "layer_input"
+                },
+                "outputs": {
+                  "y": "q_scratch"
                 }
               }
             },
@@ -217,6 +236,9 @@
               "graph_slots": {
                 "inputs": {
                   "x": "layer_input"
+                },
+                "outputs": {
+                  "y": "compressed_kv"
                 }
               }
             },
@@ -224,7 +246,11 @@
               "op": "kv_a_layernorm",
               "graph_slots": {
                 "inputs": {
-                  "x": "compressed_kv"
+                  "x": "compressed_kv",
+                  "input": "compressed_kv"
+                },
+                "outputs": {
+                  "output": "compressed_kv_normed"
                 }
               }
             },
@@ -232,8 +258,11 @@
               "op": "kv_lora_decompress",
               "graph_slots": {
                 "inputs": {
-                  "compressed_kv": "compressed_kv_normed",
-                  "kv_b": "layer_kv_b_proj"
+                  "compressed_kv": "compressed_kv_normed"
+                },
+                "outputs": {
+                  "k_nope": "k_nope",
+                  "value": "v_scratch"
                 }
               }
             },
@@ -241,10 +270,13 @@
               "op": "partial_rope_concat",
               "graph_slots": {
                 "inputs": {
-                  "q_nope": "q_nope",
-                  "q_pe": "q_pe",
+                  "q_packed": "q_scratch",
                   "k_nope": "k_nope",
-                  "k_pe": "k_pe"
+                  "k_pe": "compressed_kv"
+                },
+                "outputs": {
+                  "query": "q_scratch",
+                  "key": "k_scratch"
                 }
               }
             },
@@ -252,9 +284,9 @@
               "op": "mla_attention",
               "graph_slots": {
                 "inputs": {
-                  "query": "mla_query",
-                  "key": "mla_key",
-                  "value": "mla_value"
+                  "query": "q_scratch",
+                  "key": "k_scratch",
+                  "value": "v_scratch"
                 }
               }
             },
@@ -283,8 +315,11 @@
               "graph_slots": {
                 "inputs": {
                   "hidden": "layer_input",
-                  "indices": "router_indices",
-                  "routing_weights": "router_weights"
+                  "indices": "q_scratch",
+                  "routing_weights": "k_scratch"
+                },
+                "outputs": {
+                  "output": "mlp_scratch"
                 }
               }
             },
@@ -293,7 +328,10 @@
               "graph_slots": {
                 "inputs": {
                   "hidden": "layer_input",
-                  "routed": "moe_routed"
+                  "routed": "mlp_scratch"
+                },
+                "outputs": {
+                  "output": "main_stream"
                 }
               }
             },


### PR DESCRIPTION
## Summary
- Add Kimi-VL v8 text-decoder template hardening for MLA partial RoPE, KV LoRA decompression, and MoE routing.
- Add DeepSeek/Kimi kernel map coverage and contract inspector/audit guardrails.
- Add focused tests for Kimi template lowering and DeepSeek reference kernels.

This is compiler/circuit/kernel-contract hardening only; it does not claim a full Kimi runtime stamp yet.

## Validation
- make build/libckernel_engine.so
- .venv/bin/python unittest/test_deepseek_reference_kernels.py
- .venv/bin/python -m unittest tests.test_v8_kimi_template tests.test_v8_model_contract_inspector tests.test_v8_template_circuit_audit tests.test_v8_glm4_template
- git diff --check
- pre-commit: v7 kernel-map contracts, v7-regression-fast, v8-regression-fast
- pre-push: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, v7/v8 fast regression, v7 training-kernel parity