### PR TITLE
feat(v8): add explicit Kimi MLA decode cache

### DIFF
--- a/docs/site/_pages/architecture-links.html
+++ b/docs/site/_pages/architecture-links.html
@@ -143,6 +143,8 @@
                 <span class="subtitle">Current operator path for validated v8 multimodal inference</span></li>
             <li><a href="v8-vision-encoder.html">v8 Vision Encoder Architecture</a>
                 <span class="subtitle">How GGUF intake, template lowering, memory planning, and bridge stitching power the working vision path</span></li>
+            <li><a href="v8-mla-kimi.html">v8 MLA / Kimi Decode Cache</a>
+                <span class="subtitle">Kimi/DeepSeek-style MLA template contract, explicit cache store/read lowering, and reference kernels</span></li>
             <li><a href="v7-runbook.html">v7 Inference + Training Runbook</a>
                 <span class="subtitle">Copy/paste commands for HF GGUF inference + true_bpe training</span></li>
             <li><a href="v7-python-authoring.html">v7 Python Authoring Guide</a>

--- a/docs/site/_pages/model-kernel-matrix.html
+++ b/docs/site/_pages/model-kernel-matrix.html
@@ -38,6 +38,7 @@
     .model-card.mc-qwen::before   { background: #16a085; }
     .model-card.mc-gemma3::before { background: var(--blue); }
     .model-card.mc-gemma4::before { background: #f39c12; }
+    .model-card.mc-kimi::before   { background: #b48cff; }
     .model-card.mc-llama::before  { background: #e74c3c; }
     .model-card.mc-gpt2::before   { background: #9b59b6; }
 
@@ -627,6 +628,39 @@
         <span class="mq-chip">GGUF</span>
         <span class="mq-chip">Q4_K</span>
         <span class="mq-chip">Q8_0</span>
+      </div>
+    </div>
+
+    <!-- Kimi / MLA -->
+    <div class="model-card mc-kimi">
+      <span class="model-badge">template: kimi_vl.json</span>
+      <div class="model-title">Kimi / MLA Text Decoder</div>
+      <div class="model-arch">Multi-Head Latent Attention · partial RoPE concat · MoE path<br>Explicit prefill/decode MLA cache contract · DeepSeek-style reference kernels</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 template/lowering — explicit MLA cache store/read ops</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Kernel contract — MLA decompress, partial RoPE concat, decode cache attention</span></div>
+        <div class="mp-row"><span class="mp-dot no"></span><span class="mp-text dim">Full Kimi smoke — high-memory host required; not a laptop CI lane</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up scope: Kimi/MLA support now lowers the latent KV path explicitly instead of hiding cache behavior inside attention. Decode inserts <code>mla_kv_cache_store</code> and switches <code>mla_attention</code> to <code>deepseek_mla_attention_decode_f32</code>; prefill inserts <code>mla_kv_cache_batch_store</code>.
+      </div>
+      <div class="model-tags">
+        <span class="tag fixed">explicit MLA decode cache</span>
+        <span class="tag fixed">BF16 kv_lora path</span>
+        <span class="tag learned">template contract tested</span>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Laptop-safe contract check</span><button class="copy-command" type="button" data-copy-command="cmd-kimi-mla">Copy</button></div>
+        <pre id="cmd-kimi-mla"><code>.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py
+make build/libckernel_engine.so
+.venv/bin/python unittest/test_deepseek_reference_kernels.py
+.venv/bin/python -m unittest tests.test_v8_kimi_template</code></pre>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip">BF16</span>
+        <span class="mq-chip">FP32 reference</span>
+        <span class="mq-chip">MLA cache</span>
+        <span class="mq-chip">MoE</span>
       </div>
     </div>
 

--- a/docs/site/_pages/v8-mla-kimi.html
+++ b/docs/site/_pages/v8-mla-kimi.html
@@ -1,0 +1,231 @@
+<!-- TITLE: v8 MLA / Kimi Decode Cache -->
+<!-- NAV: ARCHITECTURE -->
+
+<style>
+.mla-hero {
+    display: grid;
+    grid-template-columns: 1.05fr 1fr;
+    gap: 1rem;
+    margin: 1rem 0 1.25rem;
+}
+.mla-panel {
+    background: linear-gradient(145deg, rgba(7,173,248,0.09), rgba(255,180,0,0.07));
+    border: 1px solid var(--grey);
+    border-radius: 10px;
+    padding: 1rem 1.1rem;
+}
+.mla-panel h2,
+.mla-panel h3 {
+    margin-top: 0;
+}
+.mla-panel h2::before,
+.mla-panel h3::before {
+    display: none;
+}
+.mla-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 0.75rem;
+}
+.mla-chip {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    background: rgba(7,173,248,0.1);
+    border: 1px solid rgba(7,173,248,0.3);
+    border-radius: 999px;
+    padding: 0.18rem 0.55rem;
+    color: var(--text-secondary);
+}
+.mla-flow {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 0.8rem;
+    margin: 1rem 0;
+}
+.mla-step {
+    background: #0f151c;
+    border: 1px solid #263242;
+    border-radius: 10px;
+    padding: 0.85rem;
+}
+.mla-step-label {
+    color: var(--orange);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    margin-bottom: 0.35rem;
+}
+.mla-step h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1rem;
+}
+.mla-table code {
+    font-size: 0.82rem;
+}
+@media (max-width: 900px) {
+    .mla-hero {
+        grid-template-columns: 1fr;
+    }
+}
+</style>
+
+<h1>v8 MLA / Kimi Decode Cache</h1>
+
+<p>
+    This page documents the v8 implementation contract for Kimi/DeepSeek-style
+    <strong>Multi-Head Latent Attention</strong> (MLA): how the template describes the latent KV path,
+    how lowering inserts explicit prefill/decode cache operations, and which C kernels currently back the graph.
+</p>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Scope</strong><br>
+        This is compiler, template, and kernel-contract support. Full Kimi model smoke is a high-memory lane and is not expected to run on a constrained laptop.
+    </div>
+</div>
+
+<div class="mla-hero">
+    <div class="mla-panel">
+        <h2>Why MLA Exists</h2>
+        <p>
+            Standard attention stores full K and V vectors in the KV cache. MLA compresses the K/V path into a smaller latent representation, then reconstructs the pieces needed by attention.
+            That makes the memory contract different from ordinary GQA/MQA, especially during decode where every token reads historical cache state.
+        </p>
+        <div class="mla-chip-row">
+            <span class="mla-chip">kv_lora_rank</span>
+            <span class="mla-chip">qk_nope_head_dim</span>
+            <span class="mla-chip">qk_rope_head_dim</span>
+            <span class="mla-chip">v_head_dim</span>
+        </div>
+    </div>
+    <div class="mla-panel">
+        <h2>Implemented Surface</h2>
+        <ul>
+            <li><code>version/v8/templates/kimi_vl.json</code> declares the MLA decode cache contract.</li>
+            <li><code>build_ir_v8.py</code> inserts MLA cache store operations and switches decode attention to the MLA decode kernel.</li>
+            <li><code>deepseek_kernels.c</code> owns the reference C MLA kernels.</li>
+            <li>Focused unit tests validate the template lowering without requiring the full Kimi artifact.</li>
+        </ul>
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="Kimi / DeepSeek-style MLA Decode Cache">
+    <img src="assets/mla-kimi-decode-cache.svg" alt="Kimi and DeepSeek-style MLA decode cache diagram showing low-rank KV compression, kv_lora_decompress, partial RoPE concat, explicit cache store, and decode attention.">
+</div>
+
+<h2>The MLA Path</h2>
+
+<div class="mla-flow">
+    <div class="mla-step">
+        <div class="mla-step-label">1 · Normalize</div>
+        <h3>Block RMSNorm</h3>
+        <p>The layer input is normalized before both the Q projection and compressed KV projection consume it.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">2 · Project</div>
+        <h3>Q + compressed KV</h3>
+        <p><code>q_proj</code> emits Q. <code>kv_a_proj</code> emits the compressed latent KV vector instead of full K and V heads.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">3 · Expand</div>
+        <h3>KV LoRA Decompress</h3>
+        <p><code>kv_lora_decompress</code> expands latent KV into no-position K and V scratch buffers using the manifest-selected FP32 or BF16 kernel.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">4 · Position</div>
+        <h3>Partial RoPE concat</h3>
+        <p>The RoPE slice is positioned and concatenated with the no-position K part. This is why Kimi cannot be treated as plain full-head RoPE.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">5 · Cache</div>
+        <h3>Explicit MLA KV store</h3>
+        <p>Prefill writes a batch cache. Decode writes the current token cache. The cache operation is explicit in IR rather than hidden inside attention.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">6 · Attend</div>
+        <h3>MLA decode attention</h3>
+        <p>Decode attention reads the explicit MLA cache and uses <code>deepseek_mla_attention_decode_f32</code>.</p>
+    </div>
+</div>
+
+<h2>Kernel Contract</h2>
+
+<table class="mla-table">
+    <thead>
+        <tr>
+            <th>Template op</th>
+            <th>Kernel</th>
+            <th>Purpose</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>kv_lora_decompress</code></td>
+            <td><code>deepseek_mla_kv_decompress_f32</code><br><code>deepseek_mla_kv_decompress_bf16</code></td>
+            <td>Expand compressed latent KV into K-noPE and V scratch buffers. The BF16 path is selected when <code>mla_kv_b_proj</code> is BF16.</td>
+        </tr>
+        <tr>
+            <td><code>partial_rope_concat</code></td>
+            <td><code>deepseek_mla_partial_rope_concat_packed_f32</code></td>
+            <td>Apply positioned RoPE to the RoPE slice and pack the K representation expected by MLA attention.</td>
+        </tr>
+        <tr>
+            <td><code>mla_kv_cache_batch_store</code></td>
+            <td><code>deepseek_mla_kv_cache_batch_store_f32</code></td>
+            <td>Store prefill K/V scratch into the MLA decode cache for a token block.</td>
+        </tr>
+        <tr>
+            <td><code>mla_kv_cache_store</code></td>
+            <td><code>deepseek_mla_kv_cache_store_f32</code></td>
+            <td>Store the current decode token K/V scratch into the MLA decode cache.</td>
+        </tr>
+        <tr>
+            <td><code>mla_attention</code></td>
+            <td><code>deepseek_mla_attention_f32</code><br><code>deepseek_mla_attention_decode_f32</code></td>
+            <td>Prefill uses the reference MLA attention path. Decode switches to the cache-reading decode kernel.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Why the Cache Is Explicit</h2>
+
+<p>
+    Ordinary transformer lowering can often treat cache store as a generic post-RoPE helper.
+    MLA needs a clearer contract because K and V are produced through a compressed latent path and partial-RoPE concat.
+    If that cache behavior is hidden inside one opaque attention kernel, the IR visualizer cannot show what is stored, tests cannot independently validate cache placement, and future MPI/pipeline execution has no clean ownership boundary for the cache buffers.
+</p>
+
+<pre><code>prefill:
+  x -> norm -> q_proj
+  x -> norm -> kv_a_proj -> kv_a_norm -> kv_lora_decompress
+  q + k_nope + rope -> partial_rope_concat
+  k/v scratch -> mla_kv_cache_batch_store
+  q + cache -> mla_attention
+
+decode:
+  x -> norm -> q_proj
+  x -> norm -> kv_a_proj -> kv_a_norm -> kv_lora_decompress
+  q + k_nope + rope(position=t) -> partial_rope_concat
+  k/v scratch -> mla_kv_cache_store
+  q + historical cache -> mla_attention_decode</code></pre>
+
+<h2>Validation</h2>
+
+<p>
+    The current laptop-safe validation is focused on contracts and kernels, not full Kimi inference:
+</p>
+
+<pre><code>.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py
+make build/libckernel_engine.so
+.venv/bin/python unittest/test_deepseek_reference_kernels.py
+.venv/bin/python -m unittest \
+  tests.test_v8_kimi_template \
+  tests.test_v8_model_contract_inspector \
+  tests.test_v8_template_circuit_audit</code></pre>
+
+<p>
+    A full Kimi run should be treated as a high-memory smoke on a larger CPU host. The important local guarantee is that the template resolves to the intended MLA kernels, the decode cache operations appear explicitly in IR, and existing promoted v8 families do not regress.
+</p>

--- a/docs/site/_pages/v8-runbook.html
+++ b/docs/site/_pages/v8-runbook.html
@@ -188,6 +188,20 @@ python -m pip install -r requirements-v8.txt</pre>
     </div>
     <p class="mini-note">Use this as the current Gemma4 GGUF coherence smoke. A healthy run should produce a normal long answer and stop by EOS or <code>--max-tokens</code>, not by prompt-marker echo or language corruption. The tested local Q4_K_M run generated 1024 coherent C-code tokens; performance work remains separate.</p>
 
+    <h3>Gemma 4 Assistant / MTP Drafter</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://google/gemma-4-E4B-it-assistant \
+  --run /tmp/ck-gemma4-assistant-runtime \
+  --context-len 1024 \
+  --force-convert --force-compile \
+  --generate-only \
+  --chat-template none \
+  --allow-raw-prompt</pre>
+    </div>
+    <p class="mini-note">The assistant artifact is a tiny speculative/MTP drafter, not a standalone chat model. A healthy bring-up converts safetensors directly to BUMP, lowers q-only shared-KV attention, generates C, and compiles <code>libmodel.so</code>. Real chat speedup comes only after pairing this runtime with a compatible Gemma4 backbone via <code>--speculative-draft-model-dir</code>.</p>
+
     <h3>Nemotron Nano 9B v2</h3>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
@@ -215,6 +229,20 @@ python -m pip install -r requirements-v8.txt</pre>
   tests/test_v8_safetensors_to_bump.py</pre>
     </div>
     <p class="mini-note">GLM4 is currently tracked as a v8 template/conversion/parity-harness lane. The patch adds GLM4 GGUF metadata handling, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK comparator. Run full real-model GLM4 smoke on a higher-memory host before promoting it to the high-memory runtime lane.</p>
+
+    <h3>Kimi / MLA Decoder Contract</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre># Low-memory validation lane: MLA template + explicit decode cache kernels
+.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py
+make build/libckernel_engine.so
+.venv/bin/python unittest/test_deepseek_reference_kernels.py
+.venv/bin/python -m unittest \
+  tests.test_v8_kimi_template \
+  tests.test_v8_model_contract_inspector \
+  tests.test_v8_template_circuit_audit</pre>
+    </div>
+    <p class="mini-note">Kimi/MLA is currently a v8 compiler/kernel-contract lane. The template now declares explicit MLA decode-cache behavior, lowering inserts <code>mla_kv_cache_store</code> / <code>mla_kv_cache_batch_store</code>, and decode attention switches to <code>deepseek_mla_attention_decode_f32</code>. See <a href="v8-mla-kimi.html">v8 MLA / Kimi Decode Cache</a> for the architecture notes. Full Kimi runtime smoke belongs on a high-memory host.</p>
 
     <h3>Qwen2 0.5B Instruct</h3>
     <div class="cmd-block">

--- a/docs/site/architecture-links.html
+++ b/docs/site/architecture-links.html
@@ -898,6 +898,9 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
+                        <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
+                        <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
                         <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
@@ -1082,6 +1085,8 @@
                 <span class="subtitle">Current operator path for validated v8 multimodal inference</span></li>
             <li><a href="v8-vision-encoder.html">v8 Vision Encoder Architecture</a>
                 <span class="subtitle">How GGUF intake, template lowering, memory planning, and bridge stitching power the working vision path</span></li>
+            <li><a href="v8-mla-kimi.html">v8 MLA / Kimi Decode Cache</a>
+                <span class="subtitle">Kimi/DeepSeek-style MLA template contract, explicit cache store/read lowering, and reference kernels</span></li>
             <li><a href="v7-runbook.html">v7 Inference + Training Runbook</a>
                 <span class="subtitle">Copy/paste commands for HF GGUF inference + true_bpe training</span></li>
             <li><a href="v7-python-authoring.html">v7 Python Authoring Guide</a>
@@ -1455,7 +1460,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-29</p>
             </div>
         </div>
     </footer>

--- a/docs/site/assets/mla-kimi-decode-cache.svg
+++ b/docs/site/assets/mla-kimi-decode-cache.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Kimi / DeepSeek-style MLA decode cache contract</title>
+  <desc id="desc">Diagram showing hidden state compressed by kv_a_proj, expanded by kv_lora_decompress, combined with partial RoPE, stored into an explicit MLA cache, and consumed by decode attention.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#171b22"/>
+      <stop offset="1" stop-color="#0b1016"/>
+    </linearGradient>
+    <linearGradient id="blue" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#07adf8"/>
+      <stop offset="1" stop-color="#64d2ff"/>
+    </linearGradient>
+    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ffb400"/>
+      <stop offset="1" stop-color="#ff7a18"/>
+    </linearGradient>
+    <linearGradient id="green" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#47b475"/>
+      <stop offset="1" stop-color="#9be7b6"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+    <marker id="arrow-blue" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0,0 L12,6 L0,12 Z" fill="#07adf8"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0,0 L12,6 L0,12 Z" fill="#ffb400"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0,0 L12,6 L0,12 Z" fill="#47b475"/>
+    </marker>
+    <style>
+      .title { fill:#f4f7fb; font:700 34px Inter,Arial,sans-serif; }
+      .subtitle { fill:#a9b4c0; font:400 17px Inter,Arial,sans-serif; }
+      .label { fill:#f4f7fb; font:700 17px Inter,Arial,sans-serif; }
+      .small { fill:#a9b4c0; font:400 13px Inter,Arial,sans-serif; }
+      .mono { fill:#dce6f2; font:500 13px JetBrains Mono,Consolas,monospace; }
+      .box { fill:#121922; stroke:#2b3846; stroke-width:1.2; }
+      .box-hot { fill:#1c1a11; stroke:#77590e; stroke-width:1.4; }
+      .box-cache { fill:#111c17; stroke:#2f6f45; stroke-width:1.4; }
+      .box-blue { fill:#111a22; stroke:#176d95; stroke-width:1.4; }
+      .lane { fill:none; stroke:#2b3846; stroke-width:1.2; stroke-dasharray:5 6; }
+      .arrow-blue { fill:none; stroke:#07adf8; stroke-width:3; marker-end:url(#arrow-blue); }
+      .arrow-orange { fill:none; stroke:#ffb400; stroke-width:3; marker-end:url(#arrow-orange); }
+      .arrow-green { fill:none; stroke:#47b475; stroke-width:3; marker-end:url(#arrow-green); }
+    </style>
+  </defs>
+
+  <rect width="1280" height="720" rx="18" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1224" height="664" rx="15" fill="none" stroke="#2c3540"/>
+
+  <text x="56" y="75" class="title">Kimi / DeepSeek-style MLA Decode Cache</text>
+  <text x="56" y="106" class="subtitle">The “LoRA” in kv_lora_decompress is architectural low-rank KV compression, not an external fine-tuning adapter.</text>
+
+  <rect x="52" y="138" width="1176" height="206" rx="14" class="lane"/>
+  <text x="72" y="166" fill="#ffb400" font-family="Inter,Arial,sans-serif" font-size="15" font-weight="700">Forward attention block</text>
+
+  <g filter="url(#shadow)">
+    <rect x="78" y="204" width="135" height="86" rx="10" class="box-blue"/>
+    <text x="104" y="235" class="label">hidden</text>
+    <text x="95" y="263" class="mono">[embed_dim]</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="260" y="166" width="165" height="72" rx="10" class="box"/>
+    <text x="293" y="196" class="label">q_proj</text>
+    <text x="285" y="219" class="mono">hidden -> Q</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="260" y="258" width="165" height="72" rx="10" class="box-hot"/>
+    <text x="289" y="288" class="label">kv_a_proj</text>
+    <text x="278" y="311" class="mono">hidden -> latent</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="472" y="258" width="178" height="72" rx="10" class="box-hot"/>
+    <text x="501" y="288" class="label">kv_a_norm</text>
+    <text x="497" y="311" class="mono">latent normalized</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="696" y="246" width="210" height="96" rx="10" class="box-hot"/>
+    <text x="731" y="280" class="label">kv_lora_decompress</text>
+    <text x="729" y="304" class="mono">B(A(hidden))</text>
+    <text x="723" y="326" class="small">expands latent -> K_noPE + V</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="696" y="146" width="210" height="76" rx="10" class="box"/>
+    <text x="735" y="177" class="label">partial RoPE</text>
+    <text x="733" y="201" class="mono">K_noPE + K_rope</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="968" y="176" width="210" height="120" rx="10" class="box-blue"/>
+    <text x="1004" y="211" class="label">mla_attention</text>
+    <text x="1000" y="236" class="mono">Q + K + V -> out</text>
+    <text x="995" y="263" class="small">prefill/reference path</text>
+  </g>
+
+  <path d="M213 230 C232 230 238 202 260 202" class="arrow-blue"/>
+  <path d="M213 264 C232 264 238 294 260 294" class="arrow-orange"/>
+  <path d="M425 294 H472" class="arrow-orange"/>
+  <path d="M650 294 H696" class="arrow-orange"/>
+  <path d="M906 286 C936 286 939 248 968 240" class="arrow-blue"/>
+  <path d="M801 246 V222" class="arrow-orange"/>
+  <path d="M906 184 H968" class="arrow-blue"/>
+  <path d="M425 202 H696" class="arrow-blue"/>
+
+  <rect x="52" y="380" width="1176" height="248" rx="14" class="lane"/>
+  <text x="72" y="408" fill="#47b475" font-family="Inter,Arial,sans-serif" font-size="15" font-weight="700">Explicit v8 decode-cache contract</text>
+
+  <g filter="url(#shadow)">
+    <rect x="94" y="450" width="238" height="108" rx="10" class="box-hot"/>
+    <text x="124" y="484" class="label">partial_rope_concat</text>
+    <text x="121" y="511" class="mono">position = current token</text>
+    <text x="121" y="535" class="small">produces current K/V scratch</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="395" y="436" width="240" height="136" rx="10" class="box-cache"/>
+    <text x="436" y="471" class="label">MLA cache store</text>
+    <text x="423" y="499" class="mono">decode: mla_kv_cache_store</text>
+    <text x="423" y="524" class="mono">prefill: batch_store</text>
+    <text x="423" y="550" class="small">explicit IR op, not hidden in attention</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="708" y="430" width="220" height="150" rx="10" class="box-cache"/>
+    <text x="747" y="465" class="label">persistent cache</text>
+    <text x="736" y="493" class="mono">K_cache[KV, T, S]</text>
+    <text x="736" y="518" class="mono">V_cache[KV, T, S]</text>
+    <text x="736" y="545" class="small">separate logical K/V widths</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="1000" y="440" width="190" height="130" rx="10" class="box-blue"/>
+    <text x="1024" y="475" class="label">decode attention</text>
+    <text x="1022" y="502" class="mono">deepseek_mla_</text>
+    <text x="1022" y="524" class="mono">attention_decode_f32</text>
+    <text x="1022" y="550" class="small">reads historical MLA cache</text>
+  </g>
+
+  <path d="M332 504 H395" class="arrow-green"/>
+  <path d="M635 504 H708" class="arrow-green"/>
+  <path d="M928 504 H1000" class="arrow-green"/>
+
+  <rect x="78" y="650" width="1124" height="34" rx="8" fill="#101821" stroke="#2b3846"/>
+  <text x="98" y="672" fill="#b8c4d0" font-family="Inter,Arial,sans-serif" font-size="14">
+    Training implication: kv_a_proj, kv_a_norm, and kv_b_proj are ordinary trainable model weights. Inference needs forward kernels now; full training later needs backward kernels through the same chain.
+  </text>
+</svg>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -898,6 +898,9 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
+                        <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
+                        <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
                         <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
@@ -977,6 +980,7 @@
     .model-card.mc-qwen::before   { background: #16a085; }
     .model-card.mc-gemma3::before { background: var(--blue); }
     .model-card.mc-gemma4::before { background: #f39c12; }
+    .model-card.mc-kimi::before   { background: #b48cff; }
     .model-card.mc-llama::before  { background: #e74c3c; }
     .model-card.mc-gpt2::before   { background: #9b59b6; }
 
@@ -1566,6 +1570,39 @@
         <span class="mq-chip">GGUF</span>
         <span class="mq-chip">Q4_K</span>
         <span class="mq-chip">Q8_0</span>
+      </div>
+    </div>
+
+    <!-- Kimi / MLA -->
+    <div class="model-card mc-kimi">
+      <span class="model-badge">template: kimi_vl.json</span>
+      <div class="model-title">Kimi / MLA Text Decoder</div>
+      <div class="model-arch">Multi-Head Latent Attention · partial RoPE concat · MoE path<br>Explicit prefill/decode MLA cache contract · DeepSeek-style reference kernels</div>
+      <div class="model-pipeline">
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">v8 template/lowering — explicit MLA cache store/read ops</span></div>
+        <div class="mp-row"><span class="mp-dot inference"></span><span class="mp-text">Kernel contract — MLA decompress, partial RoPE concat, decode cache attention</span></div>
+        <div class="mp-row"><span class="mp-dot no"></span><span class="mp-text dim">Full Kimi smoke — high-memory host required; not a laptop CI lane</span></div>
+      </div>
+      <div class="source-note">
+        Bring-up scope: Kimi/MLA support now lowers the latent KV path explicitly instead of hiding cache behavior inside attention. Decode inserts <code>mla_kv_cache_store</code> and switches <code>mla_attention</code> to <code>deepseek_mla_attention_decode_f32</code>; prefill inserts <code>mla_kv_cache_batch_store</code>.
+      </div>
+      <div class="model-tags">
+        <span class="tag fixed">explicit MLA decode cache</span>
+        <span class="tag fixed">BF16 kv_lora path</span>
+        <span class="tag learned">template contract tested</span>
+      </div>
+      <div class="model-command">
+        <div class="model-command-head"><span>Laptop-safe contract check</span><button class="copy-command" type="button" data-copy-command="cmd-kimi-mla">Copy</button></div>
+        <pre id="cmd-kimi-mla"><code>.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py
+make build/libckernel_engine.so
+.venv/bin/python unittest/test_deepseek_reference_kernels.py
+.venv/bin/python -m unittest tests.test_v8_kimi_template</code></pre>
+      </div>
+      <div class="model-quant">
+        <span class="mq-chip">BF16</span>
+        <span class="mq-chip">FP32 reference</span>
+        <span class="mq-chip">MLA cache</span>
+        <span class="mq-chip">MoE</span>
       </div>
     </div>
 
@@ -2388,7 +2425,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-29</p>
             </div>
         </div>
     </footer>

--- a/docs/site/page_metadata.json
+++ b/docs/site/page_metadata.json
@@ -13,6 +13,10 @@
       "title": "Scaling Philosophy for CPU-Only AI Systems",
       "description": "Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks."
     },
+    "cke-throughput-unit.html": {
+      "title": "CKE Throughput Unit: Bytes per Token Path",
+      "description": "The C-Kernel-Engine north-star throughput unit: aggregate active bytes cycled per second across weights, activations, KV cache, Linux runtime, and CPU clusters."
+    },
     "version-history.html": {
       "title": "Version History and Roadmap",
       "description": "Version-by-version roadmap for C-Kernel-Engine, including inference, training, parity, distributed systems, and future capability milestones."
@@ -48,6 +52,10 @@
     "v8-vision-encoder.html": {
       "title": "v8 Vision Encoder Architecture",
       "description": "Architecture page for how C-Kernel-Engine v8 lowers and runs the Qwen3-VL vision encoder, bridges the prefix, and continues generation in the decoder."
+    },
+    "v8-mla-kimi.html": {
+      "title": "v8 MLA / Kimi Decode Cache",
+      "description": "Implementation notes for C-Kernel-Engine v8 Multi-Head Latent Attention support, including Kimi/DeepSeek-style explicit decode cache lowering and kernels."
     },
     "architecture-links.html": {
       "title": "Architecture Links",

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,262 +2,266 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-mla-kimi.html</loc>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-06-26</lastmod>
+    <lastmod>2026-06-29</lastmod>
   </url>
 </urlset>

--- a/docs/site/v8-mla-kimi.html
+++ b/docs/site/v8-mla-kimi.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{PAGE_TITLE}} | C-Kernel-Engine</title>
-    <meta name="description" content="{{META_DESCRIPTION}}">
-    <meta name="robots" content="{{META_ROBOTS}}">
-    <link rel="canonical" href="{{CANONICAL_URL}}">
-    <meta property="og:title" content="{{PAGE_TITLE}} | C-Kernel-Engine">
-    <meta property="og:description" content="{{META_DESCRIPTION}}">
+    <title>v8 MLA / Kimi Decode Cache | C-Kernel-Engine</title>
+    <meta name="description" content="Implementation notes for C-Kernel-Engine v8 Multi-Head Latent Attention support, including Kimi/DeepSeek-style explicit decode cache lowering and kernels.">
+    <meta name="robots" content="index,follow">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/v8-mla-kimi.html">
+    <meta property="og:title" content="v8 MLA / Kimi Decode Cache | C-Kernel-Engine">
+    <meta property="og:description" content="Implementation notes for C-Kernel-Engine v8 Multi-Head Latent Attention support, including Kimi/DeepSeek-style explicit decode cache lowering and kernels.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{CANONICAL_URL}}">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/v8-mla-kimi.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -858,11 +858,11 @@
             <span></span>
         </button>
         <nav class="site-nav">
-            <a href="index.html" class="{{NAV_INDEX}}">Home</a>
-            <a href="spectrum.html" class="{{NAV_SPECTRUM}}" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="{{NAV_QUICKSTART}}">Getting Started</a>
-            <a href="developer-guide.html" class="{{NAV_DEVGUIDE}}">Developer Guide</a>
-            <a href="scaling.html" class="{{NAV_SCALING}}">Scaling</a>
+            <a href="index.html" class="">Home</a>
+            <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
+            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="scaling.html" class="">Scaling</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -902,7 +902,7 @@
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="{{NAV_FLASH_ATTENTION}}">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -917,11 +917,11 @@
                     </div>
                 </div>
             </div>
-            <a href="pytorch-parity.html" class="{{NAV_PARITY}}">PyTorch Parity</a>
-            <a href="test-report.html" class="{{NAV_NIGHTLY}}">Test Report</a>
-            <a href="version-history.html" class="{{NAV_VERSION}}">Versions</a>
-            <a href="research.html" class="{{NAV_RESEARCH}}">Research</a>
-            <a href="decisions.html" class="{{NAV_DECISIONS}}">ADR</a>
+            <a href="pytorch-parity.html" class="">PyTorch Parity</a>
+            <a href="test-report.html" class="">Test Report</a>
+            <a href="version-history.html" class="">Versions</a>
+            <a href="research.html" class="">Research</a>
+            <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
                 <div class="nav-dropdown-menu">
@@ -942,3 +942,466 @@
         </nav>
     </header>
     <main>
+
+<style>
+.mla-hero {
+    display: grid;
+    grid-template-columns: 1.05fr 1fr;
+    gap: 1rem;
+    margin: 1rem 0 1.25rem;
+}
+.mla-panel {
+    background: linear-gradient(145deg, rgba(7,173,248,0.09), rgba(255,180,0,0.07));
+    border: 1px solid var(--grey);
+    border-radius: 10px;
+    padding: 1rem 1.1rem;
+}
+.mla-panel h2,
+.mla-panel h3 {
+    margin-top: 0;
+}
+.mla-panel h2::before,
+.mla-panel h3::before {
+    display: none;
+}
+.mla-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 0.75rem;
+}
+.mla-chip {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    background: rgba(7,173,248,0.1);
+    border: 1px solid rgba(7,173,248,0.3);
+    border-radius: 999px;
+    padding: 0.18rem 0.55rem;
+    color: var(--text-secondary);
+}
+.mla-flow {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 0.8rem;
+    margin: 1rem 0;
+}
+.mla-step {
+    background: #0f151c;
+    border: 1px solid #263242;
+    border-radius: 10px;
+    padding: 0.85rem;
+}
+.mla-step-label {
+    color: var(--orange);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    margin-bottom: 0.35rem;
+}
+.mla-step h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1rem;
+}
+.mla-table code {
+    font-size: 0.82rem;
+}
+@media (max-width: 900px) {
+    .mla-hero {
+        grid-template-columns: 1fr;
+    }
+}
+</style>
+
+<h1>v8 MLA / Kimi Decode Cache</h1>
+
+<p>
+    This page documents the v8 implementation contract for Kimi/DeepSeek-style
+    <strong>Multi-Head Latent Attention</strong> (MLA): how the template describes the latent KV path,
+    how lowering inserts explicit prefill/decode cache operations, and which C kernels currently back the graph.
+</p>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Scope</strong><br>
+        This is compiler, template, and kernel-contract support. Full Kimi model smoke is a high-memory lane and is not expected to run on a constrained laptop.
+    </div>
+</div>
+
+<div class="mla-hero">
+    <div class="mla-panel">
+        <h2>Why MLA Exists</h2>
+        <p>
+            Standard attention stores full K and V vectors in the KV cache. MLA compresses the K/V path into a smaller latent representation, then reconstructs the pieces needed by attention.
+            That makes the memory contract different from ordinary GQA/MQA, especially during decode where every token reads historical cache state.
+        </p>
+        <div class="mla-chip-row">
+            <span class="mla-chip">kv_lora_rank</span>
+            <span class="mla-chip">qk_nope_head_dim</span>
+            <span class="mla-chip">qk_rope_head_dim</span>
+            <span class="mla-chip">v_head_dim</span>
+        </div>
+    </div>
+    <div class="mla-panel">
+        <h2>Implemented Surface</h2>
+        <ul>
+            <li><code>version/v8/templates/kimi_vl.json</code> declares the MLA decode cache contract.</li>
+            <li><code>build_ir_v8.py</code> inserts MLA cache store operations and switches decode attention to the MLA decode kernel.</li>
+            <li><code>deepseek_kernels.c</code> owns the reference C MLA kernels.</li>
+            <li>Focused unit tests validate the template lowering without requiring the full Kimi artifact.</li>
+        </ul>
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="Kimi / DeepSeek-style MLA Decode Cache">
+    <img src="assets/mla-kimi-decode-cache.svg" alt="Kimi and DeepSeek-style MLA decode cache diagram showing low-rank KV compression, kv_lora_decompress, partial RoPE concat, explicit cache store, and decode attention.">
+</div>
+
+<h2>The MLA Path</h2>
+
+<div class="mla-flow">
+    <div class="mla-step">
+        <div class="mla-step-label">1 · Normalize</div>
+        <h3>Block RMSNorm</h3>
+        <p>The layer input is normalized before both the Q projection and compressed KV projection consume it.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">2 · Project</div>
+        <h3>Q + compressed KV</h3>
+        <p><code>q_proj</code> emits Q. <code>kv_a_proj</code> emits the compressed latent KV vector instead of full K and V heads.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">3 · Expand</div>
+        <h3>KV LoRA Decompress</h3>
+        <p><code>kv_lora_decompress</code> expands latent KV into no-position K and V scratch buffers using the manifest-selected FP32 or BF16 kernel.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">4 · Position</div>
+        <h3>Partial RoPE concat</h3>
+        <p>The RoPE slice is positioned and concatenated with the no-position K part. This is why Kimi cannot be treated as plain full-head RoPE.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">5 · Cache</div>
+        <h3>Explicit MLA KV store</h3>
+        <p>Prefill writes a batch cache. Decode writes the current token cache. The cache operation is explicit in IR rather than hidden inside attention.</p>
+    </div>
+    <div class="mla-step">
+        <div class="mla-step-label">6 · Attend</div>
+        <h3>MLA decode attention</h3>
+        <p>Decode attention reads the explicit MLA cache and uses <code>deepseek_mla_attention_decode_f32</code>.</p>
+    </div>
+</div>
+
+<h2>Kernel Contract</h2>
+
+<table class="mla-table">
+    <thead>
+        <tr>
+            <th>Template op</th>
+            <th>Kernel</th>
+            <th>Purpose</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>kv_lora_decompress</code></td>
+            <td><code>deepseek_mla_kv_decompress_f32</code><br><code>deepseek_mla_kv_decompress_bf16</code></td>
+            <td>Expand compressed latent KV into K-noPE and V scratch buffers. The BF16 path is selected when <code>mla_kv_b_proj</code> is BF16.</td>
+        </tr>
+        <tr>
+            <td><code>partial_rope_concat</code></td>
+            <td><code>deepseek_mla_partial_rope_concat_packed_f32</code></td>
+            <td>Apply positioned RoPE to the RoPE slice and pack the K representation expected by MLA attention.</td>
+        </tr>
+        <tr>
+            <td><code>mla_kv_cache_batch_store</code></td>
+            <td><code>deepseek_mla_kv_cache_batch_store_f32</code></td>
+            <td>Store prefill K/V scratch into the MLA decode cache for a token block.</td>
+        </tr>
+        <tr>
+            <td><code>mla_kv_cache_store</code></td>
+            <td><code>deepseek_mla_kv_cache_store_f32</code></td>
+            <td>Store the current decode token K/V scratch into the MLA decode cache.</td>
+        </tr>
+        <tr>
+            <td><code>mla_attention</code></td>
+            <td><code>deepseek_mla_attention_f32</code><br><code>deepseek_mla_attention_decode_f32</code></td>
+            <td>Prefill uses the reference MLA attention path. Decode switches to the cache-reading decode kernel.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Why the Cache Is Explicit</h2>
+
+<p>
+    Ordinary transformer lowering can often treat cache store as a generic post-RoPE helper.
+    MLA needs a clearer contract because K and V are produced through a compressed latent path and partial-RoPE concat.
+    If that cache behavior is hidden inside one opaque attention kernel, the IR visualizer cannot show what is stored, tests cannot independently validate cache placement, and future MPI/pipeline execution has no clean ownership boundary for the cache buffers.
+</p>
+
+<pre><code>prefill:
+  x -> norm -> q_proj
+  x -> norm -> kv_a_proj -> kv_a_norm -> kv_lora_decompress
+  q + k_nope + rope -> partial_rope_concat
+  k/v scratch -> mla_kv_cache_batch_store
+  q + cache -> mla_attention
+
+decode:
+  x -> norm -> q_proj
+  x -> norm -> kv_a_proj -> kv_a_norm -> kv_lora_decompress
+  q + k_nope + rope(position=t) -> partial_rope_concat
+  k/v scratch -> mla_kv_cache_store
+  q + historical cache -> mla_attention_decode</code></pre>
+
+<h2>Validation</h2>
+
+<p>
+    The current laptop-safe validation is focused on contracts and kernels, not full Kimi inference:
+</p>
+
+<pre><code>.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py
+make build/libckernel_engine.so
+.venv/bin/python unittest/test_deepseek_reference_kernels.py
+.venv/bin/python -m unittest \
+  tests.test_v8_kimi_template \
+  tests.test_v8_model_contract_inspector \
+  tests.test_v8_template_circuit_audit</code></pre>
+
+<p>
+    A full Kimi run should be treated as a high-memory smoke on a larger CPU host. The important local guarantee is that the template resolves to the intended MLA kernels, the decode cache operations appear explicitly in IR, and existing promoted v8 families do not regress.
+</p>
+    </main>
+
+    <!-- SVG Viewer Overlay (shared across all pages) -->
+    <style>
+    .svg-viewer { cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
+    .svg-viewer:hover { transform: scale(1.01); box-shadow: 0 8px 32px rgba(255, 180, 0, 0.3); }
+    #svg-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.95); z-index: 999999; }
+    #svg-overlay .toolbar { position: fixed; top: 0; left: 0; right: 0; padding: 10px 20px; background: rgba(0,0,0,0.9); display: flex; justify-content: space-between; align-items: center; z-index: 1000000; border-bottom: 1px solid #333; }
+    #svg-overlay .toolbar .title { color: #ccc; font-size: 14px; }
+    #svg-overlay .toolbar .controls { display: flex; gap: 8px; align-items: center; }
+    #svg-overlay .toolbar button { background: #333; color: #ffb400; border: 1px solid #555; padding: 8px 14px; cursor: pointer; border-radius: 4px; font-size: 14px; }
+    #svg-overlay .toolbar button:hover { background: #444; border-color: #ffb400; }
+    #svg-overlay .toolbar .close-btn { font-size: 20px; padding: 4px 12px; }
+    #svg-overlay .toolbar .zoom-display { color: #888; font-size: 12px; min-width: 45px; text-align: center; }
+    #svg-overlay .toolbar .separator { color: #444; }
+    #svg-overlay .image-container { display: flex; justify-content: center; align-items: center; min-height: 100vh; padding: 60px 20px 20px; cursor: grab; }
+    #svg-overlay .image-container:active { cursor: grabbing; }
+    #svg-overlay .image-container img { max-width: 95%; max-height: 90vh; transform-origin: center center; }
+    #svg-overlay .nav-btn { position: fixed; top: 50%; transform: translateY(-50%); background: rgba(0,0,0,0.7); color: #ffb400; border: 1px solid #555; font-size: 30px; padding: 20px 15px; cursor: pointer; z-index: 1000000; border-radius: 4px; }
+    #svg-overlay .nav-btn:hover { background: rgba(255,180,0,0.2); border-color: #ffb400; }
+    #svg-overlay .nav-prev { left: 10px; }
+    #svg-overlay .nav-next { right: 10px; }
+    #svg-overlay .hint { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); color: #666; font-size: 12px; background: rgba(0,0,0,0.8); padding: 8px 20px; border-radius: 20px; }
+    </style>
+
+    <div id="svg-overlay">
+        <div class="toolbar">
+            <span class="title" id="svg-title">Image</span>
+            <div class="controls">
+                <button onclick="svgViewer.zoomOut()" title="Zoom Out (-)">-</button>
+                <span class="zoom-display" id="zoom-display">100%</span>
+                <button onclick="svgViewer.zoomIn()" title="Zoom In (+)">+</button>
+                <span class="separator">|</span>
+                <button onclick="svgViewer.fitWidth()" title="Fit Width (W)">Width</button>
+                <button onclick="svgViewer.fitHeight()" title="Fit Height (H)">Height</button>
+                <button onclick="svgViewer.resetZoom()" title="Reset (0)">Reset</button>
+                <span class="separator">|</span>
+                <button class="close-btn" onclick="svgViewer.close()" title="Close (ESC)">&times;</button>
+            </div>
+        </div>
+        <button class="nav-btn nav-prev" onclick="svgViewer.prev()" title="Previous">&larr;</button>
+        <button class="nav-btn nav-next" onclick="svgViewer.next()" title="Next">&rarr;</button>
+        <div class="image-container" id="svg-container">
+            <img id="svg-image" src="" alt="">
+        </div>
+        <div class="hint">Scroll to zoom | Drag to pan | W/H to fit | 0 to reset | ESC to close</div>
+    </div>
+
+    <script>
+    var svgViewer = (function() {
+        var overlay, img, titleEl, container;
+        var images = [];
+        var currentIndex = 0;
+        var scale = 1, panX = 0, panY = 0;
+        var isDragging = false, dragStartX, dragStartY, panStartX, panStartY;
+
+        function init() {
+            overlay = document.getElementById('svg-overlay');
+            img = document.getElementById('svg-image');
+            titleEl = document.getElementById('svg-title');
+            container = document.getElementById('svg-container');
+            if (!overlay || !img) return;
+
+            document.querySelectorAll('.svg-viewer').forEach(function(viewer, index) {
+                var viewerImg = viewer.querySelector('img');
+                if (viewerImg) {
+                    images.push({ src: viewerImg.src, title: viewer.getAttribute('data-title') || viewerImg.alt || 'Diagram' });
+                    viewer.onclick = function(e) { e.preventDefault(); open(index); };
+                }
+            });
+
+            container.addEventListener('wheel', function(e) {
+                e.preventDefault();
+                scale = Math.max(0.5, Math.min(10, scale + (e.deltaY > 0 ? -0.2 : 0.2)));
+                updateTransform();
+            });
+
+            container.addEventListener('mousedown', function(e) { isDragging = true; dragStartX = e.clientX; dragStartY = e.clientY; panStartX = panX; panStartY = panY; });
+            document.addEventListener('mousemove', function(e) { if (!isDragging) return; panX = panStartX + (e.clientX - dragStartX); panY = panStartY + (e.clientY - dragStartY); updateTransform(); });
+            document.addEventListener('mouseup', function() { isDragging = false; });
+
+            document.addEventListener('keydown', function(e) {
+                if (overlay.style.display !== 'block') return;
+                if (e.key === 'Escape') close();
+                if (e.key === 'ArrowLeft') prev();
+                if (e.key === 'ArrowRight') next();
+                if (e.key === '+' || e.key === '=') zoomIn();
+                if (e.key === '-') zoomOut();
+                if (e.key === '0') resetZoom();
+                if (e.key === 'w' || e.key === 'W') fitWidth();
+                if (e.key === 'h' || e.key === 'H') fitHeight();
+            });
+
+            overlay.addEventListener('click', function(e) { if (e.target === overlay || e.target === container) close(); });
+        }
+
+        function updateTransform() {
+            img.style.transform = 'translate(' + panX + 'px, ' + panY + 'px) scale(' + scale + ')';
+            var zd = document.getElementById('zoom-display');
+            if (zd) zd.textContent = Math.round(scale * 100) + '%';
+        }
+
+        function open(index) {
+            if (!images[index]) return;
+            currentIndex = index; scale = 1; panX = 0; panY = 0;
+            img.src = images[index].src;
+            titleEl.textContent = images[index].title + ' (' + (index + 1) + '/' + images.length + ')';
+            updateTransform();
+            overlay.style.display = 'block';
+            document.body.style.overflow = 'hidden';
+        }
+
+        function close() { overlay.style.display = 'none'; document.body.style.overflow = ''; }
+        function prev() { open((currentIndex - 1 + images.length) % images.length); }
+        function next() { open((currentIndex + 1) % images.length); }
+        function zoomIn() { scale = Math.min(10, scale + 0.25); updateTransform(); }
+        function zoomOut() { scale = Math.max(0.5, scale - 0.25); updateTransform(); }
+        function resetZoom() { scale = 1; panX = 0; panY = 0; updateTransform(); }
+
+        function fitWidth() {
+            if (!img.naturalWidth || !img.complete) { img.onload = fitWidth; return; }
+            scale = Math.max(0.1, Math.min(10, (window.innerWidth - 150) / img.naturalWidth));
+            panX = 0; panY = 0; updateTransform();
+        }
+
+        function fitHeight() {
+            if (!img.naturalHeight || !img.complete) { img.onload = fitHeight; return; }
+            scale = Math.max(0.1, Math.min(10, (window.innerHeight - 120) / img.naturalHeight));
+            panX = 0; panY = 0; updateTransform();
+        }
+
+        if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', init); } else { init(); }
+
+        return { open: open, close: close, prev: prev, next: next, zoomIn: zoomIn, zoomOut: zoomOut, resetZoom: resetZoom, fitWidth: fitWidth, fitHeight: fitHeight };
+    })();
+
+    // Mobile navigation
+    (function() {
+        var navToggle = document.querySelector('.nav-toggle');
+        var siteNav = document.querySelector('.site-nav');
+        var dropdowns = document.querySelectorAll('.nav-dropdown');
+
+        if (navToggle && siteNav) {
+            navToggle.addEventListener('click', function() {
+                navToggle.classList.toggle('active');
+                siteNav.classList.toggle('open');
+                navToggle.setAttribute('aria-expanded', siteNav.classList.contains('open'));
+            });
+
+            // Close menu when clicking a non-dropdown link
+            siteNav.querySelectorAll('a:not(.nav-dropdown-menu a)').forEach(function(link) {
+                link.addEventListener('click', function() {
+                    if (window.innerWidth <= 768) {
+                        navToggle.classList.remove('active');
+                        siteNav.classList.remove('open');
+                    }
+                });
+            });
+        }
+
+        // Handle dropdowns on mobile
+        dropdowns.forEach(function(dropdown) {
+            var trigger = dropdown.querySelector('.nav-trigger');
+            if (trigger) {
+                trigger.addEventListener('click', function(e) {
+                    if (window.innerWidth <= 768) {
+                        e.preventDefault();
+                        // Close other dropdowns
+                        dropdowns.forEach(function(d) {
+                            if (d !== dropdown) d.classList.remove('open');
+                        });
+                        dropdown.classList.toggle('open');
+                    }
+                });
+            }
+        });
+
+        // Close dropdowns when clicking outside on mobile
+        document.addEventListener('click', function(e) {
+            if (window.innerWidth <= 768 && !e.target.closest('.nav-dropdown')) {
+                dropdowns.forEach(function(d) { d.classList.remove('open'); });
+            }
+        });
+    })();
+    </script>
+
+    <!-- MathJax for LaTeX equations across docs pages -->
+    <script>
+    window.MathJax = {
+        tex: {
+            inlineMath: [['\\(', '\\)'], ['$', '$']],
+            displayMath: [['\\[', '\\]'], ['$$', '$$']],
+            processEscapes: true,
+            processEnvironments: true
+        },
+        options: {
+            skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+        },
+        svg: {
+            fontCache: 'global'
+        }
+    };
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+
+    <footer style="background: #2a2a2a; border-top: 1px solid #454545; color: #b0b0b0; padding: 3rem 2rem; margin-top: auto;">
+        <div style="max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem;">
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">C-Kernel-Engine</h4>
+                <p style="color: #707070; font-size: 0.875rem; margin: 0;">High-performance ML kernels with full PyTorch parity.</p>
+            </div>
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
+                </ul>
+            </div>
+            <div>
+                <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                </ul>
+            </div>
+            <div style="text-align: right;">
+                <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-29</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -898,6 +898,9 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
+                        <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
+                        <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
                         <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
@@ -1127,6 +1130,20 @@ python -m pip install -r requirements-v8.txt</pre>
     </div>
     <p class="mini-note">Use this as the current Gemma4 GGUF coherence smoke. A healthy run should produce a normal long answer and stop by EOS or <code>--max-tokens</code>, not by prompt-marker echo or language corruption. The tested local Q4_K_M run generated 1024 coherent C-code tokens; performance work remains separate.</p>
 
+    <h3>Gemma 4 Assistant / MTP Drafter</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
+  hf://google/gemma-4-E4B-it-assistant \
+  --run /tmp/ck-gemma4-assistant-runtime \
+  --context-len 1024 \
+  --force-convert --force-compile \
+  --generate-only \
+  --chat-template none \
+  --allow-raw-prompt</pre>
+    </div>
+    <p class="mini-note">The assistant artifact is a tiny speculative/MTP drafter, not a standalone chat model. A healthy bring-up converts safetensors directly to BUMP, lowers q-only shared-KV attention, generates C, and compiles <code>libmodel.so</code>. Real chat speedup comes only after pairing this runtime with a compatible Gemma4 backbone via <code>--speculative-draft-model-dir</code>.</p>
+
     <h3>Nemotron Nano 9B v2</h3>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
@@ -1154,6 +1171,20 @@ python -m pip install -r requirements-v8.txt</pre>
   tests/test_v8_safetensors_to_bump.py</pre>
     </div>
     <p class="mini-note">GLM4 is currently tracked as a v8 template/conversion/parity-harness lane. The patch adds GLM4 GGUF metadata handling, declarative safetensors mapping, a tiny synthetic safetensors conversion test, and a PyTorch-vs-CK comparator. Run full real-model GLM4 smoke on a higher-memory host before promoting it to the high-memory runtime lane.</p>
+
+    <h3>Kimi / MLA Decoder Contract</h3>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre># Low-memory validation lane: MLA template + explicit decode cache kernels
+.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py
+make build/libckernel_engine.so
+.venv/bin/python unittest/test_deepseek_reference_kernels.py
+.venv/bin/python -m unittest \
+  tests.test_v8_kimi_template \
+  tests.test_v8_model_contract_inspector \
+  tests.test_v8_template_circuit_audit</pre>
+    </div>
+    <p class="mini-note">Kimi/MLA is currently a v8 compiler/kernel-contract lane. The template now declares explicit MLA decode-cache behavior, lowering inserts <code>mla_kv_cache_store</code> / <code>mla_kv_cache_batch_store</code>, and decode attention switches to <code>deepseek_mla_attention_decode_f32</code>. See <a href="v8-mla-kimi.html">v8 MLA / Kimi Decode Cache</a> for the architecture notes. Full Kimi runtime smoke belongs on a high-memory host.</p>
 
     <h3>Qwen2 0.5B Instruct</h3>
     <div class="cmd-block">
@@ -1621,7 +1652,7 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-24</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-29</p>
             </div>
         </div>
     </footer>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -872,6 +872,14 @@ void rmsnorm_forward(const float *input,
                      int d_model,
                      int aligned_embed_dim,
                      float eps);
+void rmsnorm_forward_kv_lora(const float *input,
+                             const float *gamma,
+                             float *output,
+                             float *rstd_cache,
+                             int tokens,
+                             int d_model,
+                             int aligned_embed_dim,
+                             float eps);
 void rmsnorm_forward_no_weight(const float *input,
                                float *output,
                                float *rstd_cache,
@@ -1264,6 +1272,51 @@ void attention_forward_full_head_major_gqa_flash(const float *q,
                                                  int num_tokens,
                                                  int head_dim,
                                                  int aligned_head_dim);
+
+
+void deepseek_mla_attention_f32(const float *q,
+                                const float *k,
+                                const float *v,
+                                float *output,
+                                int num_heads,
+                                int num_kv_heads,
+                                int num_tokens,
+                                int qk_head_dim,
+                                int v_head_dim);
+
+void deepseek_mla_kv_cache_batch_store_f32(float *k_cache,
+                                           float *v_cache,
+                                           const float *k,
+                                           const float *v,
+                                           int num_tokens,
+                                           int num_kv_heads,
+                                           int qk_head_dim,
+                                           int v_head_dim,
+                                           int max_seq_len,
+                                           int cache_stride);
+
+void deepseek_mla_kv_cache_store_f32(float *k_cache,
+                                     float *v_cache,
+                                     const float *k,
+                                     const float *v,
+                                     int pos,
+                                     int num_kv_heads,
+                                     int qk_head_dim,
+                                     int v_head_dim,
+                                     int max_seq_len,
+                                     int cache_stride);
+
+void deepseek_mla_attention_decode_f32(const float *q,
+                                       const float *k_cache,
+                                       const float *v_cache,
+                                       float *output,
+                                       int num_heads,
+                                       int num_kv_heads,
+                                       int cache_len,
+                                       int qk_head_dim,
+                                       int v_head_dim,
+                                       int max_seq_len,
+                                       int cache_stride);
 
 void attention_forward_causal_head_major_gqa_flash_strided(const float *q,
                                                            const float *k,
@@ -2371,6 +2424,29 @@ void moe_swiglu_shared_forward_f32(const float *hidden,
                                    int hidden_dim,
                                    int intermediate_dim);
 
+void moe_swiglu_expert_forward_bf16(const float *hidden,
+                                    const int *indices,
+                                    const float *routing_weights,
+                                    const uint16_t *expert_gate,
+                                    const uint16_t *expert_up,
+                                    const uint16_t *expert_down,
+                                    float *output,
+                                    int rows,
+                                    int hidden_dim,
+                                    int intermediate_dim,
+                                    int n_experts,
+                                    int top_k);
+
+void moe_swiglu_shared_forward_bf16(const float *hidden,
+                                    const float *routed,
+                                    const uint16_t *shared_gate,
+                                    const uint16_t *shared_up,
+                                    const uint16_t *shared_down,
+                                    float *output,
+                                    int rows,
+                                    int hidden_dim,
+                                    int intermediate_dim);
+
 void moe_relu2_expert_backward_f32(const float *d_output,
                                    const float *hidden,
                                    const int *indices,
@@ -2548,6 +2624,16 @@ void deepseek_mla_kv_decompress_f32(const float *compressed_kv,
                                     int kv_lora_rank,
                                     int qk_nope_dim,
                                     int v_dim);
+
+void deepseek_mla_kv_decompress_bf16(const float *compressed_kv,
+                                     const uint16_t *kv_b_proj,
+                                     float *k_nope,
+                                     float *value,
+                                     int tokens,
+                                     int heads,
+                                     int kv_lora_rank,
+                                     int qk_nope_dim,
+                                     int v_dim);
 
 void deepseek_mla_partial_rope_concat_f32(const float *q_nope,
                                           const float *q_pe,

--- a/src/kernels/deepseek_kernels.c
+++ b/src/kernels/deepseek_kernels.c
@@ -10,6 +10,9 @@
 #include <float.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
+
+#include "bf16_utils.h"
 
 static inline size_t ds_mhc_idx(int t, int s, int d, int n_streams, int dim)
 {
@@ -216,6 +219,46 @@ void deepseek_mla_kv_decompress_f32(const float *compressed_kv,
     }
 }
 
+void deepseek_mla_kv_decompress_bf16(const float *compressed_kv,
+                                     const uint16_t *kv_b_proj,
+                                     float *k_nope,
+                                     float *value,
+                                     int tokens,
+                                     int heads,
+                                     int kv_lora_rank,
+                                     int qk_nope_dim,
+                                     int v_dim)
+{
+    if (!compressed_kv || !kv_b_proj || !k_nope || !value ||
+        tokens <= 0 || heads <= 0 || kv_lora_rank <= 0 || qk_nope_dim <= 0 || v_dim <= 0) {
+        return;
+    }
+
+    const int out_per_head = qk_nope_dim + v_dim;
+    for (int t = 0; t < tokens; ++t) {
+        for (int h = 0; h < heads; ++h) {
+            for (int d = 0; d < qk_nope_dim; ++d) {
+                const int out_col = h * out_per_head + d;
+                float acc = 0.0f;
+                for (int r = 0; r < kv_lora_rank; ++r) {
+                    acc += bf16_to_float(kv_b_proj[(size_t)out_col * (size_t)kv_lora_rank + (size_t)r]) *
+                           compressed_kv[ds_mla_tok_idx(t, r, kv_lora_rank)];
+                }
+                k_nope[ds_mla_thd_idx(t, h, d, heads, qk_nope_dim)] = acc;
+            }
+            for (int d = 0; d < v_dim; ++d) {
+                const int out_col = h * out_per_head + qk_nope_dim + d;
+                float acc = 0.0f;
+                for (int r = 0; r < kv_lora_rank; ++r) {
+                    acc += bf16_to_float(kv_b_proj[(size_t)out_col * (size_t)kv_lora_rank + (size_t)r]) *
+                           compressed_kv[ds_mla_tok_idx(t, r, kv_lora_rank)];
+                }
+                value[ds_mla_thd_idx(t, h, d, heads, v_dim)] = acc;
+            }
+        }
+    }
+}
+
 static void ds_mla_apply_kimi_rope(const float *src,
                                    float *dst,
                                    const float *cos_row,
@@ -310,9 +353,14 @@ void deepseek_mla_partial_rope_concat_packed_f32(const float *q_packed,
             }
 
             const float *qp = q_in + qk_nope_dim;
+            float q_pe_tmp[256];
+            if (qk_rope_dim > (int)(sizeof(q_pe_tmp) / sizeof(q_pe_tmp[0]))) {
+                return;
+            }
+            for (int i = 0; i < qk_rope_dim; ++i) q_pe_tmp[i] = qp[i];
             for (int i = 0; i < half; ++i) {
-                const float q_first = qp[2 * i];
-                const float q_second = qp[2 * i + 1];
+                const float q_first = q_pe_tmp[2 * i];
+                const float q_second = q_pe_tmp[2 * i + 1];
                 const float k_first = kp[2 * i];
                 const float k_second = kp[2 * i + 1];
                 const float c = cos_row[i];
@@ -498,4 +546,204 @@ void deepseek_hybrid_attention_f32(const float *q,
     }
     deepseek_csa_attention_f32(q, k, v, dense_indices, out, attn,
                                query_tokens, key_tokens, heads, dim, key_tokens, scale);
+}
+
+
+void deepseek_mla_attention_f32(const float *q,
+                                const float *k,
+                                const float *v,
+                                float *output,
+                                int num_heads,
+                                int num_kv_heads,
+                                int num_tokens,
+                                int qk_head_dim,
+                                int v_head_dim)
+{
+    if (!q || !k || !v || !output || num_heads <= 0 || num_kv_heads <= 0 ||
+        num_tokens <= 0 || qk_head_dim <= 0 || v_head_dim <= 0) {
+        return;
+    }
+
+    float *scores = (float *)malloc((size_t)num_tokens * sizeof(float));
+    if (!scores) return;
+
+    const float scale = 1.0f / sqrtf((float)qk_head_dim);
+    for (int t = 0; t < num_tokens; ++t) {
+        for (int h = 0; h < num_heads; ++h) {
+            const int kv_h = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+            const float *q_vec = q + ds_mla_thd_idx(t, h, 0, num_heads, qk_head_dim);
+
+            float max_score = -FLT_MAX;
+            for (int j = 0; j <= t; ++j) {
+                const float *k_vec = k + ds_mla_thd_idx(j, kv_h, 0, num_kv_heads, qk_head_dim);
+                float dot = 0.0f;
+                for (int d = 0; d < qk_head_dim; ++d) {
+                    dot += q_vec[d] * k_vec[d];
+                }
+                const float score = dot * scale;
+                scores[j] = score;
+                if (score > max_score) max_score = score;
+            }
+
+            float sum = 0.0f;
+            for (int j = 0; j <= t; ++j) {
+                const float e = expf(scores[j] - max_score);
+                scores[j] = e;
+                sum += e;
+            }
+            const float inv_sum = sum > 0.0f ? (1.0f / sum) : 0.0f;
+            float *out = output + ((size_t)t * (size_t)num_heads + (size_t)h) * (size_t)v_head_dim;
+            for (int d = 0; d < v_head_dim; ++d) out[d] = 0.0f;
+            for (int j = 0; j <= t; ++j) {
+                const float w = scores[j] * inv_sum;
+                const float *v_vec = v + ds_mla_thd_idx(j, kv_h, 0, num_kv_heads, v_head_dim);
+                for (int d = 0; d < v_head_dim; ++d) {
+                    out[d] += w * v_vec[d];
+                }
+            }
+        }
+    }
+
+    free(scores);
+}
+
+void deepseek_mla_kv_cache_batch_store_f32(float *k_cache,
+                                           float *v_cache,
+                                           const float *k,
+                                           const float *v,
+                                           int num_tokens,
+                                           int num_kv_heads,
+                                           int qk_head_dim,
+                                           int v_head_dim,
+                                           int max_seq_len,
+                                           int cache_stride)
+{
+    if (!k_cache || !v_cache || !k || !v || num_tokens <= 0 ||
+        num_kv_heads <= 0 || qk_head_dim <= 0 || v_head_dim <= 0 ||
+        max_seq_len <= 0 || cache_stride <= 0) {
+        return;
+    }
+    if (qk_head_dim > cache_stride || v_head_dim > cache_stride) {
+        return;
+    }
+    if (num_tokens > max_seq_len) {
+        num_tokens = max_seq_len;
+    }
+
+    for (int t = 0; t < num_tokens; ++t) {
+        for (int h = 0; h < num_kv_heads; ++h) {
+            const float *k_src = k + ((size_t)t * (size_t)num_kv_heads + (size_t)h) * (size_t)qk_head_dim;
+            const float *v_src = v + ((size_t)t * (size_t)num_kv_heads + (size_t)h) * (size_t)v_head_dim;
+            float *k_dst = k_cache + ((size_t)h * (size_t)max_seq_len + (size_t)t) * (size_t)cache_stride;
+            float *v_dst = v_cache + ((size_t)h * (size_t)max_seq_len + (size_t)t) * (size_t)cache_stride;
+            for (int d = 0; d < qk_head_dim; ++d) k_dst[d] = k_src[d];
+            for (int d = qk_head_dim; d < cache_stride; ++d) k_dst[d] = 0.0f;
+            for (int d = 0; d < v_head_dim; ++d) v_dst[d] = v_src[d];
+            for (int d = v_head_dim; d < cache_stride; ++d) v_dst[d] = 0.0f;
+        }
+    }
+}
+
+void deepseek_mla_kv_cache_store_f32(float *k_cache,
+                                     float *v_cache,
+                                     const float *k,
+                                     const float *v,
+                                     int pos,
+                                     int num_kv_heads,
+                                     int qk_head_dim,
+                                     int v_head_dim,
+                                     int max_seq_len,
+                                     int cache_stride)
+{
+    if (!k_cache || !v_cache || !k || !v || pos < 0 ||
+        num_kv_heads <= 0 || qk_head_dim <= 0 || v_head_dim <= 0 ||
+        max_seq_len <= 0 || cache_stride <= 0) {
+        return;
+    }
+    if (pos >= max_seq_len || qk_head_dim > cache_stride || v_head_dim > cache_stride) {
+        return;
+    }
+
+    for (int h = 0; h < num_kv_heads; ++h) {
+        const float *k_src = k + ((size_t)h * (size_t)qk_head_dim);
+        const float *v_src = v + ((size_t)h * (size_t)v_head_dim);
+        float *k_dst = k_cache + ((size_t)h * (size_t)max_seq_len + (size_t)pos) * (size_t)cache_stride;
+        float *v_dst = v_cache + ((size_t)h * (size_t)max_seq_len + (size_t)pos) * (size_t)cache_stride;
+
+        for (int d = 0; d < qk_head_dim; ++d) {
+            k_dst[d] = k_src[d];
+        }
+        for (int d = qk_head_dim; d < cache_stride; ++d) {
+            k_dst[d] = 0.0f;
+        }
+        for (int d = 0; d < v_head_dim; ++d) {
+            v_dst[d] = v_src[d];
+        }
+        for (int d = v_head_dim; d < cache_stride; ++d) {
+            v_dst[d] = 0.0f;
+        }
+    }
+}
+
+void deepseek_mla_attention_decode_f32(const float *q,
+                                       const float *k_cache,
+                                       const float *v_cache,
+                                       float *output,
+                                       int num_heads,
+                                       int num_kv_heads,
+                                       int cache_len,
+                                       int qk_head_dim,
+                                       int v_head_dim,
+                                       int max_seq_len,
+                                       int cache_stride)
+{
+    if (!q || !k_cache || !v_cache || !output || num_heads <= 0 ||
+        num_kv_heads <= 0 || cache_len <= 0 || qk_head_dim <= 0 ||
+        v_head_dim <= 0 || max_seq_len <= 0 || cache_stride <= 0) {
+        return;
+    }
+    if (qk_head_dim > cache_stride || v_head_dim > cache_stride) {
+        return;
+    }
+
+    float *scores = (float *)malloc((size_t)cache_len * sizeof(float));
+    if (!scores) return;
+
+    const float scale = 1.0f / sqrtf((float)qk_head_dim);
+    for (int h = 0; h < num_heads; ++h) {
+        const int kv_h = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
+        const float *q_vec = q + (size_t)h * (size_t)qk_head_dim;
+
+        float max_score = -FLT_MAX;
+        for (int j = 0; j < cache_len; ++j) {
+            const float *k_vec = k_cache + ((size_t)kv_h * (size_t)max_seq_len + (size_t)j) * (size_t)cache_stride;
+            float dot = 0.0f;
+            for (int d = 0; d < qk_head_dim; ++d) {
+                dot += q_vec[d] * k_vec[d];
+            }
+            const float score = dot * scale;
+            scores[j] = score;
+            if (score > max_score) max_score = score;
+        }
+
+        float sum = 0.0f;
+        for (int j = 0; j < cache_len; ++j) {
+            const float e = expf(scores[j] - max_score);
+            scores[j] = e;
+            sum += e;
+        }
+
+        const float inv_sum = sum > 0.0f ? (1.0f / sum) : 0.0f;
+        float *out = output + (size_t)h * (size_t)v_head_dim;
+        for (int d = 0; d < v_head_dim; ++d) out[d] = 0.0f;
+        for (int j = 0; j < cache_len; ++j) {
+            const float w = scores[j] * inv_sum;
+            const float *v_vec = v_cache + ((size_t)kv_h * (size_t)max_seq_len + (size_t)j) * (size_t)cache_stride;
+            for (int d = 0; d < v_head_dim; ++d) {
+                out[d] += w * v_vec[d];
+            }
+        }
+    }
+
+    free(scores);
 }

--- a/tests/test_v8_kimi_template.py
+++ b/tests/test_v8_kimi_template.py
@@ -140,10 +140,10 @@ class V8KimiTemplateTests(unittest.TestCase):
         self.assertEqual([op["op"] for op in ops].count("residual_save"), 4)
         self.assertEqual(by_layer_op[(0, "q_proj", 0)]["kernel"], "gemv_bf16")
         self.assertEqual(by_layer_op[(0, "kv_a_proj", 0)]["kernel"], "gemv_bf16")
-        self.assertEqual(by_layer_op[(0, "kv_lora_decompress", 0)]["kernel"], "deepseek_mla_kv_decompress_f32")
+        self.assertEqual(by_layer_op[(0, "kv_lora_decompress", 0)]["kernel"], "deepseek_mla_kv_decompress_bf16")
         self.assertEqual(by_layer_op[(0, "partial_rope_concat", 0)]["kernel"], "deepseek_mla_partial_rope_concat_packed_f32")
-        self.assertEqual(by_layer_op[(1, "moe_swiglu_expert_mlp", 0)]["kernel"], "moe_swiglu_expert_forward_f32")
-        self.assertEqual(by_layer_op[(1, "shared_swiglu_expert_mlp", 0)]["kernel"], "moe_swiglu_shared_forward_f32")
+        self.assertEqual(by_layer_op[(1, "moe_swiglu_expert_mlp", 0)]["kernel"], "moe_swiglu_expert_forward_bf16")
+        self.assertEqual(by_layer_op[(1, "shared_swiglu_expert_mlp", 0)]["kernel"], "moe_swiglu_shared_forward_bf16")
 
         q_source = by_layer_op[(0, "q_proj", 0)]["dataflow"]["inputs"]["x"]
         kv_source = by_layer_op[(0, "kv_a_proj", 0)]["dataflow"]["inputs"]["x"]

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -3,14 +3,14 @@
     "description": "Kernel registry generated from v8 kernel maps",
     "version": "v8",
     "generated_by": "ck_run_v8.py",
-    "source_dir": "/home/antshiv/Workspace/C-Kernel-Engine/version/v8/kernel_maps",
+    "source_dir": "/opt/app-root/src/Ashivaku/C-Kernel-Engine/version/v8/kernel_maps",
     "counts": {
-      "total": 184,
+      "total": 192,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
         "assistant_layer_scale": 1,
-        "attention": 15,
+        "attention": 16,
         "attention_projection": 1,
         "attention_sliding": 6,
         "attn_gate_sigmoid_mul": 1,
@@ -34,8 +34,9 @@
         "gemma4_per_layer_prepare": 2,
         "gemv": 14,
         "group_limited_topk_router": 1,
+        "kv_a_layernorm": 1,
         "kv_cache_store": 3,
-        "kv_lora_decompress": 1,
+        "kv_lora_decompress": 2,
         "layernorm": 2,
         "logits_store_indexed": 1,
         "mamba_conv1d_state_update": 1,
@@ -44,8 +45,11 @@
         "mamba_rmsnorm_gate": 1,
         "mamba_selective_scan": 1,
         "mamba_selective_state_update_decode": 1,
+        "mla_attention": 1,
+        "mla_kv_cache_batch_store": 1,
+        "mla_kv_cache_store": 1,
         "moe_relu2_expert_mlp": 4,
-        "moe_swiglu_expert_mlp": 2,
+        "moe_swiglu_expert_mlp": 3,
         "optimizer": 4,
         "partial_rope_concat": 2,
         "position_embeddings": 3,
@@ -75,7 +79,7 @@
         "rope_init": 2,
         "rowwise_bias_add": 1,
         "shared_relu2_expert_mlp": 1,
-        "shared_swiglu_expert_mlp": 2,
+        "shared_swiglu_expert_mlp": 3,
         "softmax": 1,
         "spatial_merge": 3,
         "speculative_commit_or_reject": 1,
@@ -3729,6 +3733,487 @@
       "notes": "Simple fp32 residual add for token-major activations.",
       "name": "ck_residual_add_token_major",
       "_source_file": "ck_residual_add_token_major.json"
+    },
+    {
+      "id": "deepseek_mla_attention_decode_f32",
+      "op": "mla_attention",
+      "variant": "decode_cache_ref_f32",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "QK"
+          ],
+          "desc": "Current-token MLA query"
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "S"
+          ],
+          "desc": "MLA key cache"
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "S"
+          ],
+          "desc": "MLA value cache"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "V"
+          ],
+          "desc": "Current-token MLA attention output"
+        }
+      ],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "QK",
+        "V",
+        "S"
+      ],
+      "params": [
+        {
+          "name": "num_heads",
+          "dtype": "int32"
+        },
+        {
+          "name": "num_kv_heads",
+          "dtype": "int32"
+        },
+        {
+          "name": "cache_len",
+          "dtype": "int32"
+        },
+        {
+          "name": "qk_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "v_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "max_seq_len",
+          "dtype": "int32"
+        },
+        {
+          "name": "cache_stride",
+          "dtype": "int32"
+        }
+      ],
+      "impl": {
+        "function": "deepseek_mla_attention_decode_f32",
+        "c_declaration": "void deepseek_mla_attention_decode_f32(const float *q, const float *k_cache, const float *v_cache, float *output, int num_heads, int num_kv_heads, int cache_len, int qk_head_dim, int v_head_dim, int max_seq_len, int cache_stride);",
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ]
+      },
+      "notes": "Reference MLA decode attention over persistent K/V cache. K uses qk_head_dim; V uses v_head_dim; both use cache_stride.",
+      "name": "deepseek_mla_attention_decode_f32",
+      "_source_file": "deepseek_mla_attention_decode_f32.json"
+    },
+    {
+      "id": "deepseek_mla_attention_f32",
+      "op": "attention",
+      "variant": "mla_causal_ref_f32",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "QK"
+          ],
+          "desc": "MLA query [tokens, heads, qk_head_dim]"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "KV",
+            "QK"
+          ],
+          "desc": "MLA key [tokens, kv_heads, qk_head_dim]"
+        },
+        {
+          "name": "v",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "KV",
+            "V"
+          ],
+          "desc": "MLA value [tokens, kv_heads, v_head_dim]"
+        }
+      ],
+      "weights": [],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "V"
+          ],
+          "desc": "Token-major MLA attention output"
+        }
+      ],
+      "dims": [
+        "T",
+        "H",
+        "KV",
+        "QK",
+        "V"
+      ],
+      "params": [
+        {
+          "name": "num_heads",
+          "dtype": "int32"
+        },
+        {
+          "name": "num_kv_heads",
+          "dtype": "int32"
+        },
+        {
+          "name": "num_tokens",
+          "dtype": "int32"
+        },
+        {
+          "name": "qk_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "v_head_dim",
+          "dtype": "int32"
+        }
+      ],
+      "impl": {
+        "function": "deepseek_mla_attention_f32",
+        "c_declaration": "void deepseek_mla_attention_f32(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int qk_head_dim, int v_head_dim);",
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "notes": "Reference MLA causal attention with q/k dim != value/output dim. Used by Kimi/DeepSeek-style MLA.",
+      "name": "deepseek_mla_attention_f32",
+      "_source_file": "deepseek_mla_attention_f32.json"
+    },
+    {
+      "id": "deepseek_mla_kv_cache_batch_store_f32",
+      "op": "mla_kv_cache_batch_store",
+      "variant": "prefill_cache_store_f32",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "KV",
+            "QK"
+          ]
+        },
+        {
+          "name": "v",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "KV",
+            "V"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "k_cache",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "MAX_T",
+            "S"
+          ]
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "MAX_T",
+            "S"
+          ]
+        }
+      ],
+      "dims": [
+        "T",
+        "KV",
+        "QK",
+        "V",
+        "MAX_T",
+        "S"
+      ],
+      "params": [
+        {
+          "name": "num_tokens",
+          "dtype": "int32"
+        },
+        {
+          "name": "num_kv_heads",
+          "dtype": "int32"
+        },
+        {
+          "name": "qk_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "v_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "max_seq_len",
+          "dtype": "int32"
+        },
+        {
+          "name": "cache_stride",
+          "dtype": "int32"
+        }
+      ],
+      "impl": {
+        "function": "deepseek_mla_kv_cache_batch_store_f32",
+        "c_declaration": "void deepseek_mla_kv_cache_batch_store_f32(float *k_cache, float *v_cache, const float *k, const float *v, int num_tokens, int num_kv_heads, int qk_head_dim, int v_head_dim, int max_seq_len, int cache_stride);",
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ]
+      },
+      "notes": "MLA prefill cache store from token-major K/V tensors into persistent head-major cache with separate logical K/V widths.",
+      "name": "deepseek_mla_kv_cache_batch_store_f32",
+      "_source_file": "deepseek_mla_kv_cache_batch_store_f32.json"
+    },
+    {
+      "id": "deepseek_mla_kv_cache_store_f32",
+      "op": "mla_kv_cache_store",
+      "variant": "decode_cache_store_f32",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "QK"
+          ],
+          "desc": "Current-token MLA key"
+        },
+        {
+          "name": "v",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "V"
+          ],
+          "desc": "Current-token MLA value"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "k_cache",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "S"
+          ],
+          "desc": "Persistent MLA K cache"
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "S"
+          ],
+          "desc": "Persistent MLA V cache with logical V width and cache stride"
+        }
+      ],
+      "dims": [
+        "KV",
+        "QK",
+        "V",
+        "T",
+        "S"
+      ],
+      "params": [
+        {
+          "name": "pos",
+          "dtype": "int32"
+        },
+        {
+          "name": "num_kv_heads",
+          "dtype": "int32"
+        },
+        {
+          "name": "qk_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "v_head_dim",
+          "dtype": "int32"
+        },
+        {
+          "name": "max_seq_len",
+          "dtype": "int32"
+        },
+        {
+          "name": "cache_stride",
+          "dtype": "int32"
+        }
+      ],
+      "impl": {
+        "function": "deepseek_mla_kv_cache_store_f32",
+        "c_declaration": "void deepseek_mla_kv_cache_store_f32(float *k_cache, float *v_cache, const float *k, const float *v, int pos, int num_kv_heads, int qk_head_dim, int v_head_dim, int max_seq_len, int cache_stride);",
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ]
+      },
+      "notes": "MLA decode cache store with separate K and V logical dimensions inside a shared cache stride.",
+      "name": "deepseek_mla_kv_cache_store_f32",
+      "_source_file": "deepseek_mla_kv_cache_store_f32.json"
+    },
+    {
+      "id": "deepseek_mla_kv_decompress_bf16",
+      "op": "kv_lora_decompress",
+      "variant": "bf16_weight",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "compressed_kv",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "R"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "kv_b_proj",
+          "dtype": "bf16",
+          "shape": [
+            "H*(Dk+Dv)",
+            "R"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "k_nope",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dk"
+          ]
+        },
+        {
+          "name": "value",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "H",
+            "Dv"
+          ]
+        }
+      ],
+      "dims": [
+        "T",
+        "H",
+        "R",
+        "Dk",
+        "Dv"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/deepseek_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "deepseek_mla_kv_decompress_bf16",
+        "c_declaration": "void deepseek_mla_kv_decompress_bf16(const float *compressed_kv, const uint16_t *kv_b_proj, float *k_nope, float *value, int tokens, int heads, int kv_lora_rank, int qk_nope_dim, int v_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_deepseek_reference_kernels.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_deepseek_reference_kernels.py",
+            "tolerance": "1e-5"
+          }
+        ]
+      },
+      "notes": "Scalar reference for DeepSeek/Kimi MLA KV LoRA decompress with BF16 kv_b_proj weights.",
+      "name": "deepseek_mla_kv_decompress_bf16",
+      "_source_file": "deepseek_mla_kv_decompress_bf16.json"
     },
     {
       "id": "deepseek_mla_kv_decompress_f32",
@@ -13287,6 +13772,122 @@
       "_source_file": "moe_swiglu_expert_backward_f32.json"
     },
     {
+      "id": "moe_swiglu_expert_forward_bf16",
+      "op": "moe_swiglu_expert_mlp",
+      "variant": "bf16_weights",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "indices",
+          "dtype": "i32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        },
+        {
+          "name": "routing_weights",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "K"
+          ]
+        }
+      ],
+      "weights": [
+        {
+          "name": "expert_gate",
+          "dtype": "bf16",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_up",
+          "dtype": "bf16",
+          "shape": [
+            "E",
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "expert_down",
+          "dtype": "bf16",
+          "shape": [
+            "E",
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I",
+        "E",
+        "K"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "moe_swiglu_expert_forward_bf16",
+        "c_declaration": "void moe_swiglu_expert_forward_bf16(const float *hidden, const int *indices, const float *routing_weights, const uint16_t *expert_gate, const uint16_t *expert_up, const uint16_t *expert_down, float *output, int rows, int hidden_dim, int intermediate_dim, int n_experts, int top_k);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_swiglu_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+            "tolerance": "3e-6"
+          }
+        ]
+      },
+      "notes": "Routed SwiGLU MoE expert reference kernel with BF16 weights for Kimi/DeepSeek-style experts: down(silu(gate(x))*up(x)), accumulated by routing weights.",
+      "name": "moe_swiglu_expert_forward_bf16",
+      "_source_file": "moe_swiglu_expert_forward_bf16.json"
+    },
+    {
       "id": "moe_swiglu_expert_forward_f32",
       "op": "moe_swiglu_expert_mlp",
       "variant": "fp32",
@@ -13536,6 +14137,110 @@
       "notes": "Backward pass for shared SwiGLU expert reference kernel.",
       "name": "moe_swiglu_shared_backward_f32",
       "_source_file": "moe_swiglu_shared_backward_f32.json"
+    },
+    {
+      "id": "moe_swiglu_shared_forward_bf16",
+      "op": "shared_swiglu_expert_mlp",
+      "variant": "bf16_weights",
+      "modes": {
+        "inference": true,
+        "training": true,
+        "backward": false
+      },
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "hidden",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        },
+        {
+          "name": "routed",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ],
+          "optional": true
+        }
+      ],
+      "weights": [
+        {
+          "name": "shared_gate",
+          "dtype": "bf16",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "shared_up",
+          "dtype": "bf16",
+          "shape": [
+            "I",
+            "H"
+          ]
+        },
+        {
+          "name": "shared_down",
+          "dtype": "bf16",
+          "shape": [
+            "H",
+            "I"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "R",
+            "H"
+          ]
+        }
+      ],
+      "dims": [
+        "R",
+        "H",
+        "I"
+      ],
+      "impl": {
+        "sources": [
+          "src/kernels/axpy_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "scalar_ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ],
+        "function": "moe_swiglu_shared_forward_bf16",
+        "c_declaration": "void moe_swiglu_shared_forward_bf16(const float *hidden, const float *routed, const uint16_t *shared_gate, const uint16_t *shared_up, const uint16_t *shared_down, float *output, int rows, int hidden_dim, int intermediate_dim);"
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_moe_swiglu_expert.py"
+        ],
+        "parity": [
+          {
+            "kind": "pytorch",
+            "command": ".venv/bin/python unittest/test_moe_swiglu_expert.py",
+            "tolerance": "3e-6"
+          }
+        ]
+      },
+      "notes": "Shared SwiGLU expert branch used by Kimi/DeepSeek-style MoE; output = routed + shared_down(silu(shared_gate(x))*shared_up(x)).",
+      "name": "moe_swiglu_shared_forward_bf16",
+      "_source_file": "moe_swiglu_shared_forward_bf16.json"
     },
     {
       "id": "moe_swiglu_shared_forward_f32",
@@ -17273,6 +17978,173 @@
       "notes": "Root Mean Square Layer Normalization. Computes: output = input / sqrt(mean(x^2) + eps) * gamma",
       "name": "rmsnorm_forward",
       "_source_file": "rmsnorm_forward.json"
+    },
+    {
+      "id": "rmsnorm_forward_kv_lora",
+      "op": "kv_a_layernorm",
+      "variant": "fp32_kv_lora",
+      "quant": {
+        "weight": "fp32",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "input",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Input activations [tokens, embed_dim]"
+        }
+      ],
+      "weights": [
+        {
+          "name": "gamma",
+          "dtype": "fp32",
+          "shape": [
+            "E"
+          ],
+          "desc": "RMSNorm scale weight"
+        }
+      ],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "Normalized output"
+        },
+        {
+          "name": "rstd",
+          "dtype": "fp32",
+          "shape": [
+            "T"
+          ],
+          "desc": "Running stddev (can be used for backward pass)"
+        }
+      ],
+      "scratch": [
+        {
+          "name": "mean",
+          "dtype": "fp32",
+          "size_bytes": "T * 4",
+          "desc": "Mean per row (reuse for variance)"
+        },
+        {
+          "name": "variance",
+          "dtype": "fp32",
+          "size_bytes": "T * 4",
+          "desc": "Variance per row"
+        }
+      ],
+      "dims": [
+        "T",
+        "E"
+      ],
+      "params": [
+        {
+          "name": "eps",
+          "dtype": "float32",
+          "desc": "Epsilon for numerical stability (typically 1e-5)"
+        }
+      ],
+      "parallelization": {
+        "supported": [
+          "token",
+          "feature"
+        ],
+        "preferred": {
+          "prefill": "feature",
+          "decode": "feature"
+        },
+        "strategies": [
+          {
+            "name": "token",
+            "partition_dim": "T",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 1
+            },
+            "notes": "Process tokens in parallel; each thread normalizes one or more tokens."
+          },
+          {
+            "name": "feature",
+            "partition_dim": "E",
+            "param_style": "range",
+            "range": {
+              "min_chunk": 64,
+              "align_bytes": 32,
+              "allow_tail": true
+            },
+            "notes": "Parallelize across embed dimension; reduction needed for mean/variance."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "E": 64
+        },
+        "notes": "For optimal performance, E should be multiple of 64 for SIMD vectorization"
+      },
+      "impl": {
+        "function": "rmsnorm_forward_kv_lora",
+        "c_declaration": "void rmsnorm_forward_kv_lora(const float *input, const float *gamma, float *output, float *rstd_cache, int tokens, int d_model, int aligned_embed_dim, float eps);",
+        "sources": [
+          "src/kernels/rmsnorm_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "avx512",
+            "requires": [
+              "avx512f",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx512f",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "avx",
+            "requires": [
+              "avx"
+            ],
+            "compile_flags": [
+              "-mavx"
+            ]
+          },
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_rmsnorm.py"
+        ],
+        "bench": [
+          "scripts/bench_rmsnorm.py"
+        ],
+        "parity": [
+          {
+            "kind": "numpy",
+            "command": "python unittest/test_rmsnorm.py --compare-numpy",
+            "tolerance": "1e-4",
+            "notes": "Compare against numpy reference implementation"
+          }
+        ]
+      },
+      "notes": "Kimi/DeepSeek MLA latent RMSNorm wrapper: normalizes kv_lora_rank compressed KV values with mla_kv_a_norm gamma.",
+      "name": "rmsnorm_forward_kv_lora",
+      "_source_file": "rmsnorm_forward_kv_lora.json"
     },
     {
       "id": "v_norm",

--- a/version/v8/kernel_maps/deepseek_mla_attention_decode_f32.json
+++ b/version/v8/kernel_maps/deepseek_mla_attention_decode_f32.json
@@ -1,0 +1,99 @@
+{
+  "id": "deepseek_mla_attention_decode_f32",
+  "op": "mla_attention",
+  "variant": "decode_cache_ref_f32",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "q",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "QK"
+      ],
+      "desc": "Current-token MLA query"
+    },
+    {
+      "name": "k_cache",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "S"
+      ],
+      "desc": "MLA key cache"
+    },
+    {
+      "name": "v_cache",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "S"
+      ],
+      "desc": "MLA value cache"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": [
+        "H",
+        "V"
+      ],
+      "desc": "Current-token MLA attention output"
+    }
+  ],
+  "dims": [
+    "H",
+    "KV",
+    "T",
+    "QK",
+    "V",
+    "S"
+  ],
+  "params": [
+    {
+      "name": "num_heads",
+      "dtype": "int32"
+    },
+    {
+      "name": "num_kv_heads",
+      "dtype": "int32"
+    },
+    {
+      "name": "cache_len",
+      "dtype": "int32"
+    },
+    {
+      "name": "qk_head_dim",
+      "dtype": "int32"
+    },
+    {
+      "name": "v_head_dim",
+      "dtype": "int32"
+    },
+    {
+      "name": "max_seq_len",
+      "dtype": "int32"
+    },
+    {
+      "name": "cache_stride",
+      "dtype": "int32"
+    }
+  ],
+  "impl": {
+    "function": "deepseek_mla_attention_decode_f32",
+    "c_declaration": "void deepseek_mla_attention_decode_f32(const float *q, const float *k_cache, const float *v_cache, float *output, int num_heads, int num_kv_heads, int cache_len, int qk_head_dim, int v_head_dim, int max_seq_len, int cache_stride);",
+    "sources": [
+      "src/kernels/deepseek_kernels.c"
+    ]
+  },
+  "notes": "Reference MLA decode attention over persistent K/V cache. K uses qk_head_dim; V uses v_head_dim; both use cache_stride.",
+  "name": "deepseek_mla_attention_decode_f32"
+}

--- a/version/v8/kernel_maps/deepseek_mla_kv_cache_batch_store_f32.json
+++ b/version/v8/kernel_maps/deepseek_mla_kv_cache_batch_store_f32.json
@@ -1,0 +1,93 @@
+{
+  "id": "deepseek_mla_kv_cache_batch_store_f32",
+  "op": "mla_kv_cache_batch_store",
+  "variant": "prefill_cache_store_f32",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "KV",
+        "QK"
+      ]
+    },
+    {
+      "name": "v",
+      "dtype": "fp32",
+      "shape": [
+        "T",
+        "KV",
+        "V"
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "k_cache",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "MAX_T",
+        "S"
+      ]
+    },
+    {
+      "name": "v_cache",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "MAX_T",
+        "S"
+      ]
+    }
+  ],
+  "dims": [
+    "T",
+    "KV",
+    "QK",
+    "V",
+    "MAX_T",
+    "S"
+  ],
+  "params": [
+    {
+      "name": "num_tokens",
+      "dtype": "int32"
+    },
+    {
+      "name": "num_kv_heads",
+      "dtype": "int32"
+    },
+    {
+      "name": "qk_head_dim",
+      "dtype": "int32"
+    },
+    {
+      "name": "v_head_dim",
+      "dtype": "int32"
+    },
+    {
+      "name": "max_seq_len",
+      "dtype": "int32"
+    },
+    {
+      "name": "cache_stride",
+      "dtype": "int32"
+    }
+  ],
+  "impl": {
+    "function": "deepseek_mla_kv_cache_batch_store_f32",
+    "c_declaration": "void deepseek_mla_kv_cache_batch_store_f32(float *k_cache, float *v_cache, const float *k, const float *v, int num_tokens, int num_kv_heads, int qk_head_dim, int v_head_dim, int max_seq_len, int cache_stride);",
+    "sources": [
+      "src/kernels/deepseek_kernels.c"
+    ]
+  },
+  "notes": "MLA prefill cache store from token-major K/V tensors into persistent head-major cache with separate logical K/V widths.",
+  "name": "deepseek_mla_kv_cache_batch_store_f32"
+}

--- a/version/v8/kernel_maps/deepseek_mla_kv_cache_store_f32.json
+++ b/version/v8/kernel_maps/deepseek_mla_kv_cache_store_f32.json
@@ -1,0 +1,94 @@
+{
+  "id": "deepseek_mla_kv_cache_store_f32",
+  "op": "mla_kv_cache_store",
+  "variant": "decode_cache_store_f32",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "k",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "QK"
+      ],
+      "desc": "Current-token MLA key"
+    },
+    {
+      "name": "v",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "V"
+      ],
+      "desc": "Current-token MLA value"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "k_cache",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "S"
+      ],
+      "desc": "Persistent MLA K cache"
+    },
+    {
+      "name": "v_cache",
+      "dtype": "fp32",
+      "shape": [
+        "KV",
+        "T",
+        "S"
+      ],
+      "desc": "Persistent MLA V cache with logical V width and cache stride"
+    }
+  ],
+  "dims": [
+    "KV",
+    "QK",
+    "V",
+    "T",
+    "S"
+  ],
+  "params": [
+    {
+      "name": "pos",
+      "dtype": "int32"
+    },
+    {
+      "name": "num_kv_heads",
+      "dtype": "int32"
+    },
+    {
+      "name": "qk_head_dim",
+      "dtype": "int32"
+    },
+    {
+      "name": "v_head_dim",
+      "dtype": "int32"
+    },
+    {
+      "name": "max_seq_len",
+      "dtype": "int32"
+    },
+    {
+      "name": "cache_stride",
+      "dtype": "int32"
+    }
+  ],
+  "impl": {
+    "function": "deepseek_mla_kv_cache_store_f32",
+    "c_declaration": "void deepseek_mla_kv_cache_store_f32(float *k_cache, float *v_cache, const float *k, const float *v, int pos, int num_kv_heads, int qk_head_dim, int v_head_dim, int max_seq_len, int cache_stride);",
+    "sources": [
+      "src/kernels/deepseek_kernels.c"
+    ]
+  },
+  "notes": "MLA decode cache store with separate K and V logical dimensions inside a shared cache stride.",
+  "name": "deepseek_mla_kv_cache_store_f32"
+}

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -2947,12 +2947,12 @@
         },
         {
           "name": "cos",
-          "source": "runtime:rope_cos",
+          "source": "runtime:rope_cos_mla_positioned",
           "cast": "const float*"
         },
         {
           "name": "sin",
-          "source": "runtime:rope_sin",
+          "source": "runtime:rope_sin_mla_positioned",
           "cast": "const float*"
         },
         {
@@ -3089,6 +3089,392 @@
         {
           "name": "intermediate_dim",
           "source": "dim:moe_intermediate_size"
+        }
+      ]
+    },
+    "moe_swiglu_expert_forward_bf16": {
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "indices",
+          "source": "activation:indices",
+          "cast": "const int*"
+        },
+        {
+          "name": "routing_weights",
+          "source": "activation:routing_weights",
+          "cast": "const float*"
+        },
+        {
+          "name": "expert_gate",
+          "source": "weight:moe_expert_gate",
+          "cast": "const uint16_t*",
+          "ctype": "const uint16_t *"
+        },
+        {
+          "name": "expert_up",
+          "source": "weight:moe_expert_up",
+          "cast": "const uint16_t*",
+          "ctype": "const uint16_t *"
+        },
+        {
+          "name": "expert_down",
+          "source": "weight:moe_expert_down",
+          "cast": "const uint16_t*",
+          "ctype": "const uint16_t *"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "hidden_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:moe_intermediate_size"
+        },
+        {
+          "name": "n_experts",
+          "source": "dim:n_routed_experts"
+        },
+        {
+          "name": "top_k",
+          "source": "dim:num_experts_per_tok"
+        }
+      ]
+    },
+    "moe_swiglu_shared_forward_bf16": {
+      "params": [
+        {
+          "name": "hidden",
+          "source": "activation:hidden",
+          "cast": "const float*"
+        },
+        {
+          "name": "routed",
+          "source": "activation:routed",
+          "cast": "const float*"
+        },
+        {
+          "name": "shared_gate",
+          "source": "weight:moe_shared_gate",
+          "cast": "const uint16_t*",
+          "ctype": "const uint16_t *"
+        },
+        {
+          "name": "shared_up",
+          "source": "weight:moe_shared_up",
+          "cast": "const uint16_t*",
+          "ctype": "const uint16_t *"
+        },
+        {
+          "name": "shared_down",
+          "source": "weight:moe_shared_down",
+          "cast": "const uint16_t*",
+          "ctype": "const uint16_t *"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rows",
+          "source": "dim:_m"
+        },
+        {
+          "name": "hidden_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "intermediate_dim",
+          "source": "dim:moe_shared_expert_intermediate_size"
+        }
+      ]
+    },
+    "deepseek_mla_kv_decompress_bf16": {
+      "params": [
+        {
+          "name": "compressed_kv",
+          "source": "activation:compressed_kv",
+          "cast": "const float*"
+        },
+        {
+          "name": "kv_b_proj",
+          "source": "weight:mla_kv_b_proj",
+          "cast": "const uint16_t*"
+        },
+        {
+          "name": "k_nope",
+          "source": "output:k_nope",
+          "cast": "float*"
+        },
+        {
+          "name": "value",
+          "source": "output:value",
+          "cast": "float*"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:_m"
+        },
+        {
+          "name": "heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "kv_lora_rank",
+          "source": "dim:kv_lora_rank"
+        },
+        {
+          "name": "qk_nope_dim",
+          "source": "dim:qk_nope_head_dim"
+        },
+        {
+          "name": "v_dim",
+          "source": "dim:v_head_dim"
+        }
+      ]
+    },
+    "rmsnorm_forward_kv_lora": {
+      "note": "Kimi MLA latent RMSNorm uses kv_lora_rank, not model hidden size.",
+      "params": [
+        {
+          "name": "input",
+          "source": "activation:input",
+          "cast": "const float*"
+        },
+        {
+          "name": "gamma",
+          "source": "weight_f:mla_kv_a_norm"
+        },
+        {
+          "name": "output",
+          "source": "output:output",
+          "cast": "float*"
+        },
+        {
+          "name": "rstd_cache",
+          "source": "null"
+        },
+        {
+          "name": "tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "d_model",
+          "source": "dim:kv_lora_rank"
+        },
+        {
+          "name": "aligned_embed_dim",
+          "source": "dim:kv_lora_input_dim"
+        },
+        {
+          "name": "eps",
+          "source": "dim:rms_eps"
+        }
+      ]
+    },
+    "deepseek_mla_attention_f32": {
+      "params": [
+        {
+          "name": "q",
+          "source": "scratch:q_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "v",
+          "source": "scratch:v_scratch",
+          "cast": "float*"
+        },
+        {
+          "name": "output",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "qk_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "v_head_dim",
+          "source": "dim:v_head_dim"
+        }
+      ]
+    },
+    "deepseek_mla_kv_cache_store_f32": {
+      "params": [
+        {
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer",
+          "cast": "float*"
+        },
+        {
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "const float*"
+        },
+        {
+          "name": "v",
+          "source": "scratch:v_scratch",
+          "cast": "const float*"
+        },
+        {
+          "name": "pos",
+          "source": "runtime:pos"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "qk_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "v_head_dim",
+          "source": "dim:v_head_dim"
+        },
+        {
+          "name": "max_seq_len",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "cache_stride",
+          "source": "dim:kv_cache_head_dim"
+        }
+      ]
+    },
+    "deepseek_mla_attention_decode_f32": {
+      "params": [
+        {
+          "name": "q",
+          "source": "scratch:q_scratch",
+          "cast": "const float*"
+        },
+        {
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer",
+          "cast": "const float*"
+        },
+        {
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer",
+          "cast": "const float*"
+        },
+        {
+          "name": "output",
+          "source": "output:out",
+          "cast": "float*"
+        },
+        {
+          "name": "num_heads",
+          "source": "dim:num_heads"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "cache_len",
+          "source": "runtime:cache_len"
+        },
+        {
+          "name": "qk_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "v_head_dim",
+          "source": "dim:v_head_dim"
+        },
+        {
+          "name": "max_seq_len",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "cache_stride",
+          "source": "dim:kv_cache_head_dim"
+        }
+      ]
+    },
+    "deepseek_mla_kv_cache_batch_store_f32": {
+      "params": [
+        {
+          "name": "k_cache",
+          "source": "runtime:kv_cache_k_layer",
+          "cast": "float*"
+        },
+        {
+          "name": "v_cache",
+          "source": "runtime:kv_cache_v_layer",
+          "cast": "float*"
+        },
+        {
+          "name": "k",
+          "source": "scratch:k_scratch",
+          "cast": "const float*"
+        },
+        {
+          "name": "v",
+          "source": "scratch:v_scratch",
+          "cast": "const float*"
+        },
+        {
+          "name": "num_tokens",
+          "source": "dim:seq_len"
+        },
+        {
+          "name": "num_kv_heads",
+          "source": "dim:num_kv_heads"
+        },
+        {
+          "name": "qk_head_dim",
+          "source": "dim:head_dim"
+        },
+        {
+          "name": "v_head_dim",
+          "source": "dim:v_head_dim"
+        },
+        {
+          "name": "max_seq_len",
+          "source": "dim:max_seq_len"
+        },
+        {
+          "name": "cache_stride",
+          "source": "dim:kv_cache_head_dim"
         }
       ]
     }

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -1449,7 +1449,7 @@ def generate_init_ops(manifest: Dict, config: Dict) -> List[Dict]:
     # ROPE INIT: Precompute cos/sin tables if model uses RoPE
     # ═══════════════════════════════════════════════════════════
     rope_type = flags.get("rope", None)
-    if rope_type in ("rope", "rope_qk", True):
+    if rope_type in ("rope", "rope_qk", "partial_rope_concat", "partial_pairwise_concat", True):
         # Get config values
         rope_theta = config["rope_theta"]
         head_dim = max(int(config["head_dim"]), int(config.get("max_rotary_dim", config["rotary_dim"]) or config["rotary_dim"]))
@@ -2763,10 +2763,14 @@ def _template_uses_rope(template: Dict[str, Any], config: Optional[Dict[str, Any
     rope_layout = _normalize_rope_layout_value(attention_contract.get("rope_layout"))
     if rope_layout == "none":
         return False
-    if rope_layout in {"split", "pairwise", "multi_section_1d", "multi_section_2d"}:
+    if rope_layout in {"split", "pairwise", "partial_pairwise_concat", "multi_section_1d", "multi_section_2d"}:
+        return True
+    flags = template.get("flags", {}) if isinstance(template.get("flags"), dict) else {}
+    rope_flag = str(flags.get("rope", "") or "").strip().lower()
+    if rope_flag in {"rope", "rope_qk", "partial_rope_concat", "partial_pairwise_concat"}:
         return True
     template_ops = _collect_template_ops(template, config)
-    return "rope_qk" in template_ops or "rope_q" in template_ops or "mrope_qk" in template_ops
+    return bool({"rope_qk", "rope_q", "mrope_qk", "partial_rope_concat"} & set(template_ops))
 
 
 def _template_uses_kv_cache(template: Dict[str, Any], config: Optional[Dict[str, Any]] = None) -> bool:
@@ -2974,6 +2978,8 @@ def compute_matmul_dims(op_name: str, config: Dict) -> Tuple[Optional[int], Opti
     if op_name in ("recurrent_alpha_proj", "recurrent_beta_proj"):
         return (recurrent_gate or None), embed
     attn_out = config.get("attn_out_dim", heads * head_dim)
+    if int(config.get("kv_lora_rank", 0) or 0) > 0 and int(config.get("v_head_dim", 0) or 0) > 0:
+        attn_out = heads * int(config.get("v_head_dim", 0) or 0)
     if op_name in ("out_proj", "attn_proj"):
         return embed, attn_out
     if op_name in ("recurrent_out_proj",):
@@ -4789,6 +4795,8 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         "mrope_qk": None,
         "rope_qk": None,
         "rope_q": None,
+        "mla_kv_cache_batch_store": None,
+        "mla_kv_cache_store": None,
         "kv_cache_store": None,  # Store K,V to KV cache (no weights)
         "kv_cache_store_shared_q": None,
         "attn": None,
@@ -4905,6 +4913,16 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             if op == "attn" and mode == "prefill" and not _attention_contract_is_causal(template, config):
                 return ["attention_forward_full_head_major_gqa_flash_strided"]
 
+        # Kimi/DeepSeek MLA decompression has the same semantic template op for
+        # FP32 and BF16 weights, but the C ABI differs for kv_b_proj.  Resolve it
+        # from the manifest-derived layer_quant before honoring a generic template
+        # default, otherwise BF16 weights can be cast as float*.
+        if op == "kv_lora_decompress":
+            kv_b_dtype = str(layer_quant.get("mla_kv_b_proj", "") or "").strip().lower()
+            if kv_b_dtype == "bf16":
+                return ["deepseek_mla_kv_decompress_bf16"]
+            return ["deepseek_mla_kv_decompress_f32"]
+
         explicit_kernel = str(template_kernels.get(op, "") or "").strip()
         if explicit_kernel:
             return [explicit_kernel]
@@ -4926,7 +4944,13 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             return ["memcpy"]
         if op == "partial_rope_concat":
             return ["deepseek_mla_partial_rope_concat_packed_f32"]
-        if op in {"v_norm", "projector_prep", "group_limited_topk_router", "mamba_in_proj_split", "mla_attention"}:
+        if op == "mla_kv_cache_batch_store":
+            return ["deepseek_mla_kv_cache_batch_store_f32"]
+        if op == "mla_kv_cache_store":
+            return ["deepseek_mla_kv_cache_store_f32"]
+        if op == "mla_attention":
+            return ["deepseek_mla_attention_f32"]
+        if op in {"v_norm", "projector_prep", "group_limited_topk_router", "mamba_in_proj_split"}:
             kernel_id = find_kernel(
                 registry,
                 op=kernel_op,
@@ -4952,11 +4976,28 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             # Gemma4 per-layer prepare is a structured header op, not a
             # dense projection. It owns BF16/quantized weights internally and
             # must stay on its dedicated kernel regardless of source dtype.
+            if op == "kv_a_layernorm":
+                return ["rmsnorm_forward_kv_lora"]
             if op == "kv_lora_decompress":
+                kv_b_dtype = str(layer_quant.get("mla_kv_b_proj", "")).lower()
+                if isinstance(weight_info, list) and weight_info:
+                    kv_b_dtype = str(weight_info[0].get("dtype", kv_b_dtype)).lower()
+                if kv_b_dtype == "bf16":
+                    return ["deepseek_mla_kv_decompress_bf16"]
                 return ["deepseek_mla_kv_decompress_f32"]
             if op == "moe_swiglu_expert_mlp":
+                gate_dtype = str(layer_quant.get("moe_expert_gate", "")).lower()
+                up_dtype = str(layer_quant.get("moe_expert_up", "")).lower()
+                down_dtype = str(layer_quant.get("moe_expert_down", "")).lower()
+                if gate_dtype == "bf16" and up_dtype == "bf16" and down_dtype == "bf16":
+                    return ["moe_swiglu_expert_forward_bf16"]
                 return ["moe_swiglu_expert_forward_f32"]
             if op == "shared_swiglu_expert_mlp":
+                gate_dtype = str(layer_quant.get("moe_shared_gate", "")).lower()
+                up_dtype = str(layer_quant.get("moe_shared_up", "")).lower()
+                down_dtype = str(layer_quant.get("moe_shared_down", "")).lower()
+                if gate_dtype == "bf16" and up_dtype == "bf16" and down_dtype == "bf16":
+                    return ["moe_swiglu_shared_forward_bf16"]
                 return ["moe_swiglu_shared_forward_f32"]
 
             if op == "gemma4_per_layer_prepare":
@@ -6289,6 +6330,10 @@ def generate_ir_lower_1(
     logits_layout = _resolve_logits_layout(config, mode)
     template = manifest.get("template", {}) if isinstance(manifest.get("template"), dict) else {}
     template_kernels = template.get("kernels", {}) if isinstance(template.get("kernels"), dict) else {}
+    template_contract = template.get("contract") if isinstance(template.get("contract"), dict) else {}
+    attention_contract = template_contract.get("attention_contract") if isinstance(template_contract.get("attention_contract"), dict) else {}
+    decode_cache_contract = attention_contract.get("decode_cache_contract") if isinstance(attention_contract.get("decode_cache_contract"), dict) else {}
+    explicit_mla_decode_cache = str(decode_cache_contract.get("type", "") or "").strip().lower() == "mla"
     uses_kv_cache = bool(config.get("_template_uses_kv_cache", _template_uses_kv_cache(template, config)))
     has_logits = bool(config.get("_template_has_logits", _template_declares_logits(template, config)))
 
@@ -6480,6 +6525,11 @@ def generate_ir_lower_1(
         for op in lowered_ops
         if str(op.get("op", "")) in {"rope_qk", "rope_q", "mrope_qk"}
     }
+    decode_mla_layers = {
+        int(op.get("layer", 0))
+        for op in lowered_ops
+        if str(op.get("op", "")) == "mla_attention"
+    }
 
     def _kv_read_layer_for(layer: int) -> int:
         try:
@@ -6534,6 +6584,36 @@ def generate_ir_lower_1(
             "_auto_inserted": True,
         }
 
+    def _make_mla_kv_store_op(anchor_op: Dict[str, Any], *, batch: bool) -> Dict[str, Any]:
+        layer = int(anchor_op["layer"])
+        function = "deepseek_mla_kv_cache_batch_store_f32" if batch else "deepseek_mla_kv_cache_store_f32"
+        return {
+            "idx": len(final_ops),  # Will be renumbered
+            "kernel": function,
+            "op": "mla_kv_cache_batch_store" if batch else "mla_kv_cache_store",
+            "layer": layer,
+            "section": anchor_op["section"],
+            "function": function,
+            "weights": {},
+            "inputs": {
+                "k": {"type": "scratch", "source": "k_scratch"},
+                "v": {"type": "scratch", "source": "v_scratch"},
+            },
+            "outputs": {
+                "kv_cache_k": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
+                "kv_cache_v": {"type": "kv_cache", "buffer": f"kv_cache_v_L{layer}"},
+            },
+            "params": copy.deepcopy(anchor_op.get("params", {})),
+            "scratch": [],
+            "_auto_inserted": True,
+        }
+
+    mla_prefill_layers = {
+        int(x.get("layer", 0))
+        for x in lowered_ops
+        if str(x.get("op", "")) in {"partial_rope_concat", "mla_attention", "kv_lora_decompress"}
+    }
+
     for i, op in enumerate(lowered_ops):
         final_ops.append(op)
 
@@ -6556,9 +6636,23 @@ def generate_ir_lower_1(
             elif should_store_after_q_rope:
                 final_ops.append(_make_decode_shared_q_kv_store_op(op))
                 kv_store_count += 1
+            elif explicit_mla_decode_cache and op_name == "partial_rope_concat" and layer in decode_mla_layers:
+                final_ops.append(_make_mla_kv_store_op(op, batch=False))
+                kv_store_count += 1
 
             # For decode mode, update attention ops to use decode kernel
-            if op["op"] in ("attn", "attn_sliding") and "attention" in op["kernel"]:
+            if explicit_mla_decode_cache and op["op"] == "mla_attention" and "mla_attention" in op["kernel"]:
+                decode_kernel = "deepseek_mla_attention_decode_f32"
+                op["kernel"] = decode_kernel
+                op["function"] = decode_kernel
+                kv_read_layer = _kv_read_layer_for(int(op.get("layer", 0)))
+                op["_kv_cache_read_layer"] = kv_read_layer
+                op.setdefault("inputs", {})
+                op["inputs"]["k_cache"] = {"type": "kv_cache", "source": f"kv_cache_k_L{kv_read_layer}"}
+                op["inputs"]["v_cache"] = {"type": "kv_cache", "source": f"kv_cache_v_L{kv_read_layer}"}
+                op["inputs"].pop("k", None)
+                op["inputs"].pop("v", None)
+            elif op["op"] in ("attn", "attn_sliding") and "attention" in op["kernel"]:
                 # Switch to decode attention kernel (sliding vs non-sliding)
                 if op["op"] == "attn_sliding":
                     decode_kernel = template_kernels.get("attn_sliding_decode") or "attention_forward_decode_head_major_gqa_flash_sliding"
@@ -6602,8 +6696,13 @@ def generate_ir_lower_1(
             # Standard q/k/v GEMM projections write token-major [T, H*D] while
             # flash attention consumes head-major [H, T, D]. Packed split paths
             # that already emit head-major simply never trigger these bridges.
+            if explicit_mla_decode_cache and op.get("op") == "partial_rope_concat" and int(op.get("layer", 0)) in mla_prefill_layers:
+                final_ops.append(_make_mla_kv_store_op(op, batch=True))
+
             if op["op"] in ("q_proj", "split_q_gate"):
                 layer = op["layer"]
+                if int(layer) in mla_prefill_layers:
+                    continue
                 transpose_q_op = {
                     "idx": len(final_ops),
                     "kernel": "transpose_qkv_to_head_major",
@@ -7005,6 +7104,8 @@ TEMPLATE_OP_WEIGHTS = {
     "attn_sliding": [],  # No model weights (kernel op handles windowing)
     "attn_shared_kv": [],  # No model weights; q_scratch is used as Q/K/V
     "attn_sliding_shared_kv": [],  # No model weights; q_scratch is used as Q/K/V with SWA
+    "mla_kv_cache_batch_store": [],
+    "mla_kv_cache_store": [],
     "kv_cache_store_shared_q": [],  # No model weights; writes q_scratch to K/V cache
     "attn_gate_sigmoid_mul": [],  # No model weights
     "out_proj": ["wo", "bo", "wo_input_min", "wo_input_max", "wo_output_min", "wo_output_max"],  # Output projection + optional bias
@@ -7925,7 +8026,7 @@ def generate_memory_layout_packed(
         if op_type in ("vision_position_ids", "position_ids_2d"):
             alloc_act("vision_positions")
 
-        if op_type == "kv_cache_store":
+        if op_type in ("kv_cache_store", "mla_kv_cache_store", "mla_kv_cache_batch_store"):
             alloc_act("k_scratch")
             alloc_act("v_scratch")
             alloc_act("kv_cache")
@@ -9150,7 +9251,7 @@ def generate_ir_lower_2(
                     })
 
         # Special handling for kv_cache_store: add k_scratch and v_scratch buffers
-        if ir_op.get("op", "") == "kv_cache_store":
+        if ir_op.get("op", "") in ("kv_cache_store", "mla_kv_cache_store", "mla_kv_cache_batch_store"):
             for scratch_name in ["k_scratch", "v_scratch"]:
                 buf = activation_buffers.get(scratch_name)
                 if buf:
@@ -10133,6 +10234,18 @@ def generate_ir_lower_3(lowered_ir: Dict, mode: str) -> Dict:
                     else:
                         op_errors.append(f"{func}.{name}: missing dim '{key}'")
                         expr = "0"
+                elif key == "kv_lora_input_dim":
+                    expr = str(int(config.get("kv_lora_rank", 0) or 0) + int(config.get("qk_rope_head_dim", 0) or 0))
+                elif key == "kv_cache_head_dim":
+                    k_head = int(config.get("mla_k_head_dim", config.get("max_k_head_dim", config.get("head_dim", 1))) or config.get("head_dim", 1) or 1)
+                    v_head = int(config.get("mla_v_head_dim", config.get("max_v_head_dim", config.get("v_head_dim", config.get("head_dim", 1)))) or config.get("v_head_dim", config.get("head_dim", 1)) or 1)
+                    base = int(config.get("head_dim", 1) or 1)
+                    expr = str(max(k_head, v_head, base))
+                elif key == "moe_shared_expert_intermediate_size":
+                    if key in config:
+                        expr = str(config[key])
+                    else:
+                        expr = str(int(config.get("moe_intermediate_size", 0) or 0) * max(1, int(config.get("n_shared_experts", 1) or 1)))
                 elif key in config:
                     expr = str(config[key])
                 elif key == "intermediate_size" and "intermediate_dim" in config:
@@ -10197,6 +10310,18 @@ def generate_ir_lower_3(lowered_ir: Dict, mode: str) -> Dict:
                     expr = "model->rope_cos"
                 elif key == "rope_sin":
                     expr = "model->rope_sin"
+                elif key == "rope_cos_mla_positioned":
+                    rope_half = max(1, int(config.get("qk_rope_head_dim", config.get("head_dim", 2)) or 2) // 2)
+                    if mode == "decode":
+                        expr = f"(model->rope_cos + (size_t)model->pos * (size_t){rope_half})"
+                    else:
+                        expr = "model->rope_cos"
+                elif key == "rope_sin_mla_positioned":
+                    rope_half = max(1, int(config.get("qk_rope_head_dim", config.get("head_dim", 2)) or 2) // 2)
+                    if mode == "decode":
+                        expr = f"(model->rope_sin + (size_t)model->pos * (size_t){rope_half})"
+                    else:
+                        expr = "model->rope_sin"
                 elif key == "pos":
                     expr = "model->rope_pos" if name == "pos_offset" else "model->pos"
                 elif key == "seq_len":

--- a/version/v8/templates/kimi_vl.json
+++ b/version/v8/templates/kimi_vl.json
@@ -63,7 +63,34 @@
       "kv_lora_rank_key": "kv_lora_rank",
       "qk_nope_head_dim_key": "qk_nope_head_dim",
       "qk_rope_head_dim_key": "qk_rope_head_dim",
-      "v_head_dim_key": "v_head_dim"
+      "v_head_dim_key": "v_head_dim",
+      "decode_cache_contract": {
+        "type": "mla",
+        "state_writes": {
+          "k_cache": {
+            "source": "k_scratch",
+            "index": "runtime.position"
+          },
+          "v_cache": {
+            "source": "v_scratch",
+            "index": "runtime.position"
+          }
+        },
+        "state_reads": {
+          "k_cache": {
+            "range": "0:runtime.cache_len"
+          },
+          "v_cache": {
+            "range": "0:runtime.cache_len"
+          }
+        },
+        "params": {
+          "cache_len": "runtime.position + 1",
+          "qk_head_dim": "qk_nope_head_dim + qk_rope_head_dim",
+          "v_head_dim": "v_head_dim",
+          "cache_stride": "kv_cache_head_dim"
+        }
+      }
     },
     "block_contract": {
       "norm_type": "rmsnorm",


### PR DESCRIPTION
## Summary

Adds explicit v8 support for Kimi / DeepSeek-style Multi-Head Latent Attention (MLA) decode-cache lowering.

This PR makes the MLA cache contract visible in the template, IR, kernel maps, and docs instead of hiding cache behavior inside the attention kernel.

## What Changed

- Adds explicit MLA cache kernels and kernel-map entries:
  - `deepseek_mla_attention_decode_f32`
  - `deepseek_mla_kv_cache_batch_store_f32`
  - `deepseek_mla_kv_cache_store_f32`
- Extends `build_ir_v8.py` so Kimi MLA decode:
  - inserts `mla_kv_cache_store`
  - inserts prefill `mla_kv_cache_batch_store`
  - switches `mla_attention` to `deepseek_mla_attention_decode_f32` for decode
  - preserves BF16-specific `kv_lora_decompress` and MoE kernel selection
- Updates `version/v8/templates/kimi_vl.json` with the explicit MLA decode-cache contract.
- Updates the Kimi template unit test to expect BF16 MLA/MoE kernels when the manifest declares BF16 weights.
- Adds docs:
  - new `v8-mla-kimi.html` architecture page
  - new SVG diagram for the MLA low-rank KV path and explicit decode cache
  - v8 runbook low-memory validation lane
  - model/kernel matrix Kimi / MLA card
  - architecture nav and sitemap metadata

## Scope

This is compiler, template, kernel-map, and reference-kernel contract support. Full Kimi model runtime smoke remains a high-memory host lane and is not expected to run on a constrained laptop.

## Validation

Local checks passed:

```bash
.venv/bin/python -m py_compile version/v8/scripts/build_ir_v8.py tests/test_v8_kimi_template.py
make build/libckernel_engine.so
.venv/bin/python unittest/test_deepseek_reference_kernels.py
.venv/bin/python -m unittest \
  tests.test_v8_kimi_template \
  tests.test_v8_model_contract_inspector \
  tests.test_v8_template_circuit_audit \
  tests.test_v8_glm4_template
bash docs/site/build.sh
git diff --cached --check
```

Pre-commit hook passed:

- v7 kernel-map contracts
- v7 regression fast
- v8 regression fast

Pre-push hook passed:

- submodule pin validation
- visualizer HTML/JS health
- CK-Engine build
- kernel parity tests
- v8 E2E text smoke
- v8 inference contracts
- v7 training contract smoke
- v7 fast regression
- v8 fast regression
- v7 training-kernel parity

## Notes

`kv_lora_decompress` here is not an external LoRA fine-tuning adapter. In MLA models it is the architectural low-rank KV expansion:

```text
hidden -> kv_a_proj -> compressed_kv
compressed_kv -> kv_a_layernorm -> compressed_kv_normed
compressed_kv_normed -> kv_b_proj -> K_noPE + V
compressed_kv tail -> K_roPE
partial_rope_concat(K_noPE, K_roPE) -> K
```

The new docs page explains this distinction and shows the full prefill/decode cache contract visually.
