### PR TITLE
Speed up Qwen3-VL staged OCR bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ V8_QWEN3VL_OCR_IMAGE ?= version/v8/test_assets/v8_ocr_clean_text.ppm
 V8_QWEN3VL_OCR_PROMPT ?= Read the text in this image. Return only the visible text.
 V8_QWEN3VL_OCR_MAX_TOKENS ?= 8
 V8_QWEN3VL_OCR_IMAGE_MIN_TOKENS ?= 128
+V8_QWEN3VL_OCR_IMAGE_MAX_TOKENS ?=
 V8_GEMMA4_MODEL ?= hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf
 V8_GEMMA4_MMPROJ ?= hf://unsloth/gemma-4-E4B-it-GGUF/mmproj-F16.gguf
 V8_GEMMA4_CACHE_DIR ?= /opt/app-root/src/.cache/ck-engine-v8/models/unsloth--gemma-4-E4B-it-GGUF
@@ -1246,6 +1247,7 @@ test-v8-qwen3vl-ocr-smoke:
 			--mmproj "hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf" \
 			--image-path "$(V8_QWEN3VL_OCR_IMAGE)" \
 			--image-min-tokens $(V8_QWEN3VL_OCR_IMAGE_MIN_TOKENS) \
+			$(if $(V8_QWEN3VL_OCR_IMAGE_MAX_TOKENS),--image-max-tokens $(V8_QWEN3VL_OCR_IMAGE_MAX_TOKENS),) \
 			--prompt "$(V8_QWEN3VL_OCR_PROMPT)" \
 			--context-len 1024 \
 			--force-compile \
@@ -1263,7 +1265,21 @@ bench-v8-qwen3vl-ocr-quick:
 		--max-tokens $(V8_QWEN3VL_OCR_MAX_TOKENS) \
 		--context-len 1024 \
 		--image-min-tokens $(V8_QWEN3VL_OCR_IMAGE_MIN_TOKENS) \
+		$(if $(V8_QWEN3VL_OCR_IMAGE_MAX_TOKENS),--image-max-tokens $(V8_QWEN3VL_OCR_IMAGE_MAX_TOKENS),) \
+		$${V8_QWEN3VL_OCR_EXTRA_ARGS:-} \
 		--json-out build/v8_qwen3vl_ocr_quick_t$${CK_NUM_THREADS:-24}.json
+
+bench-v8-qwen3vl-ocr-fast:
+	@$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/generate_ocr_assets_v8.py
+	CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
+		$(PYTHON) $(PYTHONFLAGS) benchmarks/bench_v8_qwen3vl_ocr.py \
+		--threads $${CK_NUM_THREADS:-24} \
+		--max-tokens $(V8_QWEN3VL_OCR_MAX_TOKENS) \
+		--context-len 1024 \
+		--image-min-tokens 64 \
+		--image-max-tokens 64 \
+		$${V8_QWEN3VL_OCR_EXTRA_ARGS:-} \
+		--json-out build/v8_qwen3vl_ocr_fast_t$${CK_NUM_THREADS:-24}.json
 
 bench-v8-qwen3vl-ocr:
 	@$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/generate_ocr_assets_v8.py
@@ -1273,6 +1289,8 @@ bench-v8-qwen3vl-ocr:
 		--max-tokens $(V8_QWEN3VL_OCR_MAX_TOKENS) \
 		--context-len 1024 \
 		--image-min-tokens $(V8_QWEN3VL_OCR_IMAGE_MIN_TOKENS) \
+		$(if $(V8_QWEN3VL_OCR_IMAGE_MAX_TOKENS),--image-max-tokens $(V8_QWEN3VL_OCR_IMAGE_MAX_TOKENS),) \
+		$${V8_QWEN3VL_OCR_EXTRA_ARGS:-} \
 		--json-out build/v8_qwen3vl_ocr_t$${CK_NUM_THREADS:-24}.json
 
 test-v8-gemma4-vision-smoke:
@@ -2688,7 +2706,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick bench-v8-qwen3vl-ocr-fast profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/benchmarks/bench_v8_qwen3vl_ocr.py
+++ b/benchmarks/bench_v8_qwen3vl_ocr.py
@@ -77,10 +77,12 @@ def _run_one(
     max_tokens: int,
     context_len: int,
     image_min_tokens: int,
+    image_max_tokens: int | None,
     force_compile: bool,
     force_convert: bool,
     bridge_runtime: str,
     bridge_generation_mode: str,
+    vision_activation_prefs: list[str],
     timeout: int,
 ) -> dict[str, Any]:
     env = os.environ.copy()
@@ -108,10 +110,14 @@ def _run_one(
         "--temperature",
         "0.0",
     ]
+    if image_max_tokens is not None:
+        cmd.extend(["--image-max-tokens", str(image_max_tokens)])
     if bridge_runtime:
         cmd.extend(["--bridge-runtime", bridge_runtime])
     if bridge_generation_mode:
         cmd.extend(["--bridge-generation-mode", bridge_generation_mode])
+    for pref in vision_activation_prefs:
+        cmd.extend(["--vision-activation-pref", pref])
     if force_compile:
         cmd.append("--force-compile")
     if force_convert:
@@ -200,9 +206,17 @@ def main() -> int:
     parser.add_argument("--max-tokens", type=int, default=8)
     parser.add_argument("--context-len", type=int, default=1024)
     parser.add_argument("--image-min-tokens", type=int, default=128)
+    parser.add_argument("--image-max-tokens", type=int, default=None)
     parser.add_argument("--timeout", type=int, default=1800)
     parser.add_argument("--bridge-runtime", choices=["prefill", "decode-staged"], default=None, help="Override template bridge runtime policy")
     parser.add_argument("--bridge-generation-mode", choices=["incremental-decode", "mixed-replay"], default=None, help="Override template bridge generation policy")
+    parser.add_argument(
+        "--vision-activation-pref",
+        action="append",
+        default=[],
+        metavar="OP=PREF",
+        help="Forward a vision activation preference override to ck_run_v8.py, for example out_proj=q8_0",
+    )
     parser.add_argument("--force-compile", action="store_true")
     parser.add_argument("--force-convert", action="store_true")
     parser.add_argument("--json-out", type=Path, default=ROOT / "build" / "v8_qwen3vl_ocr_bench.json")
@@ -225,10 +239,12 @@ def main() -> int:
                 max_tokens=int(args.max_tokens),
                 context_len=int(args.context_len),
                 image_min_tokens=int(args.image_min_tokens),
+                image_max_tokens=None if args.image_max_tokens is None else int(args.image_max_tokens),
                 force_compile=bool(args.force_compile),
                 force_convert=bool(args.force_convert),
                 bridge_runtime=args.bridge_runtime,
                 bridge_generation_mode=args.bridge_generation_mode,
+                vision_activation_prefs=list(args.vision_activation_pref or []),
                 timeout=int(args.timeout),
             )
         )
@@ -243,8 +259,10 @@ def main() -> int:
             "max_tokens": int(args.max_tokens),
             "context_len": int(args.context_len),
             "image_min_tokens": int(args.image_min_tokens),
+            "image_max_tokens": None if args.image_max_tokens is None else int(args.image_max_tokens),
             "bridge_runtime": args.bridge_runtime,
             "bridge_generation_mode": args.bridge_generation_mode,
+            "vision_activation_pref": list(args.vision_activation_pref or []),
         },
         "results": rows,
     }

--- a/docs/WALL_CLOCK_PERFORMANCE_BASELINE_2026-06-30.md
+++ b/docs/WALL_CLOCK_PERFORMANCE_BASELINE_2026-06-30.md
@@ -10,9 +10,42 @@ VTune, Advisor, or sudo access for this baseline.
 | Field | Value |
 |---|---|
 | Branch base | `nemotron-mamba2-reference` / PR #77 stack |
-| Patch scope | Qwen3-VL OCR bridge contract, staged-decode reporting, and wall-clock benchmark harness |
-| Expected speed impact | Low; this patch makes bridge/runtime timing measurable; hot-kernel speed work remains separate |
+| Patch scope | Qwen3-VL OCR bridge contract, staged-prefill/decode reporting, wall-clock benchmark harness |
+| Expected speed impact | Medium for Qwen3-VL OCR bridge prefill; hot-kernel GEMM speed work remains separate |
 | Timing method | Runtime-reported prompt/decode timing and CK per-op wall-clock CSV |
+
+## Qwen3-VL OCR Bridge Speed Snapshot
+
+The current Qwen3-VL bridge no longer runs the visual/text prefix through a
+pure decode-shaped activation plan.  `decode-staged` now prepares a hybrid
+decoder runtime: decode IR plus prefill-sized activations.  The mixed visual
+prefix runs batched, then generation continues through incremental decode.
+
+Latest Xeon run, 24 threads, 64 image tokens, 8 decode tokens:
+
+| Image | Encoder | Mixed prefix | Generation | Generation rate | Steady rate |
+|---|---:|---:|---:|---:|---:|
+| Clean text | 4779 ms | 3870 ms | 774 ms | 10.33 tok/s | 0.849 tok/s |
+| Table | 4719 ms | 3882 ms | 800 ms | 10.00 tok/s | 0.851 tok/s |
+| Receipt | 4780 ms | 3864 ms | 802 ms | 9.97 tok/s | 0.847 tok/s |
+| Paragraph | 5312 ms | 4029 ms | 801 ms | 9.99 tok/s | 0.789 tok/s |
+
+Read: the previous mixed-prefill path was roughly 6.8-7.2 seconds on this
+shape.  The hybrid staged path is now roughly 3.86-4.03 seconds, so the bridge
+scheduling problem is materially improved.
+
+The profiler says the next bottleneck is ordinary quantized projection work,
+not attention or bridge scheduling:
+
+| Rank | Kernel/op | Approx time |
+|---:|---|---:|
+| 1 | `gemm_nt_q4_k_q8_k` / `mlp_gate_up` | 1.81 s |
+| 2 | `gemm_nt_q4_k_q8_k` / `mlp_down` | 0.46 s |
+| 3 | `gemm_nt_q4_k_q8_k` / `q_proj` | 0.33 s |
+| 4 | `gemm_nt_q4_k_q8_k` / `out_proj` | 0.32 s |
+| 5 | attention | 0.13 s |
+
+Next target: packed/reused Q4_K/Q6_K x Q8_K batched GEMM for decoder prefill.
 
 ## Model-Level Speed Snapshot
 
@@ -61,7 +94,7 @@ build/v8_prefill_profile_gemma4-e4b-q4_k_m_p512_t24.csv
 | Qwen3.5 decode | Usually behind llama.cpp, roughly 0.6x in the documented direct comparison. |
 | Prompt/prefill | Main gap.  CKE is often 0.1x-0.3x of llama.cpp on larger or hybrid models. |
 | Gemma4 text | Correctness is much stronger now, but speed remains weak. |
-| Qwen3-VL OCR bridge | Correctness improved; speed still needs a separate controlled CK-vs-llama vision sweep. |
+| Qwen3-VL OCR bridge | Correctness improved and the staged mixed-prefix path is now about 1.7x faster on the 64-image-token OCR sweep.  Remaining gap is projection GEMM. |
 
 ## Aggregated CKE Wall-Clock Hot Spots
 
@@ -131,7 +164,7 @@ Recommended sweep dimensions:
 | 2 | Gemma4 `geglu_forward_exact` and per-layer embed/prepare | Gemma4 profiles show large scalar/glue overhead. |
 | 3 | Head-major/final logits paths | Large vocab projections dominate decode for some models. |
 | 4 | Threadpool/orchestrator tuning | Useful only after hot kernels are not decode-style row loops. |
-| 5 | Vision bridge timing split | Needed for Qwen3-VL/Gemma4V OCR: encoder, projector, replay, mixed prefill, decode. |
+| 5 | Vision bridge timing split | Now available for Qwen3-VL OCR; keep extending it to Gemma4V and larger image-token sweeps. |
 
 ## Rule For Future Updates
 

--- a/docs/site/_pages/v8-vision-encoder.html
+++ b/docs/site/_pages/v8-vision-encoder.html
@@ -608,15 +608,54 @@
 
 <div class="card">
     <p>
-        The next cleanup step is not to add more handwritten Qwen logic. It is to promote bridge policy into explicit contracts:
+        The Qwen3-VL bridge policy is now declared as a template contract instead of living only as host-runner convention:
     </p>
     <ul>
         <li><strong>Image preprocess contract:</strong> resize policy, alignment rule, normalization stats, channel layout</li>
-        <li><strong>Multimodal bridge contract:</strong> which activation is the prefix, how many rows it has, what grid metadata it carries, and which decoder entrypoint should consume it</li>
+        <li><strong>Multimodal bridge contract:</strong> mixed visual/text prefill, MRoPE 2D grid metadata, persistent decoder KV cache, and staged decode continuation</li>
         <li><strong>Chat contract:</strong> prompt shell, stop markers, and image marker placement</li>
     </ul>
     <p style="margin-bottom: 0;">
-        Once that happens, the bridge shell stops asking “is this Qwen3-VL?” and starts asking “what does the resolved contract say?”
+        The bridge shell can now ask “what does the resolved contract say?” and choose the staged runtime from that contract.
+    </p>
+</div>
+
+<h2>Current Speed Read</h2>
+
+<div class="card">
+    <p>
+        The latest Qwen3-VL OCR bridge speed work changes <code>decode-staged</code> into a hybrid decoder runtime:
+        decode IR with prefill-sized activations for the mixed image/text prefix, followed by safe incremental decode.
+        On the current Xeon sweep with 24 threads, 64 image tokens, and 8 decode tokens, the mixed-prefix phase dropped
+        from roughly <strong>6.8-7.2 seconds</strong> to roughly <strong>3.86-4.03 seconds</strong>.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Stage</th>
+                <th>Current signal</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Vision encoder</td>
+                <td>About 4.7-5.3 seconds for the four-image OCR sweep</td>
+            </tr>
+            <tr>
+                <td>Mixed prefix</td>
+                <td>About 3.9-4.0 seconds after staged prefill hardening</td>
+            </tr>
+            <tr>
+                <td>Incremental generation</td>
+                <td>About 10 tokens/second for the short 8-token OCR smoke</td>
+            </tr>
+        </tbody>
+    </table>
+    <p style="margin-bottom: 0;">
+        The profiler now points at quantized projection kernels, especially <code>gemm_nt_q4_k_q8_k</code>
+        in <code>mlp_gate_up</code>, <code>mlp_down</code>, <code>q_proj</code>, and <code>out_proj</code>.
+        Attention is not the dominant cost in this run. The next speed target is packed/reused
+        Q4_K/Q6_K x Q8_K batched GEMM for decoder prefill.
     </p>
 </div>
 

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -1550,15 +1550,54 @@
 
 <div class="card">
     <p>
-        The next cleanup step is not to add more handwritten Qwen logic. It is to promote bridge policy into explicit contracts:
+        The Qwen3-VL bridge policy is now declared as a template contract instead of living only as host-runner convention:
     </p>
     <ul>
         <li><strong>Image preprocess contract:</strong> resize policy, alignment rule, normalization stats, channel layout</li>
-        <li><strong>Multimodal bridge contract:</strong> which activation is the prefix, how many rows it has, what grid metadata it carries, and which decoder entrypoint should consume it</li>
+        <li><strong>Multimodal bridge contract:</strong> mixed visual/text prefill, MRoPE 2D grid metadata, persistent decoder KV cache, and staged decode continuation</li>
         <li><strong>Chat contract:</strong> prompt shell, stop markers, and image marker placement</li>
     </ul>
     <p style="margin-bottom: 0;">
-        Once that happens, the bridge shell stops asking “is this Qwen3-VL?” and starts asking “what does the resolved contract say?”
+        The bridge shell can now ask “what does the resolved contract say?” and choose the staged runtime from that contract.
+    </p>
+</div>
+
+<h2>Current Speed Read</h2>
+
+<div class="card">
+    <p>
+        The latest Qwen3-VL OCR bridge speed work changes <code>decode-staged</code> into a hybrid decoder runtime:
+        decode IR with prefill-sized activations for the mixed image/text prefix, followed by safe incremental decode.
+        On the current Xeon sweep with 24 threads, 64 image tokens, and 8 decode tokens, the mixed-prefix phase dropped
+        from roughly <strong>6.8-7.2 seconds</strong> to roughly <strong>3.86-4.03 seconds</strong>.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Stage</th>
+                <th>Current signal</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Vision encoder</td>
+                <td>About 4.7-5.3 seconds for the four-image OCR sweep</td>
+            </tr>
+            <tr>
+                <td>Mixed prefix</td>
+                <td>About 3.9-4.0 seconds after staged prefill hardening</td>
+            </tr>
+            <tr>
+                <td>Incremental generation</td>
+                <td>About 10 tokens/second for the short 8-token OCR smoke</td>
+            </tr>
+        </tbody>
+    </table>
+    <p style="margin-bottom: 0;">
+        The profiler now points at quantized projection kernels, especially <code>gemm_nt_q4_k_q8_k</code>
+        in <code>mlp_gate_up</code>, <code>mlp_down</code>, <code>q_proj</code>, and <code>out_proj</code>.
+        Attention is not the dominant cost in this run. The next speed target is packed/reused
+        Q4_K/Q6_K x Q8_K batched GEMM for decoder prefill.
     </p>
 </div>
 

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -289,7 +289,7 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             vision_cfg["activation_preference_by_op"],
             {
                 "mlp_down": "fp32",
-                "out_proj": "fp32",
+                "out_proj": "q8_0",
                 "branch_fc1": "fp32",
                 "branch_fc2": "fp32",
             },
@@ -438,15 +438,15 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             quantize_input_rows = next(arg for arg in quantize_input_0.get("args", []) if arg.get("name") == "rows")
             self.assertEqual(quantize_input_rows.get("expr"), str(manifest["config"]["context_length"]))
             attn = next(op for op in call_ops if op.get("op") == "attn")
-            self.assertEqual(attn.get("function"), "attention_forward_full_head_major_gqa_ggml_strided")
+            self.assertEqual(attn.get("function"), "attention_forward_full_head_major_gqa_flash_strided")
             attn_idx = next(i for i, op in enumerate(call_ops) if op.get("op") == "attn")
             transpose_idx = next(i for i, op in enumerate(call_ops) if op.get("op") == "transpose_attn_out_to_token_major")
             out_proj_idx = next(i for i, op in enumerate(call_ops) if op.get("op") == "out_proj")
             self.assertLess(attn_idx, transpose_idx)
             self.assertLess(transpose_idx, out_proj_idx)
             out_proj = next(op for op in call_ops if op.get("op") == "out_proj")
-            self.assertEqual(out_proj.get("function"), "gemm_nt_q8_0")
-            self.assertNotIn("quantize_out_proj_input", [op.get("op") for op in call_ops])
+            self.assertEqual(out_proj.get("function"), "gemm_nt_q8_0_q8_0")
+            self.assertIn("quantize_out_proj_input", [op.get("op") for op in call_ops])
             self.assertNotIn("kv_cache_batch_copy", [op.get("op") for op in call_ops])
             projector_fc1 = next(op for op in call_ops if op.get("op") == "projector_fc1")
             self.assertEqual(projector_fc1.get("function"), "gemm_nt_q8_0_q8_0")

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -245,7 +245,7 @@ def _inject_runtime_config_defaults(config: Dict[str, Any], arch: str) -> Dict[s
     elif arch_lc == "qwen3_vl_vision":
         _merge_activation_defaults({
             "mlp_down": "fp32",
-            "out_proj": "fp32",
+            "out_proj": "q8_0",
             "branch_fc1": "fp32",
             "branch_fc2": "fp32",
         })

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import csv
 import ctypes
 import hashlib
 import heapq
@@ -146,13 +147,26 @@ def _parse_activation_preference_overrides(values: list[str] | None) -> dict[str
     return overrides
 
 
+def _clean_activation_preference_baseline(config: dict[str, Any]) -> dict[str, Any]:
+    updated = dict(config)
+    model = str(updated.get("model", updated.get("arch", "")) or "").strip().lower()
+    if model == "qwen3_vl_vision":
+        updated["activation_preference_by_op"] = {
+            "mlp_down": "fp32",
+            "out_proj": "q8_0",
+            "branch_fc1": "fp32",
+            "branch_fc2": "fp32",
+        }
+    return updated
+
+
 def _apply_activation_preference_overrides(
     config: dict[str, Any],
     overrides: dict[str, str] | None,
 ) -> dict[str, Any]:
+    updated = _clean_activation_preference_baseline(config)
     if not overrides:
-        return config
-    updated = dict(config)
+        return updated
     prefs = updated.get("activation_preference_by_op")
     if not isinstance(prefs, dict):
         prefs = {}
@@ -865,6 +879,7 @@ def _runtime_fingerprint(
     mode: str,
     context_override: int | None = None,
     parity_dump: bool = False,
+    profile: bool = False,
 ) -> dict[str, Any]:
     return {
         "version": 1,
@@ -872,6 +887,7 @@ def _runtime_fingerprint(
         "manifest": _path_identity(manifest_path, hash_content=True),
         "context_override": int(context_override) if context_override is not None else None,
         "parity_dump": bool(parity_dump),
+        "profile": bool(profile),
         "build_ir_script": _path_identity(SCRIPT_DIR / "build_ir_v8.py", hash_content=True),
         "codegen_script": _path_identity(SCRIPT_DIR / "codegen_v8.py", hash_content=True),
         "codegen_prefill_script": _path_identity(SCRIPT_DIR / "codegen_prefill_v8.py", hash_content=True),
@@ -1624,7 +1640,7 @@ def _gemma4_geometry_overrides(config: dict[str, Any], image_path: Path) -> dict
     }
 
 
-def _compile_generated_model(c_path: Path, so_path: Path) -> Path:
+def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = False) -> Path:
     stamp_path = so_path.with_suffix(so_path.suffix + ".build.json")
     source_hash = hashlib.sha256(c_path.read_bytes()).hexdigest()
     source_size = int(c_path.stat().st_size)
@@ -1633,6 +1649,7 @@ def _compile_generated_model(c_path: Path, so_path: Path) -> Path:
         "source_path": str(c_path.resolve()),
         "source_sha256": source_hash,
         "source_size": source_size,
+        "profile": bool(profile),
     }
     if so_path.exists():
         cached = _json_read(stamp_path)
@@ -1644,6 +1661,7 @@ def _compile_generated_model(c_path: Path, so_path: Path) -> Path:
         "-fPIC",
         "-O3",
         "-fopenmp",
+        *( ["-DCK_PROFILE=1"] if profile else [] ),
         "-Iinclude",
         "-Iversion/v8/src",
         str(c_path),
@@ -1905,6 +1923,7 @@ def _prepare_decoder_runtime(
     output_dir: Path,
     parity_dump: bool = False,
     context_override: int | None = None,
+    profile: bool = False,
 ) -> dict[str, Any]:
     manifest, manifest_path, bump_path, config_path = _run_converter(
         gguf_path,
@@ -1931,6 +1950,7 @@ def _prepare_decoder_runtime(
         mode="decoder_hybrid",
         context_override=context_override,
         parity_dump=parity_dump,
+        profile=profile,
     )
     reusable_outputs = [
         manifest_path,
@@ -1953,8 +1973,8 @@ def _prepare_decoder_runtime(
         _log_progress(
             f"decoder runtime reuse workdir={output_dir} parity_dump={int(bool(parity_dump))}"
         )
-        _compile_generated_model(c_path, so_path)
-        _compile_generated_model(prefill_c_path, prefill_so_path)
+        _compile_generated_model(c_path, so_path, profile=profile)
+        _compile_generated_model(prefill_c_path, prefill_so_path, profile=profile)
         layout = _load_layout(decode_layout)
         if context_override is not None:
             decode_cfg = layout.get("config", {}) if isinstance(layout.get("config"), dict) else {}
@@ -2048,18 +2068,22 @@ def _prepare_decoder_runtime(
             str(prefill_call),
             "--layout",
             str(decode_layout),
+            "--prefill-layout",
+            str(prefill_layout),
             "--output",
             str(c_path),
         ]
         if parity_dump:
             sys.argv.append("--parity-dump")
+        if profile:
+            sys.argv.append("--profile")
         codegen_rc = codegen_v8.main()
     finally:
         sys.argv = old_argv
     if codegen_rc != 0:
         raise RuntimeError(f"codegen_v8 decoder failed with rc={codegen_rc}")
 
-    _compile_generated_model(c_path, so_path)
+    _compile_generated_model(c_path, so_path, profile=profile)
     old_argv = sys.argv[:]
     try:
         sys.argv = [
@@ -2073,13 +2097,15 @@ def _prepare_decoder_runtime(
         ]
         if parity_dump:
             sys.argv.append("--parity-dump")
+        if profile:
+            sys.argv.append("--profile")
         prefill_codegen_rc = codegen_v8.main()
     finally:
         sys.argv = old_argv
     if prefill_codegen_rc != 0:
         raise RuntimeError(f"codegen_v8 decoder prefill bridge failed with rc={prefill_codegen_rc}")
 
-    _compile_generated_model(prefill_c_path, prefill_so_path)
+    _compile_generated_model(prefill_c_path, prefill_so_path, profile=profile)
     _json_write(runtime_stamp, runtime_fingerprint)
     layout = _load_layout(decode_layout)
     if context_override is not None:
@@ -2322,6 +2348,44 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
         lib.ck_model_free()
 
 
+def _summarize_profile_csv(path: Path, *, top_n: int = 12) -> dict[str, Any]:
+    if not path.exists() or path.stat().st_size <= 0:
+        return {"path": str(path), "total_ms": 0.0, "by_op": [], "by_kernel_op": []}
+    by_op: dict[str, float] = {}
+    by_kernel_op: dict[tuple[str, str], float] = {}
+    total_us = 0.0
+    with path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                time_us = float(row.get("time_us") or 0.0)
+            except (TypeError, ValueError):
+                time_us = 0.0
+            op = str(row.get("op") or "")
+            kernel = str(row.get("kernel") or "")
+            total_us += time_us
+            by_op[op] = by_op.get(op, 0.0) + time_us
+            key = (kernel, op)
+            by_kernel_op[key] = by_kernel_op.get(key, 0.0) + time_us
+
+    def top_map(values: dict[Any, float], *, kernel_op: bool = False) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for key, time_us in sorted(values.items(), key=lambda item: -item[1])[:top_n]:
+            if kernel_op:
+                kernel, op = key
+                rows.append({"kernel": kernel, "op": op, "time_ms": time_us / 1000.0})
+            else:
+                rows.append({"op": str(key), "time_ms": time_us / 1000.0})
+        return rows
+
+    return {
+        "path": str(path),
+        "total_ms": total_us / 1000.0,
+        "by_op": top_map(by_op),
+        "by_kernel_op": top_map(by_kernel_op, kernel_op=True),
+    }
+
+
 def _run_decoder(
     runtime: dict[str, Any],
     prefix_embeddings: array,
@@ -2348,11 +2412,12 @@ def _run_decoder(
     min_response_tokens: int = 0,
     stream_output: bool = False,
     generation_progress_every: int = 0,
+    profile_csv_path: Path | None = None,
 ) -> dict[str, Any]:
-    # Mixed image/text prefill normally uses the prefill-layout runtime: it owns
-    # batched token-major activation rows and last-logits emission. The decode
-    # runtime remains available as an explicit staged replay diagnostic/escape
-    # hatch for architecture work.
+    # Mixed image/text prefill normally uses the prefill-capable staged decoder:
+    # decode IR plus prefill-sized activations.  That gives one model instance
+    # for batched bridge prefill followed by safe incremental ck_model_decode.
+    # The standalone prefill runtime remains available for diagnostics.
     bridge_runtime_name = str(bridge_runtime or "prefill").strip().lower()
     generation_mode = str(bridge_generation_mode or "mixed-replay").strip().lower().replace("-", "_")
     if generation_mode not in {"incremental_decode", "mixed_replay"}:
@@ -2414,48 +2479,71 @@ def _run_decoder(
             f"prompt_tokens_before={len(before_token_ids)} prompt_tokens_after={len(after_token_ids)} "
             f"grid={prefix_grid} prefix_decode_policy={prefix_decode_policy}"
         )
+        old_profile_csv_env = os.environ.get("CK_PROFILE_CSV")
+        old_profile_json_env = os.environ.get("CK_PROFILE_JSON")
+        profile_summary: dict[str, Any] | None = None
+        if profile_csv_path is not None:
+            profile_csv_path.parent.mkdir(parents=True, exist_ok=True)
+            profile_csv_path.unlink(missing_ok=True)
+            os.environ["CK_PROFILE_CSV"] = str(profile_csv_path)
+            os.environ.pop("CK_PROFILE_JSON", None)
         forward_t0 = time.perf_counter()
-        if before_token_ids and hasattr(lib, "ck_model_forward_segments_grid_ex"):
-            grid_x, grid_y = prefix_grid if prefix_grid is not None else (0, 0)
-            default_text_pos = (
-                len(before_token_ids) + max(int(grid_x), int(grid_y))
-                if prefix_grid is not None
-                else len(before_token_ids) + max(0, int(prefix_tokens))
-            )
-            resolved_text_pos = int(prefix_text_pos or default_text_pos)
-            rc = lib.ck_model_forward_segments_grid_ex(
-                before_token_arr,
-                len(before_token_ids),
-                prefix_ptr,
-                prefix_tokens,
-                resolved_prefix_dim,
-                int(grid_x),
-                int(grid_y),
-                resolved_text_pos,
-                after_token_arr,
-                len(after_token_ids),
-                logits,
-            )
-        elif hasattr(lib, "ck_model_forward_mixed_grid_ex") and prefix_grid is not None:
-            grid_x, grid_y = prefix_grid
-            resolved_text_pos = int(prefix_text_pos or max(int(grid_x), int(grid_y), int(prefix_tokens)))
-            rc = lib.ck_model_forward_mixed_grid_ex(
-                prefix_ptr,
-                prefix_tokens,
-                resolved_prefix_dim,
-                int(grid_x),
-                int(grid_y),
-                resolved_text_pos,
-                after_token_arr,
-                len(after_token_ids),
-                logits,
-            )
-        elif hasattr(lib, "ck_model_forward_mixed_ex"):
-            rc = lib.ck_model_forward_mixed_ex(prefix_ptr, prefix_tokens, resolved_prefix_dim, after_token_arr, len(after_token_ids), logits)
-        else:
-            rc = lib.ck_model_forward_mixed(prefix_ptr, prefix_tokens, after_token_arr, len(after_token_ids), logits)
-        if rc != 0:
-            raise RuntimeError(f"decoder forward_mixed failed with rc={rc}")
+        try:
+            if before_token_ids and hasattr(lib, "ck_model_forward_segments_grid_ex"):
+                grid_x, grid_y = prefix_grid if prefix_grid is not None else (0, 0)
+                default_text_pos = (
+                    len(before_token_ids) + max(int(grid_x), int(grid_y))
+                    if prefix_grid is not None
+                    else len(before_token_ids) + max(0, int(prefix_tokens))
+                )
+                resolved_text_pos = int(prefix_text_pos or default_text_pos)
+                rc = lib.ck_model_forward_segments_grid_ex(
+                    before_token_arr,
+                    len(before_token_ids),
+                    prefix_ptr,
+                    prefix_tokens,
+                    resolved_prefix_dim,
+                    int(grid_x),
+                    int(grid_y),
+                    resolved_text_pos,
+                    after_token_arr,
+                    len(after_token_ids),
+                    logits,
+                )
+            elif hasattr(lib, "ck_model_forward_mixed_grid_ex") and prefix_grid is not None:
+                grid_x, grid_y = prefix_grid
+                resolved_text_pos = int(prefix_text_pos or max(int(grid_x), int(grid_y), int(prefix_tokens)))
+                rc = lib.ck_model_forward_mixed_grid_ex(
+                    prefix_ptr,
+                    prefix_tokens,
+                    resolved_prefix_dim,
+                    int(grid_x),
+                    int(grid_y),
+                    resolved_text_pos,
+                    after_token_arr,
+                    len(after_token_ids),
+                    logits,
+                )
+            elif hasattr(lib, "ck_model_forward_mixed_ex"):
+                rc = lib.ck_model_forward_mixed_ex(prefix_ptr, prefix_tokens, resolved_prefix_dim, after_token_arr, len(after_token_ids), logits)
+            else:
+                rc = lib.ck_model_forward_mixed(prefix_ptr, prefix_tokens, after_token_arr, len(after_token_ids), logits)
+            if rc != 0:
+                raise RuntimeError(f"decoder forward_mixed failed with rc={rc}")
+            if profile_csv_path is not None:
+                if hasattr(lib, "ck_model_profile_dump"):
+                    lib.ck_model_profile_dump()
+                profile_summary = _summarize_profile_csv(profile_csv_path)
+        finally:
+            if profile_csv_path is not None:
+                if old_profile_csv_env is None:
+                    os.environ.pop("CK_PROFILE_CSV", None)
+                else:
+                    os.environ["CK_PROFILE_CSV"] = old_profile_csv_env
+                if old_profile_json_env is None:
+                    os.environ.pop("CK_PROFILE_JSON", None)
+                else:
+                    os.environ["CK_PROFILE_JSON"] = old_profile_json_env
         forward_elapsed = time.perf_counter() - forward_t0
         _log_progress(f"decoder: forward_mixed done elapsed={forward_elapsed:.2f}s")
         logits_arr = array("f", logits)
@@ -2580,6 +2668,7 @@ def _run_decoder(
             "generated_text_raw": generated_text_raw,
             "generation_stop_reason": generation_stop_reason,
             "streamed_output": bool(stream_output and tokenizer is not None and max_tokens > 0),
+            "decoder_profile": profile_summary or {},
             "timings": {
                 "decoder_forward_mixed_ms": float(forward_elapsed * 1000.0),
                 "decoder_generation_ms": float(generation_elapsed * 1000.0),
@@ -2841,6 +2930,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--generation-progress-every", type=int, default=0, help="Emit generation heartbeat every N tokens; 0 disables periodic progress logs")
     ap.add_argument("--no-stream-output", action="store_true", help="Disable live text streaming during generation and print only the final response")
     ap.add_argument("--strict-parity", action="store_true", help="Enable strict/reference parity paths in bridge decoder kernels")
+    ap.add_argument("--profile-decoder", action="store_true", help="Compile decoder with CK_PROFILE and include mixed-prefill per-op timings")
     ap.add_argument("--bridge-runtime", choices=["prefill", "decode-staged"], default=None, help="Override template multimodal bridge runtime; decode-staged enables incremental generation after mixed prefill")
     ap.add_argument(
         "--bridge-generation-mode",
@@ -2975,6 +3065,7 @@ def main(argv: list[str] | None = None) -> int:
         args.decoder_gguf.resolve(),
         decoder_dir,
         context_override=decoder_context_len,
+        profile=bool(args.profile_decoder),
     )
     decoder_prepare_elapsed = time.perf_counter() - decoder_prep_t0
     timings["decoder_prepare_ms"] = decoder_prepare_elapsed * 1000.0
@@ -3073,6 +3164,7 @@ def main(argv: list[str] | None = None) -> int:
         min_response_tokens=min_response_tokens,
         stream_output=bool(args.max_tokens) and not bool(args.no_stream_output),
         generation_progress_every=int(args.generation_progress_every),
+        profile_csv_path=(decoder_dir / "decoder_mixed_prefill_profile.csv") if bool(args.profile_decoder) else None,
     )
     if args.dump_logits_f32 is not None:
         args.dump_logits_f32.parent.mkdir(parents=True, exist_ok=True)
@@ -3123,6 +3215,7 @@ def main(argv: list[str] | None = None) -> int:
         "bridge_generation_mode": resolved_bridge_generation_mode,
         "bridge_contract": dict(bridge_contract),
         "bridge_runtime_policy": resolved_bridge_runtime,
+        "decoder_profile": decoder_report.get("decoder_profile") or {},
         "prefix_dump_path": dumped_prefix_path,
         "total_prefill_tokens": len(prompt_prefix_token_ids) + prefix_tokens + len(token_ids),
         "decoder_runtime": {

--- a/version/v8/templates/qwen3_vl_vision.json
+++ b/version/v8/templates/qwen3_vl_vision.json
@@ -75,7 +75,7 @@
     "gelu": "gelu_ggml_inplace",
     "projector_gelu": "gelu_ggml_inplace",
     "branch_gelu": "gelu_ggml_inplace",
-    "attn_prefill": "attention_forward_full_head_major_gqa_ggml_strided"
+    "attn_prefill": "attention_forward_full_head_major_gqa_flash_strided"
   },
   "sequence": [
     "vision_encoder"


### PR DESCRIPTION
## Summary

This PR applies the Qwen3-VL OCR staged-prefill speed patch and documents the new speed position.

Changes:
- Makes `decode-staged` use a hybrid decoder runtime: decode IR plus prefill-sized activations, so the mixed visual/text prefix runs batched before incremental decode continues.
- Adds decoder profiling support via `--profile-decoder`.
- Adds `bench-v8-qwen3vl-ocr-fast` and forwards image max-token / extra benchmark args.
- Promotes Qwen3-VL vision `out_proj` to the faster Q8 path and updates contract tests.
- Updates the wall-clock baseline and v8 vision docs with the staged-prefill result and the next bottleneck: packed/reused Q4_K/Q6_K x Q8_K batched GEMM for decoder prefill.

## Validation

Focused local checks:
- `git diff --check` for the staged files
- `.venv/bin/python -m py_compile version/v8/scripts/run_multimodal_bridge_v8.py version/v8/scripts/build_ir_v8.py benchmarks/bench_v8_qwen3vl_ocr.py`
- `.venv/bin/python -m unittest tests.test_v8_qwen3vl_template -v`
- `bash docs/site/build.sh`
- `make bench-v8-qwen3vl-ocr-fast V8_QWEN3VL_OCR_MAX_TOKENS=4`

Bench result on this laptop: all four OCR images returned `ok` and wrote `build/v8_qwen3vl_ocr_fast_t24.json`. The laptop is slower than the Xeon reference, but it validates the lane.

Commit/pre-push gates:
- pre-commit passed: v7-regression-fast and v8-regression-fast
- pre-push passed: submodule pins, visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, v7/v8 fast regression, and v7 training-kernel parity

## Notes

The speed data says bridge scheduling is no longer the main blocker for this shape. The profiler points at quantized projection GEMM, especially `gemm_nt_q4_k_q8_k` in `mlp_gate_up`, `mlp_down`, `q_proj`, and `out_proj`.