### PR TITLE
feat(v8): harden advanced model bring-up and runner paths

### DIFF
--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -910,6 +910,22 @@ void rope_forward_qk_split_direct_f32(float *q,
                                   pos_offset, rotary_dim, freq_base);
 }
 
+void rope_forward_q_split_direct_f32(float *q,
+                                     const float *freq_factors,
+                                     int use_freq_factors,
+                                     int num_heads,
+                                     int num_tokens,
+                                     int head_dim,
+                                     int aligned_head_dim,
+                                     int pos_offset,
+                                     int rotary_dim,
+                                     float freq_base)
+{
+    rope_forward_split_direct_one(q, freq_factors, use_freq_factors,
+                                  num_heads, num_tokens, head_dim, aligned_head_dim,
+                                  pos_offset, rotary_dim, freq_base);
+}
+
 void rope_forward_qk_gemma4_direct(float *q,
                                    float *k,
                                    const float *freq_factors,

--- a/tests/test_v8_gemma4_scaffold.py
+++ b/tests/test_v8_gemma4_scaffold.py
@@ -252,6 +252,23 @@ class V8Gemma4ScaffoldTests(unittest.TestCase):
         self.assertEqual(template["contract"]["bridge"]["dest"], "draft_backbone_stream")
         self.assertEqual(template["contract"]["verifier"]["kernel"], "speculative_verify_greedy_f32")
         self.assertEqual(template["contract"]["committer"]["kernel"], "speculative_commit_one_i32")
+        speculative = template["contract"]["speculative_contract"]
+        self.assertTrue(speculative["enabled"])
+        self.assertEqual(speculative["mode"], "target_draft_verify")
+        self.assertEqual(speculative["draft_length"], 1)
+        self.assertEqual(speculative["verify_policy"], "greedy")
+        self.assertEqual(speculative["commit_policy"], "accept_one_or_target_fallback")
+        self.assertEqual(speculative["bridge"]["source"], "target_hidden_stream")
+        self.assertEqual(speculative["bridge"]["dest"], "draft_backbone_stream")
+        self.assertEqual(speculative["token_source"], "speculative_commit_or_reject.verified_token")
+        self.assertEqual(speculative["count_source"], "constant_1")
+        self.assertIn("speculative_tokens_match_target_only_greedy", speculative["invariants"])
+        autoregressive = template["contract"]["autoregressive_contract"]
+        self.assertTrue(autoregressive["enabled"])
+        self.assertEqual(autoregressive["mode"], "speculative")
+        self.assertEqual(autoregressive["stream"], "main_generation")
+        self.assertEqual(autoregressive["position_source"], "target_position")
+        self.assertEqual(autoregressive["token_source"], "speculative_commit_or_reject.verified_token")
 
         ops = template["block_types"]["speculative_decode"]["ops"]
         self.assertEqual(

--- a/tests/test_v8_native_bridge_host.py
+++ b/tests/test_v8_native_bridge_host.py
@@ -1806,6 +1806,148 @@ class V8NativeBridgeHostTests(unittest.TestCase):
         self.assertIn("--encoder-gguf", cmd)
         self.assertIn(str(encoder), cmd)
 
+    def test_ck_run_v8_routes_local_safetensors_dir_through_safetensors_converter(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="v8_local_safetensors_") as tmpdir:
+            tmp = Path(tmpdir)
+            checkpoint = tmp / "checkpoint"
+            checkpoint.mkdir()
+            (checkpoint / "config.json").write_text("{}", encoding="utf-8")
+            (checkpoint / "model.safetensors").write_bytes(b"stub")
+
+            work_dir = tmp / "run"
+            weights_path = work_dir / "weights.bump"
+            config_path = work_dir / "config.json"
+            manifest_path = work_dir / "weights_manifest.json"
+            model_c_path = work_dir / "model_v8.c"
+            lib_path = work_dir / "libmodel.so"
+            ir_paths = {
+                "prefill_ir": work_dir / "ir1_prefill.json",
+                "prefill_layout": work_dir / "layout_prefill.json",
+                "prefill_lowered": work_dir / "lowered_prefill.json",
+                "prefill_call": work_dir / "lowered_prefill_call.json",
+                "decode_ir": work_dir / "ir1_decode.json",
+                "decode_layout": work_dir / "layout_decode.json",
+                "decode_lowered": work_dir / "lowered_decode.json",
+                "decode_call": work_dir / "lowered_decode_call.json",
+                "manifest_map": work_dir / "weights_manifest.map",
+            }
+            args = argparse.Namespace(
+                model=str(checkpoint),
+                run_dir=str(work_dir),
+                mmproj=None,
+                image_path=None,
+                synthetic_prefix_tokens=0,
+                force_download=False,
+                prompt=None,
+                image_mode="checker",
+                vision_top_k=8,
+                max_tokens=16,
+                no_chat_template=False,
+                chat_template="auto",
+                allow_raw_prompt=False,
+                thinking_mode="auto",
+                context_len=1024,
+                temperature=0.7,
+                top_k=40,
+                top_p=1.0,
+                min_p=0.0,
+                repeat_penalty=1.0,
+                repeat_last_n=64,
+                force_convert=False,
+                force_compile=False,
+                memory=False,
+                python_tokenizer=False,
+                generate_visualizer=False,
+                generate_only=True,
+                logits_layout="auto",
+                profile=False,
+                sweep_kernels=False,
+                sweep_kernels_full=False,
+            )
+
+            with mock.patch.object(ck_run_v8, "step_convert_safetensors", return_value=(weights_path, config_path, manifest_path)) as convert_safe, \
+                 mock.patch.object(ck_run_v8, "step_convert_gguf") as convert_gguf, \
+                 mock.patch.object(ck_run_v8, "step_build_ir", return_value=ir_paths), \
+                 mock.patch.object(ck_run_v8, "step_codegen", return_value=model_c_path), \
+                 mock.patch.object(ck_run_v8, "step_compile", return_value=lib_path):
+                rc = ck_run_v8.run_pipeline(args)
+
+        self.assertEqual(rc, 0)
+        convert_safe.assert_called_once_with(checkpoint.resolve(), work_dir, force=False)
+        convert_gguf.assert_not_called()
+
+    def test_ck_run_v8_routes_hf_safetensors_repo_through_safetensors_converter(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="v8_hf_safetensors_") as tmpdir:
+            tmp = Path(tmpdir)
+            checkpoint = tmp / "google--gemma-4-E4B-it-assistant"
+            checkpoint.mkdir()
+            (checkpoint / "config.json").write_text("{}", encoding="utf-8")
+            (checkpoint / "model.safetensors.index.json").write_text("{}", encoding="utf-8")
+
+            work_dir = tmp / "run"
+            weights_path = work_dir / "weights.bump"
+            config_path = work_dir / "config.json"
+            manifest_path = work_dir / "weights_manifest.json"
+            model_c_path = work_dir / "model_v8.c"
+            lib_path = work_dir / "libmodel.so"
+            ir_paths = {
+                "prefill_ir": work_dir / "ir1_prefill.json",
+                "prefill_layout": work_dir / "layout_prefill.json",
+                "prefill_lowered": work_dir / "lowered_prefill.json",
+                "prefill_call": work_dir / "lowered_prefill_call.json",
+                "decode_ir": work_dir / "ir1_decode.json",
+                "decode_layout": work_dir / "layout_decode.json",
+                "decode_lowered": work_dir / "lowered_decode.json",
+                "decode_call": work_dir / "lowered_decode_call.json",
+                "manifest_map": work_dir / "weights_manifest.map",
+            }
+            args = argparse.Namespace(
+                model="hf://google/gemma-4-E4B-it-assistant",
+                run_dir=str(work_dir),
+                mmproj=None,
+                image_path=None,
+                synthetic_prefix_tokens=0,
+                force_download=False,
+                prompt=None,
+                image_mode="checker",
+                vision_top_k=8,
+                max_tokens=16,
+                no_chat_template=False,
+                chat_template="auto",
+                allow_raw_prompt=False,
+                thinking_mode="auto",
+                context_len=1024,
+                temperature=0.7,
+                top_k=40,
+                top_p=1.0,
+                min_p=0.0,
+                repeat_penalty=1.0,
+                repeat_last_n=64,
+                force_convert=True,
+                force_compile=False,
+                memory=False,
+                python_tokenizer=False,
+                generate_visualizer=False,
+                generate_only=True,
+                logits_layout="auto",
+                profile=False,
+                sweep_kernels=False,
+                sweep_kernels_full=False,
+            )
+
+            with mock.patch.object(ck_run_v8, "step_download", return_value=checkpoint) as download, \
+                 mock.patch.object(ck_run_v8, "step_convert_safetensors", return_value=(weights_path, config_path, manifest_path)) as convert_safe, \
+                 mock.patch.object(ck_run_v8, "step_convert_gguf") as convert_gguf, \
+                 mock.patch.object(ck_run_v8, "step_build_ir", return_value=ir_paths), \
+                 mock.patch.object(ck_run_v8, "step_codegen", return_value=model_c_path), \
+                 mock.patch.object(ck_run_v8, "step_compile", return_value=lib_path):
+                rc = ck_run_v8.run_pipeline(args)
+
+        self.assertEqual(rc, 0)
+        download.assert_called_once_with("google/gemma-4-E4B-it-assistant", ck_run_v8.CACHE_DIR, force=False)
+        convert_safe.assert_called_once_with(checkpoint, work_dir, force=True)
+        convert_gguf.assert_not_called()
+
     def test_ck_run_v8_generate_visualizer_refreshes_report_for_text_run(self) -> None:
         with tempfile.TemporaryDirectory(prefix="v8_generate_visualizer_") as tmpdir:
             tmp = Path(tmpdir)

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -400,6 +400,11 @@ def detect_input_type(model_input: str) -> tuple[str, dict[str, Any]]:
         if len(parts) >= 3:
             return "hf_gguf", {"repo_id": f"{parts[0]}/{parts[1]}", "filename": "/".join(parts[2:])}
 
+    if text.startswith("hf://"):
+        repo_id = text[5:].strip("/")
+        if repo_id:
+            return "hf_id", {"model_id": repo_id}
+
     if path.is_file() and path.suffix.lower() == ".gguf":
         return "gguf", {"path": path.resolve()}
 
@@ -485,7 +490,11 @@ def step_download(model_id: str, cache_dir: Path, force: bool = False) -> Path:
         repo_dir = model_id.replace("/", "--")
         for root in _cache_roots():
             candidate_dir = root / repo_dir
-            if candidate_dir.exists() and any(candidate_dir.glob("*.gguf")):
+            if candidate_dir.exists() and (
+                any(candidate_dir.glob("*.gguf"))
+                or any(candidate_dir.glob("*.safetensors"))
+                or (candidate_dir / "model.safetensors.index.json").exists()
+            ):
                 if root == cache_dir:
                     log(f"  Using cached model at {candidate_dir}", C_DIM)
                 else:
@@ -648,6 +657,17 @@ def _find_local_gguf(model_dir: Path) -> Optional[Path]:
     return pool[0]
 
 
+def _is_safetensors_checkpoint_dir(path: Path) -> bool:
+    return (
+        path.is_dir()
+        and (path / "config.json").exists()
+        and (
+            any(path.glob("*.safetensors"))
+            or (path / "model.safetensors.index.json").exists()
+        )
+    )
+
+
 def _is_runtime_dir(path: Path) -> bool:
     return (
         path.is_dir()
@@ -686,6 +706,47 @@ def _prepare_runtime_dir_from_local_artifacts(model_dir: Path, work_dir: Path) -
         dst_manifest = src_manifest
         dst_config = src_config
     return dst_bump, dst_config, dst_manifest
+
+
+def step_convert_safetensors(
+    checkpoint_dir: Path,
+    output_dir: Path,
+    *,
+    force: bool = False,
+) -> tuple[Path, Path, Path]:
+    log_step(2, "Converting safetensors checkpoint to bump format")
+    weights_path = output_dir / "weights.bump"
+    config_path = output_dir / "config.json"
+    manifest_path = output_dir / "weights_manifest.json"
+    if weights_path.exists() and config_path.exists() and manifest_path.exists() and not force:
+        log(f"  Using cached weights at {weights_path}", C_DIM)
+        return weights_path, config_path, manifest_path
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(SCRIPTS_DIR / "convert_safetensors_to_bump_v8.py"),
+        "--checkpoint",
+        str(checkpoint_dir),
+        "--output",
+        str(weights_path),
+        "--config-out",
+        str(config_path),
+        "--manifest-out",
+        str(manifest_path),
+        "--arch",
+        "auto",
+    ]
+    run_cmd(cmd, cwd=PROJECT_ROOT)
+    for name in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "generation_config.json",
+    ):
+        _copy_optional(checkpoint_dir / name, output_dir / name)
+    if (checkpoint_dir / "tokenizer_bin").is_dir() and not (output_dir / "tokenizer_bin").exists():
+        shutil.copytree(checkpoint_dir / "tokenizer_bin", output_dir / "tokenizer_bin")
+    return weights_path, config_path, manifest_path
 
 
 def step_convert_gguf(
@@ -1148,6 +1209,12 @@ def run_pipeline(args: argparse.Namespace) -> int:
         local_gguf = _find_local_gguf(info["path"])
         if local_gguf is not None:
             gguf_path = local_gguf
+    elif input_type == "local_dir" and _is_safetensors_checkpoint_dir(info["path"]):
+        weights_path, config_path, manifest_path = step_convert_safetensors(
+            info["path"],
+            work_dir,
+            force=args.force_convert,
+        )
     elif input_type == "local_config":
         model_dir = info["path"].parent
         if not _is_runtime_dir(model_dir):
@@ -1158,6 +1225,30 @@ def run_pipeline(args: argparse.Namespace) -> int:
         local_gguf = _find_local_gguf(model_dir)
         if local_gguf is not None:
             gguf_path = local_gguf
+    elif input_type == "hf_id":
+        model_dir = step_download(info["model_id"], CACHE_DIR, force=args.force_download)
+        if _is_safetensors_checkpoint_dir(model_dir):
+            weights_path, config_path, manifest_path = step_convert_safetensors(
+                model_dir,
+                work_dir,
+                force=args.force_convert,
+            )
+        else:
+            local_gguf = _find_local_gguf(model_dir)
+            if local_gguf is None:
+                raise RuntimeError(
+                    f"HF repo {info['model_id']} has no GGUF or safetensors checkpoint artifacts. "
+                    "Expected *.gguf, *.safetensors, or model.safetensors.index.json."
+                )
+            gguf_path = local_gguf
+            repo_id_for_tokenizer = info["model_id"]
+            ensure_tokenizer_files(repo_id_for_tokenizer, work_dir)
+            weights_path, config_path, manifest_path = step_convert_gguf(
+                gguf_path,
+                work_dir,
+                force=args.force_convert,
+                context_len=args.context_len,
+            )
     else:
         gguf_path, repo_id_for_tokenizer = _resolve_gguf_input(model_input, force_download=args.force_download)
         if repo_id_for_tokenizer:

--- a/version/v8/templates/gemma4_speculative_pair.json
+++ b/version/v8/templates/gemma4_speculative_pair.json
@@ -62,6 +62,39 @@
         "accepted_count": "accepted_count",
         "rejected_count": "rejected_count"
       }
+    },
+    "speculative_contract": {
+      "enabled": true,
+      "mode": "target_draft_verify",
+      "draft_length": 1,
+      "verify_policy": "greedy",
+      "commit_policy": "accept_one_or_target_fallback",
+      "target_circuit": "target_prefill",
+      "draft_circuit": "draft_decode_step",
+      "bridge": {
+        "source": "target_hidden_stream",
+        "dest": "draft_backbone_stream"
+      },
+      "token_source": "speculative_commit_or_reject.verified_token",
+      "count_source": "constant_1",
+      "state_policy": {
+        "target": "advance_by_committed_count",
+        "draft": "sync_to_target_position"
+      },
+      "invariants": [
+        "target_is_authoritative",
+        "speculative_tokens_match_target_only_greedy",
+        "accepted_count_plus_rejected_count_equals_committed_count"
+      ]
+    },
+    "autoregressive_contract": {
+      "enabled": true,
+      "mode": "speculative",
+      "stream": "main_generation",
+      "position_source": "target_position",
+      "token_source": "speculative_commit_or_reject.verified_token",
+      "count_source": "constant_1",
+      "stop_policy": "eos_or_max_tokens"
     }
   },
   "sequence": [


### PR DESCRIPTION
## Summary
- harden v8 model bring-up for Nemotron, GLM4, Gemma4 assistant/speculative scaffolding, Kimi MLA, and vision visualizer artifacts
- add model/kernel maps, template guardrails, parity harnesses, docs pages, and visualizer/test-report coverage
- route local and hf:// safetensors checkpoints through the safetensors-to-BUMP converter instead of misclassifying them as GGUF/runtime directories

## Validation
- pre-commit: v7-regression-fast passed
- pre-commit: v8-regression-fast passed
- pre-push: build passed
- pre-push: kernel parity tests passed
- pre-push: v8 E2E text smoke passed
- pre-push: v8 inference contracts passed
- pre-push: v7 training contract smoke passed
- pre-push: v7 fast regression passed
- pre-push: v8 fast regression passed
- pre-push: v7 training-kernel parity passed
- local: .venv/bin/python -m py_compile version/v8/scripts/ck_run_v8.py tests/test_v8_native_bridge_host.py
- local: .venv/bin/python -m unittest tests.test_v8_native_bridge_host

## Notes
- Large real-model smokes remain gated by local disk/RAM availability.
- The safetensors runner fix is committed as 1e34eb6a.