### PR TITLE
Harden v8 advanced model and vision bridge coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1254,6 +1254,27 @@ test-v8-qwen3vl-ocr-smoke:
 			--temperature 0.0; \
 	fi
 
+bench-v8-qwen3vl-ocr-quick:
+	@$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/generate_ocr_assets_v8.py
+	CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+		$(PYTHON) $(PYTHONFLAGS) benchmarks/bench_v8_qwen3vl_ocr.py \
+		--images "$(V8_QWEN3VL_OCR_IMAGE)" \
+		--threads $${CK_NUM_THREADS:-24} \
+		--max-tokens $(V8_QWEN3VL_OCR_MAX_TOKENS) \
+		--context-len 1024 \
+		--image-min-tokens $(V8_QWEN3VL_OCR_IMAGE_MIN_TOKENS) \
+		--json-out build/v8_qwen3vl_ocr_quick_t$${CK_NUM_THREADS:-24}.json
+
+bench-v8-qwen3vl-ocr:
+	@$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/generate_ocr_assets_v8.py
+	CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+		$(PYTHON) $(PYTHONFLAGS) benchmarks/bench_v8_qwen3vl_ocr.py \
+		--threads $${CK_NUM_THREADS:-24} \
+		--max-tokens $(V8_QWEN3VL_OCR_MAX_TOKENS) \
+		--context-len 1024 \
+		--image-min-tokens $(V8_QWEN3VL_OCR_IMAGE_MIN_TOKENS) \
+		--json-out build/v8_qwen3vl_ocr_t$${CK_NUM_THREADS:-24}.json
+
 test-v8-gemma4-vision-smoke:
 	@avail_kb=$$(awk '/MemAvailable:/ {print $$2}' /proc/meminfo 2>/dev/null || echo 0); \
 	threshold_kb=$$(( $(V8_GEMMA4_MIN_MEM_GB) * 1024 * 1024 )); \
@@ -2667,7 +2688,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/benchmarks/bench_v8_qwen3vl_ocr.py
+++ b/benchmarks/bench_v8_qwen3vl_ocr.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Wall-clock Qwen3-VL OCR benchmark for CKE v8.
+
+This benchmark runs the existing v8 multimodal bridge path and reads the
+structured timing fields from ``bridge_report.json``. It is designed for
+OpenShift/no-sudo environments: no perf counters, only wall-clock timings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CK_RUN_V8 = ROOT / "version" / "v8" / "scripts" / "ck_run_v8.py"
+ASSET_DIR = ROOT / "version" / "v8" / "test_assets"
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+REPORT_RE = re.compile(r"Wrote bridge report to\s+([^\s\x1b]+)|done report=([^\s\x1b]+)")
+
+DEFAULT_MODEL = "hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf"
+DEFAULT_MMPROJ = "hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf"
+DEFAULT_IMAGES = [
+    ASSET_DIR / "v8_ocr_clean_text.ppm",
+    ASSET_DIR / "v8_ocr_table.ppm",
+    ASSET_DIR / "v8_ocr_receipt.ppm",
+    ASSET_DIR / "v8_ocr_paragraph.ppm",
+]
+
+
+def _run(cmd: list[str], *, env: dict[str, str], timeout: int) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    return proc.returncode, proc.stdout
+
+
+def _extract_report_path(output: str) -> Path | None:
+    clean = ANSI_RE.sub("", output)
+    matches = list(REPORT_RE.finditer(clean))
+    if not matches:
+        return None
+    match = matches[-1]
+    value = match.group(1) or match.group(2)
+    if not value:
+        return None
+    return Path(value).expanduser()
+
+
+def _num(obj: dict[str, Any], key: str) -> float:
+    value = obj.get(key, 0.0)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _run_one(
+    *,
+    model: str,
+    mmproj: str,
+    image: Path,
+    prompt: str,
+    threads: int,
+    max_tokens: int,
+    context_len: int,
+    image_min_tokens: int,
+    force_compile: bool,
+    force_convert: bool,
+    bridge_runtime: str,
+    bridge_generation_mode: str,
+    timeout: int,
+) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(threads)
+    env["OMP_NUM_THREADS"] = env.get("OMP_NUM_THREADS", "1")
+    cmd = [
+        sys.executable,
+        str(CK_RUN_V8),
+        "run",
+        model,
+        "--mmproj",
+        mmproj,
+        "--image-path",
+        str(image),
+        "--image-min-tokens",
+        str(image_min_tokens),
+        "--prompt",
+        prompt,
+        "--context-len",
+        str(context_len),
+        "--thinking-mode",
+        "suppressed",
+        "--max-tokens",
+        str(max_tokens),
+        "--temperature",
+        "0.0",
+    ]
+    if bridge_runtime:
+        cmd.extend(["--bridge-runtime", bridge_runtime])
+    if bridge_generation_mode:
+        cmd.extend(["--bridge-generation-mode", bridge_generation_mode])
+    if force_compile:
+        cmd.append("--force-compile")
+    if force_convert:
+        cmd.append("--force-convert")
+    rc, out = _run(cmd, env=env, timeout=timeout)
+    report_path = _extract_report_path(out)
+    row: dict[str, Any] = {
+        "image": str(image),
+        "image_name": image.name,
+        "returncode": int(rc),
+        "command": cmd,
+        "stdout_tail": "\n".join(ANSI_RE.sub("", out).splitlines()[-80:]),
+        "report_path": None if report_path is None else str(report_path),
+    }
+    if rc != 0 or report_path is None or not report_path.exists():
+        row["status"] = "fail"
+        return row
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    timings = report.get("timings") if isinstance(report.get("timings"), dict) else {}
+    encoder_execute_ms = _num(timings, "encoder_execute_ms")
+    decoder_forward_ms = _num(timings, "decoder_forward_mixed_ms")
+    decoder_generation_ms = _num(timings, "decoder_generation_ms")
+    steady_state_ms = encoder_execute_ms + decoder_forward_ms + decoder_generation_ms
+    generated_tokens = int(report.get("generated_token_count") or timings.get("decoder_generated_tokens") or 0)
+    row.update(
+        {
+            "status": str(report.get("status") or "ok"),
+            "generated_text": str(report.get("generated_text") or ""),
+            "generated_token_count": generated_tokens,
+            "generation_stop_reason": str(report.get("generation_stop_reason") or ""),
+            "prefix_tokens": int(report.get("prefix_tokens") or timings.get("prefix_tokens") or 0),
+            "total_prefill_tokens": int(report.get("total_prefill_tokens") or timings.get("total_prefill_tokens") or 0),
+            "timings": timings,
+            "startup_ms": _num(timings, "encoder_prepare_ms") + _num(timings, "decoder_prepare_ms"),
+            "steady_state_ms": steady_state_ms,
+            "encoder_execute_ms": encoder_execute_ms,
+            "decoder_forward_mixed_ms": decoder_forward_ms,
+            "decoder_generation_ms": decoder_generation_ms,
+            "decoder_generation_tok_s": _num(timings, "decoder_generation_tok_s"),
+            "steady_generated_tok_s": (generated_tokens / (steady_state_ms / 1000.0)) if steady_state_ms > 0 and generated_tokens > 0 else 0.0,
+        }
+    )
+    return row
+
+
+def _fmt(value: Any, digits: int = 1) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.{digits}f}"
+    return str(value)
+
+
+def _print_table(rows: list[dict[str, Any]]) -> None:
+    print("\n| Image | Status | Prefix | Prefill | Enc ms | Mixed ms | Gen ms | Gen tok/s | Steady tok/s | Text |")
+    print("|---|---:|---:|---:|---:|---:|---:|---:|---:|---|")
+    for row in rows:
+        text = str(row.get("generated_text") or "").replace("\n", "\\n")
+        if len(text) > 48:
+            text = text[:45] + "..."
+        print(
+            "| "
+            + " | ".join(
+                [
+                    str(row.get("image_name", "")),
+                    str(row.get("status", "")),
+                    str(row.get("prefix_tokens", "")),
+                    str(row.get("total_prefill_tokens", "")),
+                    _fmt(row.get("encoder_execute_ms", 0.0)),
+                    _fmt(row.get("decoder_forward_mixed_ms", 0.0)),
+                    _fmt(row.get("decoder_generation_ms", 0.0)),
+                    _fmt(row.get("decoder_generation_tok_s", 0.0), 3),
+                    _fmt(row.get("steady_generated_tok_s", 0.0), 3),
+                    f"`{text}`",
+                ]
+            )
+            + " |"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--mmproj", default=DEFAULT_MMPROJ)
+    parser.add_argument("--images", nargs="*", type=Path, default=DEFAULT_IMAGES)
+    parser.add_argument("--prompt", default="Read the text in this image. Return only the visible text.")
+    parser.add_argument("--threads", type=int, default=int(os.environ.get("CK_NUM_THREADS", "24")))
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--context-len", type=int, default=1024)
+    parser.add_argument("--image-min-tokens", type=int, default=128)
+    parser.add_argument("--timeout", type=int, default=1800)
+    parser.add_argument("--bridge-runtime", choices=["prefill", "decode-staged"], default=None, help="Override template bridge runtime policy")
+    parser.add_argument("--bridge-generation-mode", choices=["incremental-decode", "mixed-replay"], default=None, help="Override template bridge generation policy")
+    parser.add_argument("--force-compile", action="store_true")
+    parser.add_argument("--force-convert", action="store_true")
+    parser.add_argument("--json-out", type=Path, default=ROOT / "build" / "v8_qwen3vl_ocr_bench.json")
+    args = parser.parse_args()
+
+    rows = []
+    for image in args.images:
+        image = image.resolve()
+        if not image.exists():
+            rows.append({"image": str(image), "image_name": image.name, "status": "missing"})
+            continue
+        print(f"== OCR image {image.name} ==", flush=True)
+        rows.append(
+            _run_one(
+                model=str(args.model),
+                mmproj=str(args.mmproj),
+                image=image,
+                prompt=str(args.prompt),
+                threads=int(args.threads),
+                max_tokens=int(args.max_tokens),
+                context_len=int(args.context_len),
+                image_min_tokens=int(args.image_min_tokens),
+                force_compile=bool(args.force_compile),
+                force_convert=bool(args.force_convert),
+                bridge_runtime=args.bridge_runtime,
+                bridge_generation_mode=args.bridge_generation_mode,
+                timeout=int(args.timeout),
+            )
+        )
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "args": {
+            "model": str(args.model),
+            "mmproj": str(args.mmproj),
+            "images": [str(p) for p in args.images],
+            "threads": int(args.threads),
+            "max_tokens": int(args.max_tokens),
+            "context_len": int(args.context_len),
+            "image_min_tokens": int(args.image_min_tokens),
+            "bridge_runtime": args.bridge_runtime,
+            "bridge_generation_mode": args.bridge_generation_mode,
+        },
+        "results": rows,
+    }
+    args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _print_table(rows)
+    print(f"\nWrote {args.json_out}")
+    return 0 if all(row.get("status") == "ok" for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/WALL_CLOCK_PERFORMANCE_BASELINE_2026-06-30.md
+++ b/docs/WALL_CLOCK_PERFORMANCE_BASELINE_2026-06-30.md
@@ -1,0 +1,146 @@
+# Wall-Clock Performance Baseline - 2026-06-30
+
+This file captures the current C-Kernel-Engine speed position against
+llama.cpp using wall-clock timing only.  The machine used for the latest local
+checks is the 5th Gen Xeon OpenShift environment.  We do not assume `perf`,
+VTune, Advisor, or sudo access for this baseline.
+
+## Revision
+
+| Field | Value |
+|---|---|
+| Branch base | `nemotron-mamba2-reference` / PR #77 stack |
+| Patch scope | Qwen3-VL OCR bridge contract, staged-decode reporting, and wall-clock benchmark harness |
+| Expected speed impact | Low; this patch makes bridge/runtime timing measurable; hot-kernel speed work remains separate |
+| Timing method | Runtime-reported prompt/decode timing and CK per-op wall-clock CSV |
+
+## Model-Level Speed Snapshot
+
+These rows combine documented direct CK-vs-llama runs and recent local CKE
+runtime reports.  Treat them as a baseline ledger, not a single perfectly
+controlled benchmark suite.
+
+| Model | Quant | Threads | Source | llama.cpp prompt | CKE prompt | CKE/llama prompt | llama.cpp decode | CKE decode | CKE/llama decode | Notes |
+|---|---:|---:|---|---:|---:|---:|---:|---:|---:|---|
+| Qwen3.5 0.8B | Q4_K_M | 24 | direct comparison log | 96.0 tok/s | 28.7 tok/s | 0.30x | 45.9 tok/s | 28.0 tok/s | 0.61x | Older direct comparison; useful speed reference. |
+| Qwen3 0.6B | Q8_0 | local cached v8 | runtime report | n/a | 237.2 tok/s | n/a | n/a | 39.0 tok/s | n/a | CKE-only smoke after correctness work. |
+| Qwen3.5 0.8B | Q4_K_M | local cached v8 | runtime report | n/a | 20.2 tok/s | n/a | n/a | 18.1 tok/s | n/a | CKE-only smoke; slower prompt path remains visible. |
+| Gemma3 270M | Q5_K_M | local cached v8 | runtime report | n/a | 26.8 tok/s | n/a | n/a | 27.4 tok/s | n/a | CKE-only smoke. |
+| Gemma4 E4B | Q4_K_M | 24 | local chat run | n/a | about 10.6 tok/s | n/a | n/a | about 9.1 tok/s | n/a | Coherent long C-code answer; still slow. |
+| GLM-4 9B | Q4_K_M | 24 | local chat run | n/a | 16.8 tok/s | n/a | n/a | 8.2 tok/s | n/a | Coherent long C/Python/SQL answer after producer/consumer fix. |
+| Nemotron Nano 9B v2 | Q4_K_M | 24 | local chat run | n/a | 9.9 tok/s | n/a | n/a | 7.5 tok/s | n/a | Coherent text after Mamba/state fixes. |
+
+## Prefill Micro-Profile Snapshot
+
+Recent wall-clock prefill profiles show where CKE is still losing most of the
+time.  These are CKE-only profile rows from `build/v8_prefill_profile_*.csv`;
+they are useful for patch-to-patch comparisons even without hardware counters.
+
+| Model/profile | Threads | Shape | Total | Rate | Main hot path |
+|---|---:|---|---:|---:|---|
+| Qwen3.5 Q4_K_M, scalar opt-out | 12 | p128 | 958.9 ms | 133.5 tok/s | Q4_K x Q8_K `mlp_gate_up` at 353.5 ms |
+| Qwen3.5 Q4_K_M, VNNI default | 12 | p128 | 616.4 ms | 207.6 tok/s | Q4_K x Q8_K `mlp_gate_up` at 165.2 ms |
+| Gemma4 E4B Q4_K_M, scalar opt-out | 12 | p64 | 4084.4 ms | 15.7 tok/s | Q4_K x Q8_K `mlp_gate_up` at 1767.6 ms |
+| Gemma4 E4B Q4_K_M, VNNI default | 12 | p64 | 3042.5 ms | 21.0 tok/s | Q4_K x Q8_K `mlp_gate_up` at 1108.2 ms |
+
+Current profile files:
+
+```text
+build/v8_prefill_profile_qwen35-0.8b-q4_k_m_p128_t12.csv
+build/v8_prefill_profile_qwen35-0.8b-q4_k_m_p128_t24.csv
+build/v8_prefill_profile_qwen35-0.8b-q4_k_m_p512_t24.csv
+build/v8_prefill_profile_gemma4-e4b-q4_k_m_p64_t12.csv
+build/v8_prefill_profile_gemma4-e4b-q4_k_m_p512_t24.csv
+```
+
+## Current Read
+
+| Area | Status |
+|---|---|
+| Decode on small Qwen-family models | Often close enough to be usable; sometimes near llama.cpp, but not consistently faster. |
+| Qwen3.5 decode | Usually behind llama.cpp, roughly 0.6x in the documented direct comparison. |
+| Prompt/prefill | Main gap.  CKE is often 0.1x-0.3x of llama.cpp on larger or hybrid models. |
+| Gemma4 text | Correctness is much stronger now, but speed remains weak. |
+| Qwen3-VL OCR bridge | Correctness improved; speed still needs a separate controlled CK-vs-llama vision sweep. |
+
+## Aggregated CKE Wall-Clock Hot Spots
+
+These rankings come from summing `time_us` in the p512/t24 CKE prefill profile
+CSVs.  They are the best no-sudo proxy for "where time is going" on this
+machine.
+
+### Gemma4 E4B Q4_K_M p512/t24
+
+| Rank | Kernel/op | Time | Share |
+|---:|---|---:|---:|
+| 1 | `gemm_nt_q4_k_q8_k` / `mlp_gate_up` | 6965.2 ms | 31.9% |
+| 2 | `geglu_forward_exact` / `geglu` | 4036.4 ms | 18.5% |
+| 3 | `gemma4_per_layer_embed_forward` / `gemma4_per_layer_embed` | 3008.0 ms | 13.8% |
+| 4 | `attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4` / `attn_sliding` | 1735.7 ms | 8.0% |
+| 5 | `gemm_nt_q4_k_q8_k` / `mlp_down` | 1457.0 ms | 6.7% |
+
+Top three share: about 64.2% of measured prefill time.
+
+### Qwen3.5 0.8B Q4_K_M p512/t24
+
+| Rank | Kernel/op | Time | Share |
+|---:|---|---:|---:|
+| 1 | `gemm_nt_q4_k_q8_k` / `mlp_gate_up` | 499.5 ms | 21.5% |
+| 2 | `ssm_conv1d_forward` / `recurrent_ssm_conv` | 327.2 ms | 14.1% |
+| 3 | `attention_forward_causal_head_major_gqa_flash_strided` / `attn` | 288.6 ms | 12.4% |
+| 4 | `gemm_nt_q5_k` / `recurrent_qkv_proj` | 174.6 ms | 7.5% |
+| 5 | `swiglu_forward` / `silu_mul` | 154.3 ms | 6.6% |
+
+Top three share: about 48.0% of measured prefill time.
+
+## No-Sudo Measurement Plan
+
+Use wall-clock and existing CKE per-op CSVs:
+
+1. Fix the run shape:
+   - same model file
+   - same prompt tokens or same text prompt
+   - same context length
+   - same max decode tokens
+   - same thread count
+   - same temperature, preferably `0.0`
+2. Run llama.cpp and CKE with warm cache where possible.
+3. Record:
+   - prompt tok/s
+   - decode tok/s
+   - total elapsed time
+   - generated token count
+   - stop reason
+4. For CKE, also save `profile_decode.csv` or prefill profile CSV when available.
+5. Compare patch-to-patch before comparing across machines.
+
+Recommended sweep dimensions:
+
+| Dimension | Values |
+|---|---|
+| Threads | 1, 2, 4, 8, 12, 24, 48 |
+| Prompt tokens | 64, 128, 512 |
+| Decode tokens | 64, 128, 256 |
+| Models | Qwen3.5 0.8B, Gemma4 E4B, GLM-4 9B, Nemotron 9B, Qwen3-VL |
+
+## Next Speed Targets
+
+| Priority | Target | Why |
+|---:|---|---|
+| 1 | Packed/repacked Q4_K/Q6_K x Q8_K batched prefill GEMM | This is still the largest prompt/prefill gap versus llama.cpp. |
+| 2 | Gemma4 `geglu_forward_exact` and per-layer embed/prepare | Gemma4 profiles show large scalar/glue overhead. |
+| 3 | Head-major/final logits paths | Large vocab projections dominate decode for some models. |
+| 4 | Threadpool/orchestrator tuning | Useful only after hot kernels are not decode-style row loops. |
+| 5 | Vision bridge timing split | Needed for Qwen3-VL/Gemma4V OCR: encoder, projector, replay, mixed prefill, decode. |
+
+## Rule For Future Updates
+
+Every performance patch should update this baseline or add a dated sibling file
+with:
+
+- git head
+- local patch name
+- exact command shape
+- prompt/decode tok/s
+- top three CKE profile rows by wall-clock time
+- whether output quality/parity stayed acceptable

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -176,6 +176,33 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             self.assertEqual(out["merged_grid_y"], 8)
             self.assertEqual(out["vision_merged_tokens"], 128)
 
+    def test_qwen3vl_decoder_declares_bridge_generation_contract(self) -> None:
+        doc = build_ir_v8._load_builtin_template_doc("qwen3vl")
+        bridge = doc["contract"]["multimodal_bridge"]
+        self.assertEqual(bridge["prefix_policy"], "mixed_visual_text_prefill")
+        self.assertEqual(bridge["generation_policy"], "incremental_decode_after_prefill")
+        self.assertEqual(bridge["position_policy"], "mrope_2d")
+        self.assertEqual(bridge["cache_policy"], "persistent_decoder_kv")
+        self.assertEqual(bridge["runtime_policy"], "decode_staged")
+        self.assertEqual(
+            run_multimodal_bridge_v8._bridge_runtime_from_policy(bridge),
+            "decode-staged",
+        )
+        self.assertEqual(
+            run_multimodal_bridge_v8._bridge_generation_mode_from_policy(bridge),
+            "incremental-decode",
+        )
+
+    def test_unknown_bridge_contract_defaults_to_safe_replay(self) -> None:
+        self.assertEqual(
+            run_multimodal_bridge_v8._bridge_runtime_from_policy({}, fallback="prefill"),
+            "prefill",
+        )
+        self.assertEqual(
+            run_multimodal_bridge_v8._bridge_generation_mode_from_policy({}, fallback="mixed-replay"),
+            "mixed-replay",
+        )
+
     def test_builtin_template_declares_qwen3vl_vision_contract(self) -> None:
         doc = build_ir_v8._load_builtin_template_doc("qwen3_vl_vision")
         self.assertIsNotNone(doc)

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1200,6 +1200,10 @@ def run_pipeline(args: argparse.Namespace) -> int:
             cmd.extend(["--image-max-tokens", str(int(args.image_max_tokens))])
         if args.synthetic_prefix_tokens > 0:
             cmd.extend(["--synthetic-prefix-tokens", str(int(args.synthetic_prefix_tokens))])
+        if args.bridge_runtime is not None:
+            cmd.extend(["--bridge-runtime", str(args.bridge_runtime)])
+        if args.bridge_generation_mode is not None:
+            cmd.extend(["--bridge-generation-mode", str(args.bridge_generation_mode)])
         if args.context_len is not None:
             cmd.extend(["--decoder-context-len", str(int(args.context_len))])
         run_cmd(cmd, cwd=PROJECT_ROOT)
@@ -1365,6 +1369,8 @@ Examples:
     run_parser.add_argument("--image-max-tokens", type=int, default=None, help="Maximum merged visual tokens for smart-resized Qwen3-VL images")
     run_parser.add_argument("--image-mode", choices=["checker", "gradient", "gray"], default="checker")
     run_parser.add_argument("--synthetic-prefix-tokens", type=int, default=0)
+    run_parser.add_argument("--bridge-runtime", choices=["prefill", "decode-staged"], default=None, help="Multimodal bridge decoder runtime; decode-staged enables incremental generation diagnostics")
+    run_parser.add_argument("--bridge-generation-mode", choices=["incremental-decode", "mixed-replay"], default=None, help="Multimodal generation mode after visual/text prefill")
     run_parser.add_argument("--vision-top-k", type=int, default=8)
     run_parser.add_argument(
         "--vision-activation-pref",

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -929,6 +929,61 @@ def _load_builtin_chat_contract(template_name: str | None) -> dict[str, Any] | N
     return chat_contract
 
 
+def _load_builtin_bridge_contract(template_name: str | None) -> dict[str, Any] | None:
+    doc = build_ir_v8._load_builtin_template_doc(_normalize_chat_template_choice(template_name))
+    if not isinstance(doc, dict):
+        return None
+    contract_doc = doc.get("contract") if isinstance(doc.get("contract"), dict) else None
+    if not isinstance(contract_doc, dict):
+        return None
+    bridge_contract = contract_doc.get("multimodal_bridge")
+    if not isinstance(bridge_contract, dict):
+        return None
+    return bridge_contract
+
+
+def _bridge_runtime_from_policy(contract: dict[str, Any] | None, fallback: str = "prefill") -> str:
+    bridge = contract if isinstance(contract, dict) else {}
+    runtime_policy = str(bridge.get("runtime_policy") or "").strip().lower().replace("-", "_")
+    generation_policy = str(bridge.get("generation_policy") or "").strip().lower().replace("-", "_")
+    cache_policy = str(bridge.get("cache_policy") or "").strip().lower().replace("-", "_")
+    if runtime_policy in {"decode_staged", "decode", "staged"}:
+        return "decode-staged"
+    if generation_policy == "incremental_decode_after_prefill" and cache_policy == "persistent_decoder_kv":
+        return "decode-staged"
+    return fallback
+
+
+def _bridge_generation_mode_from_policy(contract: dict[str, Any] | None, fallback: str = "mixed-replay") -> str:
+    bridge = contract if isinstance(contract, dict) else {}
+    generation_policy = str(bridge.get("generation_policy") or "").strip().lower().replace("-", "_")
+    if generation_policy == "incremental_decode_after_prefill":
+        return "incremental-decode"
+    if generation_policy in {"mixed_replay", "replay_mixed_prefix"}:
+        return "mixed-replay"
+    return fallback
+
+
+def _resolve_decoder_bridge_contract(
+    decoder_gguf: Path,
+    *,
+    chat_template_mode: str = "auto",
+) -> dict[str, Any]:
+    resolved_mode = _normalize_chat_template_choice(chat_template_mode)
+    if resolved_mode not in {"", "auto", "none"}:
+        explicit = _load_builtin_bridge_contract(resolved_mode)
+        if explicit is not None:
+            return dict(explicit)
+
+    meta = _read_gguf_metadata(decoder_gguf, {"general.architecture"})
+    arch = str(meta.get("general.architecture") or "").strip().lower()
+    if arch:
+        contract = _load_builtin_bridge_contract(arch)
+        if contract is not None:
+            return dict(contract)
+    return {}
+
+
 def _fallback_chat_contract_from_template_text(chat_template: str | None) -> dict[str, Any] | None:
     template = str(chat_template or "")
     if "<|im_start|>" in template and "<|im_end|>" in template:
@@ -2279,6 +2334,7 @@ def _run_decoder(
     prefix_text_pos: int | None = None,
     prefix_decode_policy: str = "causal_mixed_prefix",
     bridge_runtime: str = "prefill",
+    bridge_generation_mode: str = "mixed-replay",
     strict_parity: bool = False,
     tokenizer: GGUFTokenizer | Any | None = None,
     stop_token_ids: list[int] | None = None,
@@ -2298,6 +2354,9 @@ def _run_decoder(
     # runtime remains available as an explicit staged replay diagnostic/escape
     # hatch for architecture work.
     bridge_runtime_name = str(bridge_runtime or "prefill").strip().lower()
+    generation_mode = str(bridge_generation_mode or "mixed-replay").strip().lower().replace("-", "_")
+    if generation_mode not in {"incremental_decode", "mixed_replay"}:
+        raise ValueError(f"unsupported bridge_generation_mode={bridge_generation_mode!r}")
     if bridge_runtime_name in {"decode", "staged", "decode-staged"}:
         model_so = Path(runtime["so_path"])
     else:
@@ -2397,7 +2456,8 @@ def _run_decoder(
             rc = lib.ck_model_forward_mixed(prefix_ptr, prefix_tokens, after_token_arr, len(after_token_ids), logits)
         if rc != 0:
             raise RuntimeError(f"decoder forward_mixed failed with rc={rc}")
-        _log_progress(f"decoder: forward_mixed done elapsed={time.perf_counter() - forward_t0:.2f}s")
+        forward_elapsed = time.perf_counter() - forward_t0
+        _log_progress(f"decoder: forward_mixed done elapsed={forward_elapsed:.2f}s")
         logits_arr = array("f", logits)
         stop_ids = {int(token_id) for token_id in list(stop_token_ids or [])}
         generated_token_ids: list[int] = []
@@ -2447,7 +2507,7 @@ def _run_decoder(
                     _log_progress(f"decoder: generation progress tokens={len(generated_token_ids)}")
                 if step + 1 >= int(effective_max_tokens):
                     break
-                if model_so == Path(runtime.get("prefill_so_path") or ""):
+                if model_so == Path(runtime.get("prefill_so_path") or "") and generation_mode == "mixed_replay":
                     replay_after_ids = after_token_ids + generated_token_ids
                     replay_after_arr = (ctypes.c_int32 * len(replay_after_ids))(*replay_after_ids) if replay_after_ids else None
                     if before_token_ids and hasattr(lib, "ck_model_forward_segments_grid_ex"):
@@ -2498,11 +2558,14 @@ def _run_decoder(
                 current_logits = logits
             if stream_output and generated_token_ids:
                 print("", flush=True)
+            generation_elapsed = time.perf_counter() - gen_t0
             _log_progress(
                 "decoder: generation done "
-                f"elapsed={time.perf_counter() - gen_t0:.2f}s generated_tokens={len(generated_token_ids)} "
+                f"elapsed={generation_elapsed:.2f}s generated_tokens={len(generated_token_ids)} "
                 f"stop={generation_stop_reason}"
             )
+        else:
+            generation_elapsed = 0.0
         generated_text = ""
         generated_text_raw = ""
         if tokenizer is not None and generated_token_ids:
@@ -2517,6 +2580,17 @@ def _run_decoder(
             "generated_text_raw": generated_text_raw,
             "generation_stop_reason": generation_stop_reason,
             "streamed_output": bool(stream_output and tokenizer is not None and max_tokens > 0),
+            "timings": {
+                "decoder_forward_mixed_ms": float(forward_elapsed * 1000.0),
+                "decoder_generation_ms": float(generation_elapsed * 1000.0),
+                "decoder_generated_tokens": int(len(generated_token_ids)),
+                "decoder_generation_tok_s": (
+                    float(len(generated_token_ids) / generation_elapsed)
+                    if generation_elapsed > 0.0 and generated_token_ids
+                    else 0.0
+                ),
+                "decoder_bridge_generation_mode": generation_mode,
+            },
         }
     finally:
         if 'old_bridge_noncausal_env' in locals():
@@ -2767,7 +2841,13 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--generation-progress-every", type=int, default=0, help="Emit generation heartbeat every N tokens; 0 disables periodic progress logs")
     ap.add_argument("--no-stream-output", action="store_true", help="Disable live text streaming during generation and print only the final response")
     ap.add_argument("--strict-parity", action="store_true", help="Enable strict/reference parity paths in bridge decoder kernels")
-    ap.add_argument("--bridge-runtime", choices=["prefill", "decode-staged"], default="prefill", help="Decoder bridge runtime to use; decode-staged is a diagnostic fallback")
+    ap.add_argument("--bridge-runtime", choices=["prefill", "decode-staged"], default=None, help="Override template multimodal bridge runtime; decode-staged enables incremental generation after mixed prefill")
+    ap.add_argument(
+        "--bridge-generation-mode",
+        choices=["incremental-decode", "mixed-replay"],
+        default=None,
+        help="Override template multimodal bridge generation policy after mixed visual/text prefill",
+    )
     ap.add_argument("--temperature", type=float, default=0.0, help="Decode temperature; 0 keeps greedy generation")
     ap.add_argument("--sample-top-k", type=int, default=40, help="Top-k sampling cutoff used during bridge generation")
     ap.add_argument("--top-p", type=float, default=1.0, help="Nucleus top-p used during bridge generation")
@@ -2795,6 +2875,12 @@ def main(argv: list[str] | None = None) -> int:
     tokenizer = GGUFTokenizer.from_gguf(str(args.decoder_gguf.resolve()))
     chat_template_mode = "none" if args.no_chat_template else args.chat_template
     chat_contract = _resolve_decoder_chat_contract(args.decoder_gguf.resolve(), chat_template_mode=chat_template_mode)
+    bridge_contract = _resolve_decoder_bridge_contract(args.decoder_gguf.resolve(), chat_template_mode=chat_template_mode)
+    resolved_bridge_runtime = str(args.bridge_runtime or _bridge_runtime_from_policy(bridge_contract, fallback="prefill"))
+    resolved_bridge_generation_mode = str(
+        args.bridge_generation_mode
+        or _bridge_generation_mode_from_policy(bridge_contract, fallback="mixed-replay")
+    )
     include_image_chunks = bool(args.encoder_gguf is not None or int(args.synthetic_prefix_tokens) > 0)
     prompt_segments = _format_multimodal_prompt_segments(
         args.prompt,
@@ -2832,10 +2918,16 @@ def main(argv: list[str] | None = None) -> int:
     prefix_embeddings = array("f")
     prefix_grid: tuple[int, int] | None = None
     prefix_text_pos: int | None = None
-    prefix_position_policy = "linear" if chat_template_mode in {"gemma3", "gemma4"} else "mrope_2d"
-    prefix_decode_policy = "non_causal_visual_chunk" if chat_template_mode in {"gemma3", "gemma4"} else "causal_mixed_prefix"
+    prefix_position_policy = str(bridge_contract.get("position_policy") or "linear").strip().lower() or "linear"
+    prefix_decode_policy = str(bridge_contract.get("decode_policy") or "causal_mixed_prefix").strip().lower() or "causal_mixed_prefix"
     encoder_report: dict[str, Any] | None = None
     dim_mismatch: dict[str, int] | None = None
+    timing_t0 = time.perf_counter()
+    timings: dict[str, float | int] = {
+        "prompt_tokens_before": int(len(prompt_prefix_token_ids)),
+        "prompt_tokens_after": int(len(token_ids)),
+        "text_prompt_tokens": int(total_text_prompt_tokens),
+    }
 
     if args.encoder_gguf is not None:
         _log_progress(f"encoder runtime prepare start gguf={args.encoder_gguf.resolve()}")
@@ -2848,13 +2940,17 @@ def main(argv: list[str] | None = None) -> int:
             image_min_tokens=args.image_min_tokens,
             image_max_tokens=args.image_max_tokens,
         )
-        _log_progress(f"encoder runtime prepare done elapsed={time.perf_counter() - encoder_prep_t0:.2f}s")
+        encoder_prepare_elapsed = time.perf_counter() - encoder_prep_t0
+        timings["encoder_prepare_ms"] = encoder_prepare_elapsed * 1000.0
+        _log_progress(f"encoder runtime prepare done elapsed={encoder_prepare_elapsed:.2f}s")
         _log_progress("encoder execution start")
+        encoder_exec_t0 = time.perf_counter()
         encoder_report = _run_encoder(
             encoder_runtime,
             args.image_mode,
             image_path=args.image_path.resolve() if args.image_path is not None else None,
         )
+        timings["encoder_execute_ms"] = (time.perf_counter() - encoder_exec_t0) * 1000.0
         _log_progress(
             "encoder execution done "
             f"prefix_tokens={int(encoder_report['prefix_tokens'])} embed_dim={int(encoder_report['embed_dim'])}"
@@ -2880,7 +2976,9 @@ def main(argv: list[str] | None = None) -> int:
         decoder_dir,
         context_override=decoder_context_len,
     )
-    _log_progress(f"decoder runtime prepare done elapsed={time.perf_counter() - decoder_prep_t0:.2f}s")
+    decoder_prepare_elapsed = time.perf_counter() - decoder_prep_t0
+    timings["decoder_prepare_ms"] = decoder_prepare_elapsed * 1000.0
+    _log_progress(f"decoder runtime prepare done elapsed={decoder_prepare_elapsed:.2f}s")
 
     prefix_embed_dim = int(decoder_runtime["embed_dim"])
     if encoder_report is not None:
@@ -2960,7 +3058,8 @@ def main(argv: list[str] | None = None) -> int:
         prefix_grid=prefix_grid,
         prefix_text_pos=prefix_text_pos,
         prefix_decode_policy=prefix_decode_policy,
-        bridge_runtime=str(args.bridge_runtime),
+        bridge_runtime=resolved_bridge_runtime,
+        bridge_generation_mode=resolved_bridge_generation_mode,
         strict_parity=bool(args.strict_parity),
         tokenizer=tokenizer,
         stop_token_ids=list(stop_policy["stop_ids"]),
@@ -2979,6 +3078,12 @@ def main(argv: list[str] | None = None) -> int:
         args.dump_logits_f32.parent.mkdir(parents=True, exist_ok=True)
         with args.dump_logits_f32.open("wb") as f:
             decoder_report["logits"].tofile(f)
+    decoder_timings = decoder_report.get("timings")
+    if isinstance(decoder_timings, dict):
+        timings.update({str(k): v for k, v in decoder_timings.items()})
+    timings["prefix_tokens"] = int(prefix_tokens)
+    timings["total_prefill_tokens"] = int(len(prompt_prefix_token_ids) + prefix_tokens + len(token_ids))
+    timings["runner_total_ms"] = (time.perf_counter() - timing_t0) * 1000.0
     _log_progress("report assembly start")
     top = _topk(decoder_report["logits"], max(1, args.report_top_k))
     top_tokens = [
@@ -3014,6 +3119,10 @@ def main(argv: list[str] | None = None) -> int:
         "prefix_grid_y": None if prefix_grid is None else int(prefix_grid[1]),
         "prefix_text_pos": None if prefix_text_pos is None else int(prefix_text_pos),
         "prefix_decode_policy": str(prefix_decode_policy),
+        "bridge_runtime": resolved_bridge_runtime,
+        "bridge_generation_mode": resolved_bridge_generation_mode,
+        "bridge_contract": dict(bridge_contract),
+        "bridge_runtime_policy": resolved_bridge_runtime,
         "prefix_dump_path": dumped_prefix_path,
         "total_prefill_tokens": len(prompt_prefix_token_ids) + prefix_tokens + len(token_ids),
         "decoder_runtime": {
@@ -3063,6 +3172,10 @@ def main(argv: list[str] | None = None) -> int:
         "generated_text": str(decoder_report.get("generated_text") or ""),
         "generated_text_raw": str(decoder_report.get("generated_text_raw") or ""),
         "generation_stop_reason": str(decoder_report.get("generation_stop_reason") or "disabled"),
+        "timings": {
+            str(k): (float(v) if isinstance(v, float) else int(v) if isinstance(v, int) else str(v))
+            for k, v in timings.items()
+        },
         "generation_config": {
             "temperature": float(args.temperature),
             "sample_top_k": int(args.sample_top_k),

--- a/version/v8/templates/qwen3_vl_vision.json
+++ b/version/v8/templates/qwen3_vl_vision.json
@@ -56,7 +56,11 @@
       "decode_policy": "causal_mixed_prefix",
       "grid_policy": "merged_hw",
       "image_begin_marker": "<|vision_start|>",
-      "image_end_marker": "<|vision_end|>"
+      "image_end_marker": "<|vision_end|>",
+      "prefix_policy": "mixed_visual_text_prefill",
+      "generation_policy": "incremental_decode_after_prefill",
+      "cache_policy": "persistent_decoder_kv",
+      "runtime_policy": "decode_staged"
     }
   },
   "kernels": {

--- a/version/v8/templates/qwen3vl.json
+++ b/version/v8/templates/qwen3vl.json
@@ -87,6 +87,15 @@
           "dim:_kv_copy_bytes"
         ]
       }
+    },
+    "multimodal_bridge": {
+      "prefix_policy": "mixed_visual_text_prefill",
+      "generation_policy": "incremental_decode_after_prefill",
+      "position_policy": "mrope_2d",
+      "cache_policy": "persistent_decoder_kv",
+      "runtime_policy": "decode_staged",
+      "image_begin_marker": "<|vision_start|>",
+      "image_end_marker": "<|vision_end|>"
     }
   },
   "kernels": {


### PR DESCRIPTION
## Summary

This PR hardens the v8 advanced-model bring-up stack and the Qwen3-VL multimodal bridge path.

Highlights:
- Adds and hardens Nemotron-H / Mamba2 reference kernels, router/MoE contracts, and high-memory smoke lanes.
- Adds GLM4, Kimi MLA/MoE, Gemma4/Gemma4 assistant, and safetensors/GGUF conversion guardrails.
- Expands v8 visualizer and multimodal dataflow artifacts so encoder, bridge, decoder, memory, and kernel contracts are easier to inspect.
- Promotes v8 inference contract/reporting lanes while keeping v7 training coverage visible.
- Adds Qwen3-VL OCR bridge correctness fixes, explicit multimodal bridge contract policy, staged-decode reporting, and a wall-clock OCR benchmark harness.
- Adds docs for CKU active-byte throughput, generated-C memory safety, Nemotron hybrid kernels, model/kernel coverage, and performance baselines.

## Latest Qwen3-VL bridge-contract commit

The latest commit declares the Qwen3-VL bridge policy directly in templates:
- prefix policy: mixed visual/text prefill
- generation policy: incremental decode after prefill
- position policy: MRoPE 2D
- cache policy: persistent decoder KV
- runtime policy: decode-staged

It also forwards bridge runtime/generation CLI controls, writes resolved bridge timing fields into bridge_report.json, and adds bench-v8-qwen3vl-ocr / bench-v8-qwen3vl-ocr-quick.

## Validation

Local focused checks:
- git diff --check for the staged Qwen3-VL bridge files
- .venv/bin/python -m py_compile version/v8/scripts/run_multimodal_bridge_v8.py version/v8/scripts/ck_run_v8.py benchmarks/bench_v8_qwen3vl_ocr.py
- .venv/bin/python -m unittest tests.test_v8_qwen3vl_template -v
- make test-v8-qwen3vl-ocr-smoke V8_QWEN3VL_CACHE_DIR=/home/antshiv/.cache/ck-engine-v8/models/Qwen--Qwen3-VL-8B-Instruct-GGUF V8_QWEN3VL_OCR_MAX_TOKENS=4

Commit/pre-push gates:
- pre-commit staged fast regressions passed: v7-regression-fast, v8-regression-fast
- pre-push passed: submodule pins, visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, v7/v8 fast regression, v7 training-kernel parity

## Notes

The Qwen3-VL OCR smoke is a bridge/runtime correctness lane, not an OCR quality stamp yet. The generated text can still be short/rough; the important contract here is that encoder prepare, mixed visual/text prefix, staged decoder execution, generation timing, and report output work end to end.