### PR TITLE
feat(v8): scaffold Gemma4 assistant speculative bringup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2543,6 +2543,21 @@ test-v8-template-circuit-audit:
 	@$(PYTHON) -m py_compile version/v8/scripts/audit_template_circuit_v8.py
 	@$(PYTHON) -m unittest tests.test_v8_template_circuit_audit -v
 
+v8-model-kernel-inspect:
+	@target="$${MODEL:-$${CONFIG:-}}"; \
+	if [ -z "$$target" ]; then \
+		echo "Usage: make v8-model-kernel-inspect MODEL=/path/to/model-dir-or-config.json"; \
+		echo "   or: make v8-model-kernel-inspect CONFIG=/path/to/config.json"; \
+		exit 2; \
+	fi; \
+	$(PYTHON) version/v8/scripts/inspect_model_contract_v8.py "$$target" $${ARGS:-}; \
+	rc=$$?; \
+	if [ "$$rc" -ne 0 ] && [ "$$rc" -ne 2 ]; then exit "$$rc"; fi
+
+test-v8-gemma4-assistant-e2e:
+	@echo "Running v8 Gemma4 assistant synthetic safetensors -> runtime E2E..."
+	@$(PYTHON) -m unittest tests.test_v8_gemma4_scaffold.V8Gemma4ScaffoldTests.test_gemma4_assistant_synthetic_checkpoint_generates_runtime -v
+
 test-architecture-contracts: test-v8-template-circuit-audit v8-kernel-map-contracts v8-validate-contracts
 	@echo "Collecting architecture contract dashboard summary..."
 	@$(PYTHON) version/v8/scripts/collect_architecture_contracts_v8.py --json-out "$(V8_ARCH_CONTRACT_JSON)"
@@ -2626,7 +2641,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-dispatch-sweep-quick test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit test-v8-qwen3vl-e2e-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/docs/site/_pages/cke-throughput-unit.html
+++ b/docs/site/_pages/cke-throughput-unit.html
@@ -1,0 +1,162 @@
+<!-- TITLE: CKE Throughput Unit -->
+<!-- NAV: cku -->
+
+<h1>CKE Throughput Unit</h1>
+
+<div class="card card-accent" style="border: 2px solid #ffb400; padding: 2rem; margin-bottom: 2rem;">
+    <h2 style="margin-top: 0; color: #ffb400;">The 1 PB/s North-Star Unit</h2>
+    <p style="font-size: 1.12em; line-height: 1.7;">
+        C-Kernel-Engine cares about a practical systems question:
+        <strong>how fast can the cumulative compute system cycle active model data to produce tokens?</strong>
+        FLOPS and TOPS are useful hardware numbers, but they do not directly answer whether a real model can move its weights, activations, KV cache, intermediate buffers, and network payloads quickly enough to generate the next token.
+    </p>
+    <p style="font-size: 1.12em; line-height: 1.7; margin-bottom: 0;">
+        The proposed CKE unit is aggregate bytes cycled per second across the full token path.
+        The north-star target is <strong>1 petabyte/sec</strong>, which is the same as <strong>1000 terabytes/sec</strong>, or <strong>1 terabyte every millisecond</strong>.
+    </p>
+</div>
+
+<div class="img-container svg-viewer" data-title="CKE Throughput Unit">
+    <img src="assets/cke-throughput-unit.svg" alt="CKE throughput unit: active bytes per token divided by token latency equals aggregate bytes cycled per second.">
+</div>
+
+<h2>The Unit</h2>
+
+<pre><code>CKU = active_bytes_per_token / seconds_per_token</code></pre>
+
+<p>
+    The unit is not just DRAM bandwidth from one socket and it is not just matrix FLOPS.
+    It is an end-to-end systems rate: how many bytes the runtime must touch, transform, cache, transmit, or reuse in order to produce tokens.
+    Depending on the model and phase, that can include:
+</p>
+
+<ul>
+    <li>active weights read for the token path</li>
+    <li>activation buffers and scratch buffers</li>
+    <li>KV cache reads and writes, or recurrent state updates for SSM-style models</li>
+    <li>prefill token blocks, decode token steps, and batching effects</li>
+    <li>NUMA traffic, cache movement, and inter-node communication</li>
+    <li>quantized layout conversion, repacking, and dequantization overhead</li>
+</ul>
+
+<h2>Why 1 PB/s?</h2>
+
+<p>
+    A very large modern model can easily imply hundreds of gigabytes to terabytes of active weight and state movement across the token path, especially before accounting for prefill, KV cache, MoE routing, recurrent state, or distributed execution.
+    Quantization and MoE reduce the active bytes touched per token, but the optimization problem remains the same: the faster the system can cycle the active bytes, the faster it can produce useful output.
+</p>
+
+<table>
+    <thead>
+        <tr>
+            <th>Active bytes per token</th>
+            <th>Token latency</th>
+            <th>Required aggregate rate</th>
+            <th>Implied token rate</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1 TB</td>
+            <td>1 second</td>
+            <td>1 TB/s</td>
+            <td>1 token/sec</td>
+        </tr>
+        <tr>
+            <td>1 TB</td>
+            <td>10 ms</td>
+            <td>100 TB/s</td>
+            <td>100 tokens/sec</td>
+        </tr>
+        <tr>
+            <td>1 TB</td>
+            <td>1 ms</td>
+            <td>1 PB/s</td>
+            <td>1000 tokens/sec</td>
+        </tr>
+        <tr>
+            <td>100 GB</td>
+            <td>1 ms</td>
+            <td>100 TB/s</td>
+            <td>1000 tokens/sec</td>
+        </tr>
+    </tbody>
+</table>
+
+<p>
+    This is why the 1 PB/s unit matters.
+    It turns a vague performance goal into a concrete systems target:
+    if the active token path is one terabyte and the target is one millisecond per token, the cumulative runtime has to behave like a one-petabyte-per-second machine.
+    That machine does not have to be one CPU.
+    It can be a coordinated set of CPU sockets, memory channels, NUMA domains, and Linux nodes.
+</p>
+
+<h2>What CKE Optimizes</h2>
+
+<p>
+    CKE does not optimize a single number in isolation.
+    It tries to organize the whole token path so useful bytes stay close to useful compute:
+</p>
+
+<ul>
+    <li><strong>Kernel layout:</strong> Q4/Q5/Q6/Q8 formats, packed layouts, SIMD-friendly loops, and shape-gated dispatch.</li>
+    <li><strong>Memory layout:</strong> contiguous bump files, planned activation buffers, cache-aligned sections, and deterministic offsets.</li>
+    <li><strong>Runtime scheduling:</strong> prefill vs decode kernels, persistent thread pools, batching, and pipeline staging.</li>
+    <li><strong>Linux tuning:</strong> CPU affinity, huge pages, NUMA placement, cache behavior, and perf/VTune/Advisor measurement.</li>
+    <li><strong>Cluster scaling:</strong> model/layer ownership, activation movement, gradient movement, MPI/RDMA paths, and topology-aware placement.</li>
+</ul>
+
+<h2>Not a FLOPS Replacement</h2>
+
+<p>
+    FLOPS still matter. Matrix units still matter. SIMD still matters.
+    But for LLM inference and training, raw arithmetic throughput is only useful when the data reaches the execution units at the right time and in the right layout.
+    CKU is a complementary metric: it asks whether the whole system can cycle the bytes that the model actually needs.
+</p>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>This is a north-star systems unit, not a current laptop benchmark.</strong><br>
+        A single workstation is not expected to cycle 1 PB/s today. The point is to make the long-horizon optimization problem explicit: organize CPU kernels, memory hierarchy, Linux scheduling, and distributed nodes so aggregate active-byte throughput keeps rising.
+    </div>
+</div>
+
+<h2>Tiny Gemma4 Assistant E2E Status</h2>
+
+<p>
+    The small Gemma4 assistant model is the <code>gemma4_assistant</code> / MTP drafter path, not the large Gemma4 E4B instruct lane.
+    It is intentionally marked as <code>standalone_text_inference_supported = false</code> because it is an assistant/draft model designed to bridge with a larger Gemma4 backbone, not a normal chat model that should answer prompts by itself.
+</p>
+
+<p>
+    Current local status for the tiny assistant path:
+</p>
+
+<ul>
+    <li><strong>Safetensors mapping:</strong> supported through the <code>gemma4_assistant</code> architecture map.</li>
+    <li><strong>Template/lowering:</strong> supports <code>assistant_pre_projection</code>, <code>q_norm</code>, <code>rope_q</code>, q-only shared-KV attention, <code>assistant_layer_scale</code>, and <code>assistant_post_projection</code>.</li>
+    <li><strong>Kernel parity:</strong> covered by <code>unittest/test_gemma4_assistant_kernels.py</code> and included in <code>nightly-quick</code> plus <code>nightly-kernels</code>.</li>
+    <li><strong>Compiler E2E:</strong> a synthetic tiny assistant checkpoint locally passes safetensors -> bump -> prefill/decode IR -> generated C -> compiled <code>libmodel.so</code>.</li>
+    <li><strong>Chat E2E:</strong> not expected as a standalone model; the next real E2E target is speculative/MTP pairing with a compatible Gemma4 backbone.</li>
+</ul>
+
+<p>
+    The local synthetic compiler smoke follows this shape:
+</p>
+
+<pre><code>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://google/gemma-4-E4B-it-assistant \
+  --run /tmp/ck-gemma4-assistant-runtime \
+  --context-len 1024 \
+  --force-convert --force-compile \
+  --generate-only \
+  --chat-template none \
+  --allow-raw-prompt</code></pre>
+
+<p>
+    The next hardening step is to make the assistant useful in the runtime, not to force it to be a standalone chatbot:
+    compile the real small assistant artifact, compile the compatible target Gemma4 backbone, then run it through CKE's speculative decode path as a draft model.
+</p>

--- a/docs/site/_pages/gemma4-speculative-pair.html
+++ b/docs/site/_pages/gemma4-speculative-pair.html
@@ -1,0 +1,234 @@
+<!-- TITLE: Gemma4 Speculative Pair Design -->
+<!-- NAV: architecture -->
+
+<h1>Gemma4 Speculative Pair Design</h1>
+
+<p>
+    This page is the implementation plan for pairing a full Gemma4 backbone with the small
+    <code>google/gemma-4-E4B-it-assistant</code> drafter model. The assistant is not a standalone
+    chatbot. It is a speculative/MTP draft decoder that consumes the backbone hidden stream and
+    proposes candidate tokens for the backbone to verify.
+</p>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Analogy</strong><br>
+        In the header/body/footer mental model, the backbone is the authoritative target decoder.
+        The assistant is a secondary draft decoder. The bridge between them behaves like an
+        encoder-to-decoder handoff because the backbone exports hidden state and the assistant
+        consumes it, but the backbone is still a decoder, not a vision-style encoder.
+    </div>
+</div>
+
+<h2>Target Shape</h2>
+
+<pre><code>prompt tokens
+  -&gt; Gemma4 E4B backbone prefill
+  -&gt; backbone KV cache + hidden stream
+  -&gt; decode loop:
+       backbone step exports hidden state H_t [1, 2560]
+       assistant_pre_projection(H_t) -&gt; draft stream [1, 256]
+       assistant 4-layer draft decoder proposes token candidates
+       backbone verifies proposed token(s)
+       accepted tokens are emitted; rejected token falls back to backbone</code></pre>
+
+<p>
+    The first working milestone should draft and verify one token. After that is correct, increase
+    <code>draft_tokens</code> to 2, 4, and 8 and measure acceptance rate versus throughput.
+</p>
+
+<h2>Composite Template</h2>
+
+<p>
+    The clean CKE implementation should be a composite circuit, not two unrelated model folders
+    joined through ad hoc Python. A future template can be named:
+</p>
+
+<pre><code>version/v8/templates/gemma4_speculative_pair.json</code></pre>
+
+<p>
+    The template should declare three blocks:
+</p>
+
+<table>
+    <thead>
+        <tr>
+            <th>Block</th>
+            <th>Role</th>
+            <th>Existing Template</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>target</code></td>
+            <td>Authoritative Gemma4 backbone that owns final correctness.</td>
+            <td><code>gemma4.json</code></td>
+        </tr>
+        <tr>
+            <td><code>draft</code></td>
+            <td>Small assistant/MTP model that proposes candidate tokens.</td>
+            <td><code>gemma4_assistant.json</code></td>
+        </tr>
+        <tr>
+            <td><code>verify</code></td>
+            <td>Accept/reject loop that compares draft tokens against target logits.</td>
+            <td>New runtime loop, not a neural layer.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Weight Namespaces</h2>
+
+<p>
+    First implementation should keep the two weight files separate for auditability:
+</p>
+
+<pre><code>/tmp/ck-gemma4-e4b-runtime/weights.bump
+/tmp/ck-gemma4-assistant-runtime/weights.bump</code></pre>
+
+<p>
+    The composite manifest can refer to both namespaces:
+</p>
+
+<pre><code>{
+  "model": "gemma4_speculative_pair",
+  "target": {
+    "template": "gemma4",
+    "weights": "target.weights.bump",
+    "hidden_export": "target_hidden_stream",
+    "hidden_size": 2560
+  },
+  "draft": {
+    "template": "gemma4_assistant",
+    "weights": "assistant.weights.bump",
+    "assistant_role": "mtp_drafter",
+    "backbone_hidden_size": 2560,
+    "hidden_size": 256
+  },
+  "bridge": {
+    "source": "target_hidden_stream",
+    "dest": "draft.backbone_stream",
+    "shape": ["T", 2560]
+  }
+}</code></pre>
+
+<p>
+    Later, the compiler can merge both into one BUMP file with target and assistant regions. That is
+    an optimization, not a requirement for the first correct runtime.
+</p>
+
+<h2>IR Contract</h2>
+
+<p>
+    The composite lowering should make the bridge explicit:
+</p>
+
+<pre><code>target.decode_step
+  outputs:
+    target_logits
+    target_hidden_stream
+    target_kv_cache
+
+draft.decode_step
+  inputs:
+    draft_token_ids
+    draft.backbone_stream &lt;- target_hidden_stream
+  outputs:
+    draft_logits
+    draft_candidate_tokens
+
+verify.step
+  inputs:
+    draft_candidate_tokens
+    target_logits
+  outputs:
+    accepted_tokens
+    rejected_token</code></pre>
+
+<p>
+    The generated C should expose explicit functions instead of hiding the protocol:
+</p>
+
+<pre><code>int ck_gemma4_pair_prefill(...);
+int ck_gemma4_pair_decode_one(...);
+int ck_gemma4_pair_draft_tokens(...);
+int ck_gemma4_pair_verify_tokens(...);
+int ck_gemma4_pair_generate_speculative(...);</code></pre>
+
+<h2>Memory Plan</h2>
+
+<p>
+    Required buffers should be visible in <code>layout_decode.json</code>:
+</p>
+
+<ul>
+    <li><code>target_main_stream</code> for Gemma4 backbone hidden state.</li>
+    <li><code>target_kv_cache</code> for the authoritative target cache.</li>
+    <li><code>draft_backbone_stream</code> for assistant input, shape <code>[T, 2560]</code>.</li>
+    <li><code>draft_main_stream</code> for assistant hidden state, shape <code>[T, 256]</code>.</li>
+    <li><code>draft_kv_cache</code> for the assistant cache.</li>
+    <li><code>draft_logits</code> and <code>target_logits</code>.</li>
+    <li><code>accepted_tokens</code>, <code>candidate_tokens</code>, and verifier scratch.</li>
+</ul>
+
+<h2>Xeon Validation Plan</h2>
+
+<p>
+    On the high-memory Xeon box, build both runtimes first:
+</p>
+
+<pre><code>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --run /tmp/ck-gemma4-e4b-runtime \
+  --context-len 2048 \
+  --force-convert --force-compile \
+  --prompt 'Give me a detailed example of C code.' \
+  --chat-template gemma4 \
+  --max-tokens 64 \
+  --temperature 0.0
+
+.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://google/gemma-4-E4B-it-assistant \
+  --run /tmp/ck-gemma4-assistant-runtime \
+  --context-len 2048 \
+  --force-convert --force-compile \
+  --generate-only \
+  --chat-template none \
+  --allow-raw-prompt</code></pre>
+
+<p>
+    Then validate in this order:
+</p>
+
+<ol>
+    <li>Backbone-only coherent decode.</li>
+    <li>Assistant-only compile and load smoke. Do not expect standalone chat.</li>
+    <li>Backbone decode exports <code>target_hidden_stream</code> with shape <code>[1, 2560]</code>.</li>
+    <li>Assistant consumes that stream and produces draft logits.</li>
+    <li>One-token draft and target verification match the Python reference protocol.</li>
+    <li>Multi-token speculative loop reports drafted, accepted, rejected, and acceptance rate.</li>
+</ol>
+
+<h2>Success Metrics</h2>
+
+<p>
+    The first useful dashboard should compare:
+</p>
+
+<ul>
+    <li><code>backbone_only_tok_per_sec</code></li>
+    <li><code>speculative_tok_per_sec</code></li>
+    <li><code>draft_tokens_per_batch</code></li>
+    <li><code>accepted_tokens</code> / <code>drafted_tokens</code></li>
+    <li><code>target_verify_ms</code></li>
+    <li><code>assistant_draft_ms</code></li>
+</ul>
+
+<p>
+    A failed acceptance rate is still useful data. It means the bridge, tokenizer, positional policy,
+    or hidden-state handoff is wrong. A high acceptance rate with no speedup means the protocol is
+    correct but the verifier is still too serial.
+</p>

--- a/docs/site/assets/cke-throughput-unit.svg
+++ b/docs/site/assets/cke-throughput-unit.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
+  <title id="title">CKE Throughput Unit</title>
+  <desc id="desc">A diagram showing how active bytes per token divided by token latency becomes aggregate bytes cycled per second across CPU nodes.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#252525"/>
+      <stop offset="1" stop-color="#171717"/>
+    </linearGradient>
+    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ffb400"/>
+      <stop offset="1" stop-color="#ff7a18"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="620" rx="18" fill="url(#bg)"/>
+  <rect x="26" y="26" width="1148" height="568" rx="14" fill="none" stroke="#454545"/>
+
+  <text x="60" y="78" fill="#f5f5f5" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700">CKE Throughput Unit</text>
+  <text x="60" y="112" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="18">How many bytes can the full system cycle per second to produce tokens?</text>
+
+  <g filter="url(#shadow)">
+    <rect x="60" y="152" width="310" height="155" rx="10" fill="#303030" stroke="#555"/>
+    <text x="88" y="194" fill="#ffb400" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Active bytes per token</text>
+    <text x="88" y="232" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="30">1 TB</text>
+    <text x="88" y="266" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">Weights + activations + KV</text>
+    <text x="88" y="288" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">+ communication touched</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="445" y="152" width="310" height="155" rx="10" fill="#303030" stroke="#555"/>
+    <text x="473" y="194" fill="#07adf8" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Token latency target</text>
+    <text x="473" y="232" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="30">1 ms</text>
+    <text x="473" y="266" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">End-to-end prefill/decode</text>
+    <text x="473" y="288" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">system time per token</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="830" y="152" width="310" height="155" rx="10" fill="#303030" stroke="#555"/>
+    <text x="858" y="194" fill="#47b475" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Aggregate data rate</text>
+    <text x="858" y="232" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="30">1 PB/s</text>
+    <text x="858" y="266" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">1000 TB/s aggregate</text>
+    <text x="858" y="288" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">across all compute nodes</text>
+  </g>
+
+  <path d="M386 230 H424" stroke="#ffb400" stroke-width="4" stroke-linecap="round"/>
+  <path d="M424 230 l-12 -8 v16 z" fill="#ffb400"/>
+  <text x="392" y="212" fill="#808080" font-family="Inter, Arial, sans-serif" font-size="15">divided by</text>
+
+  <path d="M771 230 H809" stroke="#47b475" stroke-width="4" stroke-linecap="round"/>
+  <path d="M809 230 l-12 -8 v16 z" fill="#47b475"/>
+  <text x="770" y="212" fill="#808080" font-family="Inter, Arial, sans-serif" font-size="15">equals</text>
+
+  <rect x="145" y="360" width="910" height="98" rx="12" fill="#1f1f1f" stroke="#454545"/>
+  <text x="180" y="406" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="28">CKU = active_bytes_per_token / seconds_per_token</text>
+  <text x="180" y="438" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="16">1 PB/s means the system can cycle one terabyte of active token-path data every millisecond.</text>
+
+  <g>
+    <circle cx="235" cy="520" r="16" fill="url(#orange)"/>
+    <text x="265" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">Linux tuning</text>
+    <circle cx="410" cy="520" r="16" fill="#07adf8"/>
+    <text x="440" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">SIMD / AMX kernels</text>
+    <circle cx="630" cy="520" r="16" fill="#47b475"/>
+    <text x="660" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">NUMA + memory channels</text>
+    <circle cx="910" cy="520" r="16" fill="#b48cff"/>
+    <text x="940" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">MPI / RDMA clusters</text>
+  </g>
+</svg>

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{PAGE_TITLE}} | C-Kernel-Engine</title>
-    <meta name="description" content="{{META_DESCRIPTION}}">
-    <meta name="robots" content="{{META_ROBOTS}}">
-    <link rel="canonical" href="{{CANONICAL_URL}}">
-    <meta property="og:title" content="{{PAGE_TITLE}} | C-Kernel-Engine">
-    <meta property="og:description" content="{{META_DESCRIPTION}}">
+    <title>CKE Throughput Unit: Bytes per Token Path | C-Kernel-Engine</title>
+    <meta name="description" content="The C-Kernel-Engine north-star throughput unit: aggregate active bytes cycled per second across weights, activations, KV cache, Linux runtime, and CPU clusters.">
+    <meta name="robots" content="index,follow">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html">
+    <meta property="og:title" content="CKE Throughput Unit: Bytes per Token Path | C-Kernel-Engine">
+    <meta property="og:description" content="The C-Kernel-Engine north-star throughput unit: aggregate active bytes cycled per second across weights, activations, KV cache, Linux runtime, and CPU clusters.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{CANONICAL_URL}}">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -858,11 +858,11 @@
             <span></span>
         </button>
         <nav class="site-nav">
-            <a href="index.html" class="{{NAV_INDEX}}">Home</a>
-            <a href="spectrum.html" class="{{NAV_SPECTRUM}}" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="{{NAV_QUICKSTART}}">Getting Started</a>
-            <a href="developer-guide.html" class="{{NAV_DEVGUIDE}}">Developer Guide</a>
-            <a href="scaling.html" class="{{NAV_SCALING}}">Scaling</a>
+            <a href="index.html" class="">Home</a>
+            <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
+            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="scaling.html" class="">Scaling</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -901,7 +901,7 @@
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,11 +916,11 @@
                     </div>
                 </div>
             </div>
-            <a href="pytorch-parity.html" class="{{NAV_PARITY}}">PyTorch Parity</a>
-            <a href="test-report.html" class="{{NAV_NIGHTLY}}">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
-            <a href="research.html" class="{{NAV_RESEARCH}}">Research</a>
-            <a href="decisions.html" class="{{NAV_DECISIONS}}">ADR</a>
+            <a href="pytorch-parity.html" class="">PyTorch Parity</a>
+            <a href="test-report.html" class="">Test Report</a>
+            <a href="version-history.html" class="">Versions</a>
+            <a href="research.html" class="">Research</a>
+            <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
                 <div class="nav-dropdown-menu">
@@ -941,3 +941,397 @@
         </nav>
     </header>
     <main>
+
+<h1>CKE Throughput Unit</h1>
+
+<div class="card card-accent" style="border: 2px solid #ffb400; padding: 2rem; margin-bottom: 2rem;">
+    <h2 style="margin-top: 0; color: #ffb400;">The 1 PB/s North-Star Unit</h2>
+    <p style="font-size: 1.12em; line-height: 1.7;">
+        C-Kernel-Engine cares about a practical systems question:
+        <strong>how fast can the cumulative compute system cycle active model data to produce tokens?</strong>
+        FLOPS and TOPS are useful hardware numbers, but they do not directly answer whether a real model can move its weights, activations, KV cache, intermediate buffers, and network payloads quickly enough to generate the next token.
+    </p>
+    <p style="font-size: 1.12em; line-height: 1.7; margin-bottom: 0;">
+        The proposed CKE unit is aggregate bytes cycled per second across the full token path.
+        The north-star target is <strong>1 petabyte/sec</strong>, which is the same as <strong>1000 terabytes/sec</strong>, or <strong>1 terabyte every millisecond</strong>.
+    </p>
+</div>
+
+<div class="img-container svg-viewer" data-title="CKE Throughput Unit">
+    <img src="assets/cke-throughput-unit.svg" alt="CKE throughput unit: active bytes per token divided by token latency equals aggregate bytes cycled per second.">
+</div>
+
+<h2>The Unit</h2>
+
+<pre><code>CKU = active_bytes_per_token / seconds_per_token</code></pre>
+
+<p>
+    The unit is not just DRAM bandwidth from one socket and it is not just matrix FLOPS.
+    It is an end-to-end systems rate: how many bytes the runtime must touch, transform, cache, transmit, or reuse in order to produce tokens.
+    Depending on the model and phase, that can include:
+</p>
+
+<ul>
+    <li>active weights read for the token path</li>
+    <li>activation buffers and scratch buffers</li>
+    <li>KV cache reads and writes, or recurrent state updates for SSM-style models</li>
+    <li>prefill token blocks, decode token steps, and batching effects</li>
+    <li>NUMA traffic, cache movement, and inter-node communication</li>
+    <li>quantized layout conversion, repacking, and dequantization overhead</li>
+</ul>
+
+<h2>Why 1 PB/s?</h2>
+
+<p>
+    A very large modern model can easily imply hundreds of gigabytes to terabytes of active weight and state movement across the token path, especially before accounting for prefill, KV cache, MoE routing, recurrent state, or distributed execution.
+    Quantization and MoE reduce the active bytes touched per token, but the optimization problem remains the same: the faster the system can cycle the active bytes, the faster it can produce useful output.
+</p>
+
+<table>
+    <thead>
+        <tr>
+            <th>Active bytes per token</th>
+            <th>Token latency</th>
+            <th>Required aggregate rate</th>
+            <th>Implied token rate</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1 TB</td>
+            <td>1 second</td>
+            <td>1 TB/s</td>
+            <td>1 token/sec</td>
+        </tr>
+        <tr>
+            <td>1 TB</td>
+            <td>10 ms</td>
+            <td>100 TB/s</td>
+            <td>100 tokens/sec</td>
+        </tr>
+        <tr>
+            <td>1 TB</td>
+            <td>1 ms</td>
+            <td>1 PB/s</td>
+            <td>1000 tokens/sec</td>
+        </tr>
+        <tr>
+            <td>100 GB</td>
+            <td>1 ms</td>
+            <td>100 TB/s</td>
+            <td>1000 tokens/sec</td>
+        </tr>
+    </tbody>
+</table>
+
+<p>
+    This is why the 1 PB/s unit matters.
+    It turns a vague performance goal into a concrete systems target:
+    if the active token path is one terabyte and the target is one millisecond per token, the cumulative runtime has to behave like a one-petabyte-per-second machine.
+    That machine does not have to be one CPU.
+    It can be a coordinated set of CPU sockets, memory channels, NUMA domains, and Linux nodes.
+</p>
+
+<h2>What CKE Optimizes</h2>
+
+<p>
+    CKE does not optimize a single number in isolation.
+    It tries to organize the whole token path so useful bytes stay close to useful compute:
+</p>
+
+<ul>
+    <li><strong>Kernel layout:</strong> Q4/Q5/Q6/Q8 formats, packed layouts, SIMD-friendly loops, and shape-gated dispatch.</li>
+    <li><strong>Memory layout:</strong> contiguous bump files, planned activation buffers, cache-aligned sections, and deterministic offsets.</li>
+    <li><strong>Runtime scheduling:</strong> prefill vs decode kernels, persistent thread pools, batching, and pipeline staging.</li>
+    <li><strong>Linux tuning:</strong> CPU affinity, huge pages, NUMA placement, cache behavior, and perf/VTune/Advisor measurement.</li>
+    <li><strong>Cluster scaling:</strong> model/layer ownership, activation movement, gradient movement, MPI/RDMA paths, and topology-aware placement.</li>
+</ul>
+
+<h2>Not a FLOPS Replacement</h2>
+
+<p>
+    FLOPS still matter. Matrix units still matter. SIMD still matters.
+    But for LLM inference and training, raw arithmetic throughput is only useful when the data reaches the execution units at the right time and in the right layout.
+    CKU is a complementary metric: it asks whether the whole system can cycle the bytes that the model actually needs.
+</p>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>This is a north-star systems unit, not a current laptop benchmark.</strong><br>
+        A single workstation is not expected to cycle 1 PB/s today. The point is to make the long-horizon optimization problem explicit: organize CPU kernels, memory hierarchy, Linux scheduling, and distributed nodes so aggregate active-byte throughput keeps rising.
+    </div>
+</div>
+
+<h2>Tiny Gemma4 Assistant E2E Status</h2>
+
+<p>
+    The small Gemma4 assistant model is the <code>gemma4_assistant</code> / MTP drafter path, not the large Gemma4 E4B instruct lane.
+    It is intentionally marked as <code>standalone_text_inference_supported = false</code> because it is an assistant/draft model designed to bridge with a larger Gemma4 backbone, not a normal chat model that should answer prompts by itself.
+</p>
+
+<p>
+    Current local status for the tiny assistant path:
+</p>
+
+<ul>
+    <li><strong>Safetensors mapping:</strong> supported through the <code>gemma4_assistant</code> architecture map.</li>
+    <li><strong>Template/lowering:</strong> supports <code>assistant_pre_projection</code>, <code>q_norm</code>, <code>rope_q</code>, q-only shared-KV attention, <code>assistant_layer_scale</code>, and <code>assistant_post_projection</code>.</li>
+    <li><strong>Kernel parity:</strong> covered by <code>unittest/test_gemma4_assistant_kernels.py</code> and included in <code>nightly-quick</code> plus <code>nightly-kernels</code>.</li>
+    <li><strong>Compiler E2E:</strong> a synthetic tiny assistant checkpoint locally passes safetensors -> bump -> prefill/decode IR -> generated C -> compiled <code>libmodel.so</code>.</li>
+    <li><strong>Chat E2E:</strong> not expected as a standalone model; the next real E2E target is speculative/MTP pairing with a compatible Gemma4 backbone.</li>
+</ul>
+
+<p>
+    The local synthetic compiler smoke follows this shape:
+</p>
+
+<pre><code>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://google/gemma-4-E4B-it-assistant \
+  --run /tmp/ck-gemma4-assistant-runtime \
+  --context-len 1024 \
+  --force-convert --force-compile \
+  --generate-only \
+  --chat-template none \
+  --allow-raw-prompt</code></pre>
+
+<p>
+    The next hardening step is to make the assistant useful in the runtime, not to force it to be a standalone chatbot:
+    compile the real small assistant artifact, compile the compatible target Gemma4 backbone, then run it through CKE's speculative decode path as a draft model.
+</p>
+    </main>
+
+    <!-- SVG Viewer Overlay (shared across all pages) -->
+    <style>
+    .svg-viewer { cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
+    .svg-viewer:hover { transform: scale(1.01); box-shadow: 0 8px 32px rgba(255, 180, 0, 0.3); }
+    #svg-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.95); z-index: 999999; }
+    #svg-overlay .toolbar { position: fixed; top: 0; left: 0; right: 0; padding: 10px 20px; background: rgba(0,0,0,0.9); display: flex; justify-content: space-between; align-items: center; z-index: 1000000; border-bottom: 1px solid #333; }
+    #svg-overlay .toolbar .title { color: #ccc; font-size: 14px; }
+    #svg-overlay .toolbar .controls { display: flex; gap: 8px; align-items: center; }
+    #svg-overlay .toolbar button { background: #333; color: #ffb400; border: 1px solid #555; padding: 8px 14px; cursor: pointer; border-radius: 4px; font-size: 14px; }
+    #svg-overlay .toolbar button:hover { background: #444; border-color: #ffb400; }
+    #svg-overlay .toolbar .close-btn { font-size: 20px; padding: 4px 12px; }
+    #svg-overlay .toolbar .zoom-display { color: #888; font-size: 12px; min-width: 45px; text-align: center; }
+    #svg-overlay .toolbar .separator { color: #444; }
+    #svg-overlay .image-container { display: flex; justify-content: center; align-items: center; min-height: 100vh; padding: 60px 20px 20px; cursor: grab; }
+    #svg-overlay .image-container:active { cursor: grabbing; }
+    #svg-overlay .image-container img { max-width: 95%; max-height: 90vh; transform-origin: center center; }
+    #svg-overlay .nav-btn { position: fixed; top: 50%; transform: translateY(-50%); background: rgba(0,0,0,0.7); color: #ffb400; border: 1px solid #555; font-size: 30px; padding: 20px 15px; cursor: pointer; z-index: 1000000; border-radius: 4px; }
+    #svg-overlay .nav-btn:hover { background: rgba(255,180,0,0.2); border-color: #ffb400; }
+    #svg-overlay .nav-prev { left: 10px; }
+    #svg-overlay .nav-next { right: 10px; }
+    #svg-overlay .hint { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); color: #666; font-size: 12px; background: rgba(0,0,0,0.8); padding: 8px 20px; border-radius: 20px; }
+    </style>
+
+    <div id="svg-overlay">
+        <div class="toolbar">
+            <span class="title" id="svg-title">Image</span>
+            <div class="controls">
+                <button onclick="svgViewer.zoomOut()" title="Zoom Out (-)">-</button>
+                <span class="zoom-display" id="zoom-display">100%</span>
+                <button onclick="svgViewer.zoomIn()" title="Zoom In (+)">+</button>
+                <span class="separator">|</span>
+                <button onclick="svgViewer.fitWidth()" title="Fit Width (W)">Width</button>
+                <button onclick="svgViewer.fitHeight()" title="Fit Height (H)">Height</button>
+                <button onclick="svgViewer.resetZoom()" title="Reset (0)">Reset</button>
+                <span class="separator">|</span>
+                <button class="close-btn" onclick="svgViewer.close()" title="Close (ESC)">&times;</button>
+            </div>
+        </div>
+        <button class="nav-btn nav-prev" onclick="svgViewer.prev()" title="Previous">&larr;</button>
+        <button class="nav-btn nav-next" onclick="svgViewer.next()" title="Next">&rarr;</button>
+        <div class="image-container" id="svg-container">
+            <img id="svg-image" src="" alt="">
+        </div>
+        <div class="hint">Scroll to zoom | Drag to pan | W/H to fit | 0 to reset | ESC to close</div>
+    </div>
+
+    <script>
+    var svgViewer = (function() {
+        var overlay, img, titleEl, container;
+        var images = [];
+        var currentIndex = 0;
+        var scale = 1, panX = 0, panY = 0;
+        var isDragging = false, dragStartX, dragStartY, panStartX, panStartY;
+
+        function init() {
+            overlay = document.getElementById('svg-overlay');
+            img = document.getElementById('svg-image');
+            titleEl = document.getElementById('svg-title');
+            container = document.getElementById('svg-container');
+            if (!overlay || !img) return;
+
+            document.querySelectorAll('.svg-viewer').forEach(function(viewer, index) {
+                var viewerImg = viewer.querySelector('img');
+                if (viewerImg) {
+                    images.push({ src: viewerImg.src, title: viewer.getAttribute('data-title') || viewerImg.alt || 'Diagram' });
+                    viewer.onclick = function(e) { e.preventDefault(); open(index); };
+                }
+            });
+
+            container.addEventListener('wheel', function(e) {
+                e.preventDefault();
+                scale = Math.max(0.5, Math.min(10, scale + (e.deltaY > 0 ? -0.2 : 0.2)));
+                updateTransform();
+            });
+
+            container.addEventListener('mousedown', function(e) { isDragging = true; dragStartX = e.clientX; dragStartY = e.clientY; panStartX = panX; panStartY = panY; });
+            document.addEventListener('mousemove', function(e) { if (!isDragging) return; panX = panStartX + (e.clientX - dragStartX); panY = panStartY + (e.clientY - dragStartY); updateTransform(); });
+            document.addEventListener('mouseup', function() { isDragging = false; });
+
+            document.addEventListener('keydown', function(e) {
+                if (overlay.style.display !== 'block') return;
+                if (e.key === 'Escape') close();
+                if (e.key === 'ArrowLeft') prev();
+                if (e.key === 'ArrowRight') next();
+                if (e.key === '+' || e.key === '=') zoomIn();
+                if (e.key === '-') zoomOut();
+                if (e.key === '0') resetZoom();
+                if (e.key === 'w' || e.key === 'W') fitWidth();
+                if (e.key === 'h' || e.key === 'H') fitHeight();
+            });
+
+            overlay.addEventListener('click', function(e) { if (e.target === overlay || e.target === container) close(); });
+        }
+
+        function updateTransform() {
+            img.style.transform = 'translate(' + panX + 'px, ' + panY + 'px) scale(' + scale + ')';
+            var zd = document.getElementById('zoom-display');
+            if (zd) zd.textContent = Math.round(scale * 100) + '%';
+        }
+
+        function open(index) {
+            if (!images[index]) return;
+            currentIndex = index; scale = 1; panX = 0; panY = 0;
+            img.src = images[index].src;
+            titleEl.textContent = images[index].title + ' (' + (index + 1) + '/' + images.length + ')';
+            updateTransform();
+            overlay.style.display = 'block';
+            document.body.style.overflow = 'hidden';
+        }
+
+        function close() { overlay.style.display = 'none'; document.body.style.overflow = ''; }
+        function prev() { open((currentIndex - 1 + images.length) % images.length); }
+        function next() { open((currentIndex + 1) % images.length); }
+        function zoomIn() { scale = Math.min(10, scale + 0.25); updateTransform(); }
+        function zoomOut() { scale = Math.max(0.5, scale - 0.25); updateTransform(); }
+        function resetZoom() { scale = 1; panX = 0; panY = 0; updateTransform(); }
+
+        function fitWidth() {
+            if (!img.naturalWidth || !img.complete) { img.onload = fitWidth; return; }
+            scale = Math.max(0.1, Math.min(10, (window.innerWidth - 150) / img.naturalWidth));
+            panX = 0; panY = 0; updateTransform();
+        }
+
+        function fitHeight() {
+            if (!img.naturalHeight || !img.complete) { img.onload = fitHeight; return; }
+            scale = Math.max(0.1, Math.min(10, (window.innerHeight - 120) / img.naturalHeight));
+            panX = 0; panY = 0; updateTransform();
+        }
+
+        if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', init); } else { init(); }
+
+        return { open: open, close: close, prev: prev, next: next, zoomIn: zoomIn, zoomOut: zoomOut, resetZoom: resetZoom, fitWidth: fitWidth, fitHeight: fitHeight };
+    })();
+
+    // Mobile navigation
+    (function() {
+        var navToggle = document.querySelector('.nav-toggle');
+        var siteNav = document.querySelector('.site-nav');
+        var dropdowns = document.querySelectorAll('.nav-dropdown');
+
+        if (navToggle && siteNav) {
+            navToggle.addEventListener('click', function() {
+                navToggle.classList.toggle('active');
+                siteNav.classList.toggle('open');
+                navToggle.setAttribute('aria-expanded', siteNav.classList.contains('open'));
+            });
+
+            // Close menu when clicking a non-dropdown link
+            siteNav.querySelectorAll('a:not(.nav-dropdown-menu a)').forEach(function(link) {
+                link.addEventListener('click', function() {
+                    if (window.innerWidth <= 768) {
+                        navToggle.classList.remove('active');
+                        siteNav.classList.remove('open');
+                    }
+                });
+            });
+        }
+
+        // Handle dropdowns on mobile
+        dropdowns.forEach(function(dropdown) {
+            var trigger = dropdown.querySelector('.nav-trigger');
+            if (trigger) {
+                trigger.addEventListener('click', function(e) {
+                    if (window.innerWidth <= 768) {
+                        e.preventDefault();
+                        // Close other dropdowns
+                        dropdowns.forEach(function(d) {
+                            if (d !== dropdown) d.classList.remove('open');
+                        });
+                        dropdown.classList.toggle('open');
+                    }
+                });
+            }
+        });
+
+        // Close dropdowns when clicking outside on mobile
+        document.addEventListener('click', function(e) {
+            if (window.innerWidth <= 768 && !e.target.closest('.nav-dropdown')) {
+                dropdowns.forEach(function(d) { d.classList.remove('open'); });
+            }
+        });
+    })();
+    </script>
+
+    <!-- MathJax for LaTeX equations across docs pages -->
+    <script>
+    window.MathJax = {
+        tex: {
+            inlineMath: [['\\(', '\\)'], ['$', '$']],
+            displayMath: [['\\[', '\\]'], ['$$', '$$']],
+            processEscapes: true,
+            processEnvironments: true
+        },
+        options: {
+            skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+        },
+        svg: {
+            fontCache: 'global'
+        }
+    };
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+
+    <footer style="background: #2a2a2a; border-top: 1px solid #454545; color: #b0b0b0; padding: 3rem 2rem; margin-top: auto;">
+        <div style="max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem;">
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">C-Kernel-Engine</h4>
+                <p style="color: #707070; font-size: 0.875rem; margin: 0;">High-performance ML kernels with full PyTorch parity.</p>
+            </div>
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
+                </ul>
+            </div>
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                </ul>
+            </div>
+            <div style="text-align: right;">
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-26</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/site/gemma4-speculative-pair.html
+++ b/docs/site/gemma4-speculative-pair.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{PAGE_TITLE}} | C-Kernel-Engine</title>
-    <meta name="description" content="{{META_DESCRIPTION}}">
-    <meta name="robots" content="{{META_ROBOTS}}">
-    <link rel="canonical" href="{{CANONICAL_URL}}">
-    <meta property="og:title" content="{{PAGE_TITLE}} | C-Kernel-Engine">
-    <meta property="og:description" content="{{META_DESCRIPTION}}">
+    <title>Gemma4 Speculative Pair Design  | C-Kernel-Engine</title>
+    <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <meta name="robots" content="index,follow">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html">
+    <meta property="og:title" content="Gemma4 Speculative Pair Design  | C-Kernel-Engine">
+    <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{CANONICAL_URL}}">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -858,11 +858,11 @@
             <span></span>
         </button>
         <nav class="site-nav">
-            <a href="index.html" class="{{NAV_INDEX}}">Home</a>
-            <a href="spectrum.html" class="{{NAV_SPECTRUM}}" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="{{NAV_QUICKSTART}}">Getting Started</a>
-            <a href="developer-guide.html" class="{{NAV_DEVGUIDE}}">Developer Guide</a>
-            <a href="scaling.html" class="{{NAV_SCALING}}">Scaling</a>
+            <a href="index.html" class="">Home</a>
+            <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
+            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="scaling.html" class="">Scaling</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -901,7 +901,7 @@
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -916,11 +916,11 @@
                     </div>
                 </div>
             </div>
-            <a href="pytorch-parity.html" class="{{NAV_PARITY}}">PyTorch Parity</a>
-            <a href="test-report.html" class="{{NAV_NIGHTLY}}">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
-            <a href="research.html" class="{{NAV_RESEARCH}}">Research</a>
-            <a href="decisions.html" class="{{NAV_DECISIONS}}">ADR</a>
+            <a href="pytorch-parity.html" class="">PyTorch Parity</a>
+            <a href="test-report.html" class="">Test Report</a>
+            <a href="version-history.html" class="">Versions</a>
+            <a href="research.html" class="">Research</a>
+            <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
                 <div class="nav-dropdown-menu">
@@ -941,3 +941,469 @@
         </nav>
     </header>
     <main>
+
+<h1>Gemma4 Speculative Pair Design</h1>
+
+<p>
+    This page is the implementation plan for pairing a full Gemma4 backbone with the small
+    <code>google/gemma-4-E4B-it-assistant</code> drafter model. The assistant is not a standalone
+    chatbot. It is a speculative/MTP draft decoder that consumes the backbone hidden stream and
+    proposes candidate tokens for the backbone to verify.
+</p>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Analogy</strong><br>
+        In the header/body/footer mental model, the backbone is the authoritative target decoder.
+        The assistant is a secondary draft decoder. The bridge between them behaves like an
+        encoder-to-decoder handoff because the backbone exports hidden state and the assistant
+        consumes it, but the backbone is still a decoder, not a vision-style encoder.
+    </div>
+</div>
+
+<h2>Target Shape</h2>
+
+<pre><code>prompt tokens
+  -&gt; Gemma4 E4B backbone prefill
+  -&gt; backbone KV cache + hidden stream
+  -&gt; decode loop:
+       backbone step exports hidden state H_t [1, 2560]
+       assistant_pre_projection(H_t) -&gt; draft stream [1, 256]
+       assistant 4-layer draft decoder proposes token candidates
+       backbone verifies proposed token(s)
+       accepted tokens are emitted; rejected token falls back to backbone</code></pre>
+
+<p>
+    The first working milestone should draft and verify one token. After that is correct, increase
+    <code>draft_tokens</code> to 2, 4, and 8 and measure acceptance rate versus throughput.
+</p>
+
+<h2>Composite Template</h2>
+
+<p>
+    The clean CKE implementation should be a composite circuit, not two unrelated model folders
+    joined through ad hoc Python. A future template can be named:
+</p>
+
+<pre><code>version/v8/templates/gemma4_speculative_pair.json</code></pre>
+
+<p>
+    The template should declare three blocks:
+</p>
+
+<table>
+    <thead>
+        <tr>
+            <th>Block</th>
+            <th>Role</th>
+            <th>Existing Template</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>target</code></td>
+            <td>Authoritative Gemma4 backbone that owns final correctness.</td>
+            <td><code>gemma4.json</code></td>
+        </tr>
+        <tr>
+            <td><code>draft</code></td>
+            <td>Small assistant/MTP model that proposes candidate tokens.</td>
+            <td><code>gemma4_assistant.json</code></td>
+        </tr>
+        <tr>
+            <td><code>verify</code></td>
+            <td>Accept/reject loop that compares draft tokens against target logits.</td>
+            <td>New runtime loop, not a neural layer.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Weight Namespaces</h2>
+
+<p>
+    First implementation should keep the two weight files separate for auditability:
+</p>
+
+<pre><code>/tmp/ck-gemma4-e4b-runtime/weights.bump
+/tmp/ck-gemma4-assistant-runtime/weights.bump</code></pre>
+
+<p>
+    The composite manifest can refer to both namespaces:
+</p>
+
+<pre><code>{
+  "model": "gemma4_speculative_pair",
+  "target": {
+    "template": "gemma4",
+    "weights": "target.weights.bump",
+    "hidden_export": "target_hidden_stream",
+    "hidden_size": 2560
+  },
+  "draft": {
+    "template": "gemma4_assistant",
+    "weights": "assistant.weights.bump",
+    "assistant_role": "mtp_drafter",
+    "backbone_hidden_size": 2560,
+    "hidden_size": 256
+  },
+  "bridge": {
+    "source": "target_hidden_stream",
+    "dest": "draft.backbone_stream",
+    "shape": ["T", 2560]
+  }
+}</code></pre>
+
+<p>
+    Later, the compiler can merge both into one BUMP file with target and assistant regions. That is
+    an optimization, not a requirement for the first correct runtime.
+</p>
+
+<h2>IR Contract</h2>
+
+<p>
+    The composite lowering should make the bridge explicit:
+</p>
+
+<pre><code>target.decode_step
+  outputs:
+    target_logits
+    target_hidden_stream
+    target_kv_cache
+
+draft.decode_step
+  inputs:
+    draft_token_ids
+    draft.backbone_stream &lt;- target_hidden_stream
+  outputs:
+    draft_logits
+    draft_candidate_tokens
+
+verify.step
+  inputs:
+    draft_candidate_tokens
+    target_logits
+  outputs:
+    accepted_tokens
+    rejected_token</code></pre>
+
+<p>
+    The generated C should expose explicit functions instead of hiding the protocol:
+</p>
+
+<pre><code>int ck_gemma4_pair_prefill(...);
+int ck_gemma4_pair_decode_one(...);
+int ck_gemma4_pair_draft_tokens(...);
+int ck_gemma4_pair_verify_tokens(...);
+int ck_gemma4_pair_generate_speculative(...);</code></pre>
+
+<h2>Memory Plan</h2>
+
+<p>
+    Required buffers should be visible in <code>layout_decode.json</code>:
+</p>
+
+<ul>
+    <li><code>target_main_stream</code> for Gemma4 backbone hidden state.</li>
+    <li><code>target_kv_cache</code> for the authoritative target cache.</li>
+    <li><code>draft_backbone_stream</code> for assistant input, shape <code>[T, 2560]</code>.</li>
+    <li><code>draft_main_stream</code> for assistant hidden state, shape <code>[T, 256]</code>.</li>
+    <li><code>draft_kv_cache</code> for the assistant cache.</li>
+    <li><code>draft_logits</code> and <code>target_logits</code>.</li>
+    <li><code>accepted_tokens</code>, <code>candidate_tokens</code>, and verifier scratch.</li>
+</ul>
+
+<h2>Xeon Validation Plan</h2>
+
+<p>
+    On the high-memory Xeon box, build both runtimes first:
+</p>
+
+<pre><code>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
+  --run /tmp/ck-gemma4-e4b-runtime \
+  --context-len 2048 \
+  --force-convert --force-compile \
+  --prompt 'Give me a detailed example of C code.' \
+  --chat-template gemma4 \
+  --max-tokens 64 \
+  --temperature 0.0
+
+.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://google/gemma-4-E4B-it-assistant \
+  --run /tmp/ck-gemma4-assistant-runtime \
+  --context-len 2048 \
+  --force-convert --force-compile \
+  --generate-only \
+  --chat-template none \
+  --allow-raw-prompt</code></pre>
+
+<p>
+    Then validate in this order:
+</p>
+
+<ol>
+    <li>Backbone-only coherent decode.</li>
+    <li>Assistant-only compile and load smoke. Do not expect standalone chat.</li>
+    <li>Backbone decode exports <code>target_hidden_stream</code> with shape <code>[1, 2560]</code>.</li>
+    <li>Assistant consumes that stream and produces draft logits.</li>
+    <li>One-token draft and target verification match the Python reference protocol.</li>
+    <li>Multi-token speculative loop reports drafted, accepted, rejected, and acceptance rate.</li>
+</ol>
+
+<h2>Success Metrics</h2>
+
+<p>
+    The first useful dashboard should compare:
+</p>
+
+<ul>
+    <li><code>backbone_only_tok_per_sec</code></li>
+    <li><code>speculative_tok_per_sec</code></li>
+    <li><code>draft_tokens_per_batch</code></li>
+    <li><code>accepted_tokens</code> / <code>drafted_tokens</code></li>
+    <li><code>target_verify_ms</code></li>
+    <li><code>assistant_draft_ms</code></li>
+</ul>
+
+<p>
+    A failed acceptance rate is still useful data. It means the bridge, tokenizer, positional policy,
+    or hidden-state handoff is wrong. A high acceptance rate with no speedup means the protocol is
+    correct but the verifier is still too serial.
+</p>
+    </main>
+
+    <!-- SVG Viewer Overlay (shared across all pages) -->
+    <style>
+    .svg-viewer { cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
+    .svg-viewer:hover { transform: scale(1.01); box-shadow: 0 8px 32px rgba(255, 180, 0, 0.3); }
+    #svg-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.95); z-index: 999999; }
+    #svg-overlay .toolbar { position: fixed; top: 0; left: 0; right: 0; padding: 10px 20px; background: rgba(0,0,0,0.9); display: flex; justify-content: space-between; align-items: center; z-index: 1000000; border-bottom: 1px solid #333; }
+    #svg-overlay .toolbar .title { color: #ccc; font-size: 14px; }
+    #svg-overlay .toolbar .controls { display: flex; gap: 8px; align-items: center; }
+    #svg-overlay .toolbar button { background: #333; color: #ffb400; border: 1px solid #555; padding: 8px 14px; cursor: pointer; border-radius: 4px; font-size: 14px; }
+    #svg-overlay .toolbar button:hover { background: #444; border-color: #ffb400; }
+    #svg-overlay .toolbar .close-btn { font-size: 20px; padding: 4px 12px; }
+    #svg-overlay .toolbar .zoom-display { color: #888; font-size: 12px; min-width: 45px; text-align: center; }
+    #svg-overlay .toolbar .separator { color: #444; }
+    #svg-overlay .image-container { display: flex; justify-content: center; align-items: center; min-height: 100vh; padding: 60px 20px 20px; cursor: grab; }
+    #svg-overlay .image-container:active { cursor: grabbing; }
+    #svg-overlay .image-container img { max-width: 95%; max-height: 90vh; transform-origin: center center; }
+    #svg-overlay .nav-btn { position: fixed; top: 50%; transform: translateY(-50%); background: rgba(0,0,0,0.7); color: #ffb400; border: 1px solid #555; font-size: 30px; padding: 20px 15px; cursor: pointer; z-index: 1000000; border-radius: 4px; }
+    #svg-overlay .nav-btn:hover { background: rgba(255,180,0,0.2); border-color: #ffb400; }
+    #svg-overlay .nav-prev { left: 10px; }
+    #svg-overlay .nav-next { right: 10px; }
+    #svg-overlay .hint { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); color: #666; font-size: 12px; background: rgba(0,0,0,0.8); padding: 8px 20px; border-radius: 20px; }
+    </style>
+
+    <div id="svg-overlay">
+        <div class="toolbar">
+            <span class="title" id="svg-title">Image</span>
+            <div class="controls">
+                <button onclick="svgViewer.zoomOut()" title="Zoom Out (-)">-</button>
+                <span class="zoom-display" id="zoom-display">100%</span>
+                <button onclick="svgViewer.zoomIn()" title="Zoom In (+)">+</button>
+                <span class="separator">|</span>
+                <button onclick="svgViewer.fitWidth()" title="Fit Width (W)">Width</button>
+                <button onclick="svgViewer.fitHeight()" title="Fit Height (H)">Height</button>
+                <button onclick="svgViewer.resetZoom()" title="Reset (0)">Reset</button>
+                <span class="separator">|</span>
+                <button class="close-btn" onclick="svgViewer.close()" title="Close (ESC)">&times;</button>
+            </div>
+        </div>
+        <button class="nav-btn nav-prev" onclick="svgViewer.prev()" title="Previous">&larr;</button>
+        <button class="nav-btn nav-next" onclick="svgViewer.next()" title="Next">&rarr;</button>
+        <div class="image-container" id="svg-container">
+            <img id="svg-image" src="" alt="">
+        </div>
+        <div class="hint">Scroll to zoom | Drag to pan | W/H to fit | 0 to reset | ESC to close</div>
+    </div>
+
+    <script>
+    var svgViewer = (function() {
+        var overlay, img, titleEl, container;
+        var images = [];
+        var currentIndex = 0;
+        var scale = 1, panX = 0, panY = 0;
+        var isDragging = false, dragStartX, dragStartY, panStartX, panStartY;
+
+        function init() {
+            overlay = document.getElementById('svg-overlay');
+            img = document.getElementById('svg-image');
+            titleEl = document.getElementById('svg-title');
+            container = document.getElementById('svg-container');
+            if (!overlay || !img) return;
+
+            document.querySelectorAll('.svg-viewer').forEach(function(viewer, index) {
+                var viewerImg = viewer.querySelector('img');
+                if (viewerImg) {
+                    images.push({ src: viewerImg.src, title: viewer.getAttribute('data-title') || viewerImg.alt || 'Diagram' });
+                    viewer.onclick = function(e) { e.preventDefault(); open(index); };
+                }
+            });
+
+            container.addEventListener('wheel', function(e) {
+                e.preventDefault();
+                scale = Math.max(0.5, Math.min(10, scale + (e.deltaY > 0 ? -0.2 : 0.2)));
+                updateTransform();
+            });
+
+            container.addEventListener('mousedown', function(e) { isDragging = true; dragStartX = e.clientX; dragStartY = e.clientY; panStartX = panX; panStartY = panY; });
+            document.addEventListener('mousemove', function(e) { if (!isDragging) return; panX = panStartX + (e.clientX - dragStartX); panY = panStartY + (e.clientY - dragStartY); updateTransform(); });
+            document.addEventListener('mouseup', function() { isDragging = false; });
+
+            document.addEventListener('keydown', function(e) {
+                if (overlay.style.display !== 'block') return;
+                if (e.key === 'Escape') close();
+                if (e.key === 'ArrowLeft') prev();
+                if (e.key === 'ArrowRight') next();
+                if (e.key === '+' || e.key === '=') zoomIn();
+                if (e.key === '-') zoomOut();
+                if (e.key === '0') resetZoom();
+                if (e.key === 'w' || e.key === 'W') fitWidth();
+                if (e.key === 'h' || e.key === 'H') fitHeight();
+            });
+
+            overlay.addEventListener('click', function(e) { if (e.target === overlay || e.target === container) close(); });
+        }
+
+        function updateTransform() {
+            img.style.transform = 'translate(' + panX + 'px, ' + panY + 'px) scale(' + scale + ')';
+            var zd = document.getElementById('zoom-display');
+            if (zd) zd.textContent = Math.round(scale * 100) + '%';
+        }
+
+        function open(index) {
+            if (!images[index]) return;
+            currentIndex = index; scale = 1; panX = 0; panY = 0;
+            img.src = images[index].src;
+            titleEl.textContent = images[index].title + ' (' + (index + 1) + '/' + images.length + ')';
+            updateTransform();
+            overlay.style.display = 'block';
+            document.body.style.overflow = 'hidden';
+        }
+
+        function close() { overlay.style.display = 'none'; document.body.style.overflow = ''; }
+        function prev() { open((currentIndex - 1 + images.length) % images.length); }
+        function next() { open((currentIndex + 1) % images.length); }
+        function zoomIn() { scale = Math.min(10, scale + 0.25); updateTransform(); }
+        function zoomOut() { scale = Math.max(0.5, scale - 0.25); updateTransform(); }
+        function resetZoom() { scale = 1; panX = 0; panY = 0; updateTransform(); }
+
+        function fitWidth() {
+            if (!img.naturalWidth || !img.complete) { img.onload = fitWidth; return; }
+            scale = Math.max(0.1, Math.min(10, (window.innerWidth - 150) / img.naturalWidth));
+            panX = 0; panY = 0; updateTransform();
+        }
+
+        function fitHeight() {
+            if (!img.naturalHeight || !img.complete) { img.onload = fitHeight; return; }
+            scale = Math.max(0.1, Math.min(10, (window.innerHeight - 120) / img.naturalHeight));
+            panX = 0; panY = 0; updateTransform();
+        }
+
+        if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', init); } else { init(); }
+
+        return { open: open, close: close, prev: prev, next: next, zoomIn: zoomIn, zoomOut: zoomOut, resetZoom: resetZoom, fitWidth: fitWidth, fitHeight: fitHeight };
+    })();
+
+    // Mobile navigation
+    (function() {
+        var navToggle = document.querySelector('.nav-toggle');
+        var siteNav = document.querySelector('.site-nav');
+        var dropdowns = document.querySelectorAll('.nav-dropdown');
+
+        if (navToggle && siteNav) {
+            navToggle.addEventListener('click', function() {
+                navToggle.classList.toggle('active');
+                siteNav.classList.toggle('open');
+                navToggle.setAttribute('aria-expanded', siteNav.classList.contains('open'));
+            });
+
+            // Close menu when clicking a non-dropdown link
+            siteNav.querySelectorAll('a:not(.nav-dropdown-menu a)').forEach(function(link) {
+                link.addEventListener('click', function() {
+                    if (window.innerWidth <= 768) {
+                        navToggle.classList.remove('active');
+                        siteNav.classList.remove('open');
+                    }
+                });
+            });
+        }
+
+        // Handle dropdowns on mobile
+        dropdowns.forEach(function(dropdown) {
+            var trigger = dropdown.querySelector('.nav-trigger');
+            if (trigger) {
+                trigger.addEventListener('click', function(e) {
+                    if (window.innerWidth <= 768) {
+                        e.preventDefault();
+                        // Close other dropdowns
+                        dropdowns.forEach(function(d) {
+                            if (d !== dropdown) d.classList.remove('open');
+                        });
+                        dropdown.classList.toggle('open');
+                    }
+                });
+            }
+        });
+
+        // Close dropdowns when clicking outside on mobile
+        document.addEventListener('click', function(e) {
+            if (window.innerWidth <= 768 && !e.target.closest('.nav-dropdown')) {
+                dropdowns.forEach(function(d) { d.classList.remove('open'); });
+            }
+        });
+    })();
+    </script>
+
+    <!-- MathJax for LaTeX equations across docs pages -->
+    <script>
+    window.MathJax = {
+        tex: {
+            inlineMath: [['\\(', '\\)'], ['$', '$']],
+            displayMath: [['\\[', '\\]'], ['$$', '$$']],
+            processEscapes: true,
+            processEnvironments: true
+        },
+        options: {
+            skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+        },
+        svg: {
+            fontCache: 'global'
+        }
+    };
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+
+    <footer style="background: #2a2a2a; border-top: 1px solid #454545; color: #b0b0b0; padding: 3rem 2rem; margin-top: auto;">
+        <div style="max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem;">
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">C-Kernel-Engine</h4>
+                <p style="color: #707070; font-size: 0.875rem; margin: 0;">High-performance ML kernels with full PyTorch parity.</p>
+            </div>
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
+                </ul>
+            </div>
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                </ul>
+            </div>
+            <div style="text-align: right;">
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-26</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,254 +2,262 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html</loc>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html</loc>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-06-24</lastmod>
+    <lastmod>2026-06-26</lastmod>
   </url>
 </urlset>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -907,6 +907,12 @@ void qk_norm_forward(float *q,
                      int num_tokens,
                      int head_dim,
                      float eps);
+void q_norm_forward(float *q,
+                    const float *q_gamma,
+                    int num_heads,
+                    int num_tokens,
+                    int head_dim,
+                    float eps);
 
 
 void gemma4_per_layer_prepare_forward(float *per_layer_input,
@@ -947,6 +953,11 @@ void gemma4_per_layer_embed_forward(float *hidden,
                                     int embed_dim,
                                     int per_layer_dim,
                                     float eps);
+
+void assistant_layer_scale_forward(float *hidden,
+                                   const float *scale,
+                                   int tokens,
+                                   int embed_dim);
 
 void gemma4_final_logit_softcap_forward(float *logits,
                                         int tokens,
@@ -1286,6 +1297,13 @@ void attention_forward_causal_head_major_gqa_flash_strided_gemma4(const float *q
                                                                   int head_dim,
                                                                   int aligned_head_dim,
                                                                   int kv_stride_tokens);
+void attention_forward_causal_head_major_shared_kv_gemma4(const float *q,
+                                                          float *output,
+                                                          int num_heads,
+                                                          int num_tokens,
+                                                          int head_dim,
+                                                          int aligned_head_dim,
+                                                          int kv_stride_tokens);
 
 void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q,
                                                                 const float *k,
@@ -1376,6 +1394,15 @@ void attention_forward_decode_head_major_gqa_flash_gemma4(const float *q_token,
                                                           int cache_capacity,
                                                           int head_dim,
                                                           int aligned_head_dim);
+void attention_forward_decode_head_major_shared_kv_gemma4(const float *q_token,
+                                                          const float *k_cache,
+                                                          const float *v_cache,
+                                                          float *out_token,
+                                                          int num_heads,
+                                                          int kv_tokens,
+                                                          int cache_capacity,
+                                                          int head_dim,
+                                                          int aligned_head_dim);
 
 // Chunk decode attention: q_chunk/out_chunk use compact head-major
 // [num_heads, q_tokens, aligned_head_dim] layout while K/V are stored in the
@@ -1454,6 +1481,15 @@ void attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(
     float *output,
     int num_heads,
     int num_kv_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens,
+    int sliding_window);
+void attention_forward_causal_head_major_shared_kv_sliding_gemma4(
+    const float *q,
+    float *output,
+    int num_heads,
     int num_tokens,
     int head_dim,
     int aligned_head_dim,
@@ -1910,6 +1946,17 @@ void attention_forward_decode_head_major_gqa_flash_sliding_gemma4(
     int head_dim,
     int aligned_head_dim,
     int sliding_window);
+void attention_forward_decode_head_major_shared_kv_sliding_gemma4(
+    const float *q_token,
+    const float *k_cache,
+    const float *v_cache,
+    float *out_token,
+    int num_heads,
+    int kv_tokens,
+    int cache_capacity,
+    int head_dim,
+    int aligned_head_dim,
+    int sliding_window);
 
 // TRUE Flash Attention (O(1) for decode) - Tri Dao's algorithm
 //   out: [T_q, H, D_h]
@@ -1967,6 +2014,14 @@ void kv_cache_store(float *__restrict kv_cache_k,
                     int num_kv_heads,
                     int head_dim,
                     int max_seq_len);
+void kv_cache_store_shared_q(float *__restrict kv_cache_k,
+                             float *__restrict kv_cache_v,
+                             const float *__restrict q,
+                             int layer,
+                             int pos,
+                             int num_heads,
+                             int head_dim,
+                             int max_seq_len);
 
 void kv_cache_store_f16(uint16_t *__restrict kv_cache_k,
                         uint16_t *__restrict kv_cache_v,
@@ -2696,6 +2751,16 @@ void rope_forward_qk_split_direct_f32(float *q,
                                       int pos_offset,
                                       int rotary_dim,
                                       float freq_base);
+void rope_forward_q_split_direct_f32(float *q,
+                                     const float *freq_factors,
+                                     int use_freq_factors,
+                                     int num_heads,
+                                     int num_tokens,
+                                     int head_dim,
+                                     int aligned_head_dim,
+                                     int pos_offset,
+                                     int rotary_dim,
+                                     float freq_base);
 
 void rope_forward_qk_gemma4_direct(float *q,
                                    float *k,

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -2438,6 +2438,27 @@ void nemotron_group_limited_topk_router_f32(const float *scores,
 // Argmax (top-1)
 int argmax_f32(const float *scores, int n);
 
+// Greedy speculative verification for one candidate token.
+// accepted=1 when draft_token equals argmax(target_logits), otherwise 0.
+void speculative_verify_greedy_f32(const float *target_logits,
+                                   int vocab_size,
+                                   int draft_token,
+                                   int *accepted,
+                                   int *verified_token);
+
+// Greedy one-token speculative commit state update.
+// Appends verified_token when capacity allows, advances target_position, and
+// keeps draft_position synchronized for the one-token verifier milestone.
+void speculative_commit_one_i32(int accepted,
+                                int verified_token,
+                                int *token_buffer,
+                                int *token_count,
+                                int max_tokens,
+                                int *target_position,
+                                int *draft_position,
+                                int *accepted_count,
+                                int *rejected_count);
+
 // =============================================================================
 // DeepSeek-style scalar reference kernels
 // =============================================================================

--- a/scripts/ck_chat.py
+++ b/scripts/ck_chat.py
@@ -25,6 +25,14 @@ from typing import Optional, List
 
 import numpy as np
 
+
+class SpeculativeConfig:
+    """Runtime controls for greedy speculative decoding."""
+
+    def __init__(self, draft_model: "CKModel", draft_tokens: int = 4):
+        self.draft_model = draft_model
+        self.draft_tokens = max(1, int(draft_tokens))
+
 # Auto-validation support
 AUTO_VALIDATE_AVAILABLE = False
 try:
@@ -1927,7 +1935,8 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
              repeat_last_n: int = 64,
              no_repeat_ngram_size: int = 0,
              min_new_tokens: int = 0,
-             stop_on_text: Optional[List[str]] = None) -> str:
+             stop_on_text: Optional[List[str]] = None,
+             speculative: Optional[SpeculativeConfig] = None) -> str:
     """Generate text from prompt.
 
     Args:
@@ -1954,8 +1963,21 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
     generated = []
     sample_times = []
     decode_times = []
+    draft_times = []
+    speculative_stats = {
+        "drafted": 0,
+        "accepted": 0,
+        "rejected": 0,
+        "batches": 0,
+    }
     prefill_time = 0.0
     start_time = time.time()
+
+    if speculative is not None:
+        if temperature != 0:
+            raise ValueError("speculative decoding currently requires greedy mode: set --temperature 0")
+        if not model.has_kv_decode or not speculative.draft_model.has_kv_decode:
+            raise ValueError("speculative decoding requires KV decode support on both target and draft models")
 
     def _first_text_stop() -> Optional[tuple[int, str]]:
         hit_index: Optional[int] = None
@@ -2086,6 +2108,66 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
             min_p=min_p,
         )
 
+    def _append_generated_token(next_token: int, step_idx: int) -> bool:
+        nonlocal generated_text, stop_reason, gibberish_detected
+        if model.is_eos_token(next_token):
+            stop_reason = f"eos token {int(next_token)}"
+            return True
+        generated.append(next_token)
+        generated_tokens.append(next_token)
+        token_ids.append(next_token)
+        token_text = model.decode([next_token])
+        generated_text = model.decode(generated_tokens)
+        if _check_repetition_stop():
+            return True
+        if show_token_ids:
+            display_text = _escape_text_for_display(
+                token_text, ascii_only=ascii_display, escape_newlines=escape_newlines
+            ) if safe_display else token_text
+            if show_token_pieces:
+                piece = model.token_piece(next_token)
+                piece_txt = _piece_for_debug(piece if piece is not None else "?")
+                print(f"<{next_token}|{piece_txt}:{display_text}>", end='', flush=True)
+            else:
+                print(f"<{next_token}:{display_text}>", end='', flush=True)
+        else:
+            _flush_text_output(force=False)
+        if _check_text_stop():
+            return True
+
+        if validator and (step_idx + 1) % check_every_n == 0 and len(generated_tokens) >= 10:
+            if AUTO_VALIDATE_AVAILABLE and quick_check(generated_text):
+                result = detect_gibberish(tokens=generated_tokens, text=generated_text,
+                                         vocab_size=model.vocab_size)
+                if result.is_gibberish and result.confidence > 0.5:
+                    gibberish_detected = True
+                    print(f"\n\033[91m[GIBBERISH DETECTED at token {step_idx+1}]\033[0m")
+                    return True
+
+        if len(token_ids) >= model.context_window - 1:
+            stop_reason = "context window reached"
+            return True
+        return False
+
+    def _draft_tokens_from_current_prefix(draft_model: CKModel, prefix_tokens: List[int], count: int) -> List[int]:
+        """Return greedy draft tokens from a fresh draft KV state."""
+        if not prefix_tokens:
+            return []
+        draft_model.kv_cache_reset()
+        t0 = time.time()
+        logits = draft_model.prefill(prefix_tokens)
+        out: List[int] = []
+        for _ in range(max(1, int(count))):
+            token_id = int(np.argmax(logits))
+            if draft_model.is_eos_token(token_id):
+                break
+            out.append(token_id)
+            if len(prefix_tokens) + len(out) >= min(model.context_window, draft_model.context_window) - 1:
+                break
+            logits = draft_model.decode_step(token_id)
+        draft_times.append(time.time() - t0)
+        return out
+
     if model.has_kv_decode and model.kv_cache_enable():
         use_sequential_prefill = bool(
             no_prefill or str(getattr(model, "prefill_policy", "batched")).strip().lower() == "sequential_decode"
@@ -2106,49 +2188,69 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
             logits = model.prefill(token_ids)
         prefill_time = time.time() - t0
 
-        for i in range(max_tokens):
+        i = 0
+        while i < max_tokens:
+            if speculative is not None:
+                draft_count = min(speculative.draft_tokens, int(max_tokens) - i)
+                speculative_stats["batches"] += 1
+                draft_tokens = _draft_tokens_from_current_prefix(speculative.draft_model, list(token_ids), draft_count)
+                speculative_stats["drafted"] += len(draft_tokens)
+                rejected = False
+
+                for draft_token in draft_tokens:
+                    t_sample = time.time()
+                    verifier_token = _sample_next_token(logits, i)
+                    sample_times.append(time.time() - t_sample)
+                    if int(draft_token) == int(verifier_token):
+                        speculative_stats["accepted"] += 1
+                        if _append_generated_token(int(draft_token), i):
+                            rejected = True
+                            break
+                        model.set_parity_token_index(prompt_tokens + i)
+                        t_decode = time.time()
+                        logits = model.decode_step(int(draft_token))
+                        decode_times.append(time.time() - t_decode)
+                        i += 1
+                        continue
+
+                    speculative_stats["rejected"] += 1
+                    rejected = True
+                    if _append_generated_token(int(verifier_token), i):
+                        i += 1
+                        break
+                    model.set_parity_token_index(prompt_tokens + i)
+                    t_decode = time.time()
+                    logits = model.decode_step(int(verifier_token))
+                    decode_times.append(time.time() - t_decode)
+                    i += 1
+                    break
+
+                if stop_reason is not None or gibberish_detected or len(token_ids) >= model.context_window - 1:
+                    break
+
+                if not draft_tokens:
+                    rejected = True
+
+                if not rejected and i < max_tokens:
+                    t_sample = time.time()
+                    verifier_token = _sample_next_token(logits, i)
+                    sample_times.append(time.time() - t_sample)
+                    if _append_generated_token(int(verifier_token), i):
+                        i += 1
+                        break
+                    model.set_parity_token_index(prompt_tokens + i)
+                    t_decode = time.time()
+                    logits = model.decode_step(int(verifier_token))
+                    decode_times.append(time.time() - t_decode)
+                    i += 1
+                continue
+
             # Sample
             t_sample = time.time()
             next_token = _sample_next_token(logits, i)
             sample_times.append(time.time() - t_sample)
 
-            if model.is_eos_token(next_token):
-                stop_reason = f"eos token {int(next_token)}"
-                break
-            generated.append(next_token)
-            generated_tokens.append(next_token)
-            token_ids.append(next_token)
-            token_text = model.decode([next_token])
-            generated_text = model.decode(generated_tokens)
-            if _check_repetition_stop():
-                break
-            if show_token_ids:
-                display_text = _escape_text_for_display(
-                    token_text, ascii_only=ascii_display, escape_newlines=escape_newlines
-                ) if safe_display else token_text
-                if show_token_pieces:
-                    piece = model.token_piece(next_token)
-                    piece_txt = _piece_for_debug(piece if piece is not None else "?")
-                    print(f"<{next_token}|{piece_txt}:{display_text}>", end='', flush=True)
-                else:
-                    print(f"<{next_token}:{display_text}>", end='', flush=True)
-            else:
-                _flush_text_output(force=False)
-            if _check_text_stop():
-                break
-
-            # Periodic gibberish check
-            if validator and (i + 1) % check_every_n == 0 and len(generated_tokens) >= 10:
-                if AUTO_VALIDATE_AVAILABLE and quick_check(generated_text):
-                    result = detect_gibberish(tokens=generated_tokens, text=generated_text,
-                                             vocab_size=model.vocab_size)
-                    if result.is_gibberish and result.confidence > 0.5:
-                        gibberish_detected = True
-                        print(f"\n\033[91m[GIBBERISH DETECTED at token {i+1}]\033[0m")
-                        break
-
-            if len(token_ids) >= model.context_window - 1:
-                stop_reason = "context window reached"
+            if _append_generated_token(next_token, i):
                 break
 
             # Set parity token index before decode
@@ -2158,6 +2260,7 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
             t_decode = time.time()
             logits = model.decode_step(next_token)
             decode_times.append(time.time() - t_decode)
+            i += 1
     else:
         for i in range(max_tokens):
             # Forward pass (first is prefill, rest are decode)
@@ -2175,48 +2278,7 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
             next_token = _sample_next_token(logits, i)
             sample_times.append(time.time() - t_sample)
 
-            # Check for EOS token
-            if model.is_eos_token(next_token):
-                stop_reason = f"eos token {int(next_token)}"
-                break
-
-            generated.append(next_token)
-            generated_tokens.append(next_token)
-            token_ids.append(next_token)
-
-            # Decode and print incrementally
-            token_text = model.decode([next_token])
-            generated_text = model.decode(generated_tokens)
-            if _check_repetition_stop():
-                break
-            if show_token_ids:
-                display_text = _escape_text_for_display(
-                    token_text, ascii_only=ascii_display, escape_newlines=escape_newlines
-                ) if safe_display else token_text
-                if show_token_pieces:
-                    piece = model.token_piece(next_token)
-                    piece_txt = _piece_for_debug(piece if piece is not None else "?")
-                    print(f"<{next_token}|{piece_txt}:{display_text}>", end='', flush=True)
-                else:
-                    print(f"<{next_token}:{display_text}>", end='', flush=True)
-            else:
-                _flush_text_output(force=False)
-            if _check_text_stop():
-                break
-
-            # Periodic gibberish check
-            if validator and (i + 1) % check_every_n == 0 and len(generated_tokens) >= 10:
-                if AUTO_VALIDATE_AVAILABLE and quick_check(generated_text):
-                    result = detect_gibberish(tokens=generated_tokens, text=generated_text,
-                                             vocab_size=model.vocab_size)
-                    if result.is_gibberish and result.confidence > 0.5:
-                        gibberish_detected = True
-                        print(f"\n\033[91m[GIBBERISH DETECTED at token {i+1}]\033[0m")
-                        break
-
-            # Check context limit
-            if len(token_ids) >= model.context_window - 1:
-                stop_reason = "context window reached"
+            if _append_generated_token(next_token, i):
                 break
 
     total_time = time.time() - start_time
@@ -2263,6 +2325,16 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
         sample_ms = total_sample_time * 1000
         sample_count = len(sample_times)
         sample_ms_per_token = sample_ms / sample_count if sample_count > 0 else 0
+        draft_ms = sum(draft_times) * 1000
+        draft_line = ""
+        if speculative is not None:
+            drafted = int(speculative_stats["drafted"])
+            accepted = int(speculative_stats["accepted"])
+            accept_rate = (accepted / drafted * 100.0) if drafted > 0 else 0.0
+            draft_line = (
+                f"\n speculative: {draft_ms:8.2f} ms / {int(speculative_stats['batches']):4d} batches "
+                f"({accepted}/{drafted} accepted, {accept_rate:5.1f}%, {int(speculative_stats['rejected'])} rejected)"
+            )
 
         # Total stats
         total_ms = total_time * 1000
@@ -2272,7 +2344,9 @@ def generate(model: CKModel, prompt: str, max_tokens: int = 50,
               f"prompt eval: {prefill_ms:8.2f} ms / {prompt_tokens:4d} tokens ({prefill_ms_per_token:7.2f} ms/tok, {prefill_tps:7.2f} tok/s)\n" +
               f"      decode: {decode_ms:8.2f} ms / {decode_count:4d} runs   ({decode_ms_per_token:7.2f} ms/tok, {decode_tps:7.2f} tok/s)\n" +
               f"      sample: {sample_ms:8.2f} ms / {sample_count:4d} runs   ({sample_ms_per_token:7.2f} ms/tok)\n" +
-              f"       total: {total_ms:8.2f} ms / {total_tokens:4d} tokens\033[0m")
+              f"       total: {total_ms:8.2f} ms / {total_tokens:4d} tokens" +
+              draft_line +
+              f"\033[0m")
 
     elif verbose:
         tokens_per_sec = gen_count / total_time if total_time > 0 else 0
@@ -2298,7 +2372,8 @@ def chat_loop(model: CKModel, temperature: float = 0.7, max_tokens: int = 100,
               repeat_last_n: int = 64,
               no_repeat_ngram_size: int = 0,
               memory_enabled: bool = False,
-              stop_on_text: Optional[List[str]] = None):
+              stop_on_text: Optional[List[str]] = None,
+              speculative: Optional[SpeculativeConfig] = None):
     """Interactive chat loop."""
     print("\n" + "=" * 60)
     print("  C-Kernel-Engine Chat")
@@ -2372,7 +2447,8 @@ def chat_loop(model: CKModel, temperature: float = 0.7, max_tokens: int = 100,
                           repeat_last_n=repeat_last_n,
                           no_repeat_ngram_size=no_repeat_ngram_size,
                           min_new_tokens=model.default_min_new_tokens() if model.use_chat_template else 0,
-                          stop_on_text=stop_on_text)
+                          stop_on_text=stop_on_text,
+                          speculative=speculative)
         print()
         if memory_enabled:
             conversation.append(("assistant", response))
@@ -2432,6 +2508,10 @@ def main():
                        help="Override contract thinking mode for chat-capable models (auto, visible, or suppressed)")
     parser.add_argument("--memory", action="store_true",
                        help="Keep previous prompts/responses in interactive chat (default: off)")
+    parser.add_argument("--speculative-draft-model-dir",
+                       help="Path to a compiled draft model directory for greedy speculative decoding")
+    parser.add_argument("--speculative-draft-tokens", type=int, default=4,
+                       help="Number of draft tokens to propose per speculative batch (default: 4)")
     args = parser.parse_args()
 
     # Determine parity directory
@@ -2469,6 +2549,32 @@ def main():
                       allow_raw_prompt=args.allow_raw_prompt):
         sys.exit(1)
     model.thinking_mode = str(args.thinking_mode or "auto")
+
+    draft_model = None
+    speculative = None
+    if args.speculative_draft_model_dir:
+        if args.temperature != 0:
+            print("Error: speculative decoding currently requires --temperature 0")
+            model.free()
+            sys.exit(1)
+        print(f"Loading speculative draft model from {args.speculative_draft_model_dir}...")
+        draft_model = CKModel(args.speculative_draft_model_dir)
+        if not draft_model.load(gguf_path=args.gguf, force_python_tokenizer=args.python_tokenizer,
+                                chat_template=chat_template,
+                                allow_raw_prompt=args.allow_raw_prompt):
+            model.free()
+            sys.exit(1)
+        draft_model.thinking_mode = model.thinking_mode
+        if model.vocab_size != draft_model.vocab_size:
+            print(
+                "Error: speculative draft and target vocab sizes differ "
+                f"({draft_model.vocab_size} != {model.vocab_size})"
+            )
+            draft_model.free()
+            model.free()
+            sys.exit(1)
+        speculative = SpeculativeConfig(draft_model, draft_tokens=args.speculative_draft_tokens)
+
     runtime_contract = model._load_runtime_contract()
     sampler_defaults = runtime_contract.get("sampler_defaults") if isinstance(runtime_contract, dict) else None
     if not isinstance(sampler_defaults, dict):
@@ -2520,7 +2626,8 @@ def main():
                     repeat_last_n=args.repeat_last_n,
                     no_repeat_ngram_size=args.no_repeat_ngram_size,
                     min_new_tokens=model.default_min_new_tokens() if model.use_chat_template else 0,
-                    stop_on_text=stop_markers)
+                    stop_on_text=stop_markers,
+                    speculative=speculative)
             print()
         else:
             # Interactive chat mode
@@ -2551,13 +2658,16 @@ def main():
                      repeat_last_n=args.repeat_last_n,
                      no_repeat_ngram_size=args.no_repeat_ngram_size,
                      memory_enabled=args.memory,
-                     stop_on_text=stop_markers)
+                     stop_on_text=stop_markers,
+                     speculative=speculative)
     finally:
         if tty_stdin is not None:
             try:
                 tty_stdin.close()
             except Exception:
                 pass
+        if draft_model is not None:
+            draft_model.free()
         model.free()
 
 

--- a/scripts/ck_chat.py
+++ b/scripts/ck_chat.py
@@ -414,6 +414,7 @@ class CKModel:
         self.context_window = 0
         self.has_kv_decode = False
         self.has_parity = False
+        self.has_named_activations = False
         self.eos_tokens = set()  # Will be populated during load
         self.logits_stride = None  # Optional: logits stride in floats (0 = last-only)
         self.use_chat_template = True
@@ -428,6 +429,61 @@ class CKModel:
         self.default_system_prompt = "You are a helpful assistant."
         self.prefill_policy = "batched"
         self.thinking_mode = "auto"
+
+    def _setup_named_activation_api(self) -> None:
+        """Bind optional v8 named-activation lookup symbols."""
+        self.has_named_activations = False
+        if self.lib is None:
+            return
+        try:
+            self.lib.ck_model_get_named_activation_ptr.argtypes = [ctypes.c_char_p]
+            self.lib.ck_model_get_named_activation_ptr.restype = ctypes.c_void_p
+            self.lib.ck_model_get_named_activation_nbytes.argtypes = [ctypes.c_char_p]
+            self.lib.ck_model_get_named_activation_nbytes.restype = ctypes.c_ssize_t
+            self.lib.ck_model_get_named_activation_runtime_offset.argtypes = [ctypes.c_char_p]
+            self.lib.ck_model_get_named_activation_runtime_offset.restype = ctypes.c_ssize_t
+            self.has_named_activations = True
+        except AttributeError:
+            self.has_named_activations = False
+
+    def named_activation_nbytes(self, name: str) -> int:
+        """Return byte size for a generated runtime activation, or -1 if absent."""
+        if not self.has_named_activations or self.lib is None:
+            return -1
+        return int(self.lib.ck_model_get_named_activation_nbytes(str(name).encode()))
+
+    def named_activation_runtime_offset(self, name: str) -> int:
+        """Return runtime byte offset for a generated activation, or -1 if absent."""
+        if not self.has_named_activations or self.lib is None:
+            return -1
+        return int(self.lib.ck_model_get_named_activation_runtime_offset(str(name).encode()))
+
+    def named_activation_ptr(self, name: str) -> int:
+        """Return raw pointer for a generated runtime activation, or 0 if absent."""
+        if not self.has_named_activations or self.lib is None:
+            return 0
+        ptr = self.lib.ck_model_get_named_activation_ptr(str(name).encode())
+        return int(ptr or 0)
+
+    def read_named_activation_f32(self, name: str, max_floats: Optional[int] = None) -> Optional[np.ndarray]:
+        """Copy a named activation as float32.
+
+        v8 codegen emits this API for external bridge hosts. It gives the Python
+        runtime a deterministic way to inspect buffers such as main_stream,
+        backbone_stream, vision_output, or future target_hidden_stream without
+        hard-coding memory offsets.
+        """
+        nbytes = self.named_activation_nbytes(name)
+        ptr = self.named_activation_ptr(name)
+        if nbytes <= 0 or ptr == 0:
+            return None
+        count = nbytes // ctypes.sizeof(ctypes.c_float)
+        if max_floats is not None:
+            count = min(count, max(0, int(max_floats)))
+        if count <= 0:
+            return np.zeros((0,), dtype=np.float32)
+        c_arr = (ctypes.c_float * count).from_address(ptr)
+        return np.ctypeslib.as_array(c_arr).copy()
 
     def _load_chat_contract(self) -> Optional[dict]:
         if self._chat_contract_loaded:
@@ -562,6 +618,7 @@ class CKModel:
 
         self.lib.ck_model_get_active_tokens.argtypes = []
         self.lib.ck_model_get_active_tokens.restype = ctypes.c_int
+        self._setup_named_activation_api()
         # Optional logits stride API (newer v6.6 models)
         try:
             self.lib.ck_model_get_logits_stride.argtypes = []

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -263,6 +263,7 @@ TEST_SUITES = {
     "nemotron_router": TestSuite("Nemotron Group-Limited Router", "kernels", UNITTEST_DIR / "test_nemotron_router.py"),
     "moe_relu2_expert": TestSuite("MoE ReLU2 Expert", "kernels", UNITTEST_DIR / "test_moe_relu2_expert.py"),
     "mamba2_reference": TestSuite("Mamba2 Reference Kernels", "kernels", UNITTEST_DIR / "test_mamba2_reference.py"),
+    "gemma4_assistant": TestSuite("Gemma4 Assistant/MTP Kernels", "kernels", UNITTEST_DIR / "test_gemma4_assistant_kernels.py"),
     "vision": TestSuite("Vision", "kernels", UNITTEST_DIR / "test_vision.py"),
     # NOTE: Orchestration test disabled - v6.5 uses generated code with local helpers,
     # not orchestration layer. Use llamacpp-parity-full for quantized kernel validation.
@@ -506,7 +507,7 @@ BENCH_TARGETS = {
 
 # Quick subset for fast validation
 QUICK_TESTS = [
-    "gemm", "relu", "relu2", "nemotron_router", "moe_relu2_expert", "mamba2_reference", "softmax", "rmsnorm", "attention", "attention_sliding",
+    "gemm", "relu", "relu2", "nemotron_router", "moe_relu2_expert", "mamba2_reference", "gemma4_assistant", "softmax", "rmsnorm", "attention", "attention_sliding",
     "deltanet_backward",
     "relu_bf16", "rmsnorm_bf16",
     "q4k_kernels",

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -3034,6 +3034,20 @@ void attention_forward_causal_head_major_gqa_flash_strided_gemma4(const float *q
                                                 1.0f);
 }
 
+void attention_forward_causal_head_major_shared_kv_gemma4(const float *q,
+                                                          float *output,
+                                                          int num_heads,
+                                                          int num_tokens,
+                                                          int head_dim,
+                                                          int aligned_head_dim,
+                                                          int kv_stride_tokens)
+{
+    attention_forward_causal_head_major_gqa_flash_strided_gemma4(
+        q, q, q, output, num_heads, num_heads, num_tokens,
+        head_dim, aligned_head_dim, kv_stride_tokens
+    );
+}
+
 void attention_forward_full_head_major_gqa_flash_strided_gemma4(const float *q,
                                                                 const float *k,
                                                                 const float *v,
@@ -3644,6 +3658,22 @@ void attention_forward_chunk_head_major_gqa_flash_gemma4(const float *q_chunk,
                                    scale);
         }
     }
+}
+
+void attention_forward_decode_head_major_shared_kv_gemma4(const float *q_token,
+                                                          const float *k_cache,
+                                                          const float *v_cache,
+                                                          float *out_token,
+                                                          int num_heads,
+                                                          int kv_tokens,
+                                                          int cache_capacity,
+                                                          int head_dim,
+                                                          int aligned_head_dim)
+{
+    attention_forward_decode_head_major_gqa_flash_gemma4(
+        q_token, k_cache, v_cache, out_token, num_heads, num_heads,
+        kv_tokens, cache_capacity, head_dim, aligned_head_dim
+    );
 }
 
 void attention_forward_decode_head_major_gqa_flash_f16kv(const float *q_token,

--- a/src/kernels/attention_kernels_sliding.c
+++ b/src/kernels/attention_kernels_sliding.c
@@ -590,6 +590,22 @@ void attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(
 #undef SLIDING_FLASH_IMPL_GEMMA4
 }
 
+void attention_forward_causal_head_major_shared_kv_sliding_gemma4(
+    const float *q,
+    float *output,
+    int num_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens,
+    int sliding_window)
+{
+    attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(
+        q, q, q, output, num_heads, num_heads, num_tokens,
+        head_dim, aligned_head_dim, kv_stride_tokens, sliding_window
+    );
+}
+
 void attention_forward_decode_head_major_gqa_flash_sliding(
     const float *q_token,
     const float *k_cache,
@@ -747,4 +763,22 @@ void attention_forward_decode_head_major_gqa_flash_sliding_gemma4(
     }
 
 #undef SLIDING_DECODE_IMPL_GEMMA4
+}
+
+void attention_forward_decode_head_major_shared_kv_sliding_gemma4(
+    const float *q_token,
+    const float *k_cache,
+    const float *v_cache,
+    float *out_token,
+    int num_heads,
+    int kv_tokens,
+    int cache_capacity,
+    int head_dim,
+    int aligned_head_dim,
+    int sliding_window)
+{
+    attention_forward_decode_head_major_gqa_flash_sliding_gemma4(
+        q_token, k_cache, v_cache, out_token, num_heads, num_heads,
+        kv_tokens, cache_capacity, head_dim, aligned_head_dim, sliding_window
+    );
 }

--- a/src/kernels/gemma4_per_layer_embed.c
+++ b/src/kernels/gemma4_per_layer_embed.c
@@ -263,6 +263,22 @@ void gemma4_per_layer_embed_forward(float *hidden,
     }
 }
 
+void assistant_layer_scale_forward(float *hidden,
+                                   const float *scale,
+                                   int tokens,
+                                   int embed_dim)
+{
+    if (!hidden || !scale || tokens <= 0 || embed_dim <= 0) {
+        return;
+    }
+
+    const float s = scale[0];
+    const size_t n = (size_t)tokens * (size_t)embed_dim;
+    for (size_t i = 0; i < n; ++i) {
+        hidden[i] *= s;
+    }
+}
+
 void gemma4_final_logit_softcap_forward(float *logits,
                                         int tokens,
                                         int vocab_size,

--- a/src/kernels/kv_cache_kernels.c
+++ b/src/kernels/kv_cache_kernels.c
@@ -128,6 +128,25 @@ void kv_cache_store(float *__restrict kv_cache_k,
                               head_dim);
 }
 
+void kv_cache_store_shared_q(float *__restrict kv_cache_k,
+                             float *__restrict kv_cache_v,
+                             const float *__restrict q,
+                             int layer,
+                             int pos,
+                             int num_heads,
+                             int head_dim,
+                             int max_seq_len)
+{
+    (void)layer;
+    kv_cache_write_head_major(q, q,
+                              kv_cache_k, kv_cache_v,
+                              num_heads,
+                              pos,
+                              max_seq_len,
+                              head_dim,
+                              head_dim);
+}
+
 void kv_cache_store_f16(uint16_t *__restrict kv_cache_k,
                         uint16_t *__restrict kv_cache_v,
                         const float *__restrict k,

--- a/src/kernels/qk_norm_kernels.c
+++ b/src/kernels/qk_norm_kernels.c
@@ -304,6 +304,24 @@ void qk_norm_forward(float *q, float *k,
 }
 
 /**
+ * Forward pass for Gemma4-assistant q-only per-head RMSNorm.
+ *
+ * Some Gemma4 assistant/drafter checkpoints project only Q and then reuse Q as
+ * the shared K/V stream. This wrapper keeps that public kernel contract explicit
+ * while reusing the same row-wise RMSNorm implementation as qk_norm_forward.
+ */
+void q_norm_forward(float *q,
+                    const float *q_gamma,
+                    int num_heads,
+                    int num_tokens,
+                    int head_dim,
+                    float eps)
+{
+    rmsnorm_forward(q, q_gamma, q, NULL,
+                    num_heads * num_tokens, head_dim, head_dim, eps);
+}
+
+/**
  * Backward pass for per-head QK RMSNorm.
  *
  * This computes:

--- a/src/kernels/topk_kernels.c
+++ b/src/kernels/topk_kernels.c
@@ -341,6 +341,87 @@ int argmax_f32(const float *scores, int n)
     return max_idx;
 }
 
+/* =============================================================================
+ * Speculative decode verifier
+ * ============================================================================= */
+
+/**
+ * @brief Greedy one-token speculative verification.
+ *
+ * The draft model proposes draft_token. The target model is authoritative:
+ * if draft_token equals argmax(target_logits), the candidate is accepted and
+ * emitted. Otherwise the target argmax is emitted and the draft path must be
+ * reset or rewound by the runtime loop.
+ *
+ * @param target_logits Target/backbone logits [vocab_size]
+ * @param vocab_size Number of logits
+ * @param draft_token Candidate token from draft/assistant model
+ * @param accepted Output scalar: 1 if accepted, 0 otherwise
+ * @param verified_token Output scalar: accepted draft token or target argmax
+ */
+void speculative_verify_greedy_f32(const float *target_logits,
+                                   int vocab_size,
+                                   int draft_token,
+                                   int *accepted,
+                                   int *verified_token)
+{
+    const int target_token = argmax_f32(target_logits, vocab_size);
+    const int ok = (target_token >= 0 && draft_token == target_token) ? 1 : 0;
+
+    if (accepted) {
+        *accepted = ok;
+    }
+    if (verified_token) {
+        *verified_token = ok ? draft_token : target_token;
+    }
+}
+
+/**
+ * @brief Commit one verified speculative token and update decode counters.
+ *
+ * This is the minimal state transition for the first Gemma4 assistant bridge:
+ * greedy, one draft token, target remains authoritative. For this milestone the
+ * draft cache is kept synchronized with the target position after each token.
+ * Multi-token speculative decoding can later replace this with prefix accept
+ * and partial draft-cache rollback.
+ */
+void speculative_commit_one_i32(int accepted,
+                                int verified_token,
+                                int *token_buffer,
+                                int *token_count,
+                                int max_tokens,
+                                int *target_position,
+                                int *draft_position,
+                                int *accepted_count,
+                                int *rejected_count)
+{
+    int next_count = token_count ? *token_count : 0;
+    if (token_buffer && token_count && next_count >= 0 && next_count < max_tokens) {
+        token_buffer[next_count] = verified_token;
+        next_count += 1;
+        *token_count = next_count;
+    }
+
+    if (target_position) {
+        *target_position += 1;
+        if (draft_position) {
+            *draft_position = *target_position;
+        }
+    } else if (draft_position) {
+        *draft_position += 1;
+    }
+
+    if (accepted) {
+        if (accepted_count) {
+            *accepted_count += 1;
+        }
+    } else {
+        if (rejected_count) {
+            *rejected_count += 1;
+        }
+    }
+}
+
 
 /* =============================================================================
  * Group-limited MoE router for Nemotron-H/DeepSeek-style routed experts.

--- a/tests/test_ck_chat_runtime_contract.py
+++ b/tests/test_ck_chat_runtime_contract.py
@@ -22,7 +22,51 @@ import chat_contract  # type: ignore
 import compare_first_token_logits as first_token  # type: ignore
 
 
+class _FakeCFunc:
+    def __init__(self, fn):
+        self.fn = fn
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, *args):
+        return self.fn(*args)
+
+
 class TestCKChatRuntimeContract(unittest.TestCase):
+    def test_ck_model_reads_named_activation_f32_when_runtime_exports_api(self) -> None:
+        data = np.array([1.25, -2.5, 3.75, 4.5], dtype=np.float32)
+        data_ptr = data.ctypes.data
+
+        class FakeLib:
+            def __init__(self) -> None:
+                self.ck_model_get_named_activation_ptr = _FakeCFunc(
+                    lambda name: data_ptr if name == b"target_hidden_stream" else 0
+                )
+                self.ck_model_get_named_activation_nbytes = _FakeCFunc(
+                    lambda name: data.nbytes if name == b"target_hidden_stream" else -1
+                )
+                self.ck_model_get_named_activation_runtime_offset = _FakeCFunc(
+                    lambda name: 4096 if name == b"target_hidden_stream" else -1
+                )
+
+        model = ck_chat.CKModel("/tmp/nonexistent")
+        model.lib = FakeLib()
+        model._setup_named_activation_api()
+
+        self.assertTrue(model.has_named_activations)
+        self.assertEqual(model.named_activation_nbytes("target_hidden_stream"), data.nbytes)
+        self.assertEqual(model.named_activation_runtime_offset("target_hidden_stream"), 4096)
+        self.assertEqual(model.named_activation_nbytes("missing"), -1)
+        self.assertIsNone(model.read_named_activation_f32("missing"))
+        np.testing.assert_allclose(
+            model.read_named_activation_f32("target_hidden_stream"),
+            data,
+        )
+        np.testing.assert_allclose(
+            model.read_named_activation_f32("target_hidden_stream", max_floats=2),
+            data[:2],
+        )
+
     def test_load_model_meta_preserves_non_null_config_fields(self) -> None:
         with tempfile.TemporaryDirectory(prefix="ck_chat_meta_") as td:
             run_dir = Path(td)

--- a/tests/test_ck_chat_runtime_contract.py
+++ b/tests/test_ck_chat_runtime_contract.py
@@ -563,6 +563,128 @@ class TestCKChatRuntimeContract(unittest.TestCase):
         self.assertEqual(out, "Paris")
         self.assertIn("stop: eos token 0", buf.getvalue())
 
+    def test_greedy_speculative_decode_accepts_matching_draft_tokens(self) -> None:
+        class FakeKVModel:
+            has_kv_decode = True
+            eos_tokens = {0}
+            vocab_size = 16
+            context_window = 32
+
+            def __init__(self, argmax_tokens):
+                self.argmax_tokens = list(argmax_tokens)
+                self.pos = 0
+                self.decode_calls = []
+                self.reset_calls = 0
+
+            def encode(self, text: str):
+                return [9]
+
+            def kv_cache_enable(self):
+                return True
+
+            def kv_cache_reset(self):
+                self.pos = 0
+                self.reset_calls += 1
+
+            def set_parity_token_index(self, idx: int):
+                pass
+
+            def is_eos_token(self, token_id: int) -> bool:
+                return int(token_id) == 0
+
+            def _logits(self):
+                token = self.argmax_tokens[min(self.pos, len(self.argmax_tokens) - 1)]
+                out = np.zeros((self.vocab_size,), dtype=np.float32)
+                out[int(token)] = 10.0
+                return out
+
+            def prefill(self, token_ids):
+                self.pos = 0
+                return self._logits()
+
+            def decode_step(self, token_id: int):
+                self.decode_calls.append(int(token_id))
+                self.pos += 1
+                return self._logits()
+
+            def decode(self, token_ids):
+                return "".join({1: "A", 2: "B", 3: "C"}.get(int(t), "") for t in token_ids)
+
+        target = FakeKVModel([1, 2, 3, 0])
+        draft = FakeKVModel([1, 2, 3, 0])
+        with redirect_stdout(io.StringIO()) as buf:
+            out = ck_chat.generate(
+                target,
+                "hi",
+                max_tokens=3,
+                temperature=0,
+                show_stats=True,
+                speculative=ck_chat.SpeculativeConfig(draft, draft_tokens=3),
+            )
+
+        self.assertEqual(out, "ABC")
+        self.assertEqual(target.decode_calls, [1, 2, 3])
+        self.assertIn("3/3 accepted", buf.getvalue())
+
+    def test_greedy_speculative_decode_rejects_mismatch_and_uses_verifier_token(self) -> None:
+        class FakeKVModel:
+            has_kv_decode = True
+            eos_tokens = {0}
+            vocab_size = 16
+            context_window = 32
+
+            def __init__(self, argmax_tokens):
+                self.argmax_tokens = list(argmax_tokens)
+                self.pos = 0
+
+            def encode(self, text: str):
+                return [9]
+
+            def kv_cache_enable(self):
+                return True
+
+            def kv_cache_reset(self):
+                self.pos = 0
+
+            def set_parity_token_index(self, idx: int):
+                pass
+
+            def is_eos_token(self, token_id: int) -> bool:
+                return int(token_id) == 0
+
+            def _logits(self):
+                token = self.argmax_tokens[min(self.pos, len(self.argmax_tokens) - 1)]
+                out = np.zeros((self.vocab_size,), dtype=np.float32)
+                out[int(token)] = 10.0
+                return out
+
+            def prefill(self, token_ids):
+                self.pos = 0
+                return self._logits()
+
+            def decode_step(self, token_id: int):
+                self.pos += 1
+                return self._logits()
+
+            def decode(self, token_ids):
+                return "".join({1: "A", 2: "B", 5: "V"}.get(int(t), "") for t in token_ids)
+
+        target = FakeKVModel([1, 5, 0])
+        draft = FakeKVModel([1, 2, 0])
+        with redirect_stdout(io.StringIO()) as buf:
+            out = ck_chat.generate(
+                target,
+                "hi",
+                max_tokens=2,
+                temperature=0,
+                show_stats=True,
+                speculative=ck_chat.SpeculativeConfig(draft, draft_tokens=2),
+            )
+
+        self.assertEqual(out, "AV")
+        self.assertIn("1/2 accepted", buf.getvalue())
+        self.assertIn("1 rejected", buf.getvalue())
+
     def test_decode_preserves_special_tokens_on_python_tokenizer_path(self) -> None:
         class FakeTokenizer:
             def __init__(self):

--- a/tests/test_v8_gemma4_scaffold.py
+++ b/tests/test_v8_gemma4_scaffold.py
@@ -144,6 +144,46 @@ class V8Gemma4ScaffoldTests(unittest.TestCase):
         self.assertNotIn("k_proj", shared_ops)
         self.assertNotIn("v_proj", shared_ops)
 
+    def test_gemma4_assistant_q_only_ops_are_lowerable(self) -> None:
+        import json
+        import build_ir_v8  # type: ignore
+
+        template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4_assistant.json"
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        ops = build_ir_v8._collect_template_ops(
+            template,
+            {
+                "num_layers": 2,
+                "layer_kinds": [
+                    "sliding_attention_q_only_k_eq_v",
+                    "full_attention_q_only_k_eq_v",
+                ],
+            },
+        )
+        self.assertEqual(build_ir_v8.validate_template_ops(ops), [])
+        for op in (
+            "assistant_pre_projection",
+            "q_norm",
+            "rope_q",
+            "attn_sliding_shared_kv",
+            "attn_shared_kv",
+            "assistant_layer_scale",
+            "assistant_post_projection",
+        ):
+            self.assertIn(op, ops)
+
+        for kernel_id in (
+            "assistant_layer_scale_forward",
+            "q_norm_forward",
+            "rope_forward_q_gemma4",
+            "kv_cache_store_shared_q",
+            "attention_forward_causal_head_major_shared_kv_gemma4",
+            "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+            "attention_forward_decode_head_major_shared_kv_gemma4",
+            "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
+        ):
+            self.assertTrue((REPO_ROOT / "version" / "v8" / "kernel_maps" / f"{kernel_id}.json").exists())
+
     def test_gemma4_kv_layers_use_supported_paired_qk_ops_for_first_bringup(self) -> None:
         template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4.json"
         import json

--- a/tests/test_v8_gemma4_scaffold.py
+++ b/tests/test_v8_gemma4_scaffold.py
@@ -1,4 +1,7 @@
+import json
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -15,6 +18,61 @@ from convert_gguf_to_bump_v8 import (  # type: ignore
     describe_layer_contract,
     _inject_runtime_config_defaults,
 )
+
+
+def _write_tiny_bpe_tokenizer(checkpoint: Path, vocab_size: int) -> None:
+    vocab = {
+        "<unk>": 0,
+        "<s>": 1,
+        "</s>": 2,
+        "Hello": 3,
+        "world": 4,
+        "!": 5,
+        " test": 6,
+        " code": 7,
+    }
+    for idx in range(len(vocab), vocab_size):
+        vocab[f"<tok_{idx}>"] = idx
+
+    (checkpoint / "tokenizer.json").write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "model": {
+                    "type": "BPE",
+                    "unk_token": "<unk>",
+                    "vocab": vocab,
+                    "merges": ["Hello world", " test  code"],
+                },
+                "added_tokens": [
+                    {"id": 0, "content": "<unk>"},
+                    {"id": 1, "content": "<s>"},
+                    {"id": 2, "content": "</s>"},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (checkpoint / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "tokenizer_class": "PreTrainedTokenizerFast",
+                "bos_token": {"content": "<s>"},
+                "eos_token": {"content": "</s>"},
+                "unk_token": {"content": "<unk>"},
+                "add_bos_token": True,
+                "add_eos_token": False,
+                "added_tokens_decoder": {
+                    "0": {"content": "<unk>"},
+                    "1": {"content": "<s>"},
+                    "2": {"content": "</s>"},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def _tensor(name: str, dims: tuple[int, ...]) -> TensorInfo:
@@ -183,6 +241,172 @@ class V8Gemma4ScaffoldTests(unittest.TestCase):
             "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
         ):
             self.assertTrue((REPO_ROOT / "version" / "v8" / "kernel_maps" / f"{kernel_id}.json").exists())
+
+    def test_gemma4_speculative_pair_template_declares_bridge_and_verifier(self) -> None:
+        template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4_speculative_pair.json"
+        template = json.loads(template_path.read_text(encoding="utf-8"))
+        self.assertTrue(template["experimental"])
+        self.assertEqual(template["contract"]["target"]["template"], "gemma4")
+        self.assertEqual(template["contract"]["draft"]["template"], "gemma4_assistant")
+        self.assertEqual(template["contract"]["bridge"]["source"], "target_hidden_stream")
+        self.assertEqual(template["contract"]["bridge"]["dest"], "draft_backbone_stream")
+        self.assertEqual(template["contract"]["verifier"]["kernel"], "speculative_verify_greedy_f32")
+        self.assertEqual(template["contract"]["committer"]["kernel"], "speculative_commit_one_i32")
+
+        ops = template["block_types"]["speculative_decode"]["ops"]
+        self.assertEqual(
+            [op["op"] for op in ops],
+            [
+                "target_decode_step",
+                "target_hidden_to_draft_backbone_stream",
+                "draft_decode_step",
+                "speculative_verify_greedy",
+                "speculative_commit_or_reject",
+            ],
+        )
+        verify = ops[3]["graph_slots"]
+        self.assertEqual(verify["inputs"]["target_logits"], "target_logits")
+        self.assertEqual(verify["inputs"]["draft_token"], "draft_candidate_token")
+        self.assertEqual(verify["outputs"]["accepted"], "accepted_flag")
+        self.assertEqual(verify["outputs"]["verified_token"], "verified_token")
+        commit = ops[4]["graph_slots"]
+        self.assertEqual(ops[4]["kernel"], "speculative_commit_one_i32")
+        self.assertEqual(commit["inputs"]["accepted"], "accepted_flag")
+        self.assertEqual(commit["inputs"]["verified_token"], "verified_token")
+        self.assertEqual(commit["inputs"]["token_count"], "token_count")
+        self.assertEqual(commit["outputs"]["draft_position"], "draft_position")
+        self.assertTrue((REPO_ROOT / "version" / "v8" / "kernel_maps" / "speculative_verify_greedy_f32.json").exists())
+        self.assertTrue((REPO_ROOT / "version" / "v8" / "kernel_maps" / "speculative_commit_one_i32.json").exists())
+
+    def test_gemma4_speculative_pair_probe_script_exists(self) -> None:
+        script = REPO_ROOT / "version" / "v8" / "scripts" / "run_gemma4_speculative_pair_probe_v8.py"
+        self.assertTrue(script.exists())
+        text = script.read_text(encoding="utf-8")
+        self.assertIn("target_hidden_stream", text)
+        self.assertIn("draft_backbone_stream", text)
+        self.assertIn("speculative_verify_greedy_f32", text)
+        self.assertIn("speculative_commit_one_i32", text)
+
+    def test_gemma4_assistant_synthetic_checkpoint_generates_runtime(self) -> None:
+        try:
+            import torch  # type: ignore
+            import safetensors.torch as st  # type: ignore
+        except Exception as exc:
+            self.skipTest(f"torch/safetensors unavailable: {exc}")
+
+        with tempfile.TemporaryDirectory(prefix="ck_gemma4_assistant_e2e_") as td:
+            root = Path(td)
+            checkpoint = root / "gemma4_assistant"
+            runtime = root / "runtime"
+            checkpoint.mkdir()
+            runtime.mkdir()
+
+            (checkpoint / "config.json").write_text(
+                json.dumps(
+                    {
+                        "architectures": ["Gemma4AssistantForCausalLM"],
+                        "model_type": "gemma4_assistant",
+                        "backbone_hidden_size": 16,
+                        "tie_word_embeddings": True,
+                        "use_ordered_embeddings": True,
+                        "text_config": {
+                            "model_type": "gemma4_text",
+                            "attention_bias": False,
+                            "attention_k_eq_v": True,
+                            "bos_token_id": 2,
+                            "eos_token_id": 1,
+                            "global_head_dim": 8,
+                            "head_dim": 4,
+                            "hidden_activation": "gelu_pytorch_tanh",
+                            "hidden_size": 8,
+                            "intermediate_size": 16,
+                            "layer_types": ["sliding_attention", "full_attention"],
+                            "max_position_embeddings": 128,
+                            "num_attention_heads": 2,
+                            "num_global_key_value_heads": 1,
+                            "num_hidden_layers": 2,
+                            "num_key_value_heads": 2,
+                            "num_kv_shared_layers": 2,
+                            "rms_norm_eps": 1e-6,
+                            "rope_parameters": {
+                                "full_attention": {
+                                    "partial_rotary_factor": 0.25,
+                                    "rope_theta": 1000000.0,
+                                    "rope_type": "proportional",
+                                },
+                                "sliding_attention": {
+                                    "rope_theta": 10000.0,
+                                    "rope_type": "default",
+                                },
+                            },
+                            "sliding_window": 32,
+                            "tie_word_embeddings": True,
+                            "vocab_size": 32,
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            _write_tiny_bpe_tokenizer(checkpoint, vocab_size=32)
+
+            tensors = {
+                "model.embed_tokens.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+                "model.norm.weight": torch.ones(8, dtype=torch.bfloat16),
+                "masked_embedding.centroids.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+                "masked_embedding.token_ordering": torch.arange(32, dtype=torch.int64),
+                "pre_projection.weight": torch.randn(8, 16, dtype=torch.bfloat16),
+                "post_projection.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+            }
+            for layer, q_dim in enumerate((8, 16)):
+                pfx = f"model.layers.{layer}"
+                tensors.update(
+                    {
+                        f"{pfx}.input_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                        f"{pfx}.pre_feedforward_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                        f"{pfx}.post_attention_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                        f"{pfx}.post_feedforward_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                        f"{pfx}.layer_scalar": torch.ones(1, dtype=torch.bfloat16),
+                        f"{pfx}.self_attn.q_proj.weight": torch.randn(q_dim, 8, dtype=torch.bfloat16),
+                        f"{pfx}.self_attn.q_norm.weight": torch.ones(q_dim // 2, dtype=torch.bfloat16),
+                        f"{pfx}.self_attn.o_proj.weight": torch.randn(8, q_dim, dtype=torch.bfloat16),
+                        f"{pfx}.mlp.gate_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+                        f"{pfx}.mlp.up_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+                        f"{pfx}.mlp.down_proj.weight": torch.randn(8, 16, dtype=torch.bfloat16),
+                    }
+                )
+            st.save_file(tensors, checkpoint / "model.safetensors")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "version" / "v8" / "scripts" / "ck_run_v8.py"),
+                    "run",
+                    str(checkpoint),
+                    "--run",
+                    str(runtime),
+                    "--context-len",
+                    "16",
+                    "--force-convert",
+                    "--force-compile",
+                    "--generate-only",
+                    "--chat-template",
+                    "none",
+                    "--allow-raw-prompt",
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+            )
+
+            cfg = json.loads((runtime / "config.json").read_text(encoding="utf-8"))
+            build_dir = runtime
+            self.assertEqual(cfg["model"], "gemma4_assistant")
+            self.assertFalse(cfg["standalone_text_inference_supported"])
+            self.assertEqual(cfg["layer_kinds"], ["sliding_attention_q_only_k_eq_v", "full_attention_q_only_k_eq_v"])
+            self.assertTrue((build_dir / "model_v8.c").exists())
+            self.assertTrue((build_dir / "libmodel.so").exists())
+            self.assertIn("assistant_pre_projection", (build_dir / "model_v8.c").read_text(encoding="utf-8"))
+            self.assertIn("attn_shared_kv", (build_dir / "lowered_decode_call.json").read_text(encoding="utf-8"))
 
     def test_gemma4_kv_layers_use_supported_paired_qk_ops_for_first_bringup(self) -> None:
         template_path = REPO_ROOT / "version" / "v8" / "templates" / "gemma4.json"

--- a/tests/test_v8_model_contract_inspector.py
+++ b/tests/test_v8_model_contract_inspector.py
@@ -46,6 +46,10 @@ class ModelContractInspectorTests(unittest.TestCase):
         self.assertEqual(report["status"], "supported")
         self.assertEqual(report["layer_kind_counts"], {"attention": 1, "mamba": 5, "moe": 4})
         self.assertEqual(report["missing_ops"], [])
+        self.assertEqual(report["kernel_registry"]["missing_kernel_ops"], [])
+        self.assertEqual(report["template_suggestion"]["candidate_template"], "nemotron_h.json")
+        self.assertIn("mamba", report["template_suggestion"]["block_sketch"]["body"]["ops_by_kind"])
+        self.assertIn("moe", report["template_suggestion"]["block_sketch"]["body"]["ops_by_kind"])
         self.assertNotIn("mamba_in_proj_split", report["missing_ops"])
         self.assertNotIn("mamba_conv1d_state_update", report["missing_ops"])
         self.assertNotIn("mamba_dt_softplus", report["missing_ops"])
@@ -157,6 +161,9 @@ class ModelContractInspectorTests(unittest.TestCase):
         self.assertEqual(report["arch"], "kimi_vl")
         self.assertEqual(report["status"], "bringup_required")
         self.assertEqual(report["layer_kind_counts"], {"mla_dense_mlp": 1, "mla_moe": 3})
+        self.assertEqual(report["template_suggestion"]["candidate_template"], "kimi_vl.json")
+        self.assertEqual(report["template_suggestion"]["modalities"], ["text", "vision"])
+        self.assertIn("mla_moe", report["template_suggestion"]["block_sketch"]["body"]["ops_by_kind"])
         for op in (
             "mla_attention",
             "kv_lora_decompress",
@@ -174,6 +181,16 @@ class ModelContractInspectorTests(unittest.TestCase):
             "moonvit_bridge_contract",
         ):
             self.assertIn(missing, report["missing_ops"])
+        missing_kernel_ops = {
+            row["op"] for row in report["kernel_registry"]["missing_kernel_ops"]
+        }
+        self.assertIn("moonvit_encoder", missing_kernel_ops)
+        self.assertIn("moonvit_projector", missing_kernel_ops)
+        self.assertIn("media_placeholder_merge", missing_kernel_ops)
+        self.assertIn("tiktoken_tokenizer", missing_kernel_ops)
+        self.assertNotIn("group_limited_topk_router", missing_kernel_ops)
+        self.assertNotIn("moe_swiglu_expert_mlp", missing_kernel_ops)
+        self.assertNotIn("shared_swiglu_expert_mlp", missing_kernel_ops)
         self.assertNotIn("moe_swiglu_expert_mlp", report["missing_ops"])
         self.assertNotIn("shared_swiglu_expert_mlp", report["missing_ops"])
         self.assertNotIn("kv_lora_decompress_contract", report["missing_ops"])
@@ -313,6 +330,58 @@ class ModelContractInspectorTests(unittest.TestCase):
         self.assertEqual(report["status"], "supported")
         self.assertEqual(report["layer_kind_counts"], {"attention": 4})
         self.assertEqual(report["missing_ops"], [])
+        self.assertEqual(report["kernel_registry"]["missing_kernel_ops"], [])
+        self.assertEqual(report["template_suggestion"]["candidate_template"], "qwen3.json")
+        self.assertIn("attention", report["template_suggestion"]["block_sketch"]["body"]["ops_by_kind"])
+
+    def test_inspector_weights_audit_reads_safetensors_index_from_model_dir(self) -> None:
+        cfg = {
+            "architectures": ["KimiVLForConditionalGeneration"],
+            "model_type": "kimi_vl",
+            "vision_config": {"model_type": "moonvit", "num_hidden_layers": 1},
+            "text_config": {
+                "hidden_size": 2048,
+                "intermediate_size": 11264,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 16,
+                "first_k_dense_replace": 1,
+                "moe_layer_freq": 1,
+                "hidden_act": "silu",
+            },
+        }
+        index = {
+            "metadata": {"total_parameters": 123, "total_size": 456},
+            "weight_map": {
+                "language_model.model.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_proj_with_mqa.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_a_layernorm.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.kv_b_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.0.self_attn.o_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.gate.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.experts.0.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "language_model.model.layers.1.mlp.shared_experts.gate_proj.weight": "model-00001-of-00001.safetensors",
+                "vision_tower.encoder.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors",
+                "multi_modal_projector.linear_1.weight": "model-00001-of-00001.safetensors",
+            },
+        }
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+            (root / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), str(root), "--weights-audit"],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        report = json.loads(proc.stdout)
+        self.assertEqual(report["weights_audit"]["status"], "pass")
+        self.assertEqual(report["weights_audit"]["model_map_status"], "known")
+        self.assertEqual(report["weights_audit"]["families"]["mla_attention"], 3)
+        self.assertEqual(report["weights_audit"]["required_tensor_patterns"]["missing"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -698,6 +698,131 @@ def test_glm4_safetensors_to_bump_uses_declarative_source_map(tmp_path: Path) ->
     assert entries["layer.0.b1"]["shape"] == [32]
     assert "output.weight" in names
 
+
+def test_gemma4_assistant_safetensors_to_bump_maps_q_only_drafter(tmp_path: Path) -> None:
+    torch, st = _require_torch_safetensors()
+    checkpoint = tmp_path / "gemma4_assistant"
+    out = tmp_path / "out_gemma4_assistant"
+    checkpoint.mkdir()
+    out.mkdir()
+
+    (checkpoint / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Gemma4AssistantForCausalLM"],
+                "model_type": "gemma4_assistant",
+                "backbone_hidden_size": 16,
+                "tie_word_embeddings": True,
+                "use_ordered_embeddings": False,
+                "text_config": {
+                    "model_type": "gemma4_text",
+                    "attention_bias": False,
+                    "attention_k_eq_v": True,
+                    "bos_token_id": 2,
+                    "eos_token_id": 1,
+                    "global_head_dim": 8,
+                    "head_dim": 4,
+                    "hidden_activation": "gelu_pytorch_tanh",
+                    "hidden_size": 8,
+                    "intermediate_size": 16,
+                    "layer_types": ["sliding_attention", "full_attention"],
+                    "max_position_embeddings": 128,
+                    "num_attention_heads": 2,
+                    "num_global_key_value_heads": 1,
+                    "num_hidden_layers": 2,
+                    "num_key_value_heads": 2,
+                    "num_kv_shared_layers": 2,
+                    "rms_norm_eps": 1e-6,
+                    "rope_parameters": {
+                        "full_attention": {
+                            "partial_rotary_factor": 0.25,
+                            "rope_theta": 1000000.0,
+                            "rope_type": "proportional",
+                        },
+                        "sliding_attention": {
+                            "rope_theta": 10000.0,
+                            "rope_type": "default",
+                        },
+                    },
+                    "sliding_window": 32,
+                    "tie_word_embeddings": True,
+                    "vocab_size": 32,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_tiny_bpe_tokenizer(checkpoint, vocab_size=32)
+
+    tensors = {
+        "model.embed_tokens.weight": torch.randn(32, 8, dtype=torch.bfloat16),
+        "model.norm.weight": torch.ones(8, dtype=torch.bfloat16),
+        "pre_projection.weight": torch.randn(8, 16, dtype=torch.bfloat16),
+        "post_projection.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+    }
+    q_dims = [8, 16]
+    for layer, q_dim in enumerate(q_dims):
+        pfx = f"model.layers.{layer}"
+        tensors.update(
+            {
+                f"{pfx}.input_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                f"{pfx}.pre_feedforward_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                f"{pfx}.post_attention_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                f"{pfx}.post_feedforward_layernorm.weight": torch.ones(8, dtype=torch.bfloat16),
+                f"{pfx}.layer_scalar": torch.ones(1, dtype=torch.bfloat16),
+                f"{pfx}.self_attn.q_proj.weight": torch.randn(q_dim, 8, dtype=torch.bfloat16),
+                f"{pfx}.self_attn.q_norm.weight": torch.ones(q_dim // 2, dtype=torch.bfloat16),
+                f"{pfx}.self_attn.o_proj.weight": torch.randn(8, q_dim, dtype=torch.bfloat16),
+                f"{pfx}.mlp.gate_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+                f"{pfx}.mlp.up_proj.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+                f"{pfx}.mlp.down_proj.weight": torch.randn(8, 16, dtype=torch.bfloat16),
+            }
+        )
+    st.save_file(tensors, checkpoint / "model.safetensors")
+
+    script = Path("version/v8/scripts/convert_safetensors_to_bump_v8.py")
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--checkpoint",
+            str(checkpoint),
+            "--output",
+            str(out / "weights.bump"),
+            "--config-out",
+            str(out / "config.json"),
+            "--manifest-out",
+            str(out / "weights_manifest.json"),
+            "--arch",
+            "auto",
+            "--dry-run",
+        ],
+        check=True,
+    )
+
+    manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
+    audit = json.loads((out / "conversion_audit.json").read_text(encoding="utf-8"))
+    cfg = json.loads((out / "config.json").read_text(encoding="utf-8"))
+    names = {entry["name"] for entry in manifest["entries"]}
+
+    assert manifest["model"] == "gemma4_assistant"
+    assert manifest["template"]["name"] == "gemma4_assistant"
+    assert audit["verdict"] == "pass"
+    assert audit["unmapped_source_tensors"] == []
+    assert cfg["attention_k_eq_v"] is True
+    assert cfg["assistant_role"] == "mtp_drafter"
+    assert cfg["layer_kinds"] == ["sliding_attention_q_only_k_eq_v", "full_attention_q_only_k_eq_v"]
+    assert cfg["layer_q_dim"] == [8, 16]
+    assert cfg["layer_q_norm_dim"] == [4, 8]
+    assert "assistant.pre_projection" in names
+    assert "assistant.post_projection" in names
+    assert "layer.0.wq" in names
+    assert "layer.0.q_norm" in names
+    assert "layer.0.wk" not in names
+    assert "layer.0.wv" not in names
+
+
 def test_kimi_vl_safetensors_to_bump_dry_run_maps_text_decoder(tmp_path: Path) -> None:
     torch, st = _require_torch_safetensors()
     checkpoint = tmp_path / "kimi_vl"

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -812,9 +812,16 @@ def test_gemma4_assistant_safetensors_to_bump_maps_q_only_drafter(tmp_path: Path
     assert audit["unmapped_source_tensors"] == []
     assert cfg["attention_k_eq_v"] is True
     assert cfg["assistant_role"] == "mtp_drafter"
+    assert cfg["assistant_projection_mode"] == "mtp_bridge"
+    assert cfg["assistant_layer_scalar_mode"] == "layer_output_scale"
+    assert cfg["standalone_text_inference_supported"] is False
     assert cfg["layer_kinds"] == ["sliding_attention_q_only_k_eq_v", "full_attention_q_only_k_eq_v"]
     assert cfg["layer_q_dim"] == [8, 16]
     assert cfg["layer_q_norm_dim"] == [4, 8]
+    assert cfg["layer_q_head_dim"] == [4, 8]
+    assert cfg["layer_k_head_dim"] == [4, 8]
+    assert cfg["layer_v_head_dim"] == [4, 8]
+    assert cfg["layer_rotary_dim"] == [4, 8]
     assert "assistant.pre_projection" in names
     assert "assistant.post_projection" in names
     assert "layer.0.wq" in names

--- a/unittest/test_gemma4_assistant_kernels.py
+++ b/unittest/test_gemma4_assistant_kernels.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Direct parity tests for Gemma4 assistant / q-only shared-KV kernels."""
+
+import ctypes
+import math
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB = ROOT / "build" / "libckernel_engine.so"
+F32P = ctypes.POINTER(ctypes.c_float)
+
+
+def load_lib():
+    if not LIB.exists():
+        raise unittest.SkipTest(f"missing shared library: {LIB}")
+    return ctypes.CDLL(str(LIB))
+
+
+def as_f32(values):
+    return np.ascontiguousarray(values, dtype=np.float32)
+
+
+def ptr(array):
+    return array.ctypes.data_as(F32P)
+
+
+def rmsnorm_rows(x, gamma, eps):
+    y = np.empty_like(x)
+    flat = x.reshape(-1, x.shape[-1])
+    out = y.reshape(-1, x.shape[-1])
+    for i, row in enumerate(flat):
+        rstd = 1.0 / math.sqrt(float(np.mean(row * row)) + eps)
+        out[i] = row * gamma * rstd
+    return y
+
+
+def causal_shared_q_attention(q):
+    """Reference for Gemma4 shared-KV prefill: q is also k/v, scale=1.0."""
+    heads, tokens, dim = q.shape
+    out = np.zeros_like(q)
+    for h in range(heads):
+        for t in range(tokens):
+            scores = np.array(
+                [float(np.dot(q[h, t], q[h, j])) for j in range(t + 1)],
+                dtype=np.float64,
+            )
+            scores -= float(np.max(scores))
+            weights = np.exp(scores)
+            weights /= float(np.sum(weights))
+            acc = np.zeros(dim, dtype=np.float64)
+            for j, w in enumerate(weights):
+                acc += w * q[h, j].astype(np.float64)
+            out[h, t] = acc.astype(np.float32)
+    return out
+
+
+def decode_attention(q_token, k_cache, v_cache, kv_tokens):
+    """Reference for Gemma4 decode attention: head-major cache, scale=1.0."""
+    heads, dim = q_token.shape
+    out = np.zeros_like(q_token)
+    for h in range(heads):
+        scores = np.array(
+            [float(np.dot(q_token[h], k_cache[h, j])) for j in range(kv_tokens)],
+            dtype=np.float64,
+        )
+        scores -= float(np.max(scores))
+        weights = np.exp(scores)
+        weights /= float(np.sum(weights))
+        acc = np.zeros(dim, dtype=np.float64)
+        for j, w in enumerate(weights):
+            acc += w * v_cache[h, j].astype(np.float64)
+        out[h] = acc.astype(np.float32)
+    return out
+
+
+class TestGemma4AssistantKernels(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lib = load_lib()
+        cls.lib.assistant_layer_scale_forward.argtypes = [
+            F32P,
+            F32P,
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+        cls.lib.q_norm_forward.argtypes = [
+            F32P,
+            F32P,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_float,
+        ]
+        cls.lib.kv_cache_store_shared_q.argtypes = [
+            F32P,
+            F32P,
+            F32P,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+        cls.lib.attention_forward_causal_head_major_shared_kv_gemma4.argtypes = [
+            F32P,
+            F32P,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+        cls.lib.attention_forward_decode_head_major_shared_kv_gemma4.argtypes = [
+            F32P,
+            F32P,
+            F32P,
+            F32P,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+
+    def test_assistant_layer_scale_forward_matches_numpy(self):
+        hidden = as_f32(np.arange(15, dtype=np.float32).reshape(3, 5) - 4.0)
+        scale = as_f32([0.375])
+        expected = hidden * scale[0]
+        actual = hidden.copy()
+
+        self.lib.assistant_layer_scale_forward(ptr(actual), ptr(scale), 3, 5)
+
+        np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-7)
+
+    def test_q_norm_forward_matches_rmsnorm_rows(self):
+        rng = np.random.default_rng(7)
+        q = as_f32(rng.normal(size=(3, 4, 5)))
+        gamma = as_f32(rng.normal(size=(5,)))
+        eps = 1e-6
+        expected = rmsnorm_rows(q, gamma, eps)
+        actual = q.copy()
+
+        self.lib.q_norm_forward(ptr(actual), ptr(gamma), 3, 4, 5, ctypes.c_float(eps))
+
+        np.testing.assert_allclose(actual, expected, rtol=2e-6, atol=2e-6)
+
+    def test_kv_cache_store_shared_q_copies_q_to_k_and_v(self):
+        q = as_f32(np.arange(2 * 4, dtype=np.float32).reshape(2, 4) / 10.0)
+        k_cache = as_f32(np.full((2, 3, 4), -9.0, dtype=np.float32))
+        v_cache = as_f32(np.full((2, 3, 4), -8.0, dtype=np.float32))
+
+        self.lib.kv_cache_store_shared_q(
+            ptr(k_cache), ptr(v_cache), ptr(q), 0, 1, 2, 4, 3
+        )
+
+        np.testing.assert_allclose(k_cache[:, 1, :], q, rtol=0, atol=0)
+        np.testing.assert_allclose(v_cache[:, 1, :], q, rtol=0, atol=0)
+        np.testing.assert_allclose(k_cache[:, 0, :], -9.0, rtol=0, atol=0)
+        np.testing.assert_allclose(v_cache[:, 2, :], -8.0, rtol=0, atol=0)
+
+    def test_causal_shared_kv_prefill_matches_reference(self):
+        rng = np.random.default_rng(11)
+        q = as_f32(rng.normal(scale=0.15, size=(2, 4, 6)))
+        expected = causal_shared_q_attention(q)
+        actual = np.zeros_like(q)
+
+        self.lib.attention_forward_causal_head_major_shared_kv_gemma4(
+            ptr(q), ptr(actual), 2, 4, 6, 6, 4
+        )
+
+        np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-5)
+
+    def test_decode_shared_kv_matches_reference(self):
+        rng = np.random.default_rng(13)
+        q_token = as_f32(rng.normal(scale=0.12, size=(2, 5)))
+        k_cache = as_f32(rng.normal(scale=0.10, size=(2, 4, 5)))
+        v_cache = as_f32(rng.normal(scale=0.10, size=(2, 4, 5)))
+        expected = decode_attention(q_token, k_cache, v_cache, kv_tokens=3)
+        actual = np.zeros_like(q_token)
+
+        self.lib.attention_forward_decode_head_major_shared_kv_gemma4(
+            ptr(q_token), ptr(k_cache), ptr(v_cache), ptr(actual), 2, 3, 4, 5, 5
+        )
+
+        np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittest/test_topk.py
+++ b/unittest/test_topk.py
@@ -58,6 +58,28 @@ lib.argmax_f32.argtypes = [
 ]
 lib.argmax_f32.restype = ctypes.c_int
 
+lib.speculative_verify_greedy_f32.argtypes = [
+    ctypes.POINTER(ctypes.c_float),  # target_logits
+    ctypes.c_int,                     # vocab_size
+    ctypes.c_int,                     # draft_token
+    ctypes.POINTER(ctypes.c_int),    # accepted
+    ctypes.POINTER(ctypes.c_int),    # verified_token
+]
+lib.speculative_verify_greedy_f32.restype = None
+
+lib.speculative_commit_one_i32.argtypes = [
+    ctypes.c_int,                    # accepted
+    ctypes.c_int,                    # verified_token
+    ctypes.POINTER(ctypes.c_int),    # token_buffer
+    ctypes.POINTER(ctypes.c_int),    # token_count
+    ctypes.c_int,                    # max_tokens
+    ctypes.POINTER(ctypes.c_int),    # target_position
+    ctypes.POINTER(ctypes.c_int),    # draft_position
+    ctypes.POINTER(ctypes.c_int),    # accepted_count
+    ctypes.POINTER(ctypes.c_int),    # rejected_count
+]
+lib.speculative_commit_one_i32.restype = None
+
 
 # =============================================================================
 # Helper functions
@@ -252,6 +274,127 @@ def run_argmax_tests(n=1024, warmup=10, iterations=1000):
     return report
 
 
+def run_speculative_verify_tests(n=1024, warmup=10, iterations=1000):
+    """Run one-token greedy speculative verification tests."""
+    np.random.seed(48)
+
+    logits_np = np.random.randn(n).astype(np.float32)
+    logits_np[17] = 100.0
+    logits_ptr = numpy_to_ptr(logits_np)
+
+    accepted_np = np.zeros(1, dtype=np.int32)
+    verified_np = np.zeros(1, dtype=np.int32)
+    accepted_ptr = numpy_int_ptr(accepted_np)
+    verified_ptr = numpy_int_ptr(verified_np)
+
+    report = TestReport(
+        test_name="Speculative Verify Greedy",
+        dtype="fp32",
+        shape=f"n={n}",
+        cpu_info=get_cpu_info()
+    )
+
+    def c_verify(draft_token: int):
+        accepted_np[0] = -1
+        verified_np[0] = -1
+        lib.speculative_verify_greedy_f32(logits_ptr, n, draft_token, accepted_ptr, verified_ptr)
+        return int(accepted_np[0]), int(verified_np[0])
+
+    accept_result = c_verify(17)
+    reject_result = c_verify(7)
+    passed = accept_result == (1, 17) and reject_result == (0, 17)
+
+    def c_verify_accept():
+        lib.speculative_verify_greedy_f32(logits_ptr, n, 17, accepted_ptr, verified_ptr)
+
+    c_time = time_function(c_verify_accept, warmup=warmup, iterations=iterations, name="C speculative verify")
+
+    report.add_result(TestResult(
+        name="speculative_verify_greedy_f32",
+        passed=passed,
+        max_diff=0.0 if passed else 1.0,
+        tolerance=0.0,
+        pytorch_time=None,
+        kernel_time=c_time
+    ))
+
+    return report
+
+
+def run_speculative_commit_tests(warmup=10, iterations=1000):
+    """Run one-token speculative commit state transition tests."""
+    max_tokens = 4
+    tokens_np = np.full(max_tokens, -1, dtype=np.int32)
+    token_count_np = np.zeros(1, dtype=np.int32)
+    target_pos_np = np.zeros(1, dtype=np.int32)
+    draft_pos_np = np.zeros(1, dtype=np.int32)
+    accepted_count_np = np.zeros(1, dtype=np.int32)
+    rejected_count_np = np.zeros(1, dtype=np.int32)
+
+    report = TestReport(
+        test_name="Speculative Commit One",
+        dtype="i32",
+        shape=f"max_tokens={max_tokens}",
+        cpu_info=get_cpu_info()
+    )
+
+    def c_commit(accepted: int, token: int):
+        lib.speculative_commit_one_i32(
+            accepted,
+            token,
+            numpy_int_ptr(tokens_np),
+            numpy_int_ptr(token_count_np),
+            max_tokens,
+            numpy_int_ptr(target_pos_np),
+            numpy_int_ptr(draft_pos_np),
+            numpy_int_ptr(accepted_count_np),
+            numpy_int_ptr(rejected_count_np),
+        )
+
+    c_commit(1, 17)
+    c_commit(0, 23)
+    passed = (
+        tokens_np[:2].tolist() == [17, 23] and
+        int(token_count_np[0]) == 2 and
+        int(target_pos_np[0]) == 2 and
+        int(draft_pos_np[0]) == 2 and
+        int(accepted_count_np[0]) == 1 and
+        int(rejected_count_np[0]) == 1
+    )
+
+    def c_commit_bench():
+        local_tokens = np.full(max_tokens, -1, dtype=np.int32)
+        local_count = np.zeros(1, dtype=np.int32)
+        local_target = np.zeros(1, dtype=np.int32)
+        local_draft = np.zeros(1, dtype=np.int32)
+        local_accepts = np.zeros(1, dtype=np.int32)
+        local_rejects = np.zeros(1, dtype=np.int32)
+        lib.speculative_commit_one_i32(
+            1,
+            17,
+            numpy_int_ptr(local_tokens),
+            numpy_int_ptr(local_count),
+            max_tokens,
+            numpy_int_ptr(local_target),
+            numpy_int_ptr(local_draft),
+            numpy_int_ptr(local_accepts),
+            numpy_int_ptr(local_rejects),
+        )
+
+    c_time = time_function(c_commit_bench, warmup=warmup, iterations=iterations, name="C speculative commit")
+
+    report.add_result(TestResult(
+        name="speculative_commit_one_i32",
+        passed=passed,
+        max_diff=0.0 if passed else 1.0,
+        tolerance=0.0,
+        pytorch_time=None,
+        kernel_time=c_time
+    ))
+
+    return report
+
+
 def run_batched_topk_tests(num_tokens=32, n_experts=8, k=2, warmup=10, iterations=1000):
     """Run batched top-K tests (MoE-style routing)."""
     np.random.seed(45)
@@ -346,6 +489,14 @@ if __name__ == "__main__":
     argmax_report = run_argmax_tests(n=1024, warmup=10, iterations=1000)
     argmax_report.print_report()
 
+    # Greedy speculative verifier
+    speculative_report = run_speculative_verify_tests(n=1024, warmup=10, iterations=1000)
+    speculative_report.print_report()
+
+    # Greedy speculative commit state transition
+    speculative_commit_report = run_speculative_commit_tests(warmup=10, iterations=1000)
+    speculative_commit_report.print_report()
+
     # Batched (MoE-style)
     batched_report = run_batched_topk_tests(num_tokens=32, n_experts=8, k=2, warmup=10, iterations=1000)
     batched_report.print_report()
@@ -355,6 +506,8 @@ if __name__ == "__main__":
         topk_report.all_passed() and
         softmax_report.all_passed() and
         argmax_report.all_passed() and
+        speculative_report.all_passed() and
+        speculative_commit_report.all_passed() and
         batched_report.all_passed()
     )
     if not all_passed:

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,7 +5,7 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 182,
+      "total": 184,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -78,6 +78,8 @@
         "shared_swiglu_expert_mlp": 2,
         "softmax": 1,
         "spatial_merge": 3,
+        "speculative_commit_or_reject": 1,
+        "speculative_verify_greedy": 1,
         "split_q_gate": 1,
         "split_q_gate_backward": 1,
         "split_qkv_packed_head_major": 1,
@@ -19172,6 +19174,176 @@
       "notes": "Merge contiguous groups of merge_size^2 tokens from an activation stream that already uses merged-tile traversal order.",
       "name": "spatial_merge_contiguous_tiled",
       "_source_file": "spatial_merge_contiguous_tiled.json"
+    },
+    {
+      "id": "speculative_commit_one_i32",
+      "op": "speculative_commit_or_reject",
+      "variant": "greedy_one_token",
+      "quant": {
+        "activation": "i32",
+        "output": "i32"
+      },
+      "inputs": [
+        {
+          "name": "accepted",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Acceptance flag produced by speculative_verify_greedy_f32."
+        },
+        {
+          "name": "verified_token",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Token to emit: accepted draft token or authoritative target token."
+        },
+        {
+          "name": "token_buffer",
+          "dtype": "i32",
+          "shape": [
+            "max_tokens"
+          ],
+          "desc": "Output token buffer updated in-place when capacity allows."
+        },
+        {
+          "name": "token_count",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Number of committed output tokens, updated in-place."
+        },
+        {
+          "name": "target_position",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Authoritative target decode position, advanced by one."
+        },
+        {
+          "name": "draft_position",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Draft position synchronized to target position for the one-token milestone."
+        }
+      ],
+      "outputs": [
+        {
+          "name": "accepted_count",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Number of accepted draft tokens, updated in-place."
+        },
+        {
+          "name": "rejected_count",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Number of rejected draft tokens, updated in-place."
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "max_tokens"
+      ],
+      "params": [],
+      "impl": {
+        "function": "speculative_commit_one_i32",
+        "c_declaration": "void speculative_commit_one_i32(int accepted, int verified_token, int *token_buffer, int *token_count, int max_tokens, int *target_position, int *draft_position, int *accepted_count, int *rejected_count);",
+        "sources": [
+          "src/kernels/topk_kernels.c"
+        ]
+      },
+      "tests": {
+        "parity": [
+          {
+            "kind": "ctypes",
+            "command": ".venv/bin/python unittest/test_topk.py",
+            "tolerance": "0"
+          }
+        ]
+      },
+      "notes": "First-stage speculative decode commit kernel. It commits exactly one verified token and keeps draft/target positions synchronized. Multi-token acceptance and KV rollback should be introduced as a separate widened contract.",
+      "name": "speculative_commit_one_i32",
+      "_source_file": "speculative_commit_one_i32.json"
+    },
+    {
+      "id": "speculative_verify_greedy_f32",
+      "op": "speculative_verify_greedy",
+      "variant": "greedy_one_token",
+      "quant": {
+        "activation": "fp32",
+        "output": "i32"
+      },
+      "inputs": [
+        {
+          "name": "target_logits",
+          "dtype": "fp32",
+          "shape": [
+            "vocab_size"
+          ],
+          "desc": "Authoritative target/backbone logits for the candidate position."
+        },
+        {
+          "name": "draft_token",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "Candidate token proposed by the assistant/draft model."
+        }
+      ],
+      "outputs": [
+        {
+          "name": "accepted",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "1 when draft_token equals argmax(target_logits), otherwise 0."
+        },
+        {
+          "name": "verified_token",
+          "dtype": "i32",
+          "shape": [
+            1
+          ],
+          "desc": "The emitted token: draft_token when accepted, otherwise the target argmax."
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "vocab_size"
+      ],
+      "params": [],
+      "impl": {
+        "function": "speculative_verify_greedy_f32",
+        "c_declaration": "void speculative_verify_greedy_f32(const float *target_logits, int vocab_size, int draft_token, int *accepted, int *verified_token);",
+        "sources": [
+          "src/kernels/topk_kernels.c"
+        ]
+      },
+      "tests": {
+        "parity": [
+          {
+            "kind": "ctypes",
+            "command": ".venv/bin/python unittest/test_topk.py",
+            "tolerance": "0"
+          }
+        ]
+      },
+      "notes": "First-stage speculative decode verifier. It is intentionally greedy-only and one-token-only so the target model remains authoritative while the Gemma4 assistant bridge is hardened.",
+      "name": "speculative_verify_greedy_f32",
+      "_source_file": "speculative_verify_greedy_f32.json"
     },
     {
       "id": "split_q_gate_backward_f32",

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,13 +5,14 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 173,
+      "total": 182,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
-        "attention": 13,
+        "assistant_layer_scale": 1,
+        "attention": 15,
         "attention_projection": 1,
-        "attention_sliding": 4,
+        "attention_sliding": 6,
         "attn_gate_sigmoid_mul": 1,
         "attn_gate_sigmoid_mul_backward": 1,
         "bias_add": 1,
@@ -33,7 +34,7 @@
         "gemma4_per_layer_prepare": 2,
         "gemv": 14,
         "group_limited_topk_router": 1,
-        "kv_cache_store": 2,
+        "kv_cache_store": 3,
         "kv_lora_decompress": 1,
         "layernorm": 2,
         "logits_store_indexed": 1,
@@ -46,10 +47,11 @@
         "moe_relu2_expert_mlp": 4,
         "moe_swiglu_expert_mlp": 2,
         "optimizer": 4,
-        "partial_rope_concat": 1,
+        "partial_rope_concat": 2,
         "position_embeddings": 3,
         "position_ids": 1,
         "projector_prep": 1,
+        "q_norm": 1,
         "qk_norm": 1,
         "qk_norm_backward": 1,
         "qkv_projection": 1,
@@ -68,7 +70,7 @@
         "residual_add": 1,
         "residual_save": 1,
         "rmsnorm": 2,
-        "rope": 8,
+        "rope": 9,
         "rope_backward": 2,
         "rope_init": 2,
         "rowwise_bias_add": 1,
@@ -354,6 +356,73 @@
       "notes": "Sum two token-major streams and reorder them into merged-tile traversal using the auxiliary stream as scratch.",
       "name": "add_stream_reorder_2d",
       "_source_file": "add_stream_reorder_2d.json"
+    },
+    {
+      "id": "assistant_layer_scale_forward",
+      "op": "assistant_layer_scale",
+      "variant": "fp32_inplace",
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Assistant/MTP hidden stream, scaled in place."
+        }
+      ],
+      "weights": [
+        {
+          "name": "scale",
+          "dtype": "fp32",
+          "shape": [
+            1
+          ],
+          "desc": "Per-layer assistant output scalar."
+        }
+      ],
+      "outputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Scaled assistant/MTP hidden stream."
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "T",
+        "E"
+      ],
+      "params": [],
+      "impl": {
+        "function": "assistant_layer_scale_forward",
+        "c_declaration": "void assistant_layer_scale_forward(float *hidden, const float *scale, int tokens, int embed_dim);",
+        "sources": [
+          "src/kernels/gemma4_per_layer_embed.c"
+        ]
+      },
+      "tests": {
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+            "tolerance": "1e-7"
+          }
+        ]
+      },
+      "notes": "Gemma4 assistant/MTP drafter layer scalar. This is intentionally separate from the main Gemma4 per-layer embedding kernel because the assistant path bridges from/to the backbone hidden stream.",
+      "name": "assistant_layer_scale_forward",
+      "_source_file": "assistant_layer_scale_forward.json"
     },
     {
       "id": "attention_backward_causal_head_major_gqa",
@@ -1633,6 +1702,131 @@
       "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4.json"
     },
     {
+      "id": "attention_forward_causal_head_major_shared_kv_gemma4",
+      "op": "attention",
+      "variant": "fp32_prefill_head_major_shared_kv",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor used as Q, K, and V for q-only shared-KV attention"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Attention output in head-major layout"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "T",
+        "D"
+      ],
+      "params": [],
+      "impl": {
+        "function": "attention_forward_causal_head_major_shared_kv_gemma4",
+        "c_declaration": "void attention_forward_causal_head_major_shared_kv_gemma4(const float *q, float *output, int num_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+        "sources": [
+          "src/kernels/attention_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+            "tolerance": "2e-5"
+          }
+        ]
+      },
+      "notes": "Prefill-only correctness wrapper for Gemma4 assistant q-only shared-KV attention.",
+      "name": "attention_forward_causal_head_major_shared_kv_gemma4",
+      "_source_file": "attention_forward_causal_head_major_shared_kv_gemma4.json"
+    },
+    {
+      "id": "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+      "op": "attention_sliding",
+      "variant": "fp32_prefill_head_major_shared_kv_sliding",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor used as Q, K, and V for q-only shared-KV sliding attention"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Attention output in head-major layout"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "T",
+        "D"
+      ],
+      "params": [],
+      "impl": {
+        "function": "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+        "c_declaration": "void attention_forward_causal_head_major_shared_kv_sliding_gemma4(const float *q, float *output, int num_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens, int sliding_window);",
+        "sources": [
+          "src/kernels/attention_kernels_sliding.c"
+        ],
+        "variants": [
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "notes": "Prefill-only correctness wrapper for Gemma4 assistant q-only sliding shared-KV attention.",
+      "name": "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+      "_source_file": "attention_forward_causal_head_major_shared_kv_sliding_gemma4.json"
+    },
+    {
       "id": "attention_forward_decode_head_major_gqa_flash_f16cache",
       "op": "attention",
       "variant": "decode_head_major_gqa_flash_f16cache",
@@ -1977,6 +2171,145 @@
       "notes": "Regular decode attention for head-major KV cache: single query token attends to all KV cache entries (0..kv_tokens-1).",
       "name": "attention_forward_decode_head_major_gqa_regular",
       "_source_file": "attention_forward_decode_head_major_gqa_regular.json"
+    },
+    {
+      "id": "attention_forward_decode_head_major_shared_kv_gemma4",
+      "op": "attention",
+      "variant": "fp32_decode_head_major_shared_kv",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q_token",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "D"
+          ]
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ]
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out_token",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "D"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "T",
+        "D"
+      ],
+      "params": [],
+      "impl": {
+        "function": "attention_forward_decode_head_major_shared_kv_gemma4",
+        "c_declaration": "void attention_forward_decode_head_major_shared_kv_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim);",
+        "sources": [
+          "src/kernels/attention_kernels.c"
+        ]
+      },
+      "tests": {
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+            "tolerance": "2e-5"
+          }
+        ]
+      },
+      "notes": "Gemma4 assistant decode attention over a cache populated from the q-only stream.",
+      "name": "attention_forward_decode_head_major_shared_kv_gemma4",
+      "_source_file": "attention_forward_decode_head_major_shared_kv_gemma4.json"
+    },
+    {
+      "id": "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
+      "op": "attention_sliding",
+      "variant": "fp32_decode_head_major_shared_kv_sliding",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q_token",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "D"
+          ]
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ]
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out_token",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "D"
+          ]
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "T",
+        "D"
+      ],
+      "params": [],
+      "impl": {
+        "function": "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
+        "c_declaration": "void attention_forward_decode_head_major_shared_kv_sliding_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim, int sliding_window);",
+        "sources": [
+          "src/kernels/attention_kernels_sliding.c"
+        ]
+      },
+      "notes": "Gemma4 assistant sliding decode attention over a cache populated from the q-only stream.",
+      "name": "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
+      "_source_file": "attention_forward_decode_head_major_shared_kv_sliding_gemma4.json"
     },
     {
       "id": "attention_forward_full_head_major_gqa_exact_strided",
@@ -3608,6 +3941,121 @@
       "notes": "Scalar reference for MLA partial RoPE assembly: copy q/k no-PE slices, apply Kimi/DeepSeek pair layout RoPE to q_pe and shared k_pe, then concatenate.",
       "name": "deepseek_mla_partial_rope_concat_f32",
       "_source_file": "deepseek_mla_partial_rope_concat_f32.json"
+    },
+    {
+      "id": "deepseek_mla_partial_rope_concat_packed_f32",
+      "op": "partial_rope_concat",
+      "variant": "fp32",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q_packed",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        },
+        {
+          "name": "k_nope",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk"
+          ]
+        },
+        {
+          "name": "kv_a_packed",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "R+Dr"
+          ]
+        },
+        {
+          "name": "cos",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "Dr/2"
+          ]
+        },
+        {
+          "name": "sin",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "Dr/2"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "query",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        },
+        {
+          "name": "key",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk+Dr"
+          ]
+        }
+      ],
+      "dims": [
+        "T",
+        "H",
+        "R",
+        "Dk",
+        "Dr"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "deepseek_mla_partial_rope_concat_packed_f32",
+        "c_declaration": "void deepseek_mla_partial_rope_concat_packed_f32(const float *q_packed, const float *k_nope, const float *kv_a_packed, const float *cos, const float *sin, float *query, float *key, int tokens, int heads, int kv_lora_rank, int qk_nope_dim, int qk_rope_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_deepseek_reference_kernels.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+            "tolerance": "1e-6"
+          }
+        ]
+      },
+      "notes": "Scalar reference for MLA partial RoPE assembly from packed q_proj [q_nope|q_pe] and packed kv_a_proj [compressed_kv|k_pe]. This preserves the Kimi/DeepSeek circuit without inventing compact q_pe/k_pe activation buffers.",
+      "name": "deepseek_mla_partial_rope_concat_packed_f32",
+      "_source_file": "deepseek_mla_partial_rope_concat_packed_f32.json"
     },
     {
       "id": "dense_embedding_lookup",
@@ -9892,6 +10340,73 @@
       "_source_file": "kv_cache_store_f16.json"
     },
     {
+      "id": "kv_cache_store_shared_q",
+      "op": "kv_cache_store",
+      "variant": "fp32_shared_q",
+      "quant": {
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "head_dim"
+          ],
+          "desc": "Post-RoPE Q tensor used as both K and V for the current decode token"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "kv_cache_k",
+          "dtype": "fp32",
+          "shape": [
+            "num_layers",
+            "num_heads",
+            "max_seq_len",
+            "head_dim"
+          ]
+        },
+        {
+          "name": "kv_cache_v",
+          "dtype": "fp32",
+          "shape": [
+            "num_layers",
+            "num_heads",
+            "max_seq_len",
+            "head_dim"
+          ]
+        }
+      ],
+      "dims": [
+        "num_heads",
+        "head_dim",
+        "num_layers",
+        "max_seq_len"
+      ],
+      "impl": {
+        "function": "kv_cache_store_shared_q",
+        "c_declaration": "void kv_cache_store_shared_q(float *kv_cache_k, float *kv_cache_v, const float *q, int layer, int pos, int num_heads, int head_dim, int max_seq_len);",
+        "sources": [
+          "src/kernels/kv_cache_kernels.c"
+        ]
+      },
+      "tests": {
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+            "tolerance": "0"
+          }
+        ]
+      },
+      "notes": "Gemma4 assistant q-only decode cache store. The same post-RoPE Q row is written into K and V cache.",
+      "name": "kv_cache_store_shared_q",
+      "_source_file": "kv_cache_store_shared_q.json"
+    },
+    {
       "id": "layernorm_forward",
       "op": "layernorm",
       "variant": "fp32",
@@ -13700,6 +14215,89 @@
       "_source_file": "position_embeddings_add_tiled_2d.json"
     },
     {
+      "id": "q_norm_forward",
+      "op": "q_norm",
+      "variant": "fp32",
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [num_heads, num_tokens, head_dim] to be normalized in-place"
+        }
+      ],
+      "weights": [
+        {
+          "name": "q_gamma",
+          "dtype": "fp32",
+          "shape": [
+            "D"
+          ],
+          "desc": "Q norm gamma weights [head_dim], shared across all heads"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor after per-head RMSNorm (in-place)"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "T",
+        "D"
+      ],
+      "params": [
+        {
+          "name": "eps",
+          "dtype": "float",
+          "desc": "RMSNorm epsilon"
+        }
+      ],
+      "impl": {
+        "function": "q_norm_forward",
+        "c_declaration": "void q_norm_forward(float *q, const float *q_gamma, int num_heads, int num_tokens, int head_dim, float eps);",
+        "sources": [
+          "src/kernels/qk_norm_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+            "tolerance": "2e-6"
+          }
+        ]
+      },
+      "notes": "Gemma4 assistant q-only shared-KV attention normalizes Q without a separate K projection.",
+      "name": "q_norm_forward",
+      "_source_file": "q_norm_forward.json"
+    },
+    {
       "id": "qk_norm_backward_f32",
       "op": "qk_norm_backward",
       "variant": "fp32_reference",
@@ -17022,6 +17620,93 @@
       "_source_file": "rope_backward_qk_pairwise_f32.json"
     },
     {
+      "id": "rope_forward_q_gemma4",
+      "op": "rope",
+      "variant": "fp32_head_major_q_only",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [heads, tokens, head_dim] to be rotated in-place"
+        }
+      ],
+      "weights": [
+        {
+          "name": "rope_freqs",
+          "dtype": "fp32",
+          "shape": [
+            "rotary_dim/2"
+          ],
+          "desc": "Gemma4 full-attention proportional RoPE frequency factors; ignored for sliding layers"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor after RoPE application (in-place)"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "T",
+        "D",
+        "rotary_dim"
+      ],
+      "params": [
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "pos_offset",
+          "dtype": "int32"
+        },
+        {
+          "name": "rotary_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "cache_rotary_dim",
+          "dtype": "int32",
+          "source": "dim:max_rotary_dim"
+        }
+      ],
+      "impl": {
+        "function": "rope_forward_q_split_direct_f32",
+        "c_declaration": "void rope_forward_q_split_direct_f32(float *q, const float *freq_factors, int use_freq_factors, int num_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+        "sources": [
+          "src/kernels/rope_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "notes": "Gemma4 assistant q-only RoPE. The Q stream later acts as the shared K/V stream.",
+      "name": "rope_forward_q_gemma4",
+      "_source_file": "rope_forward_q_gemma4.json"
+    },
+    {
       "id": "rope_forward_qk",
       "op": "rope",
       "variant": "fp32_head_major",
@@ -19578,121 +20263,6 @@
       "notes": "Build merged vision position IDs for 2D M-RoPE style encoders.",
       "name": "vision_position_ids_2d_merge",
       "_source_file": "vision_position_ids_2d_merge.json"
-    },
-    {
-      "id": "deepseek_mla_partial_rope_concat_packed_f32",
-      "op": "partial_rope_concat",
-      "variant": "fp32",
-      "modes": {
-        "inference": true,
-        "training": true,
-        "backward": false
-      },
-      "quant": {
-        "weight": "none",
-        "activation": "fp32",
-        "output": "fp32"
-      },
-      "inputs": [
-        {
-          "name": "q_packed",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "H",
-            "Dk+Dr"
-          ]
-        },
-        {
-          "name": "k_nope",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "H",
-            "Dk"
-          ]
-        },
-        {
-          "name": "kv_a_packed",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "R+Dr"
-          ]
-        },
-        {
-          "name": "cos",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "Dr/2"
-          ]
-        },
-        {
-          "name": "sin",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "Dr/2"
-          ]
-        }
-      ],
-      "outputs": [
-        {
-          "name": "query",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "H",
-            "Dk+Dr"
-          ]
-        },
-        {
-          "name": "key",
-          "dtype": "fp32",
-          "shape": [
-            "T",
-            "H",
-            "Dk+Dr"
-          ]
-        }
-      ],
-      "dims": [
-        "T",
-        "H",
-        "R",
-        "Dk",
-        "Dr"
-      ],
-      "impl": {
-        "sources": [
-          "src/kernels/deepseek_kernels.c"
-        ],
-        "variants": [
-          {
-            "name": "scalar_ref",
-            "requires": [],
-            "compile_flags": []
-          }
-        ],
-        "function": "deepseek_mla_partial_rope_concat_packed_f32",
-        "c_declaration": "void deepseek_mla_partial_rope_concat_packed_f32(const float *q_packed, const float *k_nope, const float *kv_a_packed, const float *cos, const float *sin, float *query, float *key, int tokens, int heads, int kv_lora_rank, int qk_nope_dim, int qk_rope_dim);"
-      },
-      "tests": {
-        "unit": [
-          "unittest/test_deepseek_reference_kernels.py"
-        ],
-        "parity": [
-          {
-            "kind": "pytorch",
-            "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
-            "tolerance": "1e-6"
-          }
-        ]
-      },
-      "notes": "Scalar reference for MLA partial RoPE assembly from packed q_proj [q_nope|q_pe] and packed kv_a_proj [compressed_kv|k_pe]. This preserves the Kimi/DeepSeek circuit without inventing compact q_pe/k_pe activation buffers.",
-      "name": "deepseek_mla_partial_rope_concat_packed_f32",
-      "_source_file": "deepseek_mla_partial_rope_concat_packed_f32.json"
     }
   ]
 }

--- a/version/v8/kernel_maps/assistant_layer_scale_forward.json
+++ b/version/v8/kernel_maps/assistant_layer_scale_forward.json
@@ -1,0 +1,65 @@
+{
+  "id": "assistant_layer_scale_forward",
+  "op": "assistant_layer_scale",
+  "variant": "fp32_inplace",
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Assistant/MTP hidden stream, scaled in place."
+    }
+  ],
+  "weights": [
+    {
+      "name": "scale",
+      "dtype": "fp32",
+      "shape": [
+        1
+      ],
+      "desc": "Per-layer assistant output scalar."
+    }
+  ],
+  "outputs": [
+    {
+      "name": "hidden",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "E"
+      ],
+      "desc": "Scaled assistant/MTP hidden stream."
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "T",
+    "E"
+  ],
+  "params": [],
+  "impl": {
+    "function": "assistant_layer_scale_forward",
+    "c_declaration": "void assistant_layer_scale_forward(float *hidden, const float *scale, int tokens, int embed_dim);",
+    "sources": [
+      "src/kernels/gemma4_per_layer_embed.c"
+    ]
+  },
+  "tests": {
+    "parity": [
+      {
+        "kind": "numpy",
+        "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+        "tolerance": "1e-7"
+      }
+    ]
+  },
+  "notes": "Gemma4 assistant/MTP drafter layer scalar. This is intentionally separate from the main Gemma4 per-layer embedding kernel because the assistant path bridges from/to the backbone hidden stream."
+}

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_shared_kv_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_shared_kv_gemma4.json
@@ -1,0 +1,47 @@
+{
+  "id": "attention_forward_causal_head_major_shared_kv_gemma4",
+  "op": "attention",
+  "variant": "fp32_prefill_head_major_shared_kv",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Query tensor used as Q, K, and V for q-only shared-KV attention"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Attention output in head-major layout"
+    }
+  ],
+  "scratch": [],
+  "dims": ["H", "T", "D"],
+  "params": [],
+  "impl": {
+    "function": "attention_forward_causal_head_major_shared_kv_gemma4",
+    "c_declaration": "void attention_forward_causal_head_major_shared_kv_gemma4(const float *q, float *output, int num_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+    "sources": ["src/kernels/attention_kernels.c"],
+    "variants": [
+      {"name": "ref", "requires": [], "compile_flags": []}
+    ]
+  },
+  "tests": {
+    "parity": [
+      {
+        "kind": "numpy",
+        "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+        "tolerance": "2e-5"
+      }
+    ]
+  },
+  "notes": "Prefill-only correctness wrapper for Gemma4 assistant q-only shared-KV attention."
+}

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_shared_kv_sliding_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_shared_kv_sliding_gemma4.json
@@ -1,0 +1,38 @@
+{
+  "id": "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+  "op": "attention_sliding",
+  "variant": "fp32_prefill_head_major_shared_kv_sliding",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Query tensor used as Q, K, and V for q-only shared-KV sliding attention"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Attention output in head-major layout"
+    }
+  ],
+  "scratch": [],
+  "dims": ["H", "T", "D"],
+  "params": [],
+  "impl": {
+    "function": "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+    "c_declaration": "void attention_forward_causal_head_major_shared_kv_sliding_gemma4(const float *q, float *output, int num_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens, int sliding_window);",
+    "sources": ["src/kernels/attention_kernels_sliding.c"],
+    "variants": [
+      {"name": "ref", "requires": [], "compile_flags": []}
+    ]
+  },
+  "notes": "Prefill-only correctness wrapper for Gemma4 assistant q-only sliding shared-KV attention."
+}

--- a/version/v8/kernel_maps/attention_forward_decode_head_major_shared_kv_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_decode_head_major_shared_kv_gemma4.json
@@ -1,0 +1,36 @@
+{
+  "id": "attention_forward_decode_head_major_shared_kv_gemma4",
+  "op": "attention",
+  "variant": "fp32_decode_head_major_shared_kv",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {"name": "q_token", "dtype": "fp32", "shape": ["H", "D"]},
+    {"name": "k_cache", "dtype": "fp32", "shape": ["H", "T", "D"]},
+    {"name": "v_cache", "dtype": "fp32", "shape": ["H", "T", "D"]}
+  ],
+  "outputs": [
+    {"name": "out_token", "dtype": "fp32", "shape": ["H", "D"]}
+  ],
+  "scratch": [],
+  "dims": ["H", "T", "D"],
+  "params": [],
+  "impl": {
+    "function": "attention_forward_decode_head_major_shared_kv_gemma4",
+    "c_declaration": "void attention_forward_decode_head_major_shared_kv_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim);",
+    "sources": ["src/kernels/attention_kernels.c"]
+  },
+  "tests": {
+    "parity": [
+      {
+        "kind": "numpy",
+        "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+        "tolerance": "2e-5"
+      }
+    ]
+  },
+  "notes": "Gemma4 assistant decode attention over a cache populated from the q-only stream."
+}

--- a/version/v8/kernel_maps/attention_forward_decode_head_major_shared_kv_sliding_gemma4.json
+++ b/version/v8/kernel_maps/attention_forward_decode_head_major_shared_kv_sliding_gemma4.json
@@ -1,0 +1,27 @@
+{
+  "id": "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
+  "op": "attention_sliding",
+  "variant": "fp32_decode_head_major_shared_kv_sliding",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {"name": "q_token", "dtype": "fp32", "shape": ["H", "D"]},
+    {"name": "k_cache", "dtype": "fp32", "shape": ["H", "T", "D"]},
+    {"name": "v_cache", "dtype": "fp32", "shape": ["H", "T", "D"]}
+  ],
+  "outputs": [
+    {"name": "out_token", "dtype": "fp32", "shape": ["H", "D"]}
+  ],
+  "scratch": [],
+  "dims": ["H", "T", "D"],
+  "params": [],
+  "impl": {
+    "function": "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
+    "c_declaration": "void attention_forward_decode_head_major_shared_kv_sliding_gemma4(const float *q_token, const float *k_cache, const float *v_cache, float *out_token, int num_heads, int kv_tokens, int cache_capacity, int head_dim, int aligned_head_dim, int sliding_window);",
+    "sources": ["src/kernels/attention_kernels_sliding.c"]
+  },
+  "notes": "Gemma4 assistant sliding decode attention over a cache populated from the q-only stream."
+}

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -31,6 +31,174 @@
         }
       ]
     },
+    "attention_forward_causal_head_major_shared_kv_gemma4": {
+      "note": "Gemma4 assistant prefill q-only attention. q_scratch is used as Q/K/V.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        }
+      ]
+    },
+    "attention_forward_causal_head_major_shared_kv_sliding_gemma4": {
+      "note": "Gemma4 assistant prefill q-only sliding attention. q_scratch is used as Q/K/V.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "float*",
+          "name": "output",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "kv_stride_tokens",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "sliding_window",
+          "source": "dim:sliding_window"
+        }
+      ]
+    },
+    "attention_forward_decode_head_major_shared_kv_gemma4": {
+      "note": "Gemma4 assistant decode q-only attention over shared-Q KV cache.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "q_token",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer"
+        },
+        {
+          "cast": "const float*",
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer"
+        },
+        {
+          "cast": "float*",
+          "name": "out_token",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "kv_tokens",
+          "source": "runtime:kv_tokens"
+        },
+        {
+          "name": "cache_capacity",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        }
+      ]
+    },
+    "attention_forward_decode_head_major_shared_kv_sliding_gemma4": {
+      "note": "Gemma4 assistant sliding decode q-only attention over shared-Q KV cache.",
+      "params": [
+        {
+          "cast": "const float*",
+          "name": "q_token",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer"
+        },
+        {
+          "cast": "const float*",
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer"
+        },
+        {
+          "cast": "float*",
+          "name": "out_token",
+          "source": "output:out"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "kv_tokens",
+          "source": "runtime:kv_tokens"
+        },
+        {
+          "name": "cache_capacity",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "sliding_window",
+          "source": "dim:sliding_window"
+        }
+      ]
+    },
     "attention_forward_causal_head_major_gqa_flash_strided_gemma4": {
       "note": "Prefill: all tokens process together with causal mask Gemma4 variant uses attention score scale 1.0 to match llama.cpp.",
       "params": [
@@ -733,6 +901,29 @@
         {
           "name": "cap",
           "source": "dim:final_logit_softcapping"
+        }
+      ]
+    },
+    "assistant_layer_scale_forward": {
+      "note": "Apply Gemma4 assistant/MTP per-layer scalar to the assistant hidden stream.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "hidden",
+          "source": "activation:hidden"
+        },
+        {
+          "cast": "const float*",
+          "name": "scale",
+          "source": "weight_f:layer_output_scale"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
         }
       ]
     },
@@ -1778,6 +1969,124 @@
         {
           "name": "merge_size",
           "source": "dim:merge_size"
+        }
+      ]
+    },
+    "q_norm_forward": {
+      "note": "Gemma4 assistant q-only per-head RMSNorm. In-place on q_scratch.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "q_gamma",
+          "source": "weight_f:q_norm"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "kv_cache_store_shared_q": {
+      "note": "Gemma4 assistant decode cache store. Writes post-RoPE Q into both K and V cache.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "kv_cache_k",
+          "source": "runtime:kv_cache_k_layer"
+        },
+        {
+          "cast": "float*",
+          "name": "kv_cache_v",
+          "source": "runtime:kv_cache_v_layer"
+        },
+        {
+          "cast": "const float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "name": "layer",
+          "source": "runtime:layer"
+        },
+        {
+          "name": "pos",
+          "source": "runtime:pos"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "max_seq_len",
+          "source": "dim:max_seq_len"
+        }
+      ]
+    },
+    "rope_forward_q_split_direct_f32": {
+      "note": "Gemma4 assistant q-only split-half direct RoPE with per-layer theta/rotary_dim and optional frequency factors.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "q",
+          "source": "scratch:q_scratch"
+        },
+        {
+          "cast": "const float*",
+          "name": "freq_factors",
+          "source": "weight_f:rope_freqs"
+        },
+        {
+          "name": "use_freq_factors",
+          "source": "dim:use_rope_freq_factors"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "aligned_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "pos_offset",
+          "source": "runtime:pos"
+        },
+        {
+          "name": "rotary_dim",
+          "source": "dim:rotary_dim"
+        },
+        {
+          "name": "freq_base",
+          "source": "dim:rope_freq_base"
         }
       ]
     },

--- a/version/v8/kernel_maps/kv_cache_store_shared_q.json
+++ b/version/v8/kernel_maps/kv_cache_store_shared_q.json
@@ -1,0 +1,45 @@
+{
+  "id": "kv_cache_store_shared_q",
+  "op": "kv_cache_store",
+  "variant": "fp32_shared_q",
+  "quant": {
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": ["num_heads", "head_dim"],
+      "desc": "Post-RoPE Q tensor used as both K and V for the current decode token"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "kv_cache_k",
+      "dtype": "fp32",
+      "shape": ["num_layers", "num_heads", "max_seq_len", "head_dim"]
+    },
+    {
+      "name": "kv_cache_v",
+      "dtype": "fp32",
+      "shape": ["num_layers", "num_heads", "max_seq_len", "head_dim"]
+    }
+  ],
+  "dims": ["num_heads", "head_dim", "num_layers", "max_seq_len"],
+  "impl": {
+    "function": "kv_cache_store_shared_q",
+    "c_declaration": "void kv_cache_store_shared_q(float *kv_cache_k, float *kv_cache_v, const float *q, int layer, int pos, int num_heads, int head_dim, int max_seq_len);",
+    "sources": ["src/kernels/kv_cache_kernels.c"]
+  },
+  "tests": {
+    "parity": [
+      {
+        "kind": "numpy",
+        "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+        "tolerance": "0"
+      }
+    ]
+  },
+  "notes": "Gemma4 assistant q-only decode cache store. The same post-RoPE Q row is written into K and V cache."
+}

--- a/version/v8/kernel_maps/q_norm_forward.json
+++ b/version/v8/kernel_maps/q_norm_forward.json
@@ -1,0 +1,61 @@
+{
+  "id": "q_norm_forward",
+  "op": "q_norm",
+  "variant": "fp32",
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Query tensor [num_heads, num_tokens, head_dim] to be normalized in-place"
+    }
+  ],
+  "weights": [
+    {
+      "name": "q_gamma",
+      "dtype": "fp32",
+      "shape": ["D"],
+      "desc": "Q norm gamma weights [head_dim], shared across all heads"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Query tensor after per-head RMSNorm (in-place)"
+    }
+  ],
+  "scratch": [],
+  "dims": ["H", "T", "D"],
+  "params": [
+    {
+      "name": "eps",
+      "dtype": "float",
+      "desc": "RMSNorm epsilon"
+    }
+  ],
+  "impl": {
+    "function": "q_norm_forward",
+    "c_declaration": "void q_norm_forward(float *q, const float *q_gamma, int num_heads, int num_tokens, int head_dim, float eps);",
+    "sources": ["src/kernels/qk_norm_kernels.c"],
+    "variants": [
+      {"name": "ref", "requires": [], "compile_flags": []}
+    ]
+  },
+  "tests": {
+    "parity": [
+      {
+        "kind": "numpy",
+        "command": ".venv/bin/python unittest/test_gemma4_assistant_kernels.py",
+        "tolerance": "2e-6"
+      }
+    ]
+  },
+  "notes": "Gemma4 assistant q-only shared-KV attention normalizes Q without a separate K projection."
+}

--- a/version/v8/kernel_maps/rope_forward_q_gemma4.json
+++ b/version/v8/kernel_maps/rope_forward_q_gemma4.json
@@ -1,0 +1,51 @@
+{
+  "id": "rope_forward_q_gemma4",
+  "op": "rope",
+  "variant": "fp32_head_major_q_only",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Query tensor [heads, tokens, head_dim] to be rotated in-place"
+    }
+  ],
+  "weights": [
+    {
+      "name": "rope_freqs",
+      "dtype": "fp32",
+      "shape": ["rotary_dim/2"],
+      "desc": "Gemma4 full-attention proportional RoPE frequency factors; ignored for sliding layers"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": ["H", "T", "D"],
+      "desc": "Query tensor after RoPE application (in-place)"
+    }
+  ],
+  "scratch": [],
+  "dims": ["H", "T", "D", "rotary_dim"],
+  "params": [
+    {"name": "aligned_head_dim", "dtype": "int32"},
+    {"name": "pos_offset", "dtype": "int32"},
+    {"name": "rotary_dim", "dtype": "int32"},
+    {"name": "cache_rotary_dim", "dtype": "int32", "source": "dim:max_rotary_dim"}
+  ],
+  "impl": {
+    "function": "rope_forward_q_split_direct_f32",
+    "c_declaration": "void rope_forward_q_split_direct_f32(float *q, const float *freq_factors, int use_freq_factors, int num_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int rotary_dim, float freq_base);",
+    "sources": ["src/kernels/rope_kernels.c"],
+    "variants": [
+      {"name": "ref", "requires": [], "compile_flags": []}
+    ]
+  },
+  "notes": "Gemma4 assistant q-only RoPE. The Q stream later acts as the shared K/V stream."
+}

--- a/version/v8/kernel_maps/speculative_commit_one_i32.json
+++ b/version/v8/kernel_maps/speculative_commit_one_i32.json
@@ -1,0 +1,79 @@
+{
+  "id": "speculative_commit_one_i32",
+  "op": "speculative_commit_or_reject",
+  "variant": "greedy_one_token",
+  "quant": {
+    "activation": "i32",
+    "output": "i32"
+  },
+  "inputs": [
+    {
+      "name": "accepted",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Acceptance flag produced by speculative_verify_greedy_f32."
+    },
+    {
+      "name": "verified_token",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Token to emit: accepted draft token or authoritative target token."
+    },
+    {
+      "name": "token_buffer",
+      "dtype": "i32",
+      "shape": ["max_tokens"],
+      "desc": "Output token buffer updated in-place when capacity allows."
+    },
+    {
+      "name": "token_count",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Number of committed output tokens, updated in-place."
+    },
+    {
+      "name": "target_position",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Authoritative target decode position, advanced by one."
+    },
+    {
+      "name": "draft_position",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Draft position synchronized to target position for the one-token milestone."
+    }
+  ],
+  "outputs": [
+    {
+      "name": "accepted_count",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Number of accepted draft tokens, updated in-place."
+    },
+    {
+      "name": "rejected_count",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Number of rejected draft tokens, updated in-place."
+    }
+  ],
+  "scratch": [],
+  "dims": ["max_tokens"],
+  "params": [],
+  "impl": {
+    "function": "speculative_commit_one_i32",
+    "c_declaration": "void speculative_commit_one_i32(int accepted, int verified_token, int *token_buffer, int *token_count, int max_tokens, int *target_position, int *draft_position, int *accepted_count, int *rejected_count);",
+    "sources": ["src/kernels/topk_kernels.c"]
+  },
+  "tests": {
+    "parity": [
+      {
+        "kind": "ctypes",
+        "command": ".venv/bin/python unittest/test_topk.py",
+        "tolerance": "0"
+      }
+    ]
+  },
+  "notes": "First-stage speculative decode commit kernel. It commits exactly one verified token and keeps draft/target positions synchronized. Multi-token acceptance and KV rollback should be introduced as a separate widened contract."
+}

--- a/version/v8/kernel_maps/speculative_verify_greedy_f32.json
+++ b/version/v8/kernel_maps/speculative_verify_greedy_f32.json
@@ -1,0 +1,55 @@
+{
+  "id": "speculative_verify_greedy_f32",
+  "op": "speculative_verify_greedy",
+  "variant": "greedy_one_token",
+  "quant": {
+    "activation": "fp32",
+    "output": "i32"
+  },
+  "inputs": [
+    {
+      "name": "target_logits",
+      "dtype": "fp32",
+      "shape": ["vocab_size"],
+      "desc": "Authoritative target/backbone logits for the candidate position."
+    },
+    {
+      "name": "draft_token",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "Candidate token proposed by the assistant/draft model."
+    }
+  ],
+  "outputs": [
+    {
+      "name": "accepted",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "1 when draft_token equals argmax(target_logits), otherwise 0."
+    },
+    {
+      "name": "verified_token",
+      "dtype": "i32",
+      "shape": [1],
+      "desc": "The emitted token: draft_token when accepted, otherwise the target argmax."
+    }
+  ],
+  "scratch": [],
+  "dims": ["vocab_size"],
+  "params": [],
+  "impl": {
+    "function": "speculative_verify_greedy_f32",
+    "c_declaration": "void speculative_verify_greedy_f32(const float *target_logits, int vocab_size, int draft_token, int *accepted, int *verified_token);",
+    "sources": ["src/kernels/topk_kernels.c"]
+  },
+  "tests": {
+    "parity": [
+      {
+        "kind": "ctypes",
+        "command": ".venv/bin/python unittest/test_topk.py",
+        "tolerance": "0"
+      }
+    ]
+  },
+  "notes": "First-stage speculative decode verifier. It is intentionally greedy-only and one-token-only so the target model remains authoritative while the Gemma4 assistant bridge is hardened."
+}

--- a/version/v8/model_maps/safetensors_ck_map.json
+++ b/version/v8/model_maps/safetensors_ck_map.json
@@ -2,6 +2,159 @@
   "version": 1,
   "description": "Declarative safetensors-to-CK source tensor mapping. Source formats are not first-class CK runtime artifacts; they map into BUMP manifest names consumed by templates.",
   "architectures": {
+    "gemma4_assistant": {
+      "template": "gemma4_assistant",
+      "family": "gemma4",
+      "aliases": [
+        "gemma4_assistant",
+        "Gemma4AssistantForCausalLM"
+      ],
+      "status": "bump_mapping_first_pass",
+      "config": {
+        "model": "gemma4_assistant",
+        "arch": "gemma4_assistant",
+        "model_type": "gemma4_assistant",
+        "rope_layout": "split",
+        "rope_param_mode": "per_layer_direct",
+        "has_qk_norm": true,
+        "attention_k_eq_v": true,
+        "prefill_policy": "batched",
+        "assistant_role": "mtp_drafter"
+      },
+      "required_tensor_families": [
+        "model.embed_tokens.weight",
+        "model.layers.{L}.input_layernorm.weight",
+        "model.layers.{L}.self_attn.q_proj.weight",
+        "model.layers.{L}.self_attn.q_norm.weight",
+        "model.layers.{L}.self_attn.o_proj.weight",
+        "model.layers.{L}.mlp.gate_proj.weight",
+        "model.layers.{L}.mlp.up_proj.weight",
+        "model.layers.{L}.mlp.down_proj.weight",
+        "model.norm.weight",
+        "pre_projection.weight",
+        "post_projection.weight"
+      ],
+      "tensor_refs": [
+        {
+          "target": "token_emb",
+          "sources": [
+            "model.embed_tokens.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.ln1_gamma",
+          "sources": [
+            "model.layers.{L}.input_layernorm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "layer.{L}.ln2_gamma",
+          "sources": [
+            "model.layers.{L}.pre_feedforward_layernorm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "layer.{L}.post_attention_norm",
+          "sources": [
+            "model.layers.{L}.post_attention_layernorm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "layer.{L}.post_ffn_norm",
+          "sources": [
+            "model.layers.{L}.post_feedforward_layernorm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "layer.{L}.wq",
+          "sources": [
+            "model.layers.{L}.self_attn.q_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.q_norm",
+          "sources": [
+            "model.layers.{L}.self_attn.q_norm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "layer.{L}.wo",
+          "sources": [
+            "model.layers.{L}.self_attn.o_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.w1",
+          "sources": [
+            "model.layers.{L}.mlp.gate_proj.weight",
+            "model.layers.{L}.mlp.up_proj.weight"
+          ],
+          "combine": "concat"
+        },
+        {
+          "target": "layer.{L}.b1",
+          "synth": "zeros_fp32",
+          "dtype": "fp32",
+          "shape": [
+            "2*intermediate_size"
+          ]
+        },
+        {
+          "target": "layer.{L}.w2",
+          "sources": [
+            "model.layers.{L}.mlp.down_proj.weight"
+          ]
+        },
+        {
+          "target": "layer.{L}.b2",
+          "synth": "zeros_fp32",
+          "dtype": "fp32",
+          "shape": [
+            "embed_dim"
+          ]
+        },
+        {
+          "target": "layer.{L}.layer_output_scale",
+          "sources": [
+            "model.layers.{L}.layer_scalar"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "final_ln_weight",
+          "sources": [
+            "model.norm.weight"
+          ],
+          "dtype": "fp32"
+        },
+        {
+          "target": "final_ln_bias",
+          "synth": "zeros_fp32",
+          "dtype": "fp32",
+          "shape": [
+            "embed_dim"
+          ]
+        },
+        {
+          "target": "assistant.pre_projection",
+          "sources": [
+            "pre_projection.weight"
+          ]
+        },
+        {
+          "target": "assistant.post_projection",
+          "sources": [
+            "post_projection.weight"
+          ]
+        }
+      ],
+      "notes": "Gemma4 assistant is a small MTP/speculative drafter, not the full Gemma4 31B decoder. It has q-only attention_k_eq_v tensors and assistant pre/post projection tensors; first-pass support maps safetensors into BUMP without inventing K/V tensors."
+    },
     "glm4": {
       "template": "glm4",
       "family": "glm",

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -348,6 +348,10 @@ OP_DATAFLOW = {
         "inputs": {"token_ids": "external:token_ids"},
         "outputs": {"out": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "assistant_pre_projection": {
+        "inputs": {"x": "backbone_stream"},
+        "outputs": {"y": {"slot": "main_stream", "dtype": "fp32"}},
+    },
     "gemma4_per_layer_prepare": {
         "inputs": {"input": "main_stream", "tokens": "external:token_ids"},
         "outputs": {"per_layer_input": {"slot": "gemma4_per_layer_stream", "dtype": "fp32"}},
@@ -421,6 +425,10 @@ OP_DATAFLOW = {
         "inputs": {"hidden": "main_stream", "per_layer_input": "gemma4_per_layer_stream"},
         "outputs": {"hidden": {"slot": "main_stream", "dtype": "fp32"}},
     },
+    "assistant_layer_scale": {
+        "inputs": {"hidden": "main_stream"},
+        "outputs": {"hidden": {"slot": "main_stream", "dtype": "fp32"}},
+    },
     "v_norm": {
         "inputs": {"input": "v_scratch"},
         "outputs": {"output": {"slot": "v_scratch", "dtype": "fp32"}},
@@ -428,6 +436,10 @@ OP_DATAFLOW = {
     "final_rmsnorm": {
         "inputs": {"input": "main_stream"},
         "outputs": {"output": {"slot": "main_stream", "dtype": "fp32"}},
+    },
+    "assistant_post_projection": {
+        "inputs": {"x": "main_stream"},
+        "outputs": {"y": {"slot": "backbone_stream", "dtype": "fp32"}},
     },
     "final_logit_softcap": {
         "inputs": {"logits": "logits"},
@@ -584,12 +596,20 @@ OP_DATAFLOW = {
             "k": {"slot": "k_scratch", "dtype": "fp32"},
         },
     },
+    "q_norm": {
+        "inputs": {"q": "q_scratch"},
+        "outputs": {"q": {"slot": "q_scratch", "dtype": "fp32"}},
+    },
     "rope_qk": {
         "inputs": {"q": "q_scratch", "k": "k_scratch"},
         "outputs": {
             "q": {"slot": "q_scratch", "dtype": "fp32"},
             "k": {"slot": "k_scratch", "dtype": "fp32"},
         },
+    },
+    "rope_q": {
+        "inputs": {"q": "q_scratch"},
+        "outputs": {"q": {"slot": "q_scratch", "dtype": "fp32"}},
     },
     "mrope_qk": {
         "inputs": {"q": "q_scratch", "k": "k_scratch", "positions": "vision_positions"},
@@ -605,12 +625,27 @@ OP_DATAFLOW = {
             "v_cache": {"slot": "kv_cache", "dtype": "fp32"},
         },
     },
+    "kv_cache_store_shared_q": {
+        "inputs": {"q": "q_scratch"},
+        "outputs": {
+            "k_cache": {"slot": "kv_cache", "dtype": "fp32"},
+            "v_cache": {"slot": "kv_cache", "dtype": "fp32"},
+        },
+    },
     "attn": {
         "inputs": {"q": "q_scratch", "k": "kv_cache", "v": "kv_cache"},
         "outputs": {"out": {"slot": "attn_scratch", "dtype": "fp32"}},
     },
     "attn_sliding": {
         "inputs": {"q": "q_scratch", "k": "kv_cache", "v": "kv_cache"},
+        "outputs": {"out": {"slot": "attn_scratch", "dtype": "fp32"}},
+    },
+    "attn_shared_kv": {
+        "inputs": {"q": "q_scratch"},
+        "outputs": {"out": {"slot": "attn_scratch", "dtype": "fp32"}},
+    },
+    "attn_sliding_shared_kv": {
+        "inputs": {"q": "q_scratch"},
         "outputs": {"out": {"slot": "attn_scratch", "dtype": "fp32"}},
     },
     "attn_gate_sigmoid_mul": {
@@ -1856,6 +1891,9 @@ def build_activation_specs(config: Dict[str, Any], mode: str, context_len: int, 
 
     # Embedding + layer buffers
     embedded_size = seq_len * embed_dim * 4
+    backbone_hidden_size = int(config.get("backbone_hidden_size", 0) or 0)
+    if backbone_hidden_size > 0:
+        add("backbone_stream", seq_len * backbone_hidden_size * 4, f"[{seq_len}, {backbone_hidden_size}]")
     add("embedded_input", embedded_size, f"[{seq_len}, {embed_dim}]")
     add("layer_input", embedded_size, f"[{seq_len}, {embed_dim}]")
     add("residual", embedded_size, f"[{seq_len}, {embed_dim}]")
@@ -2034,6 +2072,9 @@ TEMPLATE_TO_KERNEL_OP = {
     "qkv_proj": "qkv_projection",  # Or fallback to 3x matmul
     "qkv_packed_proj": "matmul",
     "q_proj": "matmul",
+    "assistant_pre_projection": "matmul",
+    "assistant_post_projection": "matmul",
+    "assistant_layer_scale": "assistant_layer_scale",
     "q_gate_proj": "matmul",
     "k_proj": "matmul",
     "v_proj": "matmul",
@@ -2107,6 +2148,12 @@ TEMPLATE_TO_KERNEL_OP = {
 
     # QK norm (Qwen3-style: per-head RMSNorm on Q and K after projection)
     "qk_norm": "qk_norm",  # Dedicated kernel wrapping rmsnorm_forward twice
+    "q_norm": "q_norm",  # Gemma4 assistant q-only RMSNorm before RoPE
+
+    "rope_q": "rope",
+    "attn_shared_kv": "attention",
+    "attn_sliding_shared_kv": "attention_sliding",
+    "kv_cache_store_shared_q": "kv_cache_store",
 
     # Footer ops
     "final_rmsnorm": "rmsnorm",
@@ -2126,6 +2173,8 @@ WEIGHT_TO_KERNEL_INPUT = {
     "ssm_alpha": "W", "ssm_beta": "W", "ssm_out": "W",
     "patch_emb": "W", "patch_emb_aux": "W",
     "mm0_w": "W", "mm1_w": "W",
+    "assistant_pre_projection": "W", "assistant_post_projection": "W",
+    "layer_output_scale": "scale",
     "branch_fc1_w": "W", "branch_fc2_w": "W",
     # Biases → bias (if kernel has it)
     "bq": "bias", "bk": "bias", "bv": "bias", "bo": "bias",
@@ -2717,7 +2766,7 @@ def _template_uses_rope(template: Dict[str, Any], config: Optional[Dict[str, Any
     if rope_layout in {"split", "pairwise", "multi_section_1d", "multi_section_2d"}:
         return True
     template_ops = _collect_template_ops(template, config)
-    return "rope_qk" in template_ops or "mrope_qk" in template_ops
+    return "rope_qk" in template_ops or "rope_q" in template_ops or "mrope_qk" in template_ops
 
 
 def _template_uses_kv_cache(template: Dict[str, Any], config: Optional[Dict[str, Any]] = None) -> bool:
@@ -2728,7 +2777,8 @@ def _template_uses_kv_cache(template: Dict[str, Any], config: Optional[Dict[str,
         return False
     if kv_layout:
         return True
-    return "attn" in _collect_template_ops(template, config) or "attn_sliding" in _collect_template_ops(template, config)
+    template_ops = _collect_template_ops(template, config)
+    return bool({"attn", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv"} & set(template_ops))
 
 
 def _resolve_decode_kv_cache_dtype(template: Dict[str, Any], config: Optional[Dict[str, Any]] = None) -> str:
@@ -2899,6 +2949,10 @@ def compute_matmul_dims(op_name: str, config: Dict) -> Tuple[Optional[int], Opti
     attn_gate_dim = int(config.get("attn_gate_dim", 0) or 0)
     if op_name in ("q_proj",):
         return heads * head_dim, embed
+    if op_name in ("assistant_pre_projection",):
+        return embed, int(config.get("backbone_hidden_size", embed) or embed)
+    if op_name in ("assistant_post_projection",):
+        return int(config.get("backbone_hidden_size", embed) or embed), embed
     if op_name in ("qkv_packed_proj",):
         return (heads * head_dim) + 2 * (kv_heads * head_dim), embed
     if op_name in ("q_gate_proj",):
@@ -3080,7 +3134,7 @@ def apply_layer_attention_dims(op_name: str, params: Dict, layer: int, config: D
             params["rope_freq_base"] = rope_freq_base
             params["use_rope_freq_factors"] = int(config.get("use_rope_freq_factors", 0) or 0)
         return
-    if model_lc != "gemma4":
+    if model_lc not in ("gemma4", "gemma4_assistant"):
         return
 
     embed_dim = int(config.get("embed_dim", 0) or 0)
@@ -3120,18 +3174,33 @@ def apply_layer_attention_dims(op_name: str, params: Dict, layer: int, config: D
         params["_output_dim"] = q_dim
         params["_input_dim"] = q_dim
         params["input_dim"] = q_dim
-    elif op_name in ("qk_norm", "rope_qk", "kv_cache_store", "attn", "attn_sliding"):
+    elif op_name in (
+        "qk_norm",
+        "q_norm",
+        "rope_qk",
+        "rope_q",
+        "kv_cache_store",
+        "attn",
+        "attn_sliding",
+        "attn_shared_kv",
+        "attn_sliding_shared_kv",
+    ):
         params["head_dim"] = q_head_dim
         params["q_head_dim"] = q_head_dim
         params["k_head_dim"] = k_head_dim
         params["v_head_dim"] = v_head_dim
         params["q_dim"] = q_dim
-        params["k_dim"] = k_dim
-        params["v_dim"] = v_dim
+        if op_name in ("q_norm", "rope_q", "attn_shared_kv", "attn_sliding_shared_kv"):
+            params["k_dim"] = q_dim
+            params["v_dim"] = q_dim
+            params["num_kv_heads"] = int(config.get("num_heads", 1) or 1)
+        else:
+            params["k_dim"] = k_dim
+            params["v_dim"] = v_dim
         params["rotary_dim"] = rotary_dim
         params["n_dims"] = rotary_dim
         params["rope_freq_base"] = rope_freq_base
-        params["use_rope_freq_factors"] = 1 if (op_name == "rope_qk" and rope_kind == "full") else 0
+        params["use_rope_freq_factors"] = 1 if (op_name in ("rope_qk", "rope_q") and rope_kind == "full") else 0
         if sliding_window > 0:
             params["sliding_window"] = sliding_window
     elif op_name == "v_norm":
@@ -4310,6 +4379,14 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         )
         if patch_entry:
             header_quant["patch_emb"] = patch_entry
+    if "assistant_pre_projection" not in header_quant:
+        pre_proj_entry = entry_dtype.get("assistant.pre_projection")
+        if pre_proj_entry:
+            header_quant["assistant_pre_projection"] = pre_proj_entry
+    if "assistant_post_projection" not in header_quant:
+        post_proj_entry = entry_dtype.get("assistant.post_projection")
+        if post_proj_entry:
+            header_quant["assistant_post_projection"] = post_proj_entry
     config = manifest.get("config", {})
     template_flags = template.get("flags", {}) if isinstance(template.get("flags"), dict) else {}
     logits_weight_source = _resolve_logits_weight_source(config, weight_index)
@@ -4636,6 +4713,8 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "qkv_packed_proj": ["attn_qkv"],
         "qkv_proj": ["wq", "wk", "wv"],  # Split into 3 matmuls if no fused kernel
         "q_proj": ["wq"],
+        "assistant_pre_projection": ["assistant_pre_projection"],
+        "assistant_post_projection": ["assistant_post_projection"],
         "q_gate_proj": ["wq"],
         "k_proj": ["wk"],
         "v_proj": ["wv"],
@@ -4694,10 +4773,12 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             "per_layer_post_norm",
             "layer_output_scale",
         ],
+        "assistant_layer_scale": None,
         "final_logit_softcap": None,
         "v_norm": [],
         "final_rmsnorm": None,
         "qk_norm": None,  # Per-head RMSNorm gamma is always fp32
+        "q_norm": None,  # Gemma4 assistant per-head Q RMSNorm gamma is fp32
 
         # Ops without weights (compute-only)
         "patchify": None,
@@ -4707,9 +4788,13 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "split_qkv_packed": None,
         "mrope_qk": None,
         "rope_qk": None,
+        "rope_q": None,
         "kv_cache_store": None,  # Store K,V to KV cache (no weights)
+        "kv_cache_store_shared_q": None,
         "attn": None,
         "attn_sliding": None,
+        "attn_shared_kv": None,
+        "attn_sliding_shared_kv": None,
         "split_q_gate": None,
         "recurrent_split_qkv": None,
         "recurrent_dt_gate": None,
@@ -4767,9 +4852,42 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         # Template-specified kernel overrides (keeps IR dumb and data-driven)
         if op == "rope_qk":
             return [_resolve_rope_qk_kernel(config, template_kernels)]
+        if op == "rope_q":
+            override = str(template_kernels.get("rope_q", "") or "").strip()
+            return [override or "rope_forward_q_gemma4"]
         if op == "mrope_qk":
             override = str(template_kernels.get("mrope_qk", "") or "").strip()
             return [override or "mrope_qk_vision"]
+        if op == "kv_cache_store_shared_q":
+            return ["kv_cache_store_shared_q"]
+        if op == "assistant_layer_scale":
+            return ["assistant_layer_scale_forward"]
+
+        if op in ("attn_shared_kv", "attn_sliding_shared_kv"):
+            if op == "attn_sliding_shared_kv":
+                mode_key = f"attn_sliding_shared_kv_{mode}"
+                attn_kernel = (
+                    template_kernels.get(mode_key)
+                    or template_kernels.get("attn_sliding_shared_kv")
+                    or (
+                        "attention_forward_causal_head_major_shared_kv_sliding_gemma4"
+                        if mode == "prefill"
+                        else "attention_forward_decode_head_major_shared_kv_sliding_gemma4"
+                    )
+                )
+            else:
+                mode_key = f"attn_shared_kv_{mode}"
+                attn_kernel = (
+                    template_kernels.get(mode_key)
+                    or template_kernels.get("attn_shared_kv")
+                    or (
+                        "attention_forward_causal_head_major_shared_kv_gemma4"
+                        if mode == "prefill"
+                        else "attention_forward_decode_head_major_shared_kv_gemma4"
+                    )
+                )
+            if attn_kernel:
+                return [attn_kernel]
 
         if op in ("attn", "attn_sliding"):
             mode_key = f"{op}_{mode}"
@@ -6355,12 +6473,12 @@ def generate_ir_lower_1(
     decode_attention_layers = {
         int(op.get("layer", 0))
         for op in lowered_ops
-        if str(op.get("op", "")) in {"attn", "attn_sliding"}
+        if str(op.get("op", "")) in {"attn", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv"}
     }
     decode_rope_layers = {
         int(op.get("layer", 0))
         for op in lowered_ops
-        if str(op.get("op", "")) in {"rope_qk", "mrope_qk"}
+        if str(op.get("op", "")) in {"rope_qk", "rope_q", "mrope_qk"}
     }
 
     def _kv_read_layer_for(layer: int) -> int:
@@ -6394,6 +6512,28 @@ def generate_ir_lower_1(
             "_auto_inserted": True,
         }
 
+    def _make_decode_shared_q_kv_store_op(anchor_op: Dict[str, Any]) -> Dict[str, Any]:
+        layer = int(anchor_op["layer"])
+        return {
+            "idx": len(final_ops),  # Will be renumbered
+            "kernel": "kv_cache_store_shared_q",
+            "op": "kv_cache_store_shared_q",
+            "layer": layer,
+            "section": anchor_op["section"],
+            "function": "kv_cache_store_shared_q",
+            "weights": {},
+            "inputs": {
+                "q": {"type": "scratch", "source": "q_scratch"},
+            },
+            "outputs": {
+                "kv_cache_k": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
+                "kv_cache_v": {"type": "kv_cache", "buffer": f"kv_cache_v_L{layer}"},
+            },
+            "params": copy.deepcopy(anchor_op.get("params", {})),
+            "scratch": [],
+            "_auto_inserted": True,
+        }
+
     for i, op in enumerate(lowered_ops):
         final_ops.append(op)
 
@@ -6401,6 +6541,10 @@ def generate_ir_lower_1(
             layer = int(op.get("layer", 0))
             op_name = str(op.get("op", ""))
             should_store_after_rope = op_name in {"rope_qk", "mrope_qk"}
+            should_store_after_q_rope = (
+                op_name == "rope_q"
+                and layer in decode_attention_layers
+            )
             should_store_after_v = (
                 op_name == "v_proj"
                 and layer in decode_attention_layers
@@ -6408,6 +6552,9 @@ def generate_ir_lower_1(
             )
             if should_store_after_rope or should_store_after_v:
                 final_ops.append(_make_decode_kv_store_op(op))
+                kv_store_count += 1
+            elif should_store_after_q_rope:
+                final_ops.append(_make_decode_shared_q_kv_store_op(op))
                 kv_store_count += 1
 
             # For decode mode, update attention ops to use decode kernel
@@ -6433,6 +6580,18 @@ def generate_ir_lower_1(
                 # Remove scratch K/V references if present
                 op["inputs"].pop("k", None)
                 op["inputs"].pop("v", None)
+            elif op["op"] in ("attn_shared_kv", "attn_sliding_shared_kv") and "attention" in op["kernel"]:
+                if op["op"] == "attn_sliding_shared_kv":
+                    decode_kernel = template_kernels.get("attn_sliding_shared_kv_decode") or "attention_forward_decode_head_major_shared_kv_sliding_gemma4"
+                else:
+                    decode_kernel = template_kernels.get("attn_shared_kv_decode") or "attention_forward_decode_head_major_shared_kv_gemma4"
+                op["kernel"] = decode_kernel
+                op["function"] = decode_kernel
+                kv_read_layer = _kv_read_layer_for(int(op.get("layer", 0)))
+                op["_kv_cache_read_layer"] = kv_read_layer
+                op.setdefault("inputs", {})
+                op["inputs"]["k_cache"] = {"type": "kv_cache", "source": f"kv_cache_k_L{kv_read_layer}"}
+                op["inputs"]["v_cache"] = {"type": "kv_cache", "source": f"kv_cache_v_L{kv_read_layer}"}
 
         elif mode == "prefill":
             # Prefill layout bridges are a graph contract, not a decoder/KV-cache
@@ -6501,7 +6660,7 @@ def generate_ir_lower_1(
             # projection/residual path consumes token-major [T, H*D]. Emit the
             # bridge for all prefill graphs, regardless of whether a KV cache
             # also exists.
-            if op["op"] in ("attn", "attn_sliding"):
+            if op["op"] in ("attn", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv"):
                 layer = op["layer"]
                 transpose_attn_out_op = {
                     "idx": len(final_ops),
@@ -6521,6 +6680,8 @@ def generate_ir_lower_1(
                     # TODO(contract): validate this op against runtime_invariants contract:
                     # _kv_copy_bytes must exist and match
                     # (num_kv_heads * head_dim * seq_len * sizeof(fp32)).
+                    shared_q_prefill = op["op"] in ("attn_shared_kv", "attn_sliding_shared_kv")
+                    copy_src = "q_scratch" if shared_q_prefill else "k_scratch"
                     kv_batch_copy_op = {
                         "idx": len(final_ops),
                         "kernel": "kv_cache_batch_copy",
@@ -6530,8 +6691,8 @@ def generate_ir_lower_1(
                         "function": "kv_cache_batch_copy",  # Codegen emits two memcpy calls (K and V)
                         "weights": {},
                         "inputs": {
-                            "k_src": {"type": "scratch", "source": "k_scratch"},
-                            "v_src": {"type": "scratch", "source": "v_scratch"},
+                            "k_src": {"type": "scratch", "source": copy_src},
+                            "v_src": {"type": "scratch", "source": "q_scratch" if shared_q_prefill else "v_scratch"},
                         },
                         "outputs": {
                             "k_dst": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
@@ -6692,6 +6853,7 @@ WEIGHT_PATTERNS = {
     "per_layer_inp_gate": ["layer.{L}.per_layer_inp_gate"],
     "per_layer_proj": ["layer.{L}.per_layer_proj"],
     "per_layer_post_norm": ["layer.{L}.per_layer_post_norm"],
+    "layer_output_scale": ["layer.{L}.layer_output_scale"],
     "patch_emb": [
         "patch_emb.weight",
         "patch_embeddings.weight",
@@ -6730,6 +6892,8 @@ WEIGHT_PATTERNS = {
     "mm0_b": ["mm.0.bias"],
     "mm1_w": ["mm.2.weight", "mm.input_projection.weight"],
     "mm1_b": ["mm.2.bias"],
+    "assistant_pre_projection": ["assistant.pre_projection"],
+    "assistant_post_projection": ["assistant.post_projection"],
     "attn_qkv": ["layer.{L}.attn_qkv", "layer.{L}.attn_qkv.weight", "v.blk.{L}.attn_qkv.weight"],
     "ln1_gamma": ["layer.{L}.ln1_gamma", "layers.{L}.attention_norm.weight", "layer.{L}.attn_norm", "layer.{L}.block_norm", "v.blk.{L}.ln1.weight"],
     "ln2_gamma": ["layer.{L}.ln2_gamma", "layers.{L}.ffn_norm.weight", "layer.{L}.post_attention_norm", "v.blk.{L}.ln2.weight"],
@@ -6764,6 +6928,7 @@ TEMPLATE_OP_WEIGHTS = {
     "vision_position_ids": [],
     "position_ids_2d": [],
     "dense_embedding_lookup": ["token_emb"],  # Token embeddings only (pos_emb for non-RoPE)
+    "assistant_pre_projection": ["assistant_pre_projection"],
 
     # Attention block (body + footer)
     # Body: uses ln1_gamma, ln2_gamma (per-layer)
@@ -6786,6 +6951,7 @@ TEMPLATE_OP_WEIGHTS = {
         "per_layer_post_norm",
         "layer_output_scale",
     ],
+    "assistant_layer_scale": ["layer_output_scale"],
     "final_logit_softcap": [],
     "v_norm": [],
     "final_rmsnorm": ["final_ln_weight", "final_ln_bias"],
@@ -6831,10 +6997,15 @@ TEMPLATE_OP_WEIGHTS = {
     "partial_rope_concat": [],
     "mla_attention": [],
     "qk_norm": ["q_norm", "k_norm"],  # Per-head RMSNorm gamma weights for Q and K
+    "q_norm": ["q_norm"],  # Per-head RMSNorm gamma weights for Q-only shared-KV attention
     "rope_qk": [],  # No model weights (uses precomputed tables)
+    "rope_q": [],  # No model weights (uses direct RoPE params/frequency factors)
     "mrope_qk": [],  # No model weights (runtime positions + RoPE params)
     "attn": [],  # No model weights
     "attn_sliding": [],  # No model weights (kernel op handles windowing)
+    "attn_shared_kv": [],  # No model weights; q_scratch is used as Q/K/V
+    "attn_sliding_shared_kv": [],  # No model weights; q_scratch is used as Q/K/V with SWA
+    "kv_cache_store_shared_q": [],  # No model weights; writes q_scratch to K/V cache
     "attn_gate_sigmoid_mul": [],  # No model weights
     "out_proj": ["wo", "bo", "wo_input_min", "wo_input_max", "wo_output_min", "wo_output_max"],  # Output projection + optional bias
     "residual_add": [],  # No model weights
@@ -6861,6 +7032,7 @@ TEMPLATE_OP_WEIGHTS = {
 
     # Footer
     "weight_tying": [],  # Metadata only
+    "assistant_post_projection": ["assistant_post_projection"],
     # logits source is resolved at runtime contract time:
     # - tied -> token_emb
     # - untied -> lm_head/output.weight
@@ -7091,6 +7263,37 @@ def generate_memory_layout(
                 "because V RMSNorm is unweighted"
             )
 
+    if model_family == "gemma4_assistant":
+        projection_mode = str(config.get("assistant_projection_mode", "") or "").strip().lower()
+        layer_scalar_mode = str(config.get("assistant_layer_scalar_mode", "") or "").strip().lower()
+        if projection_mode == "external_backbone_bridge":
+            # The Gemma4 assistant checkpoint is a drafter/assistant model.  Its
+            # pre/post projection tensors bridge the large backbone hidden width
+            # to the smaller assistant hidden width. They are not part of the
+            # standalone token decoder graph, where forcing them into the normal
+            # embedding stream would make the dimensions wrong.
+            ignored_assistant_bridge = {
+                w for w in model_weights
+                if w in {"assistant.pre_projection", "assistant.post_projection"}
+            }
+            if ignored_assistant_bridge:
+                model_weights -= ignored_assistant_bridge
+                print(
+                    f"  Ignoring {len(ignored_assistant_bridge)} Gemma4 assistant bridge tensors "
+                    "for standalone decoder lowering"
+                )
+        if layer_scalar_mode == "external_backbone_bridge":
+            ignored_layer_scalar = {
+                w for w in model_weights
+                if w.startswith("layer.") and w.endswith(".layer_output_scale")
+            }
+            if ignored_layer_scalar:
+                model_weights -= ignored_layer_scalar
+                print(
+                    f"  Ignoring {len(ignored_layer_scalar)} Gemma4 assistant layer scalar tensors "
+                    "for standalone decoder lowering"
+                )
+
     # Weights expected but not used by IR1
     unused_by_ir1 = expected_weights - ir1_used_weights
 
@@ -7293,6 +7496,9 @@ def generate_memory_layout(
     # Embedded input: embedding lookup output [seq_len, embed_dim]
     # For decode: [1, embed_dim], for prefill: [context_len, embed_dim]
     embedded_size = seq_len * embed_dim * 4
+    backbone_hidden_size = int(config.get("backbone_hidden_size", 0) or 0)
+    if backbone_hidden_size > 0:
+        add_buffer("backbone_stream", seq_len * backbone_hidden_size * 4, f"[{seq_len}, {backbone_hidden_size}]")
     add_buffer("embedded_input", embedded_size, f"[{seq_len}, {embed_dim}]")
 
     # Layer input buffer (for ping-pong)
@@ -7709,6 +7915,9 @@ def generate_memory_layout_packed(
             alloc_act("q_scratch")
             alloc_act("k_scratch")
             alloc_act("rope_cache")
+        if op_type == "rope_q":
+            alloc_act("q_scratch")
+            alloc_act("rope_cache")
         if op_type == "mrope_qk" or (op_type == "rope_qk" and kernel_type == "mrope_qk_vision"):
             alloc_act("q_scratch")
             alloc_act("k_scratch")
@@ -7719,6 +7928,9 @@ def generate_memory_layout_packed(
         if op_type == "kv_cache_store":
             alloc_act("k_scratch")
             alloc_act("v_scratch")
+            alloc_act("kv_cache")
+        if op_type == "kv_cache_store_shared_q":
+            alloc_act("q_scratch")
             alloc_act("kv_cache")
 
         if op_type == "attn" or "attention" in kernel_type:
@@ -7741,8 +7953,8 @@ def generate_memory_layout_packed(
         if "embedding" in kernel_type.lower():
             current_input_buffer = "embedded_input"
             current_output_buffer = "layer_input"
-        elif op_type in ("q_proj", "q_gate_proj", "split_q_gate", "attn_gate_sigmoid_mul", "k_proj", "v_proj", "qkv_proj", "rope_qk", "mrope_qk", "vision_position_ids", "position_ids_2d", "bias_add") or \
-                (mode == "prefill" and op_type in ("attn", "attn_sliding")):
+        elif op_type in ("q_proj", "q_gate_proj", "split_q_gate", "attn_gate_sigmoid_mul", "k_proj", "v_proj", "qkv_proj", "q_norm", "rope_qk", "rope_q", "mrope_qk", "vision_position_ids", "position_ids_2d", "bias_add") or \
+                (mode == "prefill" and op_type in ("attn", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv")):
             pass
         else:
             current_input_buffer, current_output_buffer = current_output_buffer, current_input_buffer
@@ -7964,6 +8176,8 @@ def generate_ir_lower_2(
         "A_BRANCH_MLP": "branch_mlp",
         "A_BRANCH_COLLECT": "branch_collect",
         "A_VISION_OUTPUT": "vision_output",
+        "A_BACKBONE_STREAM": "backbone_stream",
+        "backbone_stream": "backbone_stream",
         "A_LOGITS": "logits",
         "A_RECURRENT_PACKED": "recurrent_packed",
         "A_RECURRENT_Z": "recurrent_z",
@@ -8500,6 +8714,60 @@ def generate_ir_lower_2(
                     "ptr_expr": f"activations + {dst_buf['offset']}",
                 }
                 last_output_buffer = dst_buf_name
+        elif op_type == "assistant_pre_projection":
+            src_buf = activation_buffers.get("backbone_stream")
+            dst_buf = activation_buffers.get("embedded_input")
+            if src_buf:
+                lowered_op["activations"]["A"] = {
+                    "buffer": "backbone_stream",
+                    "activation_offset": src_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {src_buf['offset']}",
+                }
+            if dst_buf:
+                lowered_op["outputs"]["C"] = {
+                    "buffer": "embedded_input",
+                    "activation_offset": dst_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {dst_buf['offset']}",
+                }
+                last_output_buffer = "embedded_input"
+                current_input_buffer = "embedded_input"
+                current_output_buffer = "layer_input"
+        elif op_type == "assistant_post_projection":
+            src_buf = activation_buffers.get("embedded_input")
+            dst_buf = activation_buffers.get("backbone_stream")
+            if src_buf:
+                lowered_op["activations"]["A"] = {
+                    "buffer": "embedded_input",
+                    "activation_offset": src_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {src_buf['offset']}",
+                }
+            if dst_buf:
+                lowered_op["outputs"]["C"] = {
+                    "buffer": "backbone_stream",
+                    "activation_offset": dst_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {dst_buf['offset']}",
+                }
+                last_output_buffer = "embedded_input"
+        elif op_type == "assistant_layer_scale":
+            stream_buf = activation_buffers.get("embedded_input")
+            if stream_buf:
+                lowered_op["activations"]["hidden"] = {
+                    "buffer": "embedded_input",
+                    "activation_offset": stream_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {stream_buf['offset']}",
+                }
+                lowered_op["outputs"]["hidden"] = {
+                    "buffer": "embedded_input",
+                    "activation_offset": stream_buf["offset"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {stream_buf['offset']}",
+                }
+                last_output_buffer = "embedded_input"
         elif op_type == "logits":
             # Footer logits projection: input buffer must match kernel activation dtype.
             # - fp32 activation kernels (gemv_q8_0 / gemm_nt_q8_0) read embedded_input
@@ -8788,7 +9056,7 @@ def generate_ir_lower_2(
                     # Fallback to legacy logic for unplanned ops
                     if "embedding" in ir_op.get("kernel", "").lower():
                         output_buf_name = "embedded_input"
-                    elif ir_op.get("op") in ("attn", "attn_sliding"):
+                    elif ir_op.get("op") in ("attn", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv"):
                         output_buf_name = "attn_scratch"
                     elif ir_op.get("op") == "logits":
                         output_buf_name = "logits"
@@ -8828,10 +9096,11 @@ def generate_ir_lower_2(
                     "ptr_expr": f"activations + {scratch_offset}",
                 })
 
-        # Special handling for QK norm: add q_scratch and k_scratch buffers
-        # QK norm operates in-place on scratch buffers between QKV projection and RoPE
-        if ir_op.get("op", "") == "qk_norm":
-            for scratch_name in ["q_scratch", "k_scratch"]:
+        # Special handling for QK/Q-only norm: operate in-place on scratch buffers
+        # between projection and RoPE.
+        if ir_op.get("op", "") in ("qk_norm", "q_norm"):
+            scratch_names = ["q_scratch", "k_scratch"] if ir_op.get("op", "") == "qk_norm" else ["q_scratch"]
+            for scratch_name in scratch_names:
                 buf = activation_buffers.get(scratch_name)
                 if buf:
                     lowered_op["scratch"].append({
@@ -8845,7 +9114,7 @@ def generate_ir_lower_2(
         # Special handling for RoPE: add q_scratch and k_scratch buffers
         # RoPE always uses the scratch buffers (where k_proj/v_proj just wrote)
         # in both decode and prefill modes
-        if ir_op.get("op", "") == "rope_qk":
+        if ir_op.get("op", "") in ("rope_qk", "rope_q"):
             q_buf = activation_buffers.get("q_scratch")
             if q_buf:
                 lowered_op["scratch"].append({
@@ -8856,15 +9125,16 @@ def generate_ir_lower_2(
                     "ptr_expr": f"activations + {q_buf['offset']}",
                 })
 
-            k_buf = activation_buffers.get("k_scratch")
-            if k_buf:
-                lowered_op["scratch"].append({
-                    "name": "k_scratch",
-                    "scratch_offset": k_buf["offset"],
-                    "size": k_buf["size"],
-                    "dtype": "fp32",
-                    "ptr_expr": f"activations + {k_buf['offset']}",
-                })
+            if ir_op.get("op", "") == "rope_qk":
+                k_buf = activation_buffers.get("k_scratch")
+                if k_buf:
+                    lowered_op["scratch"].append({
+                        "name": "k_scratch",
+                        "scratch_offset": k_buf["offset"],
+                        "size": k_buf["size"],
+                        "dtype": "fp32",
+                        "ptr_expr": f"activations + {k_buf['offset']}",
+                    })
         if ir_op.get("op", "") == "mrope_qk" or (
             ir_op.get("op", "") == "rope_qk" and ir_op.get("kernel", "") == "mrope_qk_vision"
         ):
@@ -8891,6 +9161,17 @@ def generate_ir_lower_2(
                         "dtype": "fp32",
                         "ptr_expr": f"activations + {buf['offset']}",
                     })
+
+        if ir_op.get("op", "") == "kv_cache_store_shared_q":
+            q_buf = activation_buffers.get("q_scratch")
+            if q_buf:
+                lowered_op["scratch"].append({
+                    "name": "q_scratch",
+                    "scratch_offset": q_buf["offset"],
+                    "size": q_buf["size"],
+                    "dtype": "fp32",
+                    "ptr_expr": f"activations + {q_buf['offset']}",
+                })
 
         # Special handling for attention: add q_scratch, k_scratch, v_scratch buffers
         # Note: op type is "attn" but kernel contains "attention"
@@ -9205,11 +9486,11 @@ def generate_ir_lower_2(
         elif op_type in ("patch_proj", "patch_proj_aux", "position_embeddings", "patch_bias_add", "vision_position_ids", "position_ids_2d", "add_stream"):
             current_input_buffer = "embedded_input"
             current_output_buffer = "layer_input"
-        elif op_type in ("q_proj", "q_gate_proj", "split_q_gate", "split_qkv_packed", "attn_gate_sigmoid_mul", "k_proj", "v_proj", "qkv_proj", "qkv_packed_proj", "rope_qk", "mrope_qk",
+        elif op_type in ("q_proj", "q_gate_proj", "split_q_gate", "split_qkv_packed", "attn_gate_sigmoid_mul", "k_proj", "v_proj", "qkv_proj", "qkv_packed_proj", "q_norm", "rope_qk", "rope_q", "mrope_qk",
                          "recurrent_qk_l2_norm",
                          "mlp_gate_up", "mlp_up", "silu_mul", "geglu", "gelu", "mlp_down", "projector_fc1", "projector_gelu", "projector_prep", "projector_fc2", "branch_fc1", "branch_gelu", "branch_fc2", "branch_concat", "spatial_merge", "bias_add") or \
                 (ir_op.get("section", "") == "branch" and op_type == "layernorm") or \
-                (mode == "prefill" and op_type in ("attn", "attn_sliding")):
+                (mode == "prefill" and op_type in ("attn", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv")):
             # Ops that don't advance the token-major stream, don't ping-pong
             pass
         else:
@@ -9371,7 +9652,7 @@ def validate_buffer_assignments(lowered_ir: Dict) -> None:
                 )
 
         # ===== ATTENTION OPERATIONS =====
-        if op_name in ("attn", "attention", "attn_sliding"):
+        if op_name in ("attn", "attention", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv"):
             outputs = op.get("outputs", {})
             activations = op.get("activations", {})
 
@@ -9392,11 +9673,12 @@ def validate_buffer_assignments(lowered_ir: Dict) -> None:
             k_cache = activations.get("k_cache") or activations.get("k")
             if k_cache:
                 k_buf = k_cache.get("buffer", "")
-                if k_buf not in ("kv_cache",):
+                allowed_k = ("q_scratch", "kv_cache") if op_name in ("attn_shared_kv", "attn_sliding_shared_kv") else ("kv_cache",)
+                if k_buf not in allowed_k:
                     raise RuntimeError(
                         f"\n❌ HARD FAULT: Invalid buffer assignment\n"
                         f"   op={op_name} layer={layer}\n"
-                        f"   expected k_cache input: kv_cache\n"
+                        f"   expected k_cache input: {'/'.join(allowed_k)}\n"
                         f"   got: {k_buf}\n"
                         f"   Fix: Add kernel I/O -> dataflow name mapping in generate_ir_lower_2()\n"
                     )
@@ -9404,17 +9686,18 @@ def validate_buffer_assignments(lowered_ir: Dict) -> None:
             v_cache = activations.get("v_cache") or activations.get("v")
             if v_cache:
                 v_buf = v_cache.get("buffer", "")
-                if v_buf not in ("kv_cache",):
+                allowed_v = ("q_scratch", "kv_cache") if op_name in ("attn_shared_kv", "attn_sliding_shared_kv") else ("kv_cache",)
+                if v_buf not in allowed_v:
                     raise RuntimeError(
                         f"\n❌ HARD FAULT: Invalid buffer assignment\n"
                         f"   op={op_name} layer={layer}\n"
-                        f"   expected v_cache input: kv_cache\n"
+                        f"   expected v_cache input: {'/'.join(allowed_v)}\n"
                         f"   got: {v_buf}\n"
                         f"   Fix: Add kernel I/O -> dataflow name mapping in generate_ir_lower_2()\n"
                     )
 
         # ===== ROPE QK =====
-        elif op_name in ("rope_qk", "rope", "mrope_qk"):
+        elif op_name in ("rope_qk", "rope_q", "rope", "mrope_qk"):
             outputs = op.get("outputs", {})
             activations = op.get("activations", {})
 

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1011,6 +1011,10 @@ def step_run_chat(work_dir: Path, args: argparse.Namespace, *, gguf_path: Path |
         cmd.append("--python-tokenizer")
     if args.memory:
         cmd.append("--memory")
+    if getattr(args, "speculative_draft_model_dir", None):
+        cmd.extend(["--speculative-draft-model-dir", str(args.speculative_draft_model_dir)])
+    if getattr(args, "speculative_draft_tokens", None) is not None:
+        cmd.extend(["--speculative-draft-tokens", str(int(args.speculative_draft_tokens))])
 
     os.execvpe(sys.executable, cmd, env)
 
@@ -1243,6 +1247,10 @@ Examples:
     run_parser.add_argument("--thinking-mode", choices=["auto", "visible", "suppressed"], default="auto")
     run_parser.add_argument("--python-tokenizer", action="store_true")
     run_parser.add_argument("--memory", action="store_true")
+    run_parser.add_argument("--speculative-draft-model-dir", default=None,
+                            help="Path to a compiled draft model directory for greedy speculative decoding")
+    run_parser.add_argument("--speculative-draft-tokens", type=int, default=4,
+                            help="Number of draft tokens to propose per speculative batch")
     run_parser.add_argument("--force-download", action="store_true")
     run_parser.add_argument("--force-convert", action="store_true")
     run_parser.add_argument("--force-compile", action="store_true")

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -963,6 +963,8 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
         layer_q_dim: list[int] = []
         layer_o_input_dim: list[int] = []
         layer_q_norm_dim: list[int] = []
+        layer_q_head_dim: list[int] = []
+        layer_rotary_dim: list[int] = []
         for layer in range(num_layers):
             q = headers.get(f"model.layers.{layer}.self_attn.q_proj.weight")
             o = headers.get(f"model.layers.{layer}.self_attn.o_proj.weight")
@@ -970,6 +972,9 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             layer_q_dim.append(int(q.shape[0]) if q and q.shape else int(cfg.get("num_heads") or 0) * int(cfg.get("head_dim") or 0))
             layer_o_input_dim.append(int(o.shape[1]) if o and len(o.shape) >= 2 else layer_q_dim[-1])
             layer_q_norm_dim.append(int(qn.shape[0]) if qn and qn.shape else int(cfg.get("head_dim") or 0))
+            q_head = layer_q_norm_dim[-1]
+            layer_q_head_dim.append(q_head)
+            layer_rotary_dim.append(q_head)
         rope_params = text.get("rope_parameters") if isinstance(text.get("rope_parameters"), dict) else {}
         full_rope = rope_params.get("full_attention") if isinstance(rope_params.get("full_attention"), dict) else {}
         sliding_rope = rope_params.get("sliding_attention") if isinstance(rope_params.get("sliding_attention"), dict) else {}
@@ -980,6 +985,8 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "assistant_role": "mtp_drafter",
             "backbone_hidden_size": int(hf.get("backbone_hidden_size") or 0),
             "attention_k_eq_v": bool(text.get("attention_k_eq_v", True)),
+            "num_kv_heads": int(cfg.get("num_heads") or text.get("num_attention_heads") or 0),
+            "num_key_value_heads": int(cfg.get("num_heads") or text.get("num_attention_heads") or 0),
             "hidden_activation": str(text.get("hidden_activation") or "gelu_pytorch_tanh"),
             "intermediate_dim": int(cfg.get("intermediate_size") or 0),
             "max_seq_len": int(cfg.get("context_length") or 0),
@@ -1003,6 +1010,10 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "layer_q_dim": layer_q_dim,
             "layer_o_input_dim": layer_o_input_dim,
             "layer_q_norm_dim": layer_q_norm_dim,
+            "layer_q_head_dim": layer_q_head_dim,
+            "layer_k_head_dim": layer_q_head_dim[:],
+            "layer_v_head_dim": layer_q_head_dim[:],
+            "layer_rotary_dim": layer_rotary_dim,
             "rope_layout": "split",
             "rope_param_mode": "per_layer_direct",
             "rope_theta": float(full_rope.get("rope_theta", cfg.get("rope_theta", 1000000.0)) or 1000000.0),
@@ -1016,6 +1027,9 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "use_ordered_embeddings": bool(hf.get("use_ordered_embeddings", False)),
             "assistant_pre_projection": True,
             "assistant_post_projection": True,
+            "assistant_projection_mode": "mtp_bridge",
+            "assistant_layer_scalar_mode": "layer_output_scale",
+            "standalone_text_inference_supported": False,
         })
 
     if arch == "glm4":

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -751,6 +751,9 @@ def _llama_family_text_refs(config: dict[str, Any], headers: dict[str, HeaderTen
 
 def _infer_arch(hf: dict[str, Any]) -> str:
     text = hf.get("text_config") if isinstance(hf.get("text_config"), dict) else hf
+    root_mt = str(hf.get("model_type") or "").lower()
+    if root_mt == "gemma4_assistant":
+        return "gemma4_assistant"
     mt = str(text.get("model_type") or hf.get("model_type") or "").lower()
     arch_names = [str(x).lower() for x in (text.get("architectures") or hf.get("architectures") or []) if isinstance(x, str)]
     contracts = (_load_safetensors_ck_map().get("architectures") or {})
@@ -783,6 +786,8 @@ def _refs_for_arch(arch: str, config: dict[str, Any], headers: dict[str, HeaderT
     mapped_refs = _refs_from_safetensors_contract(arch, config, headers)
     if mapped_refs is not None:
         return mapped_refs
+    if arch == "gemma4_assistant":
+        return _refs_from_safetensors_contract("gemma4_assistant", config, headers) or _llama_family_text_refs(config, headers)
     if arch == "gemma4":
         return _gemma4_text_refs(config, headers)
     if arch == "qwen35":
@@ -943,6 +948,74 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "has_attention_biases": False,
             "has_qk_norm": False,
             "prefill_policy": "batched",
+        })
+
+    if arch == "gemma4_assistant":
+        headers = _load_safetensors_headers(model_dir)
+        num_layers = int(cfg.get("num_layers") or 0)
+        layer_types = [str(x) for x in (text.get("layer_types") or [])]
+        if not layer_types and num_layers > 0:
+            layer_types = ["full_attention" if layer == num_layers - 1 else "sliding_attention" for layer in range(num_layers)]
+        layer_kinds = [
+            "full_attention_q_only_k_eq_v" if kind == "full_attention" else "sliding_attention_q_only_k_eq_v"
+            for kind in layer_types
+        ]
+        layer_q_dim: list[int] = []
+        layer_o_input_dim: list[int] = []
+        layer_q_norm_dim: list[int] = []
+        for layer in range(num_layers):
+            q = headers.get(f"model.layers.{layer}.self_attn.q_proj.weight")
+            o = headers.get(f"model.layers.{layer}.self_attn.o_proj.weight")
+            qn = headers.get(f"model.layers.{layer}.self_attn.q_norm.weight")
+            layer_q_dim.append(int(q.shape[0]) if q and q.shape else int(cfg.get("num_heads") or 0) * int(cfg.get("head_dim") or 0))
+            layer_o_input_dim.append(int(o.shape[1]) if o and len(o.shape) >= 2 else layer_q_dim[-1])
+            layer_q_norm_dim.append(int(qn.shape[0]) if qn and qn.shape else int(cfg.get("head_dim") or 0))
+        rope_params = text.get("rope_parameters") if isinstance(text.get("rope_parameters"), dict) else {}
+        full_rope = rope_params.get("full_attention") if isinstance(rope_params.get("full_attention"), dict) else {}
+        sliding_rope = rope_params.get("sliding_attention") if isinstance(rope_params.get("sliding_attention"), dict) else {}
+        cfg.update({
+            "model": "gemma4_assistant",
+            "arch": "gemma4_assistant",
+            "model_type": "gemma4_assistant",
+            "assistant_role": "mtp_drafter",
+            "backbone_hidden_size": int(hf.get("backbone_hidden_size") or 0),
+            "attention_k_eq_v": bool(text.get("attention_k_eq_v", True)),
+            "hidden_activation": str(text.get("hidden_activation") or "gelu_pytorch_tanh"),
+            "intermediate_dim": int(cfg.get("intermediate_size") or 0),
+            "max_seq_len": int(cfg.get("context_length") or 0),
+            "global_head_dim": int(text.get("global_head_dim") or cfg.get("head_dim") or 0),
+            "num_global_key_value_heads": int(text.get("num_global_key_value_heads") or 0),
+            "num_kv_shared_layers": int(text.get("num_kv_shared_layers") or num_layers),
+            "layer_types": layer_types,
+            "layer_kinds": layer_kinds,
+            "hybrid_block_pattern": layer_kinds[:],
+            "layer_attention_policy": [
+                "q_only_full_attention" if kind.startswith("full") else "q_only_sliding_attention"
+                for kind in layer_kinds
+            ],
+            "layer_kv_policy": ["q_equals_k_equals_v" for _ in layer_kinds],
+            "layer_recurrent_policy": ["none" for _ in layer_kinds],
+            "layer_state_policy": ["none" for _ in layer_kinds],
+            "layer_moe_policy": ["none" for _ in layer_kinds],
+            "layer_mlp_policy": ["gelu_pytorch_tanh" for _ in layer_kinds],
+            "layer_rope_kind": ["full" if kind.startswith("full") else "sliding" for kind in layer_kinds],
+            "layer_sliding_window": [int(text.get("sliding_window") or 0) if not kind.startswith("full") else 0 for kind in layer_kinds],
+            "layer_q_dim": layer_q_dim,
+            "layer_o_input_dim": layer_o_input_dim,
+            "layer_q_norm_dim": layer_q_norm_dim,
+            "rope_layout": "split",
+            "rope_param_mode": "per_layer_direct",
+            "rope_theta": float(full_rope.get("rope_theta", cfg.get("rope_theta", 1000000.0)) or 1000000.0),
+            "rope_theta_swa": float(sliding_rope.get("rope_theta", cfg.get("rope_theta_swa", 10000.0)) or 10000.0),
+            "rope_partial_rotary_factor": float(full_rope.get("partial_rotary_factor", 1.0) or 1.0),
+            "has_attention_biases": bool(text.get("attention_bias", False)),
+            "has_qk_norm": True,
+            "has_k_norm": False,
+            "prefill_policy": "batched",
+            "tie_word_embeddings": bool(hf.get("tie_word_embeddings", text.get("tie_word_embeddings", True))),
+            "use_ordered_embeddings": bool(hf.get("use_ordered_embeddings", False)),
+            "assistant_pre_projection": True,
+            "assistant_post_projection": True,
         })
 
     if arch == "glm4":
@@ -1305,7 +1378,7 @@ def main() -> int:
     ap.add_argument("--ram-dir", type=Path, default=Path("/dev/shm"), help="tmpfs directory for --ram-output; default: /dev/shm")
     ap.add_argument("--config-out", required=True, type=Path)
     ap.add_argument("--manifest-out", required=True, type=Path)
-    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h", "glm4", "kimi_vl"])
+    ap.add_argument("--arch", default="auto", choices=["auto", "gemma4", "gemma4_assistant", "gemma3", "llama", "qwen2", "qwen3", "qwen35", "nemotron_h", "glm4", "kimi_vl"])
     ap.add_argument("--config-template", type=Path, help="existing v8 config/manifest to reuse explicit runtime policy")
     ap.add_argument("--dtype", default="preserve", choices=["preserve", "bf16", "fp32"])
     ap.add_argument("--dry-run", action="store_true", help="validate mapping and write JSON reports only; do not write BUMP")

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -801,6 +801,148 @@ def _refs_for_arch(arch: str, config: dict[str, Any], headers: dict[str, HeaderT
     raise SystemExit(f"Unsupported safetensors arch for v8 importer: {arch}")
 
 
+def _build_gemma4_attention_plan_from_hf(text: dict[str, Any], headers: dict[str, HeaderTensor]) -> dict[str, Any]:
+    num_layers = int(text.get("num_hidden_layers") or 0)
+    if num_layers <= 0:
+        raise SystemExit("Gemma4 config missing num_hidden_layers")
+
+    layer_types = [str(x) for x in (text.get("layer_types") or [])]
+    if not layer_types:
+        interval = int(text.get("full_attention_interval") or 5)
+        layer_types = ["full_attention" if (layer + 1) % interval == 0 else "sliding_attention" for layer in range(num_layers)]
+    if len(layer_types) != num_layers:
+        raise SystemExit(f"Gemma4 layer_types length {len(layer_types)} != num_layers {num_layers}")
+
+    shared_kv_layers = int(text.get("num_kv_shared_layers") or 0)
+    if shared_kv_layers < 0 or shared_kv_layers > num_layers:
+        raise SystemExit(
+            f"Gemma4 num_kv_shared_layers must be between 0 and num_layers "
+            f"(got {shared_kv_layers}, num_layers={num_layers})"
+        )
+    first_shared_kv_layer = num_layers - shared_kv_layers
+    full_kv_producer = first_shared_kv_layer - 1
+    sliding_kv_producer = first_shared_kv_layer - 2
+
+    sliding_window = int(text.get("sliding_window") or 0)
+    num_heads = int(text.get("num_attention_heads") or 0)
+    num_kv_heads = int(text.get("num_key_value_heads") or 0)
+    default_head_dim = int(text.get("head_dim") or 0)
+
+    rope_params = text.get("rope_parameters") if isinstance(text.get("rope_parameters"), dict) else {}
+    full_rope = rope_params.get("full_attention") if isinstance(rope_params.get("full_attention"), dict) else {}
+    sliding_rope = rope_params.get("sliding_attention") if isinstance(rope_params.get("sliding_attention"), dict) else {}
+    full_partial = float(full_rope.get("partial_rotary_factor", 1.0) or 1.0)
+    sliding_partial = float(sliding_rope.get("partial_rotary_factor", 1.0) or 1.0)
+
+    layer_kinds: list[str] = []
+    layer_kv_policy: list[str] = []
+    layer_kv_source: list[int] = []
+    layer_sliding_window: list[int] = []
+    layer_rope_kind: list[str] = []
+    layer_q_head_dim: list[int] = []
+    layer_k_head_dim: list[int] = []
+    layer_v_head_dim: list[int] = []
+    layer_rotary_dim: list[int] = []
+    layer_q_dim: list[int] = []
+    layer_kv_dim: list[int] = []
+    layer_attention_plan: list[dict[str, Any]] = []
+
+    for layer, raw_kind in enumerate(layer_types):
+        attention_kind = "full" if raw_kind == "full_attention" else "sliding"
+        owns_kv = layer < first_shared_kv_layer
+        if owns_kv:
+            kv_source = layer
+        elif attention_kind == "sliding":
+            kv_source = sliding_kv_producer
+        else:
+            kv_source = full_kv_producer
+        if kv_source < 0:
+            raise SystemExit("Gemma4 shared-KV plan has no producer layer to reuse")
+
+        prefix = f"model.language_model.layers.{layer}.self_attn"
+        q = headers.get(f"{prefix}.q_proj.weight")
+        k = headers.get(f"{prefix}.k_proj.weight")
+        v = headers.get(f"{prefix}.v_proj.weight")
+        q_dim = int(q.shape[0]) if q and q.shape else num_heads * default_head_dim
+        k_dim = int(k.shape[0]) if k and k.shape else num_kv_heads * default_head_dim
+        v_dim = int(v.shape[0]) if v and v.shape else k_dim
+        q_head_dim = int(q_dim // max(1, num_heads)) if q_dim else default_head_dim
+        k_head_dim = int(k_dim // max(1, num_kv_heads)) if k_dim else default_head_dim
+        v_head_dim = int(v_dim // max(1, num_kv_heads)) if v_dim else k_head_dim
+        partial = full_partial if attention_kind == "full" else sliding_partial
+        rotary_dim = int(q_head_dim * partial)
+
+        kind = f"{attention_kind}_attention_kv" if owns_kv else f"{attention_kind}_attention_shared_kv"
+        layer_kinds.append(kind)
+        layer_kv_policy.append("produce" if owns_kv else "reuse")
+        layer_kv_source.append(kv_source)
+        layer_sliding_window.append(sliding_window if attention_kind == "sliding" else 0)
+        layer_rope_kind.append("full" if attention_kind == "full" else "swa")
+        layer_q_head_dim.append(q_head_dim)
+        layer_k_head_dim.append(k_head_dim)
+        layer_v_head_dim.append(v_head_dim)
+        layer_rotary_dim.append(rotary_dim)
+        layer_q_dim.append(q_dim)
+        layer_kv_dim.append(k_dim)
+        layer_attention_plan.append({
+            "layer": layer,
+            "kind": kind,
+            "attention_kind": attention_kind,
+            "kv_policy": "produce" if owns_kv else "reuse",
+            "kv_source_layer": kv_source,
+            "sliding_window": sliding_window if attention_kind == "sliding" else 0,
+            "rope_kind": "full" if attention_kind == "full" else "swa",
+            "q_head_dim": q_head_dim,
+            "k_head_dim": k_head_dim,
+            "v_head_dim": v_head_dim,
+            "rotary_dim": rotary_dim,
+            "q_dim": q_dim,
+            "kv_dim": k_dim,
+        })
+
+    layer_k_cache_offset: list[int] = []
+    layer_v_cache_offset: list[int] = []
+    kv_cache_token_stride_total = 0
+    for k_head, v_head in zip(layer_k_head_dim, layer_v_head_dim):
+        k_elems = num_kv_heads * int(k_head)
+        v_elems = num_kv_heads * int(v_head)
+        layer_k_cache_offset.append(kv_cache_token_stride_total)
+        kv_cache_token_stride_total += k_elems
+        layer_v_cache_offset.append(kv_cache_token_stride_total)
+        kv_cache_token_stride_total += v_elems
+
+    return {
+        "layer_types": layer_types,
+        "layer_kinds": layer_kinds,
+        "hybrid_block_pattern": layer_kinds[:],
+        "layer_attention_plan": layer_attention_plan,
+        "layer_kv_policy": layer_kv_policy,
+        "layer_kv_source": layer_kv_source,
+        "layer_sliding_window": layer_sliding_window,
+        "layer_rope_kind": layer_rope_kind,
+        "layer_q_head_dim": layer_q_head_dim,
+        "layer_k_head_dim": layer_k_head_dim,
+        "layer_v_head_dim": layer_v_head_dim,
+        "layer_rotary_dim": layer_rotary_dim,
+        "layer_q_dim": layer_q_dim,
+        "layer_kv_dim": layer_kv_dim,
+        "layer_k_cache_offset": layer_k_cache_offset,
+        "layer_v_cache_offset": layer_v_cache_offset,
+        "kv_cache_layer_stride_variable": True,
+        "kv_cache_token_stride_total": kv_cache_token_stride_total,
+        "max_q_head_dim": max(layer_q_head_dim) if layer_q_head_dim else 0,
+        "max_k_head_dim": max(layer_k_head_dim) if layer_k_head_dim else 0,
+        "max_v_head_dim": max(layer_v_head_dim) if layer_v_head_dim else 0,
+        "kv_cache_head_dim": max(
+            max(layer_k_head_dim) if layer_k_head_dim else 0,
+            max(layer_v_head_dim) if layer_v_head_dim else 0,
+        ),
+        "max_rotary_dim": max(layer_rotary_dim) if layer_rotary_dim else 0,
+        "shared_kv_layers": shared_kv_layers,
+        "first_shared_kv_layer": first_shared_kv_layer,
+    }
+
+
 def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> dict[str, Any]:
     hf = _hf_config(model_dir)
     base = _load_runtime_config_template(config_template)
@@ -1032,6 +1174,26 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "standalone_text_inference_supported": False,
         })
 
+    if arch == "gemma4":
+        headers = _load_safetensors_headers(model_dir)
+        attention_plan = _build_gemma4_attention_plan_from_hf(text, headers)
+        cfg.update({
+            "model": "gemma4",
+            "arch": "gemma4",
+            "model_type": "gemma4",
+            "intermediate_dim": int(cfg.get("intermediate_size") or 0),
+            "max_seq_len": int(cfg.get("context_length") or 0),
+            "has_attention_biases": bool(text.get("attention_bias", False)),
+            "has_qk_norm": True,
+            "prefill_policy": "batched",
+            "gemma4_per_layer_embedding": True,
+            "rope_layout": "split",
+            "rope_param_mode": "per_layer_direct",
+            "num_kv_shared_layers": int(text.get("num_kv_shared_layers") or 0),
+            "sampler_defaults": {"repeat_penalty": 1.05, "repeat_last_n": 64},
+        })
+        cfg.update(attention_plan)
+
     if arch == "glm4":
         partial_key = "partial_rotary_factor"
         contract = _safetensors_arch_contract("glm4")
@@ -1194,6 +1356,8 @@ def _ref_transform(arch: str, ref: TensorRef) -> str | None:
 def _ignored_source_tensor(arch: str, name: str) -> str | None:
     if name.startswith("mtp.") or name.startswith("model.mtp."):
         return "mtp_decoder_block_not_in_main_pass"
+    if arch == "gemma4_assistant" and name.startswith("masked_embedding."):
+        return "ordered_embedding_sidecar_not_in_current_runtime"
     if arch == "qwen35" and (name.startswith("model.visual.") or name.startswith("visual.")):
         return "vision_tower_not_in_decoder_pass"
     if arch == "qwen35" and name.startswith("model.vision_model."):

--- a/version/v8/scripts/inspect_model_contract_v8.py
+++ b/version/v8/scripts/inspect_model_contract_v8.py
@@ -17,8 +17,16 @@ from pathlib import Path
 from typing import Any
 
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+
 SUPPORTED_DENSE_ARCHES = {"llama", "qwen2", "qwen3", "gemma3"}
 SUPPORTED_HYBRID_ARCHES = {"qwen35", "gemma4", "nemotron_h", "kimi_vl"}
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8").replace("Infinity", "1e100")
+    return json.loads(text)
 
 
 def _load_config(path: Path) -> dict[str, Any]:
@@ -26,8 +34,15 @@ def _load_config(path: Path) -> dict[str, Any]:
         path = path / "config.json"
     if not path.exists():
         raise FileNotFoundError(path)
-    text = path.read_text(encoding="utf-8").replace("Infinity", "1e100")
-    return json.loads(text)
+    return _load_json_file(path)
+
+
+def _model_root(path: Path) -> Path:
+    if path.is_dir():
+        return path
+    if path.name == "config.json":
+        return path.parent
+    return path.parent
 
 
 def _text_config(config: dict[str, Any]) -> dict[str, Any]:
@@ -209,14 +224,208 @@ def _missing_ops(arch: str, required_ops: list[str]) -> list[str]:
     return sorted(set(missing))
 
 
-def inspect_config(config: dict[str, Any]) -> dict[str, Any]:
+def _load_registry_ops(registry_path: Path | None = None) -> set[str]:
+    path = registry_path or (REPO_ROOT / "version" / "v8" / "kernel_maps" / "KERNEL_REGISTRY.json")
+    try:
+        registry = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return set()
+    return {str(k.get("op")) for k in registry.get("kernels", []) if k.get("op")}
+
+
+def _registry_requirements_for_op(op: str) -> list[list[str]]:
+    """Return OR-groups of registry ops that satisfy a conceptual model op."""
+    mapping: dict[str, list[list[str]]] = {
+        "embedding": [["embedding"]],
+        "rmsnorm": [["rmsnorm"]],
+        "matmul": [["gemv"], ["gemm"]],
+        "residual_add": [["residual_add"]],
+        "logits": [["gemv"], ["gemm"]],
+        "attention": [["attention"]],
+        "mla_attention": [["attention"]],
+        "rope": [["rope"]],
+        "kv_lora_decompress": [["kv_lora_decompress"]],
+        "partial_rope_concat": [["partial_rope_concat"]],
+        "recurrent_dt_gate": [["recurrent_dt_gate"]],
+        "recurrent_conv_state_update": [["recurrent_conv_state_update"]],
+        "ssm_conv1d": [["ssm_conv1d"]],
+        "recurrent_qk_l2_norm": [["recurrent_qk_l2_norm"]],
+        "gated_deltanet": [["gated_deltanet"]],
+        "recurrent_norm_gate": [["recurrent_norm_gate"]],
+        "mamba_in_proj_split": [["mamba_in_proj_split"]],
+        "mamba_conv1d_state_update": [["mamba_conv1d_state_update"]],
+        "mamba_dt_softplus": [["mamba_dt_softplus"]],
+        "mamba_selective_scan": [["mamba_selective_scan"]],
+        "mamba_rmsnorm_gate": [["mamba_rmsnorm_gate"]],
+        "mamba_out_proj": [["gemv"], ["gemm"]],
+        "group_limited_topk_router": [["group_limited_topk_router"]],
+        "sigmoid_router_scores": [["attn_gate_sigmoid_mul"]],
+        "moe_relu2_expert_mlp": [["moe_relu2_expert_mlp"]],
+        "shared_expert_mlp": [["shared_relu2_expert_mlp"], ["shared_swiglu_expert_mlp"]],
+        "shared_relu2_expert_mlp": [["shared_relu2_expert_mlp"]],
+        "moe_swiglu_expert_mlp": [["moe_swiglu_expert_mlp"]],
+        "shared_swiglu_expert_mlp": [["shared_swiglu_expert_mlp"]],
+        "relu2_mlp": [["relu2"]],
+        "swiglu_or_geglu": [["swiglu"], ["geglu"], ["gelu"]],
+        "gemma4_per_layer_embed": [["gemma4_per_layer_embed"]],
+        "gemma4_final_logit_softcap": [["final_logit_softcap"]],
+    }
+    return mapping.get(op, [[op]])
+
+
+def _kernel_registry_report(required_ops: list[str]) -> dict[str, Any]:
+    registry_ops = _load_registry_ops()
+    supported: list[str] = []
+    missing: list[dict[str, Any]] = []
+    for op in required_ops:
+        groups = _registry_requirements_for_op(op)
+        unsatisfied = [group for group in groups if not any(candidate in registry_ops for candidate in group)]
+        if not unsatisfied:
+            supported.append(op)
+        else:
+            missing.append(
+                {
+                    "op": op,
+                    "registry_candidates": groups,
+                    "missing_candidate_groups": unsatisfied,
+                }
+            )
+    return {
+        "supported_ops": supported,
+        "missing_kernel_ops": missing,
+        "registry_loaded": bool(registry_ops),
+    }
+
+
+def _template_body_ops_for_kind(kind: str, arch: str) -> list[str]:
+    if kind in {"attention", "full_attention"}:
+        return ["attn_norm", "q_proj", "k_proj", "v_proj", "qk_norm", "rope_qk", "attn", "out_proj", "residual_add", "ffn_norm", "mlp_gate_up", "silu_mul", "mlp_down", "residual_add"]
+    if kind == "sliding_attention":
+        return ["attn_norm", "q_proj", "k_proj", "v_proj", "qk_norm", "rope_qk", "attn_sliding", "out_proj", "residual_add", "ffn_norm", "mlp_gate_up", "silu_mul", "mlp_down", "residual_add"]
+    if kind == "attention_or_sliding_attention":
+        return ["attn_norm", "q_proj", "k_proj", "v_proj", "qk_norm", "rope_qk", "attn_or_attn_sliding", "out_proj", "residual_add", "ffn_norm", "mlp_gate_up", "silu_mul", "mlp_down", "residual_add"]
+    if kind == "deltanet":
+        return ["attn_norm", "recurrent_qkv_proj", "recurrent_dt_gate", "recurrent_conv_state_update", "recurrent_qk_l2_norm", "recurrent_core", "recurrent_norm_gate", "recurrent_out_proj", "residual_add", "ffn_norm", "mlp_gate_up", "silu_mul", "mlp_down", "residual_add"]
+    if kind == "mamba":
+        return ["attn_norm", "mamba_in_proj", "mamba_in_proj_split", "mamba_conv1d_silu", "mamba_dt_softplus", "mamba_selective_scan", "mamba_rmsnorm_gate", "mamba_out_proj", "residual_add"]
+    if kind == "moe":
+        return ["attn_norm", "q_proj", "k_proj", "v_proj", "rope_qk", "attn", "out_proj", "residual_add", "ffn_norm", "moe_router", "group_limited_topk_router", "moe_relu2_expert_mlp", "shared_relu2_expert_mlp", "residual_add"]
+    if kind == "mla_dense_mlp":
+        return ["attn_norm", "q_proj", "kv_a_proj", "kv_a_layernorm", "kv_lora_decompress", "partial_rope_concat", "mla_attention", "out_proj", "residual_add", "ffn_norm", "mlp_gate_up", "silu_mul", "mlp_down", "residual_add"]
+    if kind == "mla_moe":
+        return ["attn_norm", "q_proj", "kv_a_proj", "kv_a_layernorm", "kv_lora_decompress", "partial_rope_concat", "mla_attention", "out_proj", "residual_add", "ffn_norm", "moe_router", "group_limited_topk_router", "moe_swiglu_expert_mlp", "shared_swiglu_expert_mlp", "residual_add"]
+    if arch == "gemma4" and kind in {"sliding_attention_shared_kv", "full_attention_shared_kv"}:
+        attn = "attn_sliding_shared_kv" if kind.startswith("sliding") else "attn_shared_kv"
+        return ["attn_norm", "q_proj", "q_norm", "rope_q", attn, "out_proj", "post_attention_norm", "residual_add", "ffn_norm", "mlp_gate_up", "gelu", "mlp_down", "post_ffn_norm", "residual_add", "gemma4_per_layer_embed"]
+    return ["attn_norm", "q_proj", "k_proj", "v_proj", "rope_qk", "attn", "out_proj", "residual_add", "ffn_norm", "mlp_gate_up", "silu_mul", "mlp_down", "residual_add"]
+
+
+def _template_candidate_name(arch: str) -> str | None:
+    candidates = {
+        "llama": "llama.json",
+        "qwen2": "qwen2.json",
+        "qwen3": "qwen3.json",
+        "qwen35": "qwen35.json",
+        "gemma3": "gemma3.json",
+        "gemma4": "gemma4.json",
+        "nemotron_h": "nemotron_h.json",
+        "kimi_vl": "kimi_vl.json",
+    }
+    name = candidates.get(arch)
+    if name and (REPO_ROOT / "version" / "v8" / "templates" / name).exists():
+        return name
+    return name
+
+
+def suggest_template(config: dict[str, Any]) -> dict[str, Any]:
+    arch = _infer_arch(config)
+    layer_kinds = _layer_kinds(arch, config)
+    unique_kinds = sorted(set(layer_kinds))
+    text = _text_config(config)
+    template_name = _template_candidate_name(arch)
+    existing = bool(template_name and (REPO_ROOT / "version" / "v8" / "templates" / template_name).exists())
+    header = ["bpe_tokenizer", "dense_embedding_lookup"]
+    if arch == "gemma4":
+        header.append("gemma4_per_layer_prepare")
+    if arch == "kimi_vl":
+        header = ["tiktoken_tokenizer", "dense_embedding_lookup"]
+    body_by_kind = {kind: _template_body_ops_for_kind(kind, arch) for kind in unique_kinds}
+    footer = ["final_rmsnorm", "weight_tying", "logits"]
+    if arch == "gemma4":
+        footer = ["final_rmsnorm", "final_logit_softcap", "weight_tying", "logits"]
+    modalities = ["text"]
+    if isinstance(config.get("vision_config"), dict):
+        modalities.append("vision")
+    if isinstance(config.get("audio_config"), dict):
+        modalities.append("audio")
+    return {
+        "candidate_template": template_name,
+        "candidate_template_exists": existing,
+        "confidence": "existing_template" if existing else "sketch",
+        "modalities": modalities,
+        "sequence": ["decoder"],
+        "block_sketch": {
+            "header": header,
+            "body": {
+                "kind_config_key": "layer_kinds" if unique_kinds else None,
+                "ops_by_kind": body_by_kind,
+            },
+            "footer": footer,
+        },
+        "shape_hints": {
+            "hidden_size": int(text.get("hidden_size") or 0),
+            "intermediate_size": int(text.get("intermediate_size") or 0),
+            "num_layers": int(text.get("num_hidden_layers") or len(layer_kinds) or 0),
+            "num_attention_heads": int(text.get("num_attention_heads") or 0),
+            "num_key_value_heads": int(text.get("num_key_value_heads") or 0),
+        },
+    }
+
+
+def _find_safetensors_index(root: Path) -> Path | None:
+    candidates = [
+        root / "model.safetensors.index.json",
+        root / "model.safetensors.index.json".replace("model.", ""),
+    ]
+    candidates.extend(sorted(root.glob("*.safetensors.index.json")))
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def _weights_audit(root: Path, arch: str) -> dict[str, Any]:
+    index = _find_safetensors_index(root)
+    if index is None:
+        return {
+            "status": "skipped",
+            "reason": "no model.safetensors.index.json found",
+        }
+    import audit_safetensors_index_v8  # type: ignore
+
+    report = audit_safetensors_index_v8.audit_index(index, arch=arch)
+    return {
+        "status": "pass" if report.get("status", "pass") != "fail" else "fail",
+        "index": str(index),
+        "families": report.get("families", {}),
+        "layer_count": report.get("layer_count", 0),
+        "tensor_count": report.get("tensor_count", 0),
+        "shard_count": report.get("shard_count", 0),
+        "model_map_status": report.get("model_map_status"),
+        "required_tensor_patterns": report.get("required_tensor_patterns"),
+    }
+
+
+def inspect_config(config: dict[str, Any], *, model_root: Path | None = None, include_weights: bool = False) -> dict[str, Any]:
     text = _text_config(config)
     arch = _infer_arch(config)
     layer_kinds = _layer_kinds(arch, config)
     required_ops = _required_ops(arch, config, layer_kinds)
     missing_ops = _missing_ops(arch, required_ops)
+    kernel_report = _kernel_registry_report(required_ops)
+    template_suggestion = suggest_template(config)
     status = "supported" if not missing_ops else "bringup_required"
-    return {
+    report = {
         "arch": arch,
         "model_type": text.get("model_type") or config.get("model_type"),
         "architectures": config.get("architectures", []),
@@ -229,8 +438,13 @@ def inspect_config(config: dict[str, Any]) -> dict[str, Any]:
         "layer_kind_counts": dict(sorted(Counter(layer_kinds).items())),
         "required_ops": required_ops,
         "missing_ops": missing_ops,
+        "kernel_registry": kernel_report,
+        "template_suggestion": template_suggestion,
         "notes": _notes(arch, config, layer_kinds, missing_ops),
     }
+    if include_weights:
+        report["weights_audit"] = _weights_audit(model_root or Path("."), arch)
+    return report
 
 
 def _notes(arch: str, config: dict[str, Any], layer_kinds: list[str], missing_ops: list[str]) -> list[str]:
@@ -275,9 +489,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Inspect a model config and report CK v8 compatibility contract")
     ap.add_argument("config", type=Path, help="config.json or model directory")
     ap.add_argument("--json-out", type=Path)
+    ap.add_argument("--weights-audit", action="store_true", help="audit safetensors index tensor families if present")
+    ap.add_argument("--suggest-template", action="store_true", help="include candidate template/circuit sketch (currently included by default)")
     args = ap.parse_args()
 
-    report = inspect_config(_load_config(args.config))
+    report = inspect_config(_load_config(args.config), model_root=_model_root(args.config), include_weights=args.weights_audit)
     text = json.dumps(report, indent=2, sort_keys=True) + "\n"
     if args.json_out:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)

--- a/version/v8/scripts/run_gemma4_speculative_pair_probe_v8.py
+++ b/version/v8/scripts/run_gemma4_speculative_pair_probe_v8.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+
+
+def _find_runtime_lib(run_dir: Path) -> Path:
+    for name in ("libmodel.so", "ck-kernel-inference.so", "ck-kernel-decode.so"):
+        candidate = run_dir / name
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"no generated runtime library found in {run_dir}")
+
+
+def _find_weights(run_dir: Path) -> Path:
+    candidate = run_dir / "weights.bump"
+    if not candidate.exists():
+        raise FileNotFoundError(f"weights.bump not found in {run_dir}")
+    return candidate
+
+
+class RuntimeProbe:
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        self.lib_path = _find_runtime_lib(run_dir)
+        self.weights_path = _find_weights(run_dir)
+        self.lib = ctypes.CDLL(str(self.lib_path))
+        self.initialized = False
+
+        self.lib.ck_model_init.argtypes = [ctypes.c_char_p]
+        self.lib.ck_model_init.restype = ctypes.c_int
+        self.lib.ck_model_free.argtypes = []
+        self.lib.ck_model_free.restype = None
+
+        self.has_named_activations = False
+        try:
+            self.lib.ck_model_get_named_activation_ptr.argtypes = [ctypes.c_char_p]
+            self.lib.ck_model_get_named_activation_ptr.restype = ctypes.c_void_p
+            self.lib.ck_model_get_named_activation_nbytes.argtypes = [ctypes.c_char_p]
+            self.lib.ck_model_get_named_activation_nbytes.restype = ctypes.c_ssize_t
+            self.lib.ck_model_get_named_activation_runtime_offset.argtypes = [ctypes.c_char_p]
+            self.lib.ck_model_get_named_activation_runtime_offset.restype = ctypes.c_ssize_t
+            self.has_named_activations = True
+        except AttributeError:
+            self.has_named_activations = False
+
+    def init(self) -> None:
+        rc = int(self.lib.ck_model_init(str(self.weights_path).encode()))
+        if rc != 0:
+            raise RuntimeError(f"ck_model_init failed for {self.run_dir} with code {rc}")
+        self.initialized = True
+
+    def close(self) -> None:
+        if self.initialized:
+            self.lib.ck_model_free()
+            self.initialized = False
+
+    def activation_info(self, name: str) -> dict[str, Any]:
+        if not self.has_named_activations:
+            return {"name": name, "present": False, "reason": "runtime lacks named activation API"}
+        b_name = name.encode()
+        nbytes = int(self.lib.ck_model_get_named_activation_nbytes(b_name))
+        offset = int(self.lib.ck_model_get_named_activation_runtime_offset(b_name))
+        ptr = int(self.lib.ck_model_get_named_activation_ptr(b_name) or 0)
+        return {
+            "name": name,
+            "present": bool(nbytes > 0 and ptr != 0),
+            "nbytes": nbytes,
+            "runtime_offset": offset,
+            "ptr_nonzero": bool(ptr != 0),
+        }
+
+
+def _load_engine_lib() -> ctypes.CDLL:
+    candidates = (
+        REPO_ROOT / "build" / "libckernel_engine.so",
+        REPO_ROOT / "libckernel_engine.so",
+    )
+    for path in candidates:
+        if path.exists():
+            lib = ctypes.CDLL(str(path))
+            lib.speculative_verify_greedy_f32.argtypes = [
+                ctypes.POINTER(ctypes.c_float),
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.POINTER(ctypes.c_int),
+            ]
+            lib.speculative_verify_greedy_f32.restype = None
+            lib.speculative_commit_one_i32.argtypes = [
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.c_int,
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.POINTER(ctypes.c_int),
+            ]
+            lib.speculative_commit_one_i32.restype = None
+            return lib
+    raise FileNotFoundError("build/libckernel_engine.so not found; run make build/libckernel_engine.so")
+
+
+def run_kernel_smoke() -> dict[str, Any]:
+    lib = _load_engine_lib()
+    vocab = 16
+    logits = (ctypes.c_float * vocab)(*[0.0] * vocab)
+    logits[5] = 10.0
+    accepted = ctypes.c_int(-1)
+    verified = ctypes.c_int(-1)
+    lib.speculative_verify_greedy_f32(logits, vocab, 5, ctypes.byref(accepted), ctypes.byref(verified))
+    accept_case = (accepted.value, verified.value)
+    lib.speculative_verify_greedy_f32(logits, vocab, 3, ctypes.byref(accepted), ctypes.byref(verified))
+    reject_case = (accepted.value, verified.value)
+
+    token_buf = (ctypes.c_int * 4)(-1, -1, -1, -1)
+    token_count = ctypes.c_int(0)
+    target_pos = ctypes.c_int(0)
+    draft_pos = ctypes.c_int(0)
+    accepted_count = ctypes.c_int(0)
+    rejected_count = ctypes.c_int(0)
+    lib.speculative_commit_one_i32(
+        1,
+        5,
+        token_buf,
+        ctypes.byref(token_count),
+        4,
+        ctypes.byref(target_pos),
+        ctypes.byref(draft_pos),
+        ctypes.byref(accepted_count),
+        ctypes.byref(rejected_count),
+    )
+    lib.speculative_commit_one_i32(
+        0,
+        7,
+        token_buf,
+        ctypes.byref(token_count),
+        4,
+        ctypes.byref(target_pos),
+        ctypes.byref(draft_pos),
+        ctypes.byref(accepted_count),
+        ctypes.byref(rejected_count),
+    )
+    passed = (
+        accept_case == (1, 5)
+        and reject_case == (0, 5)
+        and list(token_buf)[:2] == [5, 7]
+        and token_count.value == 2
+        and target_pos.value == 2
+        and draft_pos.value == 2
+        and accepted_count.value == 1
+        and rejected_count.value == 1
+    )
+    return {
+        "passed": passed,
+        "accept_case": list(accept_case),
+        "reject_case": list(reject_case),
+        "tokens": list(token_buf),
+        "token_count": token_count.value,
+        "target_position": target_pos.value,
+        "draft_position": draft_pos.value,
+        "accepted_count": accepted_count.value,
+        "rejected_count": rejected_count.value,
+    }
+
+
+def probe_pair(target_run: Path | None, draft_run: Path | None) -> dict[str, Any]:
+    out: dict[str, Any] = {"kernel_smoke": run_kernel_smoke()}
+    probes: list[RuntimeProbe] = []
+    try:
+        if target_run is not None:
+            target = RuntimeProbe(target_run)
+            probes.append(target)
+            target.init()
+            out["target"] = {
+                "run_dir": str(target_run),
+                "lib": str(target.lib_path),
+                "has_named_activations": target.has_named_activations,
+                "candidate_hidden_exports": [
+                    target.activation_info(name)
+                    for name in ("target_hidden_stream", "main_stream", "layer_output")
+                ],
+            }
+        if draft_run is not None:
+            draft = RuntimeProbe(draft_run)
+            probes.append(draft)
+            draft.init()
+            out["draft"] = {
+                "run_dir": str(draft_run),
+                "lib": str(draft.lib_path),
+                "has_named_activations": draft.has_named_activations,
+                "candidate_backbone_inputs": [
+                    draft.activation_info(name)
+                    for name in ("draft_backbone_stream", "backbone_stream")
+                ],
+            }
+    finally:
+        for probe in reversed(probes):
+            probe.close()
+    out["passed"] = bool(out["kernel_smoke"]["passed"])
+    if target_run is not None:
+        out["passed"] = out["passed"] and any(
+            item.get("present") for item in out.get("target", {}).get("candidate_hidden_exports", [])
+        )
+    if draft_run is not None:
+        out["passed"] = out["passed"] and any(
+            item.get("present") for item in out.get("draft", {}).get("candidate_backbone_inputs", [])
+        )
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Probe Gemma4 target + assistant speculative runtime bridge readiness.")
+    ap.add_argument("--target-run", type=Path, help="Generated Gemma4 backbone runtime directory.")
+    ap.add_argument("--draft-run", type=Path, help="Generated Gemma4 assistant runtime directory.")
+    ap.add_argument("--kernel-smoke-only", action="store_true", help="Only validate speculative verifier/commit kernels.")
+    args = ap.parse_args()
+
+    if args.kernel_smoke_only:
+        result = {"passed": True, "kernel_smoke": run_kernel_smoke()}
+        result["passed"] = bool(result["kernel_smoke"]["passed"])
+    else:
+        result = probe_pair(args.target_run, args.draft_run)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("passed") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/templates/gemma4.json
+++ b/version/v8/templates/gemma4.json
@@ -104,9 +104,14 @@
   },
   "kernels": {
     "rope_qk": "rope_forward_qk_split_direct",
+    "rope_q": "rope_forward_q_gemma4",
     "rope_init": "rope_precompute_cache_split",
     "attn": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
     "attn_sliding": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+    "attn_shared_kv_prefill": "attention_forward_causal_head_major_shared_kv_gemma4",
+    "attn_sliding_shared_kv_prefill": "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+    "attn_shared_kv_decode": "attention_forward_decode_head_major_shared_kv_gemma4",
+    "attn_sliding_shared_kv_decode": "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
     "attn_decode": "attention_forward_decode_head_major_gqa_flash_gemma4",
     "attn_sliding_decode": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4"
   },

--- a/version/v8/templates/gemma4_assistant.json
+++ b/version/v8/templates/gemma4_assistant.json
@@ -83,7 +83,9 @@
       "pre_projection_weight": "assistant.pre_projection",
       "post_projection_weight": "assistant.post_projection",
       "target_backbone_hidden_size_config_key": "backbone_hidden_size",
-      "attention_k_eq_v": true
+      "attention_k_eq_v": true,
+      "bridge_input_slot": "backbone_stream",
+      "bridge_output_slot": "backbone_stream"
     },
     "logits_contract": {
       "final_norm": "rmsnorm",
@@ -98,9 +100,14 @@
   },
   "kernels": {
     "rope_qk": "rope_forward_qk_split_direct",
+    "rope_q": "rope_forward_q_gemma4",
     "rope_init": "rope_precompute_cache_split",
     "attn": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
     "attn_sliding": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+    "attn_shared_kv_prefill": "attention_forward_causal_head_major_shared_kv_gemma4",
+    "attn_sliding_shared_kv_prefill": "attention_forward_causal_head_major_shared_kv_sliding_gemma4",
+    "attn_shared_kv_decode": "attention_forward_decode_head_major_shared_kv_gemma4",
+    "attn_sliding_shared_kv_decode": "attention_forward_decode_head_major_shared_kv_sliding_gemma4",
     "attn_decode": "attention_forward_decode_head_major_gqa_flash_gemma4",
     "attn_sliding_decode": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4"
   },
@@ -116,7 +123,8 @@
       ],
       "header": [
         "bpe_tokenizer",
-        "dense_embedding_lookup"
+        "dense_embedding_lookup",
+        "assistant_pre_projection"
       ],
       "body": {
         "type": "hybrid_sliding_attention",
@@ -158,7 +166,8 @@
             "gelu",
             "mlp_down",
             "post_ffn_norm",
-            "residual_add"
+            "residual_add",
+            "assistant_layer_scale"
           ],
           "full_attention_q_only_k_eq_v": [
             "attn_norm",
@@ -174,12 +183,14 @@
             "gelu",
             "mlp_down",
             "post_ffn_norm",
-            "residual_add"
+            "residual_add",
+            "assistant_layer_scale"
           ]
         }
       },
       "footer": [
         "final_rmsnorm",
+        "assistant_post_projection",
         "weight_tying",
         "logits"
       ]

--- a/version/v8/templates/gemma4_assistant.json
+++ b/version/v8/templates/gemma4_assistant.json
@@ -1,0 +1,188 @@
+{
+  "version": 1,
+  "name": "gemma4_assistant",
+  "family": "gemma4",
+  "status": "bump_mapping_first_pass",
+  "flags": {
+    "use_qkv_bias": false,
+    "activation": "gelu_pytorch_tanh",
+    "rope": "rope",
+    "tokenizer": "sentencepiece",
+    "scale_embeddings_sqrt_dim": true,
+    "has_qk_norm": true,
+    "attention": "q_only_k_eq_v_hybrid_sliding_window",
+    "assistant_role": "mtp_drafter"
+  },
+  "contract": {
+    "tokenizer_contract": {
+      "tokenizer_type": "sentencepiece",
+      "bos_policy": "model_defined",
+      "eos_policy": "model_defined",
+      "special_tokens": {
+        "source": "manifest_or_hf"
+      }
+    },
+    "chat_contract": {
+      "version": 1,
+      "name": "gemma4_assistant",
+      "raw_prompt_allowed": false,
+      "turn_prefix": "<|turn>{role}\n",
+      "turn_suffix": "<turn|>\n",
+      "assistant_generation_prefix": "<|turn>model\n",
+      "role_labels": {
+        "system": "system",
+        "user": "user",
+        "assistant": "model"
+      },
+      "system_prompt_mode": "dedicated_turn",
+      "system_prompt_separator": "\n\n",
+      "default_system_prompt": "",
+      "inject_default_system_prompt": false,
+      "force_bos_text_if_tokenizer_add_bos_false": "<bos>",
+      "last_user_prefix": "",
+      "last_user_prefix_suppression_markers": [],
+      "stop_text_markers": [
+        "<turn|>"
+      ],
+      "token_stop_markers": [
+        "<turn|>"
+      ],
+      "template_markers": [
+        "<|turn>",
+        "<turn|>",
+        "<|image|>",
+        "<|audio|>",
+        "<|think|>"
+      ],
+      "min_response_tokens": 8,
+      "image_begin_marker": "<|image>",
+      "image_end_marker": "<image|>"
+    },
+    "attention_contract": {
+      "rope_layout": "split",
+      "rope_type": "rope",
+      "qk_norm": "q_only",
+      "kv_layout": "q_equals_k_equals_v",
+      "attn_variant": "q_only_k_eq_v_hybrid_sliding_attention",
+      "layer_policy_config_key": "layer_attention_plan",
+      "layer_kind_config_key": "layer_kinds",
+      "kv_policy_config_key": "layer_kv_policy",
+      "sliding_window_config_key": "layer_sliding_window",
+      "rope_kind_config_key": "layer_rope_kind",
+      "rope_param_mode": "per_layer_direct"
+    },
+    "block_contract": {
+      "norm_type": "rmsnorm",
+      "mlp_formula": "gate_up -> gelu_pytorch_tanh -> down",
+      "activation": "gelu_pytorch_tanh",
+      "qkv_bias": false,
+      "body_type": "q_only_k_eq_v_hybrid_sliding_attention"
+    },
+    "assistant_contract": {
+      "role": "mtp_drafter",
+      "pre_projection_weight": "assistant.pre_projection",
+      "post_projection_weight": "assistant.post_projection",
+      "target_backbone_hidden_size_config_key": "backbone_hidden_size",
+      "attention_k_eq_v": true
+    },
+    "logits_contract": {
+      "final_norm": "rmsnorm",
+      "lm_head": "weight_tying",
+      "logits_layout": "auto"
+    },
+    "quant_contract": {
+      "kernel_select": "weight_dtype_registry",
+      "activation_dtype": "fp32_or_q8_path",
+      "per_tensor_mixed_quant": true
+    }
+  },
+  "kernels": {
+    "rope_qk": "rope_forward_qk_split_direct",
+    "rope_init": "rope_precompute_cache_split",
+    "attn": "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
+    "attn_sliding": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
+    "attn_decode": "attention_forward_decode_head_major_gqa_flash_gemma4",
+    "attn_sliding_decode": "attention_forward_decode_head_major_gqa_flash_sliding_gemma4"
+  },
+  "sequence": [
+    "decoder"
+  ],
+  "block_types": {
+    "decoder": {
+      "sequence": [
+        "header",
+        "body",
+        "footer"
+      ],
+      "header": [
+        "bpe_tokenizer",
+        "dense_embedding_lookup"
+      ],
+      "body": {
+        "type": "hybrid_sliding_attention",
+        "kind_config_key": "layer_kinds",
+        "default_kind": "sliding_attention_q_only_k_eq_v",
+        "quant_aliases_common": {
+          "ln1_gamma": "attn_norm",
+          "ln2_gamma": "ffn_norm",
+          "post_attention_norm": "attn_post_norm",
+          "post_ffn_norm": "ffn_post_norm",
+          "w1": "ffn_gate",
+          "w3": "ffn_up",
+          "w2": "ffn_down"
+        },
+        "quant_aliases_by_kind": {
+          "sliding_attention_q_only_k_eq_v": {
+            "wq": "attn_q",
+            "wo": "attn_output",
+            "q_norm": "attn_q_norm"
+          },
+          "full_attention_q_only_k_eq_v": {
+            "wq": "attn_q",
+            "wo": "attn_output",
+            "q_norm": "attn_q_norm"
+          }
+        },
+        "ops_by_kind": {
+          "sliding_attention_q_only_k_eq_v": [
+            "attn_norm",
+            "q_proj",
+            "q_norm",
+            "rope_q",
+            "attn_sliding_shared_kv",
+            "out_proj",
+            "post_attention_norm",
+            "residual_add",
+            "ffn_norm",
+            "mlp_gate_up",
+            "gelu",
+            "mlp_down",
+            "post_ffn_norm",
+            "residual_add"
+          ],
+          "full_attention_q_only_k_eq_v": [
+            "attn_norm",
+            "q_proj",
+            "q_norm",
+            "rope_q",
+            "attn_shared_kv",
+            "out_proj",
+            "post_attention_norm",
+            "residual_add",
+            "ffn_norm",
+            "mlp_gate_up",
+            "gelu",
+            "mlp_down",
+            "post_ffn_norm",
+            "residual_add"
+          ]
+        }
+      },
+      "footer": [
+        "final_rmsnorm",
+        "weight_tying",
+        "logits"
+      ]
+    }
+  }
+}

--- a/version/v8/templates/gemma4_speculative_pair.json
+++ b/version/v8/templates/gemma4_speculative_pair.json
@@ -1,0 +1,168 @@
+{
+  "version": 1,
+  "name": "gemma4_speculative_pair",
+  "family": "gemma4",
+  "experimental": true,
+  "description": "Composite Gemma4 target + Gemma4 assistant/MTP drafter speculative circuit. This is a circuit contract scaffold; full codegen lowering is hardened on Xeon.",
+  "flags": {
+    "composite_runtime": true,
+    "target_template": "gemma4",
+    "draft_template": "gemma4_assistant",
+    "verify_mode": "greedy",
+    "draft_tokens_initial": 1
+  },
+  "contract": {
+    "target": {
+      "role": "authoritative_decoder",
+      "template": "gemma4",
+      "weight_namespace": "target",
+      "hidden_export": "target_hidden_stream",
+      "hidden_size": 2560
+    },
+    "draft": {
+      "role": "mtp_drafter",
+      "template": "gemma4_assistant",
+      "weight_namespace": "draft",
+      "backbone_hidden_input": "draft_backbone_stream",
+      "hidden_size": 256,
+      "backbone_hidden_size": 2560,
+      "standalone_text_inference_supported": false
+    },
+    "bridge": {
+      "op": "target_hidden_to_draft_backbone_stream",
+      "source": "target_hidden_stream",
+      "dest": "draft_backbone_stream",
+      "shape": ["T", 2560],
+      "dtype": "fp32"
+    },
+    "verifier": {
+      "op": "speculative_verify_greedy",
+      "kernel": "speculative_verify_greedy_f32",
+      "inputs": {
+        "target_logits": "target_logits",
+        "draft_token": "draft_candidate_token"
+      },
+      "outputs": {
+        "accepted": "accepted_flag",
+        "verified_token": "verified_token"
+      }
+    },
+    "committer": {
+      "op": "speculative_commit_or_reject",
+      "kernel": "speculative_commit_one_i32",
+      "inputs": {
+        "accepted": "accepted_flag",
+        "verified_token": "verified_token"
+      },
+      "state": {
+        "token_buffer": "token_buffer",
+        "token_count": "token_count",
+        "target_position": "target_position",
+        "draft_position": "draft_position",
+        "accepted_count": "accepted_count",
+        "rejected_count": "rejected_count"
+      }
+    }
+  },
+  "sequence": [
+    "target_prefill",
+    "speculative_decode"
+  ],
+  "block_types": {
+    "target_prefill": {
+      "type": "composite_ref",
+      "template": "gemma4",
+      "outputs": [
+        "target_kv_cache",
+        "target_hidden_stream",
+        "target_logits"
+      ]
+    },
+    "speculative_decode": {
+      "type": "composite_sequence",
+      "ops": [
+        {
+          "op": "target_decode_step",
+          "template": "gemma4",
+          "graph_slots": {
+            "outputs": {
+              "logits": "target_logits",
+              "hidden": "target_hidden_stream",
+              "kv_cache": "target_kv_cache"
+            }
+          }
+        },
+        {
+          "op": "target_hidden_to_draft_backbone_stream",
+          "kernel": "memcpy",
+          "graph_slots": {
+            "inputs": {
+              "src": "target_hidden_stream"
+            },
+            "outputs": {
+              "dst": "draft_backbone_stream"
+            }
+          }
+        },
+        {
+          "op": "draft_decode_step",
+          "template": "gemma4_assistant",
+          "graph_slots": {
+            "inputs": {
+              "backbone_stream": "draft_backbone_stream"
+            },
+            "outputs": {
+              "logits": "draft_logits",
+              "candidate_token": "draft_candidate_token",
+              "kv_cache": "draft_kv_cache"
+            }
+          }
+        },
+        {
+          "op": "speculative_verify_greedy",
+          "kernel": "speculative_verify_greedy_f32",
+          "graph_slots": {
+            "inputs": {
+              "target_logits": "target_logits",
+              "draft_token": "draft_candidate_token"
+            },
+            "outputs": {
+              "accepted": "accepted_flag",
+              "verified_token": "verified_token"
+            }
+          }
+        },
+        {
+          "op": "speculative_commit_or_reject",
+          "kernel": "speculative_commit_one_i32",
+          "graph_slots": {
+            "inputs": {
+              "accepted": "accepted_flag",
+              "verified_token": "verified_token",
+              "token_buffer": "token_buffer",
+              "token_count": "token_count",
+              "target_position": "target_position",
+              "draft_position": "draft_position",
+              "accepted_count": "accepted_count",
+              "rejected_count": "rejected_count"
+            },
+            "outputs": {
+              "token_buffer": "token_buffer",
+              "token_count": "token_count",
+              "target_position": "target_position",
+              "draft_position": "draft_position",
+              "accepted_count": "accepted_count",
+              "rejected_count": "rejected_count"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "notes": [
+    "First implementation is greedy one-token speculative verification.",
+    "The target/backbone remains authoritative; assistant output is accepted only after target verification.",
+    "The target decoder is not an encoder, but the bridge is encoder-like: it exports hidden state consumed by the assistant decoder.",
+    "Keep target and draft BUMP files separate for the first implementation; merge later only after correctness is proven."
+  ]
+}


### PR DESCRIPTION
## Summary

This PR hardens the v8 Gemma4 assistant/MTP path and adds the first concrete speculative target+draft bring-up scaffold.

### Gemma4 assistant / MTP runtime
- Add Gemma4 assistant/MTP bridge lowering for pre-projection, post-projection, q-only attention, shared-KV attention, and assistant layer scaling.
- Add q-only Gemma4 contracts for `q_norm`, q-only RoPE, shared-Q KV cache store, shared-KV prefill/decode attention, and sliding shared-KV bindings.
- Add synthetic Gemma4 assistant safetensors -> BUMP -> IR -> generated C runtime coverage.
- Add `gemma4_speculative_pair.json`, a composite decoder+decoder target/draft template contract for Gemma4 backbone + Gemma4 assistant.

### Speculative decode kernels
- Add `speculative_verify_greedy_f32`.
  - Target logits remain authoritative.
  - Draft token is accepted only when it matches the target argmax.
- Add `speculative_commit_one_i32`.
  - Commits one verified token.
  - Advances target/draft positions.
  - Tracks accepted/rejected counts.
- Add v8 kernel maps and registry entries for both speculative kernels.
- Extend `unittest/test_topk.py` with verifier/committer ctypes coverage.

### Host bridge / runtime inspection
- Add optional named-activation accessors to `scripts/ck_chat.py`.
  - Allows host-side access to generated v8 buffers such as `target_hidden_stream`, `main_stream`, `backbone_stream`, and vision bridge buffers without hard-coded offsets.
- Add `run_gemma4_speculative_pair_probe_v8.py`.
  - `--kernel-smoke-only` validates verifier/commit kernels.
  - `--target-run ... --draft-run ...` checks whether generated target/draft runtimes expose the required bridge activations.

### v8 model-family bring-up inspector
- Extend `inspect_model_contract_v8.py` into a model bring-up radar.
- It now reports:
  - inferred architecture
  - layer-kind schedule
  - required conceptual ops
  - missing model/template contracts
  - missing kernel-registry ops
  - candidate template/circuit sketch
  - optional safetensors-index tensor family audit via `--weights-audit`
- Add Make wrapper:
  - `make v8-model-kernel-inspect MODEL=/path/to/model-or-config.json`
  - `make v8-model-kernel-inspect MODEL=/path/to/model ARGS=--weights-audit`
- The Make wrapper treats return code `2` as a normal “bringup required” report, while still failing on execution errors.

### Docs
- Add Gemma4 speculative pair design page.
- Add CKE throughput unit / 1 PB/s north-star page.
- Regenerate docs site pages and sitemap for the new pages.

## Validation

- `.venv/bin/python -m py_compile scripts/ck_chat.py version/v8/scripts/inspect_model_contract_v8.py version/v8/scripts/run_gemma4_speculative_pair_probe_v8.py tests/test_ck_chat_runtime_contract.py tests/test_v8_model_contract_inspector.py tests/test_v8_gemma4_scaffold.py unittest/test_topk.py`
- `make build/libckernel_engine.so`
- `.venv/bin/python unittest/test_topk.py`
- `.venv/bin/python -m unittest tests.test_v8_gemma4_scaffold -v`
- `.venv/bin/python -m unittest tests.test_v8_model_contract_inspector -v`
- `.venv/bin/python -m unittest tests.test_ck_chat_runtime_contract.TestCKChatRuntimeContract.test_ck_model_reads_named_activation_f32_when_runtime_exports_api -v`
- `.venv/bin/python version/v8/scripts/run_gemma4_speculative_pair_probe_v8.py --kernel-smoke-only`
- `make v8-model-kernel-inspect CONFIG=/tmp/ck_qwen3_inspect_config.json`
- `make v8-model-kernel-inspect MODEL=/tmp/ck_kimi_inspect_model ARGS=--weights-audit`
- `bash docs/site/build.sh`
- `git diff --cached --check`
- pre-commit staged snapshot:
  - `v7-regression-fast` passed
  - `v8-regression-fast` passed
- pre-push:
  - submodule pin validation passed
  - visualizer health passed
  - CK-Engine build passed
  - kernel parity passed
  - v8 E2E text smoke passed
  - v8 inference contracts passed
  - v7 training contract smoke passed
  - v7 fast regression passed
  - v8 fast regression passed
  - v7 training-kernel parity passed

## Current Status

This closes the direct Gemma4 assistant q-only/shared-KV kernel and lowering-contract gap, and adds the first concrete speculative decoder+decoder scaffold. Full real Gemma4 assistant E2E still needs the high-memory Xeon path to wire target hidden export -> assistant backbone stream -> verify/commit loop against real Gemma4 backbone and assistant artifacts.

The new v8 model inspector is intentionally staged: config-only and safetensors-index audit are implemented now; the next layer is `--dry-lower`, which should run converter/build-IR validation into a temp manifest and report the first concrete lowering failure.
