### PR TITLE
feat(v8): harden advanced model bring-up and parity coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -615,8 +615,11 @@ PY_TESTS := unittest/test_layernorm.py \
             unittest/test_qk_norm.py \
             tests/test_deltanet.py \
             unittest/test_recurrent_conv_state_update.py \
+            unittest/test_nemotron_router.py \
+            unittest/test_moe_relu2_expert.py \
             unittest/test_mamba2_reference.py \
             unittest/test_deepseek_reference_kernels.py \
+            unittest/test_gemma4_assistant_kernels.py \
             unittest/test_swiglu.py \
             unittest/test_fused_swiglu_decode.py \
             unittest/test_fused_attention_decode.py \

--- a/unittest/test_deepseek_reference_kernels.py
+++ b/unittest/test_deepseek_reference_kernels.py
@@ -38,6 +38,12 @@ lib.deepseek_mla_partial_rope_concat_f32.argtypes = [fptr, fptr, fptr, fptr, fpt
 lib.deepseek_mla_partial_rope_concat_f32.restype = None
 lib.deepseek_mla_partial_rope_concat_packed_f32.argtypes = [fptr, fptr, fptr, fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
 lib.deepseek_mla_partial_rope_concat_packed_f32.restype = None
+lib.deepseek_mla_kv_cache_batch_store_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.deepseek_mla_kv_cache_batch_store_f32.restype = None
+lib.deepseek_mla_kv_cache_store_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.deepseek_mla_kv_cache_store_f32.restype = None
+lib.deepseek_mla_attention_decode_f32.argtypes = [fptr, fptr, fptr, fptr, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+lib.deepseek_mla_attention_decode_f32.restype = None
 
 
 def ptr(a):
@@ -224,6 +230,82 @@ class TestDeepSeekReferenceKernels(unittest.TestCase):
         )
         np.testing.assert_allclose(query, q_ref.numpy(), rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(key, k_ref.numpy(), rtol=1e-6, atol=1e-6)
+
+    def test_mla_kv_cache_batch_store_uses_head_major_padded_layout(self):
+        rng = np.random.default_rng(31)
+        tokens, kv_heads, qk_dim, v_dim, max_seq, stride = 3, 2, 4, 3, 5, 6
+        k = np.ascontiguousarray(rng.normal(scale=0.2, size=(tokens, kv_heads, qk_dim)).astype(np.float32))
+        v = np.ascontiguousarray(rng.normal(scale=0.2, size=(tokens, kv_heads, v_dim)).astype(np.float32))
+        k_cache = np.full((kv_heads, max_seq, stride), -7.0, dtype=np.float32)
+        v_cache = np.full((kv_heads, max_seq, stride), -8.0, dtype=np.float32)
+
+        lib.deepseek_mla_kv_cache_batch_store_f32(
+            ptr(k_cache), ptr(v_cache), ptr(k), ptr(v),
+            tokens, kv_heads, qk_dim, v_dim, max_seq, stride,
+        )
+
+        for t in range(tokens):
+            for h in range(kv_heads):
+                np.testing.assert_allclose(k_cache[h, t, :qk_dim], k[t, h], rtol=0.0, atol=0.0)
+                np.testing.assert_allclose(v_cache[h, t, :v_dim], v[t, h], rtol=0.0, atol=0.0)
+                np.testing.assert_allclose(k_cache[h, t, qk_dim:], 0.0, rtol=0.0, atol=0.0)
+                np.testing.assert_allclose(v_cache[h, t, v_dim:], 0.0, rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(k_cache[:, tokens:, :], -7.0, rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(v_cache[:, tokens:, :], -8.0, rtol=0.0, atol=0.0)
+
+    def test_mla_kv_cache_decode_store_writes_only_requested_position(self):
+        rng = np.random.default_rng(37)
+        kv_heads, qk_dim, v_dim, max_seq, stride = 3, 4, 2, 6, 5
+        pos = 4
+        k = np.ascontiguousarray(rng.normal(scale=0.2, size=(kv_heads, qk_dim)).astype(np.float32))
+        v = np.ascontiguousarray(rng.normal(scale=0.2, size=(kv_heads, v_dim)).astype(np.float32))
+        k_cache = np.full((kv_heads, max_seq, stride), -3.0, dtype=np.float32)
+        v_cache = np.full((kv_heads, max_seq, stride), -4.0, dtype=np.float32)
+
+        lib.deepseek_mla_kv_cache_store_f32(
+            ptr(k_cache), ptr(v_cache), ptr(k), ptr(v),
+            pos, kv_heads, qk_dim, v_dim, max_seq, stride,
+        )
+
+        for h in range(kv_heads):
+            np.testing.assert_allclose(k_cache[h, pos, :qk_dim], k[h], rtol=0.0, atol=0.0)
+            np.testing.assert_allclose(v_cache[h, pos, :v_dim], v[h], rtol=0.0, atol=0.0)
+            np.testing.assert_allclose(k_cache[h, pos, qk_dim:], 0.0, rtol=0.0, atol=0.0)
+            np.testing.assert_allclose(v_cache[h, pos, v_dim:], 0.0, rtol=0.0, atol=0.0)
+        mask = np.ones((kv_heads, max_seq), dtype=bool)
+        mask[:, pos] = False
+        np.testing.assert_allclose(k_cache[mask], -3.0, rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(v_cache[mask], -4.0, rtol=0.0, atol=0.0)
+
+    def test_mla_decode_attention_matches_reference_cache_read(self):
+        rng = np.random.default_rng(41)
+        heads, kv_heads, cache_len, qk_dim, v_dim, max_seq, stride = 4, 2, 3, 5, 3, 6, 7
+        q = np.ascontiguousarray(rng.normal(scale=0.12, size=(heads, qk_dim)).astype(np.float32))
+        k_cache = np.zeros((kv_heads, max_seq, stride), dtype=np.float32)
+        v_cache = np.zeros((kv_heads, max_seq, stride), dtype=np.float32)
+        k_cache[:, :cache_len, :qk_dim] = rng.normal(scale=0.11, size=(kv_heads, cache_len, qk_dim)).astype(np.float32)
+        v_cache[:, :cache_len, :v_dim] = rng.normal(scale=0.09, size=(kv_heads, cache_len, v_dim)).astype(np.float32)
+        out = np.empty((heads, v_dim), dtype=np.float32)
+
+        ref = np.zeros_like(out)
+        scale = 1.0 / math.sqrt(qk_dim)
+        for h in range(heads):
+            kv_h = h * kv_heads // heads
+            scores = np.array(
+                [float(np.dot(q[h], k_cache[kv_h, j, :qk_dim])) * scale for j in range(cache_len)],
+                dtype=np.float64,
+            )
+            weights = np.exp(scores - np.max(scores))
+            weights /= np.sum(weights)
+            for j, w in enumerate(weights):
+                ref[h] += (w * v_cache[kv_h, j, :v_dim]).astype(np.float32)
+
+        lib.deepseek_mla_attention_decode_f32(
+            ptr(q), ptr(k_cache), ptr(v_cache), ptr(out),
+            heads, kv_heads, cache_len, qk_dim, v_dim, max_seq, stride,
+        )
+
+        np.testing.assert_allclose(out, ref, rtol=1e-6, atol=1e-6)
 
     def test_csa_attention_forward_backward(self):
         torch.manual_seed(13)

--- a/unittest/test_gemma4_assistant_kernels.py
+++ b/unittest/test_gemma4_assistant_kernels.py
@@ -12,6 +12,7 @@ import numpy as np
 ROOT = Path(__file__).resolve().parents[1]
 LIB = ROOT / "build" / "libckernel_engine.so"
 F32P = ctypes.POINTER(ctypes.c_float)
+I32P = ctypes.POINTER(ctypes.c_int)
 
 
 def load_lib():
@@ -26,6 +27,10 @@ def as_f32(values):
 
 def ptr(array):
     return array.ctypes.data_as(F32P)
+
+
+def iptr(array):
+    return array.ctypes.data_as(I32P)
 
 
 def rmsnorm_rows(x, gamma, eps):
@@ -125,6 +130,24 @@ class TestGemma4AssistantKernels(unittest.TestCase):
             ctypes.c_int,
             ctypes.c_int,
         ]
+        cls.lib.speculative_verify_greedy_f32.argtypes = [
+            F32P,
+            ctypes.c_int,
+            ctypes.c_int,
+            I32P,
+            I32P,
+        ]
+        cls.lib.speculative_commit_one_i32.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            I32P,
+            I32P,
+            ctypes.c_int,
+            I32P,
+            I32P,
+            I32P,
+            I32P,
+        ]
 
     def test_assistant_layer_scale_forward_matches_numpy(self):
         hidden = as_f32(np.arange(15, dtype=np.float32).reshape(3, 5) - 4.0)
@@ -187,6 +210,80 @@ class TestGemma4AssistantKernels(unittest.TestCase):
         )
 
         np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-5)
+
+    def test_speculative_verify_accepts_matching_draft_token(self):
+        logits = as_f32([-0.5, 0.25, 2.0, 1.25])
+        accepted = np.array([-1], dtype=np.int32)
+        verified = np.array([-1], dtype=np.int32)
+
+        self.lib.speculative_verify_greedy_f32(ptr(logits), 4, 2, iptr(accepted), iptr(verified))
+
+        self.assertEqual(int(accepted[0]), 1)
+        self.assertEqual(int(verified[0]), 2)
+
+    def test_speculative_verify_rejects_and_uses_target_argmax(self):
+        logits = as_f32([-0.5, 0.25, 2.0, 1.25])
+        accepted = np.array([-1], dtype=np.int32)
+        verified = np.array([-1], dtype=np.int32)
+
+        self.lib.speculative_verify_greedy_f32(ptr(logits), 4, 1, iptr(accepted), iptr(verified))
+
+        self.assertEqual(int(accepted[0]), 0)
+        self.assertEqual(int(verified[0]), 2)
+
+    def test_speculative_commit_updates_buffer_positions_and_counters(self):
+        token_buffer = np.full(4, -99, dtype=np.int32)
+        token_count = np.array([1], dtype=np.int32)
+        target_position = np.array([7], dtype=np.int32)
+        draft_position = np.array([3], dtype=np.int32)
+        accepted_count = np.array([2], dtype=np.int32)
+        rejected_count = np.array([5], dtype=np.int32)
+
+        self.lib.speculative_commit_one_i32(
+            1,
+            42,
+            iptr(token_buffer),
+            iptr(token_count),
+            4,
+            iptr(target_position),
+            iptr(draft_position),
+            iptr(accepted_count),
+            iptr(rejected_count),
+        )
+
+        self.assertEqual(token_buffer.tolist(), [-99, 42, -99, -99])
+        self.assertEqual(int(token_count[0]), 2)
+        self.assertEqual(int(target_position[0]), 8)
+        self.assertEqual(int(draft_position[0]), 8)
+        self.assertEqual(int(accepted_count[0]), 3)
+        self.assertEqual(int(rejected_count[0]), 5)
+
+    def test_speculative_commit_reject_counter_and_full_buffer_guard(self):
+        token_buffer = np.array([7, 8], dtype=np.int32)
+        token_count = np.array([2], dtype=np.int32)
+        target_position = np.array([4], dtype=np.int32)
+        draft_position = np.array([4], dtype=np.int32)
+        accepted_count = np.array([0], dtype=np.int32)
+        rejected_count = np.array([0], dtype=np.int32)
+
+        self.lib.speculative_commit_one_i32(
+            0,
+            11,
+            iptr(token_buffer),
+            iptr(token_count),
+            2,
+            iptr(target_position),
+            iptr(draft_position),
+            iptr(accepted_count),
+            iptr(rejected_count),
+        )
+
+        self.assertEqual(token_buffer.tolist(), [7, 8])
+        self.assertEqual(int(token_count[0]), 2)
+        self.assertEqual(int(target_position[0]), 5)
+        self.assertEqual(int(draft_position[0]), 5)
+        self.assertEqual(int(accepted_count[0]), 0)
+        self.assertEqual(int(rejected_count[0]), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- harden v8 advanced model bring-up for Nemotron/Mamba2, GLM4, Gemma4 assistant/speculative scaffold, Kimi MLA, and vision/runtime paths
- add direct C-level parity coverage for Gemma4 assistant/MTP speculative verifier and committer kernels
- add direct C-level parity coverage for Kimi/DeepSeek MLA explicit KV cache store and decode attention kernels
- include advanced family parity suites in the standard kernel test list

## Validation
- make build/libckernel_engine.so
- .venv/bin/python -m py_compile unittest/test_gemma4_assistant_kernels.py unittest/test_deepseek_reference_kernels.py unittest/test_nemotron_router.py unittest/test_moe_relu2_expert.py unittest/test_mamba2_reference.py
- .venv/bin/python unittest/test_gemma4_assistant_kernels.py -v
- .venv/bin/python unittest/test_deepseek_reference_kernels.py -v
- .venv/bin/python unittest/test_nemotron_router.py
- .venv/bin/python unittest/test_moe_relu2_expert.py
- .venv/bin/python unittest/test_mamba2_reference.py
- pre-commit: v7-regression-fast passed
- pre-commit: v8-regression-fast passed
- pre-push: build, kernel parity, v8 E2E text smoke, v8 contracts, v7 training smoke, v7/v8 fast regression, and training-kernel parity passed

## Notes
- Real large-model Gemma/Kimi/GLM smokes remain gated by local RAM/disk availability.
- Latest parity coverage commit: 119527ae.