### PR TITLE
Advance v8 model coverage, vision OCR, and prefill perf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2452,6 +2452,8 @@ test-gemv-omp-verbose: $(GEMV_OMP_BIN)
 
 THREADPOOL_BIN := $(BUILD_DIR)/test_threadpool_parity
 Q4K_DISPATCH_MATRIX_BIN := $(BUILD_DIR)/bench_q4k_dispatch_matrix
+Q4K_GATEUP_SWIGLU_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu
+Q4K_GATEUP_SWIGLU_OMP_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu_omp_standalone
 V66_SRC_DIR    := version/v6.6/src
 V8_SRC_DIR     := version/v8/src
 
@@ -2494,6 +2496,30 @@ bench-q4k-dispatch-matrix: $(Q4K_DISPATCH_MATRIX_BIN)
 bench-q4k-dispatch-matrix-quick: $(Q4K_DISPATCH_MATRIX_BIN)
 	@echo "Running Q4_K dispatch matrix benchmark (quick)..."
 	LD_LIBRARY_PATH=$(BUILD_DIR):llama.cpp:$$LD_LIBRARY_PATH $(Q4K_DISPATCH_MATRIX_BIN) --quick
+
+$(Q4K_GATEUP_SWIGLU_BIN): $(LIB) benchmarks/bench_q4k_gateup_swiglu.c
+	@mkdir -p $(BUILD_DIR)
+	$(CC) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) \
+		benchmarks/bench_q4k_gateup_swiglu.c \
+		-L$(BUILD_DIR) -lckernel_engine -lm -lpthread \
+		-Wl,-rpath,$(BUILD_DIR) \
+		-o $(Q4K_GATEUP_SWIGLU_BIN)
+
+bench-q4k-gateup-swiglu: $(Q4K_GATEUP_SWIGLU_BIN)
+	@echo "Running Q4_K gate_up+SwiGLU fused benchmark..."
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(Q4K_GATEUP_SWIGLU_BIN)
+
+$(Q4K_GATEUP_SWIGLU_OMP_BIN): $(LIB) research/q4k_gateup_swiglu/bench_q4k_gateup_swiglu_omp_standalone.c
+	@mkdir -p $(BUILD_DIR)
+	$(CC) -O3 -march=native -fopenmp -Iinclude -I$(V8_SRC_DIR) \
+		research/q4k_gateup_swiglu/bench_q4k_gateup_swiglu_omp_standalone.c \
+		-L$(BUILD_DIR) -lckernel_engine -lm -lpthread \
+		-Wl,-rpath,$(BUILD_DIR) \
+		-o $(Q4K_GATEUP_SWIGLU_OMP_BIN)
+
+bench-q4k-gateup-swiglu-omp: $(Q4K_GATEUP_SWIGLU_OMP_BIN)
+	@echo "Running standalone OpenMP Q4_K gate_up+SwiGLU benchmark..."
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(Q4K_GATEUP_SWIGLU_OMP_BIN)
 
 # Representative Gemma4-sized Q6_K x Q8_K prefill dispatch benchmark.
 # This is benchmark/dispatch coverage, not a correctness gate for every PR.

--- a/benchmarks/bench_q4k_gateup_swiglu.c
+++ b/benchmarks/bench_q4k_gateup_swiglu.c
@@ -1,0 +1,211 @@
+
+/*
+ * bench_q4k_gateup_swiglu.c
+ *
+ * Focused Qwen3-VL OCR MLP gate/up benchmark.
+ * Compares the current unfused path:
+ *   gemm_nt_q4_k_q8_k(A, W_gate_up) -> swiglu_forward_exact
+ * against the experimental fused VNNI path:
+ *   Q4_K gate/up row pair + Q8_K activation rows -> SiLU output
+ */
+
+#include "ck_threadpool.h"
+#include "ckernel_quant.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+extern void quantize_row_q8_k(const float *x, void *vy, int k);
+extern void gemm_nt_q4_k_q8_k(const void *A, const void *B, const float *bias,
+                              float *C, int M, int N, int K);
+extern void swiglu_forward_exact(const float *input, float *output, int tokens, int dim);
+extern void gemm_nt_q4_k_q8_k_gateup_swiglu_fused_vnni(const void *A_q8,
+                                                        const void *B_gate_up,
+                                                        const float *bias,
+                                                        float *C,
+                                                        int M,
+                                                        int D,
+                                                        int K,
+                                                        int threads);
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1.0e6;
+}
+
+static uint32_t rng_state = 0x456789abu;
+static uint32_t rng_u32(void) {
+    rng_state = rng_state * 1664525u + 1013904223u;
+    return rng_state;
+}
+static float rng_f32(float scale) {
+    const uint32_t v = rng_u32() >> 8;
+    const float u = (float)v / (float)0x00ffffffu;
+    return (u * 2.0f - 1.0f) * scale;
+}
+static void fill_f32(float *p, size_t n, float scale) {
+    for (size_t i = 0; i < n; ++i) p[i] = rng_f32(scale);
+}
+static void fill_q4k(uint8_t *dst, int N, int K) {
+    const int blocks = N * (K / QK_K);
+    for (int b = 0; b < blocks; ++b) {
+        block_q4_K *blk = (block_q4_K *)(void *)(dst + (size_t)b * sizeof(block_q4_K));
+        blk->d = 0x3c00;     /* 1.0 */
+        blk->dmin = 0x3800;  /* 0.5 */
+        for (int i = 0; i < (int)sizeof(blk->scales); ++i) blk->scales[i] = (uint8_t)(rng_u32() & 0xffu);
+        for (int i = 0; i < (int)sizeof(blk->qs); ++i) blk->qs[i] = (uint8_t)(rng_u32() & 0xffu);
+    }
+}
+static void quantize_acts_q8k(const float *src, uint8_t *dst, int M, int K) {
+    const size_t row_bytes = (size_t)(K / QK_K) * sizeof(block_q8_K);
+    for (int m = 0; m < M; ++m) {
+        quantize_row_q8_k(src + (size_t)m * (size_t)K, dst + (size_t)m * row_bytes, K);
+    }
+}
+static float max_abs_diff(const float *a, const float *b, size_t n) {
+    float mx = 0.0f;
+    for (size_t i = 0; i < n; ++i) {
+        float d = fabsf(a[i] - b[i]);
+        if (d > mx) mx = d;
+    }
+    return mx;
+}
+static float max_abs_val(const float *a, size_t n) {
+    float mx = 0.0f;
+    for (size_t i = 0; i < n; ++i) {
+        float v = fabsf(a[i]);
+        if (v > mx) mx = v;
+    }
+    return mx;
+}
+static double cosine_sim(const float *a, const float *b, size_t n) {
+    double dot = 0.0, aa = 0.0, bb = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+        dot += (double)a[i] * (double)b[i];
+        aa += (double)a[i] * (double)a[i];
+        bb += (double)b[i] * (double)b[i];
+    }
+    return (aa > 0.0 && bb > 0.0) ? dot / sqrt(aa * bb) : 0.0;
+}
+
+typedef void (*bench_fn)(void *);
+static double bench_ms(bench_fn fn, void *ctx, int warmup, int iters) {
+    for (int i = 0; i < warmup; ++i) fn(ctx);
+    const double t0 = now_ms();
+    for (int i = 0; i < iters; ++i) fn(ctx);
+    const double t1 = now_ms();
+    return (t1 - t0) / (double)iters;
+}
+
+typedef struct {
+    const uint8_t *A_q8;
+    const uint8_t *W;
+    const float *bias;
+    float *gate_up;
+    float *out;
+    int M;
+    int D;
+    int K;
+    int threads;
+} ctx_t;
+
+static void run_unfused(void *p) {
+    ctx_t *c = (ctx_t *)p;
+    gemm_nt_q4_k_q8_k(c->A_q8, c->W, c->bias, c->gate_up, c->M, 2 * c->D, c->K);
+    swiglu_forward_exact(c->gate_up, c->out, c->M, c->D);
+}
+static void run_fused(void *p) {
+    ctx_t *c = (ctx_t *)p;
+    gemm_nt_q4_k_q8_k_gateup_swiglu_fused_vnni(c->A_q8, c->W, c->bias, c->out, c->M, c->D, c->K, c->threads);
+}
+
+int main(int argc, char **argv) {
+    int M = 79;
+    int D = 12288;
+    int K = 4096;
+    int iters = 8;
+    int warmup = 2;
+    int mode = 0; /* 0=both, 1=unfused, 2=fused */
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--iters") == 0 && i + 1 < argc) iters = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--warmup") == 0 && i + 1 < argc) warmup = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--M") == 0 && i + 1 < argc) M = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--D") == 0 && i + 1 < argc) D = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--K") == 0 && i + 1 < argc) K = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--mode") == 0 && i + 1 < argc) {
+            const char *m = argv[++i];
+            if (strcmp(m, "unfused") == 0) mode = 1;
+            else if (strcmp(m, "fused") == 0) mode = 2;
+            else mode = 0;
+        }
+    }
+    const char *th_env = getenv("CK_NUM_THREADS");
+    int threads = th_env && th_env[0] ? atoi(th_env) : 1;
+    if (threads <= 0) threads = 1;
+
+    const size_t q8_bytes = (size_t)M * (size_t)(K / QK_K) * sizeof(block_q8_K);
+    const size_t q4_bytes = (size_t)(2 * D) * (size_t)(K / QK_K) * sizeof(block_q4_K);
+    const size_t gateup_elems = (size_t)M * (size_t)(2 * D);
+    const size_t out_elems = (size_t)M * (size_t)D;
+
+    float *A = (float *)malloc((size_t)M * (size_t)K * sizeof(float));
+    uint8_t *A_q8 = (uint8_t *)malloc(q8_bytes);
+    uint8_t *W = (uint8_t *)malloc(q4_bytes);
+    float *bias = (float *)malloc((size_t)(2 * D) * sizeof(float));
+    float *gate_up = (float *)malloc(gateup_elems * sizeof(float));
+    float *out_ref = (float *)malloc(out_elems * sizeof(float));
+    float *out = (float *)malloc(out_elems * sizeof(float));
+    if (!A || !A_q8 || !W || !bias || !gate_up || !out_ref || !out) {
+        fprintf(stderr, "allocation failed\n");
+        return 2;
+    }
+
+    fill_f32(A, (size_t)M * (size_t)K, 0.05f);
+    fill_f32(bias, (size_t)(2 * D), 0.01f);
+    fill_q4k(W, 2 * D, K);
+    quantize_acts_q8k(A, A_q8, M, K);
+
+    ctx_t ctx = {.A_q8 = A_q8, .W = W, .bias = bias, .gate_up = gate_up, .out = out_ref,
+                 .M = M, .D = D, .K = K, .threads = threads};
+    run_unfused(&ctx);
+
+    ctx.out = out;
+    memset(out, 0, out_elems * sizeof(float));
+    run_fused(&ctx);
+    const float diff = max_abs_diff(out_ref, out, out_elems);
+    const float max_ref = max_abs_val(out_ref, out_elems);
+    const double cos = cosine_sim(out_ref, out, out_elems);
+
+    double unfused = 0.0;
+    double fused = 0.0;
+    if (mode == 0 || mode == 1) {
+        ctx.out = out_ref;
+        unfused = bench_ms(run_unfused, &ctx, warmup, iters);
+    }
+    if (mode == 0 || mode == 2) {
+        ctx.out = out;
+        fused = bench_ms(run_fused, &ctx, warmup, iters);
+    }
+
+    const double w_mib = (double)q4_bytes / (1024.0 * 1024.0);
+    const double scratch_mib = (double)(gateup_elems * sizeof(float)) / (1024.0 * 1024.0);
+    printf("Q4_K gate_up+SwiGLU M=%d D=%d K=%d threads=%d warmup=%d iters=%d mode=%s\n", M, D, K, threads, warmup, iters, mode == 1 ? "unfused" : (mode == 2 ? "fused" : "both"));
+    printf("weights=%.1f MiB gate_up_scratch=%.1f MiB output=%.1f MiB\n",
+           w_mib, scratch_mib, (double)(out_elems * sizeof(float)) / (1024.0 * 1024.0));
+    printf("unfused_ms %.3f\n", unfused);
+    printf("fused_ms   %.3f\n", fused);
+    if (unfused > 0.0 && fused > 0.0) printf("speedup    %.3fx\n", unfused / fused);
+    printf("max_diff   %.6g\n", diff);
+    printf("max_ref    %.6g\n", max_ref);
+    printf("rel_diff   %.6g\n", max_ref > 0.0f ? diff / max_ref : 0.0f);
+    printf("cosine     %.9f\n", cos);
+
+    free(A); free(A_q8); free(W); free(bias); free(gate_up); free(out_ref); free(out);
+    ck_threadpool_global_destroy();
+    return (diff < 1e-3f || (max_ref > 0.0f && diff / max_ref < 1e-5f) || cos > 0.999999) ? 0 : 1;
+}

--- a/research/q4k_gateup_swiglu/README.md
+++ b/research/q4k_gateup_swiglu/README.md
@@ -1,0 +1,100 @@
+# Q4_K Gate/Up + SwiGLU Standalone Research Harness
+
+This folder contains standalone experiments for the Qwen3-VL OCR MLP hot path:
+
+```text
+M = 79 tokens
+D = 12288 hidden/intermediate half-dim
+K = 4096 input dim
+weights = ~54 MiB Q4_K gate_up matrix
+```
+
+The goal is to tune cache-aware Q4_K x Q8_K gate/up + SwiGLU kernels before promoting them into a default v8 runtime path. The C file links against the main CK engine for block definitions, Q8_K activation quantization, the current reference GEMM/SwiGLU path, and optionally the CK threadpool. It can run the same x16 packed-panel microkernel through either OpenMP or CK threadpool scheduling.
+
+The v8 prefill codegen now has an experimental opt-in integration guarded by:
+
+```bash
+CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1
+```
+
+Keep this disabled by default. The current implementation lazily packs x16 panels at runtime and keeps that cache alive until process exit. The next production step is conversion/load-time prepacking plus shape and ISA gating.
+
+Build:
+
+```bash
+make --no-print-directory build/bench_q4k_gateup_swiglu_omp_standalone
+```
+
+Representative run on Xeon Gold 6542Y, physical cores only:
+
+```bash
+/usr/bin/env KMP_BLOCKTIME=0 OMP_NUM_THREADS=16 taskset -c 0-23 \
+  build/bench_q4k_gateup_swiglu_omp_standalone \
+  --threads 16 --tile-m 8 --iters 10 --warmup 2 --mode x16 --scheduler ck
+```
+
+Useful sweeps:
+
+```bash
+for tm in 1 2 4 8; do
+  for t in 1 2 4 8 12 16 20 24 32 48; do
+    cpus=0-23; [ "$t" -gt 24 ] && cpus=0-47
+    /usr/bin/env KMP_BLOCKTIME=0 OMP_NUM_THREADS=$t taskset -c $cpus \
+      build/bench_q4k_gateup_swiglu_omp_standalone \
+      --threads $t --tile-m $tm --iters 4 --warmup 1 --mode x16 --scheduler ck
+  done
+done
+```
+
+VTune software hotspots, no hardware PMU required:
+
+```bash
+/opt/app-root/src/Programs/intel/oneapi_2025/vtune/2025.7/bin64/vtune \
+  -collect hotspots \
+  -knob sampling-mode=sw \
+  -knob enable-characterization-insights=false \
+  -knob enable-stack-collection=true \
+  -r build/vtune_q4_gate_omp_x16_t8_16_sw \
+  -- /usr/bin/env KMP_BLOCKTIME=0 OMP_NUM_THREADS=16 taskset -c 0-23 \
+     build/bench_q4k_gateup_swiglu_omp_standalone \
+     --threads 16 --tile-m 8 --iters 8 --warmup 1 --mode x16 --scheduler ck
+```
+
+Current finding on this Xeon:
+
+```text
+Best OpenMP region: tile_m=8, 16 physical threads, ~26-32 ms/layer depending on runtime noise
+Best CK-threadpool region: tile_m=8, 20 physical threads, ~24.7 ms/layer in one sweep
+Current hot-op region: ~37-40 ms/layer
+Parity: rel_diff ~4.3e-7, cosine 1.0
+SMT/48 threads is worse.
+```
+
+This is research/perf infrastructure, not a default production path. Do not enable it globally until model-level sweeps prove a material win on the target hardware.
+
+
+Scheduler comparison:
+
+```bash
+for sched in omp ck; do
+  /usr/bin/env KMP_BLOCKTIME=0 OMP_NUM_THREADS=16 CK_NUM_THREADS=16 taskset -c 0-23 \
+    build/bench_q4k_gateup_swiglu_omp_standalone \
+    --threads 16 --tile-m 8 --iters 8 --warmup 2 --mode x16 --scheduler $sched
+done
+```
+
+Measured example:
+
+```text
+scheduler=omp: ~26.3 ms/layer
+scheduler=ck:  ~25.2 ms/layer
+```
+
+
+Deterministic cache model:
+
+```bash
+python3 research/q4k_gateup_swiglu/cache_model.py --M 79 --D 12288 --K 4096
+```
+
+This computes `tile_m` and `active_threads` from L1/L2/L3 and physical-core topology. Benchmark sweeps validate the model, but defaults should come from this deterministic cache calculation rather than a single noisy OpenShift timing run.

--- a/research/q4k_gateup_swiglu/bench_q4k_gateup_swiglu_omp_standalone.c
+++ b/research/q4k_gateup_swiglu/bench_q4k_gateup_swiglu_omp_standalone.c
@@ -1,0 +1,395 @@
+
+/*
+ * Standalone OpenMP Q4_K x Q8_K gate_up + SwiGLU benchmark.
+ *
+ * This file is intentionally not wired into CK runtime. It is a CPU-tuning
+ * harness for the Qwen3-VL OCR MLP gate_up shape: M=79, D=12288, K=4096.
+ * It compares CK's current unfused reference path against an OpenMP-owned
+ * x16 packed-panel fused prototype.
+ */
+
+#include "ckernel_quant.h"
+#include "ck_threadpool.h"
+
+#include <immintrin.h>
+#include <math.h>
+#include <omp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+extern void quantize_row_q8_k(const float *x, void *vy, int k);
+extern void gemm_nt_q4_k_q8_k(const void *A, const void *B, const float *bias,
+                              float *C, int M, int N, int K);
+extern void swiglu_forward_exact(const float *input, float *output, int tokens, int dim);
+
+typedef struct {
+    ck_half d[16];
+    ck_half dmin[16];
+    uint8_t sc[16][8];
+    uint8_t m[16][8];
+    uint8_t qs[16][QK_K / 2];
+    uint8_t active;
+    uint8_t reserved[15];
+} q4k_x16_panel_t;
+
+static inline float fp16_to_fp32(uint16_t h) {
+    const uint32_t s = ((uint32_t)h & 0x8000u) << 16;
+    uint32_t e = ((uint32_t)h >> 10) & 0x1fu;
+    uint32_t f = (uint32_t)h & 0x03ffu;
+    uint32_t out;
+    if (e == 0) {
+        if (f == 0) out = s;
+        else {
+            e = 1;
+            while ((f & 0x0400u) == 0) { f <<= 1; --e; }
+            f &= 0x03ffu;
+            out = s | ((e + (127 - 15)) << 23) | (f << 13);
+        }
+    } else if (e == 31) {
+        out = s | 0x7f800000u | (f << 13);
+    } else {
+        out = s | ((e + (127 - 15)) << 23) | (f << 13);
+    }
+    float v;
+    memcpy(&v, &out, sizeof(v));
+    return v;
+}
+
+static inline void unpack_q4_k_scales_local(const uint8_t *scales, uint8_t *sc, uint8_t *m) {
+    for (int i = 0; i < 4; ++i) sc[i] = scales[i] & 0x3f;
+    for (int i = 0; i < 4; ++i) m[i] = scales[i + 4] & 0x3f;
+    for (int i = 0; i < 4; ++i) {
+        sc[i + 4] = (uint8_t)(((scales[i] >> 6) & 0x03) | ((scales[i + 8] & 0x0f) << 2));
+        m[i + 4] = (uint8_t)(((scales[i + 4] >> 6) & 0x03) | ((scales[i + 8] >> 4) << 2));
+    }
+}
+
+static void pack_x16(const block_q4_K *src, q4k_x16_panel_t *dst, int N, int K) {
+    const int groups = (N + 15) / 16;
+    const int blocks_per_row = K / QK_K;
+    memset(dst, 0, (size_t)groups * (size_t)blocks_per_row * sizeof(*dst));
+    for (int g = 0; g < groups; ++g) {
+        const int n0 = g * 16;
+        const int active = (n0 + 16 <= N) ? 16 : (N - n0);
+        for (int b = 0; b < blocks_per_row; ++b) {
+            q4k_x16_panel_t *panel = dst + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+            panel->active = (uint8_t)active;
+            for (int lane = 0; lane < active; ++lane) {
+                const block_q4_K *w = src + (size_t)(n0 + lane) * (size_t)blocks_per_row + (size_t)b;
+                panel->d[lane] = w->d;
+                panel->dmin[lane] = w->dmin;
+                unpack_q4_k_scales(w->scales, panel->sc[lane], panel->m[lane]);
+                memcpy(panel->qs[lane], w->qs, QK_K / 2);
+            }
+        }
+    }
+}
+
+static inline int hsum256_epi32_local(__m256i v) {
+    __m128i lo = _mm256_castsi256_si128(v);
+    __m128i hi = _mm256_extracti128_si256(v, 1);
+    __m128i s = _mm_add_epi32(lo, hi);
+    s = _mm_add_epi32(s, _mm_shuffle_epi32(s, 0x4e));
+    s = _mm_add_epi32(s, _mm_shuffle_epi32(s, 0xb1));
+    return _mm_cvtsi128_si32(s);
+}
+
+static inline __m256i unpack_q4_32(__m256i packed, int high) {
+    const __m256i mask = _mm256_set1_epi8(0x0f);
+    return high ? _mm256_and_si256(_mm256_srli_epi16(packed, 4), mask)
+                : _mm256_and_si256(packed, mask);
+}
+
+static inline int32_t dot32_vnni(__m256i q4, __m256i q8) {
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+    __m256i acc = _mm256_setzero_si256();
+    acc = _mm256_dpbusd_epi32(acc, q4, q8);
+    return hsum256_epi32_local(acc);
+#else
+    const __m256i prod16 = _mm256_maddubs_epi16(q4, q8);
+    const __m256i ones = _mm256_set1_epi16(1);
+    return hsum256_epi32_local(_mm256_madd_epi16(prod16, ones));
+#endif
+}
+
+static inline void accum_panel(float acc[8][16], const q4k_x16_panel_t *w, int active,
+                               const block_q8_K *A, int blocks_per_vec, int block_index,
+                               int m0, int m_count) {
+    for (int j = 0, is = 0, qoff = 0; j < QK_K; j += 64, is += 2, qoff += 32) {
+        for (int lane = 0; lane < active; ++lane) {
+            const uint8_t *qs = &w->qs[lane][qoff];
+            const __m256i packed = _mm256_loadu_si256((const __m256i *)qs);
+            const __m256i q4lo = unpack_q4_32(packed, 0);
+            const __m256i q4hi = unpack_q4_32(packed, 1);
+            const float wd = CK_FP16_TO_FP32(w->d[lane]);
+            const float wdmin = CK_FP16_TO_FP32(w->dmin[lane]);
+            const float sc_lo = (float)w->sc[lane][is];
+            const float sc_hi = (float)w->sc[lane][is + 1];
+            const float min_lo = (float)w->m[lane][is];
+            const float min_hi = (float)w->m[lane][is + 1];
+            for (int mt = 0; mt < m_count; ++mt) {
+                const block_q8_K *x = A + (size_t)(m0 + mt) * (size_t)blocks_per_vec + (size_t)block_index;
+                const __m256i q8lo = _mm256_loadu_si256((const __m256i *)&x->qs[j]);
+                const __m256i q8hi = _mm256_loadu_si256((const __m256i *)&x->qs[j + 32]);
+                const int32_t sum_lo = dot32_vnni(q4lo, q8lo);
+                const int32_t sum_hi = dot32_vnni(q4hi, q8hi);
+                const int32_t bsum_lo = (int32_t)x->bsums[j / 16] + (int32_t)x->bsums[j / 16 + 1];
+                const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] + (int32_t)x->bsums[(j + 32) / 16 + 1];
+                const float xd = x->d;
+                acc[mt][lane] += (wd * xd) * sc_lo * (float)sum_lo;
+                acc[mt][lane] -= (wdmin * xd) * min_lo * (float)bsum_lo;
+                acc[mt][lane] += (wd * xd) * sc_hi * (float)sum_hi;
+                acc[mt][lane] -= (wdmin * xd) * min_hi * (float)bsum_hi;
+            }
+        }
+    }
+}
+
+static inline float silu_f32(float x) { return x / (1.0f + expf(-x)); }
+
+
+typedef struct {
+    const block_q8_K *A;
+    const q4k_x16_panel_t *W;
+    const float *bias;
+    float *C;
+    int M;
+    int D;
+    int K;
+    int tile_m;
+    int blocks_per_vec;
+    int blocks_per_row;
+    int groups_d;
+    int total_jobs;
+} ck_x16_work_t;
+
+static void run_x16_job(const ck_x16_work_t *a, int job) {
+    const int tm_size = a->tile_m > 0 ? (a->tile_m > 8 ? 8 : a->tile_m) : 4;
+    const int mt = (a->M + tm_size - 1) / tm_size;
+    const int g = job / mt;
+    const int tm = job - g * mt;
+    const int m0 = tm * tm_size;
+    const int m1 = (m0 + tm_size < a->M) ? (m0 + tm_size) : a->M;
+    const int m_count = m1 - m0;
+    const int d0 = g * 16;
+    const int active = (d0 + 16 <= a->D) ? 16 : (a->D - d0);
+    if (m_count <= 0 || active <= 0) return;
+
+    float acc_gate[8][16];
+    float acc_up[8][16];
+    for (int mm = 0; mm < m_count; ++mm) {
+        for (int lane = 0; lane < active; ++lane) {
+            acc_gate[mm][lane] = a->bias ? a->bias[d0 + lane] : 0.0f;
+            acc_up[mm][lane] = a->bias ? a->bias[a->D + d0 + lane] : 0.0f;
+        }
+    }
+    for (int b = 0; b < a->blocks_per_row; ++b) {
+        const q4k_x16_panel_t *wg = a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
+        const q4k_x16_panel_t *wu = a->W + (size_t)(a->groups_d + g) * (size_t)a->blocks_per_row + (size_t)b;
+        accum_panel(acc_gate, wg, active, a->A, a->blocks_per_vec, b, m0, m_count);
+        accum_panel(acc_up, wu, active, a->A, a->blocks_per_vec, b, m0, m_count);
+    }
+    for (int mm = 0; mm < m_count; ++mm) {
+        float *c = a->C + (size_t)(m0 + mm) * (size_t)a->D;
+        for (int lane = 0; lane < active; ++lane) c[d0 + lane] = silu_f32(acc_gate[mm][lane]) * acc_up[mm][lane];
+    }
+}
+
+static void ck_x16_worker(int ith, int nth, void *args) {
+    const ck_x16_work_t *a = (const ck_x16_work_t *)args;
+    for (int job = ith; job < a->total_jobs; job += nth) run_x16_job(a, job);
+}
+
+static void ckpool_x16_fused(const block_q8_K *A, const q4k_x16_panel_t *W, const float *bias,
+                             float *C, int M, int D, int K, int tile_m, int threads) {
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int tm_size = tile_m > 0 ? (tile_m > 8 ? 8 : tile_m) : 4;
+    ck_x16_work_t work = {
+        .A = A,
+        .W = W,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .D = D,
+        .K = K,
+        .tile_m = tm_size,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+        .groups_d = (D + 15) / 16,
+    };
+    const int mt = (M + tm_size - 1) / tm_size;
+    work.total_jobs = mt * work.groups_d;
+    int active = threads > 0 ? threads : (pool ? ck_threadpool_n_threads(pool) : 1);
+    if (active < 1) active = 1;
+    if (active > work.total_jobs) active = work.total_jobs;
+    if (!pool || active <= 1) ck_x16_worker(0, 1, &work);
+    else ck_threadpool_dispatch_n(pool, active, ck_x16_worker, &work);
+}
+
+static void omp_x16_fused(const block_q8_K *A, const q4k_x16_panel_t *W, const float *bias,
+                          float *C, int M, int D, int K, int tile_m, int threads, int schedule_kind) {
+    const int blocks_per_vec = K / QK_K;
+    const int blocks_per_row = K / QK_K;
+    const int groups_d = (D + 15) / 16;
+    const int tm_size = tile_m > 0 ? (tile_m > 8 ? 8 : tile_m) : 4;
+    const int mt = (M + tm_size - 1) / tm_size;
+    const int total = mt * groups_d;
+    omp_set_num_threads(threads);
+
+#pragma omp parallel for schedule(static)
+    for (int job = 0; job < total; ++job) {
+        (void)schedule_kind;
+        const int g = job / mt;
+        const int tm = job - g * mt;
+        const int m0 = tm * tm_size;
+        const int m1 = (m0 + tm_size < M) ? (m0 + tm_size) : M;
+        const int m_count = m1 - m0;
+        const int d0 = g * 16;
+        const int active = (d0 + 16 <= D) ? 16 : (D - d0);
+        float acc_gate[8][16];
+        float acc_up[8][16];
+        for (int mm = 0; mm < m_count; ++mm) {
+            for (int lane = 0; lane < active; ++lane) {
+                acc_gate[mm][lane] = bias ? bias[d0 + lane] : 0.0f;
+                acc_up[mm][lane] = bias ? bias[D + d0 + lane] : 0.0f;
+            }
+        }
+        for (int b = 0; b < blocks_per_row; ++b) {
+            const q4k_x16_panel_t *wg = W + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+            const q4k_x16_panel_t *wu = W + (size_t)(groups_d + g) * (size_t)blocks_per_row + (size_t)b;
+            accum_panel(acc_gate, wg, active, A, blocks_per_vec, b, m0, m_count);
+            accum_panel(acc_up, wu, active, A, blocks_per_vec, b, m0, m_count);
+        }
+        for (int mm = 0; mm < m_count; ++mm) {
+            float *c = C + (size_t)(m0 + mm) * (size_t)D;
+            for (int lane = 0; lane < active; ++lane) c[d0 + lane] = silu_f32(acc_gate[mm][lane]) * acc_up[mm][lane];
+        }
+    }
+}
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1.0e6;
+}
+static uint32_t rng_state = 0x456789abu;
+static uint32_t rng_u32(void) { rng_state = rng_state * 1664525u + 1013904223u; return rng_state; }
+static float rng_f32(float scale) { return (((float)(rng_u32() >> 8) / (float)0x00ffffffu) * 2.0f - 1.0f) * scale; }
+static void fill_f32(float *p, size_t n, float scale) { for (size_t i = 0; i < n; ++i) p[i] = rng_f32(scale); }
+static void fill_q4k(uint8_t *dst, int N, int K) {
+    const int blocks = N * (K / QK_K);
+    for (int b = 0; b < blocks; ++b) {
+        block_q4_K *blk = (block_q4_K *)(void *)(dst + (size_t)b * sizeof(block_q4_K));
+        blk->d = 0x3c00;
+        blk->dmin = 0x3800;
+        for (int i = 0; i < (int)sizeof(blk->scales); ++i) blk->scales[i] = (uint8_t)(rng_u32() & 0xffu);
+        for (int i = 0; i < (int)sizeof(blk->qs); ++i) blk->qs[i] = (uint8_t)(rng_u32() & 0xffu);
+    }
+}
+static void quantize_acts_q8k(const float *src, uint8_t *dst, int M, int K) {
+    const size_t row_bytes = (size_t)(K / QK_K) * sizeof(block_q8_K);
+    for (int m = 0; m < M; ++m) quantize_row_q8_k(src + (size_t)m * (size_t)K, dst + (size_t)m * row_bytes, K);
+}
+static float max_abs_diff(const float *a, const float *b, size_t n) {
+    float mx = 0.0f;
+    for (size_t i = 0; i < n; ++i) { float d = fabsf(a[i] - b[i]); if (d > mx) mx = d; }
+    return mx;
+}
+static float max_abs_val(const float *a, size_t n) {
+    float mx = 0.0f;
+    for (size_t i = 0; i < n; ++i) { float v = fabsf(a[i]); if (v > mx) mx = v; }
+    return mx;
+}
+static double cosine_sim(const float *a, const float *b, size_t n) {
+    double dot = 0.0, aa = 0.0, bb = 0.0;
+    for (size_t i = 0; i < n; ++i) { dot += (double)a[i] * b[i]; aa += (double)a[i] * a[i]; bb += (double)b[i] * b[i]; }
+    return (aa > 0.0 && bb > 0.0) ? dot / sqrt(aa * bb) : 0.0;
+}
+
+int main(int argc, char **argv) {
+    int M = 79, D = 12288, K = 4096, iters = 8, warmup = 2, threads = 16, tile_m = 4;
+    const char *mode = "both";
+    const char *scheduler = "omp";
+    for (int i = 1; i < argc; ++i) {
+        if (!strcmp(argv[i], "--M") && i + 1 < argc) M = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--D") && i + 1 < argc) D = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--K") && i + 1 < argc) K = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--iters") && i + 1 < argc) iters = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--warmup") && i + 1 < argc) warmup = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--threads") && i + 1 < argc) threads = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--tile-m") && i + 1 < argc) tile_m = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--mode") && i + 1 < argc) mode = argv[++i];
+        else if (!strcmp(argv[i], "--scheduler") && i + 1 < argc) scheduler = argv[++i];
+    }
+
+    const size_t q8_bytes = (size_t)M * (size_t)(K / QK_K) * sizeof(block_q8_K);
+    const size_t q4_bytes = (size_t)(2 * D) * (size_t)(K / QK_K) * sizeof(block_q4_K);
+    const size_t x16_bytes = (size_t)((2 * D + 15) / 16) * (size_t)(K / QK_K) * sizeof(q4k_x16_panel_t);
+    const size_t gateup_elems = (size_t)M * (size_t)(2 * D);
+    const size_t out_elems = (size_t)M * (size_t)D;
+
+    float *A = (float *)malloc((size_t)M * (size_t)K * sizeof(float));
+    uint8_t *A_q8 = (uint8_t *)malloc(q8_bytes);
+    uint8_t *W = (uint8_t *)malloc(q4_bytes);
+    q4k_x16_panel_t *W_x16 = (q4k_x16_panel_t *)malloc(x16_bytes);
+    float *bias = (float *)malloc((size_t)(2 * D) * sizeof(float));
+    float *gate_up = (float *)malloc(gateup_elems * sizeof(float));
+    float *out_ref = (float *)malloc(out_elems * sizeof(float));
+    float *out_x16 = (float *)malloc(out_elems * sizeof(float));
+    if (!A || !A_q8 || !W || !W_x16 || !bias || !gate_up || !out_ref || !out_x16) { fprintf(stderr, "alloc failed\n"); return 2; }
+
+    fill_f32(A, (size_t)M * (size_t)K, 0.05f);
+    fill_f32(bias, (size_t)(2 * D), 0.01f);
+    fill_q4k(W, 2 * D, K);
+    quantize_acts_q8k(A, A_q8, M, K);
+    const double p0 = now_ms();
+    pack_x16((const block_q4_K *)W, W_x16, 2 * D, K);
+    const double pack_ms = now_ms() - p0;
+
+    gemm_nt_q4_k_q8_k(A_q8, W, bias, gate_up, M, 2 * D, K);
+    swiglu_forward_exact(gate_up, out_ref, M, D);
+    if (!strcmp(scheduler, "ck")) ckpool_x16_fused((const block_q8_K *)A_q8, W_x16, bias, out_x16, M, D, K, tile_m, threads);
+    else omp_x16_fused((const block_q8_K *)A_q8, W_x16, bias, out_x16, M, D, K, tile_m, threads, 0);
+    const float diff = max_abs_diff(out_ref, out_x16, out_elems);
+    const float max_ref = max_abs_val(out_ref, out_elems);
+    const double cos = cosine_sim(out_ref, out_x16, out_elems);
+
+    double ref_ms = 0.0, x16_ms = 0.0;
+    if (strcmp(mode, "x16") != 0) {
+        for (int i = 0; i < warmup; ++i) { gemm_nt_q4_k_q8_k(A_q8, W, bias, gate_up, M, 2 * D, K); swiglu_forward_exact(gate_up, out_ref, M, D); }
+        const double t0 = now_ms();
+        for (int i = 0; i < iters; ++i) { gemm_nt_q4_k_q8_k(A_q8, W, bias, gate_up, M, 2 * D, K); swiglu_forward_exact(gate_up, out_ref, M, D); }
+        ref_ms = (now_ms() - t0) / (double)iters;
+    }
+    if (strcmp(mode, "ref") != 0) {
+        for (int i = 0; i < warmup; ++i) {
+            if (!strcmp(scheduler, "ck")) ckpool_x16_fused((const block_q8_K *)A_q8, W_x16, bias, out_x16, M, D, K, tile_m, threads);
+            else omp_x16_fused((const block_q8_K *)A_q8, W_x16, bias, out_x16, M, D, K, tile_m, threads, 0);
+        }
+        const double t0 = now_ms();
+        for (int i = 0; i < iters; ++i) {
+            if (!strcmp(scheduler, "ck")) ckpool_x16_fused((const block_q8_K *)A_q8, W_x16, bias, out_x16, M, D, K, tile_m, threads);
+            else omp_x16_fused((const block_q8_K *)A_q8, W_x16, bias, out_x16, M, D, K, tile_m, threads, 0);
+        }
+        x16_ms = (now_ms() - t0) / (double)iters;
+    }
+
+    printf("standalone_q4k_gateup_swiglu M=%d D=%d K=%d threads=%d tile_m=%d iters=%d mode=%s scheduler=%s\n", M, D, K, threads, tile_m, iters, mode, scheduler);
+    printf("weights=%.1fMiB packed_x16=%.1fMiB scratch=%.1fMiB output=%.1fMiB pack_ms=%.3f\n",
+           (double)q4_bytes / 1048576.0, (double)x16_bytes / 1048576.0,
+           (double)(gateup_elems * sizeof(float)) / 1048576.0,
+           (double)(out_elems * sizeof(float)) / 1048576.0, pack_ms);
+    printf("ref_ms %.3f\n", ref_ms);
+    printf("x16_ms %.3f\n", x16_ms);
+    if (ref_ms > 0.0 && x16_ms > 0.0) printf("speedup %.3fx\n", ref_ms / x16_ms);
+    printf("max_diff %.6g\n", diff);
+    printf("max_ref %.6g\n", max_ref);
+    printf("rel_diff %.6g\n", max_ref > 0.0f ? diff / max_ref : 0.0f);
+    printf("cosine %.9f\n", cos);
+
+    free(A); free(A_q8); free(W); free(W_x16); free(bias); free(gate_up); free(out_ref); free(out_x16);
+    return (diff < 1e-3f || (max_ref > 0.0f && diff / max_ref < 1e-5f) || cos > 0.999999) ? 0 : 1;
+}

--- a/research/q4k_gateup_swiglu/cache_model.py
+++ b/research/q4k_gateup_swiglu/cache_model.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Deterministic cache model for Q4_K gate_up + SwiGLU research kernels.
+
+This does not try to learn from benchmark timing. It derives a conservative
+starting tile/thread plan from the CPU cache hierarchy and the M/D/K shape.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+QK_K = 256
+Q4K_BLOCK_BYTES = 144
+Q8K_BLOCK_BYTES = 292  # sizeof(block_q8_K): d + qs[256] + bsums[16] + padding/alignment in CK builds
+CACHE_LINE = 64
+
+
+def read_int(path: Path, default: int) -> int:
+    try:
+        s = path.read_text().strip().upper()
+    except OSError:
+        return default
+    mult = 1
+    if s.endswith("K"):
+        mult = 1024
+        s = s[:-1]
+    elif s.endswith("M"):
+        mult = 1024 * 1024
+        s = s[:-1]
+    try:
+        return int(s) * mult
+    except ValueError:
+        return default
+
+
+def cache_info(cpu: int = 0) -> dict[str, int]:
+    base = Path(f"/sys/devices/system/cpu/cpu{cpu}/cache")
+    out = {"l1d": 48 * 1024, "l2": 2 * 1024 * 1024, "l3": 60 * 1024 * 1024, "line": 64}
+    if not base.exists():
+        return out
+    for idx in base.glob("index*"):
+        try:
+            level = idx.joinpath("level").read_text().strip()
+            typ = idx.joinpath("type").read_text().strip()
+        except OSError:
+            continue
+        size = read_int(idx / "size", 0)
+        line = read_int(idx / "coherency_line_size", CACHE_LINE)
+        if level == "1" and typ == "Data":
+            out["l1d"] = size
+        elif level == "2" and typ == "Unified":
+            out["l2"] = size
+        elif level == "3" and typ == "Unified":
+            out["l3"] = size
+        out["line"] = line or out["line"]
+    return out
+
+
+def physical_cores() -> int:
+    cores = set()
+    try:
+        for cpu_dir in Path("/sys/devices/system/cpu").glob("cpu[0-9]*"):
+            topo = cpu_dir / "topology"
+            pkg = (topo / "physical_package_id").read_text().strip()
+            core = (topo / "core_id").read_text().strip()
+            cores.add((pkg, core))
+    except OSError:
+        return 1
+    return max(1, len(cores))
+
+
+def floor_multiple(x: int, m: int) -> int:
+    return max(m, (x // m) * m)
+
+
+def choose_tile_m(l1d: int, l2: int, k: int, n_lanes: int, max_tile_m: int) -> int:
+    row_bytes = (k // QK_K) * Q4K_BLOCK_BYTES
+    paired_panel = 2 * n_lanes * row_bytes
+    # Keep the paired gate/up panel comfortably in L2. 1/8 L2 is conservative
+    # enough to leave room for Q8 rows, stacks, output lines, and prefetch noise.
+    l2_panel_budget = l2 // 8
+    if paired_panel > l2_panel_budget:
+        # Reduce lanes in future kernels; for this x16 experiment, keep tile_m small.
+        return 1
+
+    q8_row = (k // QK_K) * Q8K_BLOCK_BYTES
+    # Let Q8 token rows occupy up to 1/4 L2. They are reused across the current
+    # panel and should not evict the whole weight panel.
+    max_by_l2 = max(1, (l2 // 4) // max(1, q8_row))
+    # L1 cannot hold the full paired x16 panel; use it for active block slices.
+    # Keep output writes for tile_m*n_lanes under about half L1d.
+    max_by_l1_out = max(1, (l1d // 2) // max(1, n_lanes * 4))
+    return max(1, min(max_tile_m, max_by_l2, max_by_l1_out))
+
+
+def choose_threads(l2: int, l3: int, physical: int, weight_bytes: int) -> int:
+    # Deterministic cache rule:
+    # Each active core should own enough of the weight stream to make progress,
+    # but not so many cores that the per-core share is far below L2 and all cores
+    # fight over the same L3-sized matrix. Target a per-core share near 1.25x L2.
+    target_share = max(1, int(1.25 * l2))
+    by_share = max(1, (weight_bytes + target_share - 1) // target_share)
+
+    # L3 is shared. Keep total active cores below physical cores and avoid SMT by
+    # construction. Leave some L3 headroom for activations/output/runtime.
+    l3_usable = int(0.85 * l3)
+    if weight_bytes > l3_usable:
+        # If weights exceed usable L3, avoid full-core saturation by reserving
+        # about 1/6 of physical cores for lower contention.
+        by_l3_pressure = max(1, physical - max(1, physical // 6))
+    else:
+        by_l3_pressure = physical
+
+    threads = min(physical, max(1, by_share), by_l3_pressure)
+    # Keep thread count aligned to groups of 4 for balanced static work chunks.
+    if threads >= 8:
+        threads = floor_multiple(threads, 4)
+    return max(1, threads)
+
+
+def model(m: int, d: int, k: int, lanes: int, max_tile_m: int) -> dict[str, object]:
+    c = cache_info()
+    phys = physical_cores()
+    row_bytes = (k // QK_K) * Q4K_BLOCK_BYTES
+    q8_row = (k // QK_K) * Q8K_BLOCK_BYTES
+    weight_bytes = 2 * d * row_bytes
+    packed_x16_bytes = ((2 * d + lanes - 1) // lanes) * (k // QK_K) * (2 + 2 + 8 + 8 + QK_K // 2) * lanes
+    paired_panel = 2 * lanes * row_bytes
+    tile_m = choose_tile_m(c["l1d"], c["l2"], k, lanes, max_tile_m)
+    threads = choose_threads(c["l2"], c["l3"], phys, weight_bytes)
+    return {
+        "shape": {"M": m, "D": d, "K": k, "lanes": lanes},
+        "cache": {"L1d": c["l1d"], "L2_per_core": c["l2"], "L3_shared": c["l3"], "line": c["line"], "physical_cores": phys},
+        "bytes": {
+            "q4k_row": row_bytes,
+            "gate_up_weights": weight_bytes,
+            "packed_x16_estimate": packed_x16_bytes,
+            "q8_row": q8_row,
+            "q8_activation_rows": m * q8_row,
+            "paired_gate_up_x16_panel": paired_panel,
+            "gate_up_scratch_fp32": m * 2 * d * 4,
+            "swiglu_output_fp32": m * d * 4,
+        },
+        "recommendation": {"tile_m": tile_m, "active_threads": threads, "avoid_smt": True},
+        "rationale": {
+            "tile_m": "largest token tile that keeps Q8 rows/output within L2/L1 budgets while the paired x16 Q4 panel fits L2",
+            "threads": "physical-core cap from weight_bytes / (1.25*L2), reduced if the weight stream exceeds ~85% of shared L3",
+        },
+    }
+
+
+def human(n: int) -> str:
+    if n >= 1024 * 1024:
+        return f"{n / (1024 * 1024):.2f} MiB"
+    if n >= 1024:
+        return f"{n / 1024:.2f} KiB"
+    return f"{n} B"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--M", type=int, default=79)
+    ap.add_argument("--D", type=int, default=12288)
+    ap.add_argument("--K", type=int, default=4096)
+    ap.add_argument("--lanes", type=int, default=16)
+    ap.add_argument("--max-tile-m", type=int, default=8)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+    r = model(args.M, args.D, args.K, args.lanes, args.max_tile_m)
+    if args.json:
+        print(json.dumps(r, indent=2))
+        return 0
+    print("Q4_K gate_up+SwiGLU deterministic cache model")
+    print(f"shape: M={args.M} D={args.D} K={args.K} lanes={args.lanes}")
+    print("cache:")
+    for k, v in r["cache"].items():
+        print(f"  {k}: {human(v) if k != 'physical_cores' else v}")
+    print("working set:")
+    for k, v in r["bytes"].items():
+        print(f"  {k}: {human(v)}")
+    print("recommendation:")
+    print(f"  tile_m: {r['recommendation']['tile_m']}")
+    print(f"  active_threads: {r['recommendation']['active_threads']}")
+    print(f"  avoid_smt: {r['recommendation']['avoid_smt']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -26,6 +26,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -85,6 +86,20 @@ static inline int32_t dot_q4_k_q8_k_32_vnni_q8v(const uint8_t *q4_packed_32,
     acc = _mm256_dpbusd_epi32(acc, q4_bytes, q8_bytes);
     return hsum256_epi32(acc);
 }
+
+static inline __m256i q4_k_unpack_32_vnni_bytes(__m256i packed, int high_nibble) {
+    const __m256i mask4 = _mm256_set1_epi8(0x0F);
+    return high_nibble
+        ? _mm256_and_si256(_mm256_srli_epi16(packed, 4), mask4)
+        : _mm256_and_si256(packed, mask4);
+}
+
+static inline int32_t dot_q4_k_q8_k_32_vnni_q4v_q8v(__m256i q4_bytes, __m256i q8_bytes) {
+    __m256i acc = _mm256_setzero_si256();
+    acc = _mm256_dpbusd_epi32(acc, q4_bytes, q8_bytes);
+    return hsum256_epi32(acc);
+}
+
 
 static inline float dot_q4_k_q8_k_vnni_block(const block_q4_K *w,
                                              const block_q8_K *x) {
@@ -164,6 +179,26 @@ typedef struct {
     uint8_t reserved[7];
 } block_q4_K_packed_meta_x8;
 
+typedef struct {
+    ck_half d[16];
+    ck_half dmin[16];
+    uint8_t sc[16][8];
+    uint8_t m[16][8];
+    uint8_t qs[16][QK_K / 2];
+    uint8_t active;
+    uint8_t reserved[15];
+} block_q4_K_packed_meta_x16;
+
+typedef struct {
+    ck_half d[16];
+    ck_half dmin[16];
+    uint8_t sc[16][8];
+    uint8_t m[16][8];
+    uint8_t qs[16][QK_K];
+    uint8_t active;
+    uint8_t reserved[15];
+} block_q4_K_packed_u8_x16;
+
 size_t q4_k_packed_u8_block_size(void)
 {
     return sizeof(block_q4_K_packed_u8);
@@ -177,6 +212,16 @@ size_t q4_k_packed_meta_block_size(void)
 size_t q4_k_packed_meta_x8_block_size(void)
 {
     return sizeof(block_q4_K_packed_meta_x8);
+}
+
+size_t q4_k_packed_meta_x16_block_size(void)
+{
+    return sizeof(block_q4_K_packed_meta_x16);
+}
+
+size_t q4_k_packed_u8_x16_block_size(void)
+{
+    return sizeof(block_q4_K_packed_u8_x16);
 }
 
 void pack_q4_k_to_packed_u8(const void *src, void *dst, int N, int K)
@@ -253,12 +298,83 @@ void pack_q4_k_to_packed_meta_x8(const void *src, void *dst, int N, int K)
     }
 }
 
+void pack_q4_k_to_packed_meta_x16(const void *src, void *dst, int N, int K)
+{
+    if (!src || !dst || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    const block_q4_K *in = (const block_q4_K *)src;
+    block_q4_K_packed_meta_x16 *out = (block_q4_K_packed_meta_x16 *)dst;
+    const int blocks_per_row = K / QK_K;
+    const int groups = (N + 15) / 16;
+    memset(out, 0, (size_t)groups * (size_t)blocks_per_row * sizeof(*out));
+
+    for (int g = 0; g < groups; ++g) {
+        const int n0 = g * 16;
+        const int active = (n0 + 16 <= N) ? 16 : (N - n0);
+        for (int b = 0; b < blocks_per_row; ++b) {
+            block_q4_K_packed_meta_x16 *pb = out + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+            pb->active = (uint8_t)active;
+            for (int lane = 0; lane < active; ++lane) {
+                const block_q4_K *sb = in + (size_t)(n0 + lane) * (size_t)blocks_per_row + (size_t)b;
+                pb->d[lane] = sb->d;
+                pb->dmin[lane] = sb->dmin;
+                unpack_q4_k_scales(sb->scales, pb->sc[lane], pb->m[lane]);
+                memcpy(pb->qs[lane], sb->qs, sizeof(pb->qs[lane]));
+            }
+        }
+    }
+}
+
+void pack_q4_k_to_packed_u8_x16(const void *src, void *dst, int N, int K)
+{
+    if (!src || !dst || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    const block_q4_K *in = (const block_q4_K *)src;
+    block_q4_K_packed_u8_x16 *out = (block_q4_K_packed_u8_x16 *)dst;
+    const int blocks_per_row = K / QK_K;
+    const int groups = (N + 15) / 16;
+    memset(out, 0, (size_t)groups * (size_t)blocks_per_row * sizeof(*out));
+
+    for (int g = 0; g < groups; ++g) {
+        const int n0 = g * 16;
+        const int active = (n0 + 16 <= N) ? 16 : (N - n0);
+        for (int b = 0; b < blocks_per_row; ++b) {
+            block_q4_K_packed_u8_x16 *pb = out + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+            pb->active = (uint8_t)active;
+            for (int lane = 0; lane < active; ++lane) {
+                const block_q4_K *sb = in + (size_t)(n0 + lane) * (size_t)blocks_per_row + (size_t)b;
+                pb->d[lane] = sb->d;
+                pb->dmin[lane] = sb->dmin;
+                unpack_q4_k_scales(sb->scales, pb->sc[lane], pb->m[lane]);
+                for (int j = 0, q_offset = 0; j < QK_K; j += 64, q_offset += 32) {
+                    const uint8_t *qs = &sb->qs[q_offset];
+                    for (int l = 0; l < 32; ++l) {
+                        pb->qs[lane][j + l] = qs[l] & 0x0F;
+                        pb->qs[lane][j + 32 + l] = qs[l] >> 4;
+                    }
+                }
+            }
+        }
+    }
+}
+
 #if defined(__AVX512VNNI__) && defined(__AVX512VL__)
 static inline int32_t dot_q4_packed_u8_q8_32_vnni(const uint8_t *q4_32,
                                                    const int8_t *q8_32)
 {
     const __m256i q4 = _mm256_loadu_si256((const __m256i *)q4_32);
     const __m256i q8 = _mm256_loadu_si256((const __m256i *)q8_32);
+    __m256i acc = _mm256_setzero_si256();
+    acc = _mm256_dpbusd_epi32(acc, q4, q8);
+    return hsum256_epi32(acc);
+}
+
+static inline int32_t dot_q4_packed_u8_q8_32_vnni_q8v(const uint8_t *q4_32,
+                                                       __m256i q8)
+{
+    const __m256i q4 = _mm256_loadu_si256((const __m256i *)q4_32);
     __m256i acc = _mm256_setzero_si256();
     acc = _mm256_dpbusd_epi32(acc, q4, q8);
     return hsum256_epi32(acc);
@@ -336,6 +452,147 @@ static inline void accum_q4_k_packed_meta_x8_q8_k_block(float acc[8],
                                                          const block_q4_K_packed_meta_x8 *w,
                                                          int active,
                                                          const block_q8_K *x)
+{
+    const float xd = x->d;
+    for (int j = 0, is = 0, q_offset = 0; j < QK_K; j += 64, is += 2, q_offset += 32) {
+        const int8_t *q8_lo_ptr = &x->qs[j];
+        const int8_t *q8_hi_ptr = &x->qs[j + 32];
+        const int32_t bsum_lo = (int32_t)x->bsums[j / 16] +
+                                (int32_t)x->bsums[j / 16 + 1];
+        const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
+                                (int32_t)x->bsums[(j + 32) / 16 + 1];
+
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#elif defined(__AVX2__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#endif
+
+        for (int lane = 0; lane < active; ++lane) {
+            const uint8_t *qs = &w->qs[lane][q_offset];
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+            const int32_t sum_lo = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_lo, 0);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_hi, 1);
+#elif defined(__AVX2__)
+            const int32_t sum_lo = dot_q4_k_q8_k_32_avx2_q8v(qs, q8_lo, 0);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_avx2_q8v(qs, q8_hi, 1);
+#else
+            int32_t sum_lo = 0;
+            int32_t sum_hi = 0;
+            for (int l = 0; l < 32; ++l) {
+                sum_lo += (int32_t)(qs[l] & 0x0F) * (int32_t)q8_lo_ptr[l];
+                sum_hi += (int32_t)(qs[l] >> 4) * (int32_t)q8_hi_ptr[l];
+            }
+#endif
+            const float d = CK_FP16_TO_FP32(w->d[lane]) * xd;
+            const float dmin = CK_FP16_TO_FP32(w->dmin[lane]) * xd;
+            acc[lane] += d * (float)w->sc[lane][is] * (float)sum_lo;
+            acc[lane] -= dmin * (float)w->m[lane][is] * (float)bsum_lo;
+            acc[lane] += d * (float)w->sc[lane][is + 1] * (float)sum_hi;
+            acc[lane] -= dmin * (float)w->m[lane][is + 1] * (float)bsum_hi;
+        }
+    }
+}
+
+
+
+static inline void accum_q4_k_packed_u8_x16_q8_k_block(float acc[16],
+                                                        const block_q4_K_packed_u8_x16 *w,
+                                                        int active,
+                                                        const block_q8_K *x)
+{
+    const float xd = x->d;
+    for (int j = 0; j < QK_K; j += 32) {
+        const int is = j / 32;
+        const int8_t *q8_ptr = &x->qs[j];
+        const int32_t bsum = (int32_t)x->bsums[j / 16] + (int32_t)x->bsums[j / 16 + 1];
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+        const __m256i q8 = _mm256_loadu_si256((const __m256i *)q8_ptr);
+#endif
+        for (int lane = 0; lane < active; ++lane) {
+            const uint8_t *q4 = &w->qs[lane][j];
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+            const int32_t sumi = dot_q4_packed_u8_q8_32_vnni_q8v(q4, q8);
+#else
+            const int32_t sumi = dot_q4_packed_u8_q8_32_ref(q4, q8_ptr);
+#endif
+            const float d = CK_FP16_TO_FP32(w->d[lane]) * xd;
+            const float dmin = CK_FP16_TO_FP32(w->dmin[lane]) * xd;
+            acc[lane] += d * (float)w->sc[lane][is] * (float)sumi;
+            acc[lane] -= dmin * (float)w->m[lane][is] * (float)bsum;
+        }
+    }
+}
+
+
+static inline void accum_q4_k_packed_meta_x16_q8_k_block_mreuse(float acc[8][16],
+                                                                 const block_q4_K_packed_meta_x16 *w,
+                                                                 int active,
+                                                                 const block_q8_K *A,
+                                                                 int blocks_per_vec,
+                                                                 int block_index,
+                                                                 int m0,
+                                                                 int m_count)
+{
+    for (int j = 0, is = 0, q_offset = 0; j < QK_K; j += 64, is += 2, q_offset += 32) {
+        for (int lane = 0; lane < active; ++lane) {
+            const uint8_t *qs = &w->qs[lane][q_offset];
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+            const __m256i packed = _mm256_loadu_si256((const __m256i *)qs);
+            const __m256i q4_lo = q4_k_unpack_32_vnni_bytes(packed, 0);
+            const __m256i q4_hi = q4_k_unpack_32_vnni_bytes(packed, 1);
+#endif
+            const float wd = CK_FP16_TO_FP32(w->d[lane]);
+            const float wdmin = CK_FP16_TO_FP32(w->dmin[lane]);
+            const float sc_lo = (float)w->sc[lane][is];
+            const float sc_hi = (float)w->sc[lane][is + 1];
+            const float min_lo = (float)w->m[lane][is];
+            const float min_hi = (float)w->m[lane][is + 1];
+
+            for (int mt = 0; mt < m_count; ++mt) {
+                const block_q8_K *x = A + (size_t)(m0 + mt) * (size_t)blocks_per_vec + (size_t)block_index;
+                const int8_t *q8_lo_ptr = &x->qs[j];
+                const int8_t *q8_hi_ptr = &x->qs[j + 32];
+                const int32_t bsum_lo = (int32_t)x->bsums[j / 16] +
+                                        (int32_t)x->bsums[j / 16 + 1];
+                const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
+                                        (int32_t)x->bsums[(j + 32) / 16 + 1];
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+                const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+                const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+                const int32_t sum_lo = dot_q4_k_q8_k_32_vnni_q4v_q8v(q4_lo, q8_lo);
+                const int32_t sum_hi = dot_q4_k_q8_k_32_vnni_q4v_q8v(q4_hi, q8_hi);
+#elif defined(__AVX2__)
+                const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+                const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+                const int32_t sum_lo = dot_q4_k_q8_k_32_avx2_q8v(qs, q8_lo, 0);
+                const int32_t sum_hi = dot_q4_k_q8_k_32_avx2_q8v(qs, q8_hi, 1);
+#else
+                int32_t sum_lo = 0;
+                int32_t sum_hi = 0;
+                for (int l = 0; l < 32; ++l) {
+                    sum_lo += (int32_t)(qs[l] & 0x0F) * (int32_t)q8_lo_ptr[l];
+                    sum_hi += (int32_t)(qs[l] >> 4) * (int32_t)q8_hi_ptr[l];
+                }
+#endif
+                const float xd = x->d;
+                const float d = wd * xd;
+                const float dmin = wdmin * xd;
+                acc[mt][lane] += d * sc_lo * (float)sum_lo;
+                acc[mt][lane] -= dmin * min_lo * (float)bsum_lo;
+                acc[mt][lane] += d * sc_hi * (float)sum_hi;
+                acc[mt][lane] -= dmin * min_hi * (float)bsum_hi;
+            }
+        }
+    }
+}
+
+static inline void accum_q4_k_packed_meta_x16_q8_k_block(float acc[16],
+                                                          const block_q4_K_packed_meta_x16 *w,
+                                                          int active,
+                                                          const block_q8_K *x)
 {
     const float xd = x->d;
     for (int j = 0, is = 0, q_offset = 0; j < QK_K; j += 64, is += 2, q_offset += 32) {
@@ -536,6 +793,36 @@ typedef struct {
     int tile_m;
     int jobs;
 } gemm_q4_packed_meta_x8_thread_work_t;
+
+typedef struct {
+    const block_q8_K *A;
+    const block_q4_K_packed_meta_x16 *W;
+    const float *bias;
+    float *C;
+    int M;
+    int N;
+    int K;
+    int blocks_per_vec;
+    int blocks_per_row;
+    int groups;
+    int tile_m;
+    int jobs;
+} gemm_q4_packed_meta_x16_thread_work_t;
+
+typedef struct {
+    const block_q8_K *A;
+    const block_q4_K_packed_u8_x16 *W;
+    const float *bias;
+    float *C;
+    int M;
+    int N;
+    int K;
+    int blocks_per_vec;
+    int blocks_per_row;
+    int groups;
+    int tile_m;
+    int jobs;
+} gemm_q4_packed_u8_x16_thread_work_t;
 
 static void gemm_q4_packed_meta_thread_fn(int ith, int nth, void *args)
 {
@@ -828,6 +1115,396 @@ void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(const void *A_q8,
 }
 
 
+static void gemm_q4_packed_meta_x16_mtile_thread_fn(int ith, int nth, void *args)
+{
+    gemm_q4_packed_meta_x16_thread_work_t *a = (gemm_q4_packed_meta_x16_thread_work_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) {
+        return;
+    }
+    int tile_m = a->tile_m > 0 ? a->tile_m : 4;
+    if (tile_m > 8) tile_m = 8;
+    const int mt = (a->M + tile_m - 1) / tile_m;
+    const int total = mt * a->groups;
+
+    for (int job = ith; job < total; job += nth) {
+        const int g = job / mt;
+        const int tm = job - g * mt;
+        const int m0 = tm * tile_m;
+        const int m1 = (m0 + tile_m < a->M) ? (m0 + tile_m) : a->M;
+        const int n0 = g * 16;
+        const int active = (n0 + 16 <= a->N) ? 16 : (a->N - n0);
+        if (m0 >= a->M || g >= a->groups) {
+            continue;
+        }
+
+        float acc[8][16];
+        for (int mt_lane = 0; mt_lane < m1 - m0; ++mt_lane) {
+            for (int lane = 0; lane < active; ++lane) {
+                acc[mt_lane][lane] = a->bias ? a->bias[n0 + lane] : 0.0f;
+            }
+        }
+
+        for (int b = 0; b < a->blocks_per_row; ++b) {
+            const block_q4_K_packed_meta_x16 *w_group =
+                a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
+            for (int m = m0; m < m1; ++m) {
+                const block_q8_K *a_row = a->A + (size_t)m * (size_t)a->blocks_per_vec;
+                accum_q4_k_packed_meta_x16_q8_k_block(acc[m - m0], w_group, active, &a_row[b]);
+            }
+        }
+
+        for (int m = m0; m < m1; ++m) {
+            float *c_row = a->C + (size_t)m * (size_t)a->N;
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[n0 + lane] = acc[m - m0][lane];
+            }
+        }
+    }
+}
+
+
+static void gemm_q4_packed_meta_x16_mreuse_thread_fn(int ith, int nth, void *args)
+{
+    gemm_q4_packed_meta_x16_thread_work_t *a = (gemm_q4_packed_meta_x16_thread_work_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) {
+        return;
+    }
+    int tile_m = a->tile_m > 0 ? a->tile_m : 4;
+    if (tile_m > 8) tile_m = 8;
+    const int mt = (a->M + tile_m - 1) / tile_m;
+    const int total = mt * a->groups;
+
+    for (int job = ith; job < total; job += nth) {
+        const int g = job / mt;
+        const int tm = job - g * mt;
+        const int m0 = tm * tile_m;
+        const int m1 = (m0 + tile_m < a->M) ? (m0 + tile_m) : a->M;
+        const int m_count = m1 - m0;
+        const int n0 = g * 16;
+        const int active = (n0 + 16 <= a->N) ? 16 : (a->N - n0);
+        if (m0 >= a->M || g >= a->groups || m_count <= 0) {
+            continue;
+        }
+
+        float acc[8][16];
+        for (int mt_lane = 0; mt_lane < m_count; ++mt_lane) {
+            for (int lane = 0; lane < active; ++lane) {
+                acc[mt_lane][lane] = a->bias ? a->bias[n0 + lane] : 0.0f;
+            }
+        }
+
+        for (int b = 0; b < a->blocks_per_row; ++b) {
+            const block_q4_K_packed_meta_x16 *w_group =
+                a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
+            accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc, w_group, active, a->A,
+                                                          a->blocks_per_vec, b, m0, m_count);
+        }
+
+        for (int m = m0; m < m1; ++m) {
+            float *c_row = a->C + (size_t)m * (size_t)a->N;
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[n0 + lane] = acc[m - m0][lane];
+            }
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_meta_x16_q8_k_threaded_mreuse(const void *A_q8,
+                                                        const void *B_packed_x16,
+                                                        const float *bias,
+                                                        float *C,
+                                                        int M, int N, int K,
+                                                        int tile_m,
+                                                        int active_threads)
+{
+    if (!A_q8 || !B_packed_x16 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int pool_threads = pool ? ck_threadpool_n_threads(pool) : 1;
+    const int groups = (N + 15) / 16;
+    int tm = tile_m > 0 ? tile_m : 4;
+    if (tm > 8) tm = 8;
+    const int mt = (M + tm - 1) / tm;
+    const int jobs = mt * groups;
+    if (active_threads <= 0 || active_threads > pool_threads) {
+        active_threads = pool_threads;
+    }
+    if (active_threads > jobs) {
+        active_threads = jobs;
+    }
+    gemm_q4_packed_meta_x16_thread_work_t work = {
+        .A = (const block_q8_K *)A_q8,
+        .W = (const block_q4_K_packed_meta_x16 *)B_packed_x16,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .N = N,
+        .K = K,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+        .groups = groups,
+        .tile_m = tm,
+        .jobs = jobs,
+    };
+    if (active_threads <= 1) {
+        gemm_q4_packed_meta_x16_mreuse_thread_fn(0, 1, &work);
+        return;
+    }
+    ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_packed_meta_x16_mreuse_thread_fn, &work);
+}
+
+void gemm_nt_q4_k_packed_meta_x16_q8_k_threaded_mtile(const void *A_q8,
+                                                       const void *B_packed_x16,
+                                                       const float *bias,
+                                                       float *C,
+                                                       int M, int N, int K,
+                                                       int tile_m,
+                                                       int active_threads)
+{
+    if (!A_q8 || !B_packed_x16 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int pool_threads = pool ? ck_threadpool_n_threads(pool) : 1;
+    const int groups = (N + 15) / 16;
+    int tm = tile_m > 0 ? tile_m : 4;
+    if (tm > 8) tm = 8;
+    const int mt = (M + tm - 1) / tm;
+    const int jobs = mt * groups;
+    if (active_threads <= 0 || active_threads > pool_threads) {
+        active_threads = pool_threads;
+    }
+    if (active_threads > jobs) {
+        active_threads = jobs;
+    }
+    gemm_q4_packed_meta_x16_thread_work_t work = {
+        .A = (const block_q8_K *)A_q8,
+        .W = (const block_q4_K_packed_meta_x16 *)B_packed_x16,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .N = N,
+        .K = K,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+        .groups = groups,
+        .tile_m = tm,
+        .jobs = jobs,
+    };
+    if (active_threads <= 1) {
+        gemm_q4_packed_meta_x16_mtile_thread_fn(0, 1, &work);
+        return;
+    }
+    ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_packed_meta_x16_mtile_thread_fn, &work);
+}
+
+
+typedef struct {
+    const block_q8_K *A;
+    const block_q4_K_packed_meta_x16 *W;
+    const float *bias;
+    float *C;
+    int M;
+    int D;
+    int K;
+    int tile_m;
+    int blocks_per_vec;
+    int blocks_per_row;
+    int groups_d;
+    int jobs;
+} gemm_q4_gateup_swiglu_x16_work_t;
+
+static inline float ck_silu_f32(float x)
+{
+    return x / (1.0f + expf(-x));
+}
+
+static void gemm_q4_gateup_swiglu_x16_thread_fn(int ith, int nth, void *args)
+{
+    gemm_q4_gateup_swiglu_x16_work_t *a = (gemm_q4_gateup_swiglu_x16_work_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) {
+        return;
+    }
+
+    int tile_m = a->tile_m > 0 ? a->tile_m : 4;
+    if (tile_m > 8) tile_m = 8;
+    const int mt = (a->M + tile_m - 1) / tile_m;
+
+    for (int job = ith; job < a->jobs; job += nth) {
+        const int g = job / mt;
+        const int tm = job - g * mt;
+        const int m0 = tm * tile_m;
+        const int m1 = (m0 + tile_m < a->M) ? (m0 + tile_m) : a->M;
+        const int m_count = m1 - m0;
+        const int d0 = g * 16;
+        const int active = (d0 + 16 <= a->D) ? 16 : (a->D - d0);
+        if (m_count <= 0 || active <= 0 || g >= a->groups_d) {
+            continue;
+        }
+
+        float acc_gate[8][16];
+        float acc_up[8][16];
+        for (int mt_lane = 0; mt_lane < m_count; ++mt_lane) {
+            for (int lane = 0; lane < active; ++lane) {
+                acc_gate[mt_lane][lane] = a->bias ? a->bias[d0 + lane] : 0.0f;
+                acc_up[mt_lane][lane] = a->bias ? a->bias[a->D + d0 + lane] : 0.0f;
+            }
+        }
+
+        for (int b = 0; b < a->blocks_per_row; ++b) {
+            const block_q4_K_packed_meta_x16 *w_gate =
+                a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
+            const block_q4_K_packed_meta_x16 *w_up =
+                a->W + (size_t)(a->groups_d + g) * (size_t)a->blocks_per_row + (size_t)b;
+            accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc_gate, w_gate, active, a->A,
+                                                          a->blocks_per_vec, b, m0, m_count);
+            accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc_up, w_up, active, a->A,
+                                                          a->blocks_per_vec, b, m0, m_count);
+        }
+
+        for (int m = m0; m < m1; ++m) {
+            float *c_row = a->C + (size_t)m * (size_t)a->D;
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[d0 + lane] = ck_silu_f32(acc_gate[m - m0][lane]) * acc_up[m - m0][lane];
+            }
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_meta_x16_gateup_swiglu_fused_vnni(const void *A_q8,
+                                                            const void *B_packed_x16,
+                                                            const float *bias,
+                                                            float *C,
+                                                            int M, int D, int K,
+                                                            int tile_m,
+                                                            int active_threads)
+{
+    if (!A_q8 || !B_packed_x16 || !C || M <= 0 || D <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int pool_threads = pool ? ck_threadpool_n_threads(pool) : 1;
+    int tm = tile_m > 0 ? tile_m : 4;
+    if (tm > 8) tm = 8;
+    const int groups_d = (D + 15) / 16;
+    const int mt = (M + tm - 1) / tm;
+    const int jobs = mt * groups_d;
+    if (active_threads <= 0 || active_threads > pool_threads) {
+        active_threads = pool_threads;
+    }
+    if (active_threads > jobs) {
+        active_threads = jobs;
+    }
+    if (active_threads < 1) {
+        active_threads = 1;
+    }
+
+    gemm_q4_gateup_swiglu_x16_work_t work = {
+        .A = (const block_q8_K *)A_q8,
+        .W = (const block_q4_K_packed_meta_x16 *)B_packed_x16,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .D = D,
+        .K = K,
+        .tile_m = tm,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+        .groups_d = groups_d,
+        .jobs = jobs,
+    };
+    if (!pool || active_threads <= 1) {
+        gemm_q4_gateup_swiglu_x16_thread_fn(0, 1, &work);
+        return;
+    }
+    ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_gateup_swiglu_x16_thread_fn, &work);
+}
+
+
+static void gemm_q4_packed_u8_x16_mtile_thread_fn(int ith, int nth, void *args)
+{
+    gemm_q4_packed_u8_x16_thread_work_t *a = (gemm_q4_packed_u8_x16_thread_work_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) return;
+    int tile_m = a->tile_m > 0 ? a->tile_m : 4;
+    if (tile_m > 8) tile_m = 8;
+    const int mt = (a->M + tile_m - 1) / tile_m;
+    const int total = mt * a->groups;
+
+    for (int job = ith; job < total; job += nth) {
+        const int g = job / mt;
+        const int tm = job - g * mt;
+        const int m0 = tm * tile_m;
+        const int m1 = (m0 + tile_m < a->M) ? (m0 + tile_m) : a->M;
+        const int n0 = g * 16;
+        const int active = (n0 + 16 <= a->N) ? 16 : (a->N - n0);
+        if (m0 >= a->M || g >= a->groups) continue;
+
+        float acc[8][16];
+        for (int mt_lane = 0; mt_lane < m1 - m0; ++mt_lane) {
+            for (int lane = 0; lane < active; ++lane) {
+                acc[mt_lane][lane] = a->bias ? a->bias[n0 + lane] : 0.0f;
+            }
+        }
+
+        for (int b = 0; b < a->blocks_per_row; ++b) {
+            const block_q4_K_packed_u8_x16 *w_group =
+                a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
+            for (int m = m0; m < m1; ++m) {
+                const block_q8_K *a_row = a->A + (size_t)m * (size_t)a->blocks_per_vec;
+                accum_q4_k_packed_u8_x16_q8_k_block(acc[m - m0], w_group, active, &a_row[b]);
+            }
+        }
+
+        for (int m = m0; m < m1; ++m) {
+            float *c_row = a->C + (size_t)m * (size_t)a->N;
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[n0 + lane] = acc[m - m0][lane];
+            }
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_u8_x16_q8_k_threaded_mtile(const void *A_q8,
+                                                     const void *B_packed_u8_x16,
+                                                     const float *bias,
+                                                     float *C,
+                                                     int M, int N, int K,
+                                                     int tile_m,
+                                                     int active_threads)
+{
+    if (!A_q8 || !B_packed_u8_x16 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) return;
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int pool_threads = pool ? ck_threadpool_n_threads(pool) : 1;
+    const int groups = (N + 15) / 16;
+    int tm = tile_m > 0 ? tile_m : 4;
+    if (tm > 8) tm = 8;
+    const int mt = (M + tm - 1) / tm;
+    const int jobs = mt * groups;
+    if (active_threads <= 0 || active_threads > pool_threads) active_threads = pool_threads;
+    if (active_threads > jobs) active_threads = jobs;
+    gemm_q4_packed_u8_x16_thread_work_t work = {
+        .A = (const block_q8_K *)A_q8,
+        .W = (const block_q4_K_packed_u8_x16 *)B_packed_u8_x16,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .N = N,
+        .K = K,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+        .groups = groups,
+        .tile_m = tm,
+        .jobs = jobs,
+    };
+    if (active_threads <= 1) {
+        gemm_q4_packed_u8_x16_mtile_thread_fn(0, 1, &work);
+        return;
+    }
+    ck_threadpool_dispatch_n(pool, active_threads, gemm_q4_packed_u8_x16_mtile_thread_fn, &work);
+}
+
+
 void gemv_q4_k_q8_k_vnni(float *y,
                          const void *W,
                          const void *x_q8,
@@ -863,6 +1540,106 @@ void gemv_q4_k_q8_k_vnni(float *y,
      * borderline logit movement against scalar/reference behavior.
      */
     gemv_q4_k_q8_k_ref(y, W, x_q8, M, K);
+}
+
+
+static inline float ck_q4k_silu_f32(float x)
+{
+    return x / (1.0f + expf(-x));
+}
+
+typedef struct {
+    const block_q8_K *A;
+    const block_q4_K *W;
+    const float *bias;
+    float *C;
+    int M;
+    int D;
+    int K;
+    int blocks_per_vec;
+    int blocks_per_row;
+} gemm_q4_gateup_swiglu_work_t;
+
+static void gemm_q4_gateup_swiglu_thread_fn(int ith, int nth, void *args)
+{
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+    gemm_q4_gateup_swiglu_work_t *a = (gemm_q4_gateup_swiglu_work_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) return;
+
+    const int dd = (a->D + nth - 1) / nth;
+    const int d0 = dd * ith;
+    const int d1 = (d0 + dd < a->D) ? (d0 + dd) : a->D;
+    if (d0 >= a->D) return;
+
+    for (int d = d0; d < d1; ++d) {
+        const block_q4_K *w_gate = a->W + (size_t)d * (size_t)a->blocks_per_row;
+        const block_q4_K *w_up = a->W + (size_t)(a->D + d) * (size_t)a->blocks_per_row;
+        const float b_gate = a->bias ? a->bias[d] : 0.0f;
+        const float b_up = a->bias ? a->bias[a->D + d] : 0.0f;
+        for (int m = 0; m < a->M; ++m) {
+            const block_q8_K *x = a->A + (size_t)m * (size_t)a->blocks_per_vec;
+            float gate = b_gate;
+            float up = b_up;
+            for (int b = 0; b < a->blocks_per_row; ++b) {
+                gate += dot_q4_k_q8_k_vnni_block(&w_gate[b], &x[b]);
+                up += dot_q4_k_q8_k_vnni_block(&w_up[b], &x[b]);
+            }
+            a->C[(size_t)m * (size_t)a->D + (size_t)d] = ck_q4k_silu_f32(gate) * up;
+        }
+    }
+#else
+    (void)ith;
+    (void)nth;
+    (void)args;
+#endif
+}
+
+void gemm_nt_q4_k_q8_k_gateup_swiglu_fused_vnni(const void *A_q8,
+                                                 const void *B_gate_up,
+                                                 const float *bias,
+                                                 float *C,
+                                                 int M,
+                                                 int D,
+                                                 int K,
+                                                 int threads)
+{
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+    if (!A_q8 || !B_gate_up || !C || M <= 0 || D <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+
+    ck_threadpool_t *pool = ck_threadpool_global();
+    int active = threads > 0 ? threads : (pool ? ck_threadpool_n_threads(pool) : 1);
+    if (active < 1) active = 1;
+    if (active > D) active = D;
+
+    gemm_q4_gateup_swiglu_work_t work = {
+        .A = (const block_q8_K *)A_q8,
+        .W = (const block_q4_K *)B_gate_up,
+        .bias = bias,
+        .C = C,
+        .M = M,
+        .D = D,
+        .K = K,
+        .blocks_per_vec = K / QK_K,
+        .blocks_per_row = K / QK_K,
+    };
+
+    if (active <= 1 || !pool) {
+        gemm_q4_gateup_swiglu_thread_fn(0, 1, &work);
+        return;
+    }
+    ck_threadpool_dispatch_n(pool, active, gemm_q4_gateup_swiglu_thread_fn, &work);
+#else
+    (void)A_q8;
+    (void)B_gate_up;
+    (void)bias;
+    (void)C;
+    (void)M;
+    (void)D;
+    (void)K;
+    (void)threads;
+#endif
 }
 
 

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -1024,6 +1024,8 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
+    const char *q4k_gateup_swiglu_x16_env = getenv("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
+    int ck_enable_q4k_gateup_swiglu_x16 = q4k_gateup_swiglu_x16_env ? (atoi(q4k_gateup_swiglu_x16_env) != 0) : 0;
 
     /* Copy input tokens to activation buffer (follow same pattern as decode) */
     memcpy((void*)(model->bump + A_TOKEN_IDS), tokens, (size_t)num_tokens * sizeof(int32_t));
@@ -1454,6 +1456,84 @@ def _emit_prefill_gemm_fp32_override(op: Dict, seq_idx: int, *, debug_flag_name:
     return "\n".join(lines)
 
 
+
+def _emit_prefill_q4_gateup_swiglu_x16(
+    gate_op: Dict,
+    swiglu_op: Dict,
+    seq_idx: int,
+    fused_var: str,
+    *,
+    debug_flag_name: str,
+    debug_input_name: str,
+    profile: bool = False,
+) -> str:
+    args_list = gate_op.get("args", [])
+    m_arg = next(
+        (
+            arg
+            for arg in args_list
+            if isinstance(arg, dict) and str(arg.get("name", "")).lower() == "m"
+        ),
+        None,
+    )
+    a_expr = _find_arg_expr(args_list, arg_name="A") or _find_arg_expr(args_list, arg_name="a")
+    b_expr = _find_arg_expr(args_list, arg_name="B") or _find_arg_expr(args_list, arg_name="b")
+    bias_expr = _find_arg_expr(args_list, arg_name="bias") or "NULL"
+    m_expr = _find_arg_expr(args_list, arg_name="M") or _find_arg_expr(args_list, arg_name="m") or "num_tokens"
+    if isinstance(m_arg, dict) and str(m_arg.get("source", "")).lower() == "dim:_m":
+        # Embedded-prefix prefill only replays the active prefix rows.
+        m_expr = "num_tokens"
+    n_expr = _find_arg_expr(args_list, arg_name="N") or _find_arg_expr(args_list, arg_name="n")
+    k_expr = _find_arg_expr(args_list, arg_name="K") or _find_arg_expr(args_list, arg_name="k")
+    swiglu_args = swiglu_op.get("args", [])
+    out_expr = (
+        _find_arg_expr(swiglu_args, arg_name="output")
+        or _find_arg_expr(swiglu_args, arg_name="out")
+        or _find_arg_expr(swiglu_args, arg_name="y")
+        or _find_arg_expr(swiglu_args, arg_name="C")
+        or _find_arg_expr(swiglu_args, arg_name="c")
+        or _find_arg_expr(swiglu_args, arg_name="data")
+    )
+    if not a_expr or not b_expr or not out_expr or not n_expr or not k_expr:
+        raise RuntimeError("prefill q4 gate/up swiglu fusion missing args")
+
+    layer_value = gate_op.get("layer", -1)
+    layer = int(layer_value) if layer_value is not None else -1
+    d_expr = f"(({n_expr}) / 2)"
+    lines = [
+        f"    /* Op {seq_idx}: fused gemm_nt_q4_k_q8_k + swiglu (mlp_gate_up) layer={layer} */",
+        f"    int {fused_var} = 0;",
+        f"    if (ck_enable_q4k_gateup_swiglu_x16 && !{debug_flag_name}) {{",
+    ]
+    if profile:
+        lines.append("        CK_PROFILE_BEGIN();")
+    lines.extend([
+        "        gemm_nt_q4_k_q8_k_gateup_swiglu_x16_parallel_dispatch(",
+        f"            {a_expr},",
+        f"            {b_expr},",
+        f"            {bias_expr},",
+        f"            {out_expr},",
+        f"            {m_expr},",
+        f"            {d_expr},",
+        f"            {k_expr}",
+        "        );",
+        f"        {fused_var} = 1;",
+    ])
+    if profile:
+        lines.append(f'        CK_PROFILE_END("prefill", "gemm_nt_q4_k_q8_k_gateup_swiglu_x16", "mlp_gate_up_swiglu", {layer});')
+    lines.append("    } else {")
+    old_code = _emit_prefill_gemm_fp32_override(
+        gate_op,
+        seq_idx,
+        debug_flag_name=debug_flag_name,
+        debug_input_name=debug_input_name,
+        profile=profile,
+        dump=False,
+    )
+    lines.extend("    " + line if line else line for line in old_code.splitlines())
+    lines.append("    }")
+    return "\n".join(lines)
+
 def emit_prefill_from_embedded_function(
     ops: List[Dict],
     config: Dict,
@@ -1509,6 +1589,8 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
+    const char *q4k_gateup_swiglu_x16_env = getenv("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
+    int ck_enable_q4k_gateup_swiglu_x16 = q4k_gateup_swiglu_x16_env ? (atoi(q4k_gateup_swiglu_x16_env) != 0) : 0;
     const float *ck_debug_mlp_gate_up_fp32_input = NULL;
 """
     prologue = prologue.replace(
@@ -1535,8 +1617,11 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     residual_add_count_total = 0
     residual_add_counts_by_layer: Dict[int, int] = {}
 
+    skip_swiglu_guard: Optional[str] = None
     for seq_idx, op in enumerate(ops):
         op_type = str(op.get("op", ""))
+        if skip_swiglu_guard and op_type not in {"silu_mul", "swiglu"}:
+            skip_swiglu_guard = None
         if op_type == "residual_add" and "op_instance_idx" not in op and "instance" not in op:
             layer_for_instance = int(op.get("layer", -1))
             inst = residual_add_counts_by_layer.get(layer_for_instance, 0)
@@ -1571,14 +1656,32 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                 profile=profile,
             )
         elif op_type == "mlp_gate_up" and str(op.get("function", "")) in {"gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"}:
-            op_code = _emit_prefill_gemm_fp32_override(
-                op,
-                seq_idx,
-                debug_flag_name="debug_mlp_gate_up_fp32",
-                debug_input_name="ck_debug_mlp_gate_up_fp32_input",
-                profile=profile,
-                dump=dump,
-            )
+            next_op = ops[seq_idx + 1] if seq_idx + 1 < len(ops) else None
+            if (
+                str(op.get("function", "")) == "gemm_nt_q4_k_q8_k"
+                and isinstance(next_op, dict)
+                and str(next_op.get("op", "")) in {"silu_mul", "swiglu"}
+            ):
+                fused_var = f"ck_q4_gateup_swiglu_x16_fused_{seq_idx}"
+                op_code = _emit_prefill_q4_gateup_swiglu_x16(
+                    op,
+                    next_op,
+                    seq_idx,
+                    fused_var,
+                    debug_flag_name="debug_mlp_gate_up_fp32",
+                    debug_input_name="ck_debug_mlp_gate_up_fp32_input",
+                    profile=profile,
+                )
+                skip_swiglu_guard = fused_var
+            else:
+                op_code = _emit_prefill_gemm_fp32_override(
+                    op,
+                    seq_idx,
+                    debug_flag_name="debug_mlp_gate_up_fp32",
+                    debug_input_name="ck_debug_mlp_gate_up_fp32_input",
+                    profile=profile,
+                    dump=dump,
+                )
         elif is_qwen3vl and op_type == "quantize_mlp_down_input" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
             op_code = _emit_prefill_quant_debug_override(
                 op,
@@ -1601,6 +1704,9 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
             op_code = emit_prefill_op(op, seq_idx, config, profile=profile, dump=dump)
             if is_qwen3vl and op_type == "rope_qk":
                 op_code = op_code.replace("mrope_qk_text(", "ck_qwen3vl_prefill_mrope_qk(")
+        if skip_swiglu_guard and op_type in {"silu_mul", "swiglu"}:
+            op_code = f"    if (!{skip_swiglu_guard}) {{\n" + "\n".join("    " + line if line else line for line in op_code.splitlines()) + "\n    }"
+            skip_swiglu_guard = None
         lines.append(op_code)
         lines.append(f"    if (stop_seq == {seq_idx}) return;")
         if is_qwen3vl and op_type == "residual_add":

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -53,8 +53,10 @@ extern void gemm_nt_q4_k_q8_k(const void *A, const void *B, const float *bias,
 extern void gemv_q4_k_q8_k(float *y, const void *W, const void *x_q8, int M, int K);
 extern size_t q4_k_packed_meta_block_size(void);
 extern size_t q4_k_packed_meta_x8_block_size(void);
+extern size_t q4_k_packed_meta_x16_block_size(void);
 extern void pack_q4_k_to_packed_meta(const void *src, void *dst, int N, int K);
 extern void pack_q4_k_to_packed_meta_x8(const void *src, void *dst, int N, int K);
+extern void pack_q4_k_to_packed_meta_x16(const void *src, void *dst, int N, int K);
 extern void gemm_nt_q4_k_packed_meta_q8_k_threaded(const void *A_q8,
                                                     const void *B_packed,
                                                     const float *bias,
@@ -80,6 +82,13 @@ extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(const void *A_q8,
                                                             int M, int N, int K,
                                                             int tile_m,
                                                             int threads);
+extern void gemm_nt_q4_k_packed_meta_x16_gateup_swiglu_fused_vnni(const void *A_q8,
+                                                                   const void *B_packed_x16,
+                                                                   const float *bias,
+                                                                   float *C,
+                                                                   int M, int D, int K,
+                                                                   int tile_m,
+                                                                   int active_threads);
 extern void gemm_nt_q4_k_packed_meta_q8_k_tile(const void *A_q8,
                                                const void *B_packed,
                                                const float *bias,
@@ -88,6 +97,7 @@ extern void gemm_nt_q4_k_packed_meta_q8_k_tile(const void *A_q8,
                                                int m0, int m1, int n0, int n1);
 extern void gemm_nt_q6_k_q8_k(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
+extern void swiglu_forward_exact(const float *input, float *output, int tokens, int dim);
 extern void gemm_nt_q6_k_q8_k_tile(const void *A, const void *B, const float *bias,
                                     float *C, int M, int N, int K,
                                     int m0, int m1, int n0, int n1);
@@ -185,6 +195,18 @@ typedef struct ck_q4k_packed_meta_x8_cache_entry {
 
 static pthread_mutex_t ck_q4k_packed_meta_x8_cache_mu = PTHREAD_MUTEX_INITIALIZER;
 static ck_q4k_packed_meta_x8_cache_entry_t *ck_q4k_packed_meta_x8_cache_head = NULL;
+
+
+typedef struct ck_q4k_packed_meta_x16_cache_entry {
+    const void *src;
+    int N;
+    int K;
+    void *packed;
+    struct ck_q4k_packed_meta_x16_cache_entry *next;
+} ck_q4k_packed_meta_x16_cache_entry_t;
+
+static pthread_mutex_t ck_q4k_packed_meta_x16_cache_mu = PTHREAD_MUTEX_INITIALIZER;
+static ck_q4k_packed_meta_x16_cache_entry_t *ck_q4k_packed_meta_x16_cache_head = NULL;
 
 /* Q4_K packed-meta prefill experiment
  * -----------------------------------
@@ -302,6 +324,44 @@ static void *ck_get_q4k_packed_meta_x8_cached(const void *B, int N, int K)
     return packed;
 }
 
+
+static void *ck_get_q4k_packed_meta_x16_cached(const void *B, int N, int K)
+{
+    if (!B || N <= 0 || K <= 0 || (K % QK_K) != 0) return NULL;
+
+    pthread_mutex_lock(&ck_q4k_packed_meta_x16_cache_mu);
+    for (ck_q4k_packed_meta_x16_cache_entry_t *e = ck_q4k_packed_meta_x16_cache_head; e; e = e->next) {
+        if (e->src == B && e->N == N && e->K == K) {
+            void *packed = e->packed;
+            pthread_mutex_unlock(&ck_q4k_packed_meta_x16_cache_mu);
+            return packed;
+        }
+    }
+
+    const size_t groups = (size_t)((N + 15) / 16);
+    const size_t blocks = groups * (size_t)(K / QK_K);
+    const size_t bytes = blocks * q4_k_packed_meta_x16_block_size();
+    void *packed = malloc(bytes);
+    ck_q4k_packed_meta_x16_cache_entry_t *entry =
+        (ck_q4k_packed_meta_x16_cache_entry_t *)malloc(sizeof(*entry));
+    if (!packed || !entry) {
+        free(packed);
+        free(entry);
+        pthread_mutex_unlock(&ck_q4k_packed_meta_x16_cache_mu);
+        return NULL;
+    }
+
+    pack_q4_k_to_packed_meta_x16(B, packed, N, K);
+    entry->src = B;
+    entry->N = N;
+    entry->K = K;
+    entry->packed = packed;
+    entry->next = ck_q4k_packed_meta_x16_cache_head;
+    ck_q4k_packed_meta_x16_cache_head = entry;
+    pthread_mutex_unlock(&ck_q4k_packed_meta_x16_cache_mu);
+    return packed;
+}
+
 static int ck_should_use_q4k_packed_meta_prefill(int M, int N, int K)
 {
     if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_META_PREFILL")) return 0;
@@ -311,6 +371,13 @@ static int ck_should_use_q4k_packed_meta_prefill(int M, int N, int K)
     if (M < min_m) return 0;
 
     if (getenv("CK_FORCE_Q4K_PACKED_META_PREFILL")) return 1;
+
+    /* On the 24-physical-core Xeon Qwen3-VL OCR path, short-prefix wide
+     * projections such as M=79,N=24576,K=4096 and N=4096,K=4096 are faster
+     * through the canonical output-row Q4_K schedule than the lazy packed-meta
+     * N-split cache path. Keep packed-meta available through FORCE/env, but do
+     * not select it by default for this wide short-prefix family. */
+    if (M < 128 && N >= 4096 && K >= 4096) return 0;
 
     /* The dispatch matrix benchmark tracks canonical serial, canonical pool,
      * packed M-split, packed N-split, and a llama.cpp shim. Local AVX2 data
@@ -679,6 +746,35 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
     ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q8_0_q8_0, &args);
 }
 
+
+void gemm_nt_q4_k_q8_k_gateup_swiglu_x16_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int D, int K)
+{
+    if (!A || !B || !C || M <= 0 || D <= 0 || K <= 0 || (K % QK_K) != 0) return;
+
+    const int N = D * 2;
+    ck_threadpool_t *pool = ck_threadpool_global();
+    void *packed = ck_get_q4k_packed_meta_x16_cached(B, N, K);
+    if (packed) {
+        const int tile_m = ck_env_int_or2("CK_Q4K_GATEUP_SWIGLU_X16_TILE_M", "CK_PREFILL_TILE_M", 8);
+        int active = pool ? ck_threadpool_n_threads(pool) : 1;
+        const int cap = ck_env_int_or2("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", "CK_GEMM_THREAD_CAP", 20);
+        if (cap > 0 && active > cap) active = cap;
+        gemm_nt_q4_k_packed_meta_x16_gateup_swiglu_fused_vnni(
+            A, packed, bias, C, M, D, K, tile_m, active);
+        return;
+    }
+
+    /* Correctness fallback for allocation/packing failure. This path is not
+     * performance-critical because the fused call is env-gated by codegen. */
+    float *tmp = (float *)malloc((size_t)M * (size_t)N * sizeof(float));
+    if (!tmp) return;
+    gemm_nt_q4_k_q8_k_parallel_dispatch(A, B, bias, tmp, M, N, K);
+    swiglu_forward_exact(tmp, C, M, D);
+    free(tmp);
+}
+
 void gemm_nt_q4_k_q8_k_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K)
@@ -746,6 +842,7 @@ void gemm_nt_q4_k_q8_k_parallel_dispatch(
         .M = M, .N = N, .K = K,
         .A_row_bytes = A_row_bytes
     };
+
     /* Canonical fallback safety path:
      * CK_DISABLE_Q4K_PACKED_META_PREFILL must be a reliable escape hatch for
      * debugging a new packed layout. Do not fall back to the raw Q4_K GEMM for

--- a/version/v8/src/ck_parallel_prefill_v8.h
+++ b/version/v8/src/ck_parallel_prefill_v8.h
@@ -50,6 +50,10 @@ void gemm_nt_q4_k_q8_k_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K);
 
+void gemm_nt_q4_k_q8_k_gateup_swiglu_x16_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int D, int K);
+
 void gemm_nt_q6_k_q8_k_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K);


### PR DESCRIPTION
## Summary

This PR advances the v8 runtime/model bring-up stack across several fronts:

- Adds and hardens Nemotron-H, Mamba2, GLM4, Kimi MLA, Gemma4 assistant/speculative, and Qwen3-VL template/circuit/kernel coverage.
- Expands Qwen3-VL multimodal bridge/OCR support, staged decoder execution, visualizer artifacts, and regression/reporting coverage.
- Adds architecture/test-report documentation, concept pages, CKU throughput docs, model/kernel matrix updates, and visual diagrams for newer kernels.
- Adds v8 prefill profiling/sweep infrastructure and opt-in packed Q4_K/Q8_K prefill research lanes.
- Adds the latest experimental opt-in Q4_K gate/up + SwiGLU x16 path behind CK_ENABLE_Q4K_GATEUP_SWIGLU_X16.

## Guardrails

The x16 gate/up SwiGLU path is intentionally disabled by default. It uses lazy runtime x16 packing today and should stay research-only until conversion/load-time prepacking plus shape/ISA gating are added.

## Validation

Recent local validation includes:

- Pre-commit v7-regression-fast: passed
- Pre-commit v8-regression-fast: passed
- Pre-push build: passed
- Pre-push kernel parity: passed
- Pre-push v8 E2E text smoke: passed
- Pre-push v8 inference contracts: passed
- Pre-push v7 training contract smoke: passed
- Pre-push v7/v8 fast regressions: passed
- Pre-push v7 training-kernel parity: passed
- Qwen3-VL OCR smoke opt-off: passed
- Qwen3-VL OCR smoke opt-in with CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1: passed
- Standalone x16 benchmark on this laptop: 193.963 ms to 173.525 ms, 1.118x, rel_diff 4.31633e-07, cosine 1.0

## Notes

The standalone x16 result on this laptop is modest, while Xeon AVX512/VNNI data is stronger. Treat the new x16 path as opt-in perf infrastructure and use the next round to move packing to conversion/model-load time and add shape/ISA gating.