### PR TITLE
Harden v8 Qwen3-VL OCR bridge profiling and attention threading

### DIFF
--- a/benchmarks/bench_v8_qwen3vl_ocr.py
+++ b/benchmarks/bench_v8_qwen3vl_ocr.py
@@ -83,6 +83,7 @@ def _run_one(
     bridge_runtime: str,
     bridge_generation_mode: str,
     vision_activation_prefs: list[str],
+    profile_decoder: bool,
     timeout: int,
 ) -> dict[str, Any]:
     env = os.environ.copy()
@@ -116,6 +117,8 @@ def _run_one(
         cmd.extend(["--bridge-runtime", bridge_runtime])
     if bridge_generation_mode:
         cmd.extend(["--bridge-generation-mode", bridge_generation_mode])
+    if profile_decoder:
+        cmd.append("--profile")
     for pref in vision_activation_prefs:
         cmd.extend(["--vision-activation-pref", pref])
     if force_compile:
@@ -137,6 +140,7 @@ def _run_one(
         return row
     report = json.loads(report_path.read_text(encoding="utf-8"))
     timings = report.get("timings") if isinstance(report.get("timings"), dict) else {}
+    decoder_profile = report.get("decoder_profile") if isinstance(report.get("decoder_profile"), dict) else {}
     encoder_execute_ms = _num(timings, "encoder_execute_ms")
     decoder_forward_ms = _num(timings, "decoder_forward_mixed_ms")
     decoder_generation_ms = _num(timings, "decoder_generation_ms")
@@ -158,6 +162,7 @@ def _run_one(
             "decoder_generation_ms": decoder_generation_ms,
             "decoder_generation_tok_s": _num(timings, "decoder_generation_tok_s"),
             "steady_generated_tok_s": (generated_tokens / (steady_state_ms / 1000.0)) if steady_state_ms > 0 and generated_tokens > 0 else 0.0,
+            "decoder_profile": decoder_profile,
         }
     )
     return row
@@ -217,6 +222,11 @@ def main() -> int:
         metavar="OP=PREF",
         help="Forward a vision activation preference override to ck_run_v8.py, for example out_proj=q8_0",
     )
+    parser.add_argument(
+        "--profile-decoder",
+        action="store_true",
+        help="Compile the decoder with CK_PROFILE and include mixed-prefill top ops in the JSON report",
+    )
     parser.add_argument("--force-compile", action="store_true")
     parser.add_argument("--force-convert", action="store_true")
     parser.add_argument("--json-out", type=Path, default=ROOT / "build" / "v8_qwen3vl_ocr_bench.json")
@@ -245,6 +255,7 @@ def main() -> int:
                 bridge_runtime=args.bridge_runtime,
                 bridge_generation_mode=args.bridge_generation_mode,
                 vision_activation_prefs=list(args.vision_activation_pref or []),
+                profile_decoder=bool(args.profile_decoder),
                 timeout=int(args.timeout),
             )
         )
@@ -263,6 +274,7 @@ def main() -> int:
             "bridge_runtime": args.bridge_runtime,
             "bridge_generation_mode": args.bridge_generation_mode,
             "vision_activation_pref": list(args.vision_activation_pref or []),
+            "profile_decoder": bool(args.profile_decoder),
         },
         "results": rows,
     }

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -22,6 +22,7 @@
 #include "bf16_utils.h"
 #include "attention_oracle_ggml.h"
 #include "ckernel_engine.h"
+#include "ck_threadpool.h"
 #if CK_ENABLE_LLAMA_CPP_PARITY
 #include "../../llama.cpp/ggml/include/ggml.h"
 #endif
@@ -2849,6 +2850,98 @@ static CK_NOINLINE CK_OPTNONE void attention_forward_full_head_major_gqa_ggml_ti
  *
  * After changes: make test && make llamacpp-parity-full
  */
+
+typedef struct {
+    const float *q;
+    const float *k;
+    const float *v;
+    float *output;
+    int num_heads;
+    int num_kv_heads;
+    int num_tokens;
+    int head_dim;
+    int aligned_head_dim;
+    int kv_stride_tokens;
+    int causal;
+    float scale;
+} ck_attention_parallel_args_t;
+
+static inline void ck_attention_flash_query_auto(const float *q_vec,
+                                                 const float *k_head,
+                                                 const float *v_head,
+                                                 int kv_tokens,
+                                                 int head_dim,
+                                                 int aligned_head_dim,
+                                                 float scale,
+                                                 float *out_vec)
+{
+#if defined(__AVX512F__)
+    attention_flash_query_causal_avx512(q_vec, k_head, v_head,
+                                        kv_tokens, head_dim, aligned_head_dim,
+                                        scale, out_vec);
+#elif defined(__AVX2__)
+    attention_flash_query_causal_avx2(q_vec, k_head, v_head,
+                                      kv_tokens, head_dim, aligned_head_dim,
+                                      scale, out_vec);
+#elif defined(__AVX__)
+    attention_flash_query_causal_avx(q_vec, k_head, v_head,
+                                     kv_tokens, head_dim, aligned_head_dim,
+                                     scale, out_vec);
+#else
+    attention_flash_query_causal(q_vec, k_head, v_head,
+                                 kv_tokens, head_dim, aligned_head_dim,
+                                 scale, out_vec);
+#endif
+}
+
+static void ck_attention_full_grid_work(int ith, int nth, void *opaque)
+{
+    ck_attention_parallel_args_t *args = (ck_attention_parallel_args_t *) opaque;
+    const int T = args->num_tokens;
+    const int total = args->num_heads * T;
+    const size_t kv_head_stride = (size_t) args->kv_stride_tokens * (size_t) args->aligned_head_dim;
+
+    for (int idx = ith; idx < total; idx += nth) {
+        const int h = idx / T;
+        const int i = idx - h * T;
+        const int kv_head = (int) ((long long) h * (long long) args->num_kv_heads / (long long) args->num_heads);
+        const float *k_head = args->k + (size_t) kv_head * kv_head_stride;
+        const float *v_head = args->v + (size_t) kv_head * kv_head_stride;
+        const float *q_vec = args->q + qkv_index(h, i, 0, T, args->aligned_head_dim);
+        float *out_vec = args->output + qkv_index(h, i, 0, T, args->aligned_head_dim);
+        const int kv_tokens = args->causal ? (i + 1) : T;
+        ck_attention_flash_query_auto(q_vec, k_head, v_head,
+                                      kv_tokens,
+                                      args->head_dim,
+                                      args->aligned_head_dim,
+                                      args->scale,
+                                      out_vec);
+    }
+}
+
+static int ck_attention_parallel_enabled(int total_queries, int num_tokens, int head_dim)
+{
+    const char *disable = getenv("CK_DISABLE_ATTENTION_THREADPOOL");
+    if (disable && disable[0] && strcmp(disable, "0") != 0) return 0;
+    if (total_queries < 2048 || num_tokens < 128 || head_dim <= 0) return 0;
+    return 1;
+}
+
+static int ck_attention_pick_active_threads(const ck_threadpool_t *pool, int total_queries, int num_tokens)
+{
+    int nth = pool ? ck_threadpool_n_threads(pool) : 1;
+    if (nth <= 1) return 1;
+    const char *cap_env = getenv("CK_ATTENTION_THREAD_CAP");
+    int cap = cap_env && cap_env[0] ? atoi(cap_env) : 24;
+    if (cap < 1) cap = 1;
+    if (cap > nth) cap = nth;
+    int active = (total_queries + 127) / 128;
+    if (num_tokens >= 1024 && active < 8) active = 8;
+    if (active > cap) active = cap;
+    if (active > nth) active = nth;
+    return active < 1 ? 1 : active;
+}
+
 static void attention_forward_head_major_gqa_flash_impl(const float *q,
                                                         const float *k,
                                                         const float *v,
@@ -2904,6 +2997,30 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
 #else
     #define FLASH_QUERY_IMPL attention_flash_query_causal
 #endif
+
+    const int total_queries = num_heads * T;
+    if (ck_attention_parallel_enabled(total_queries, T, head_dim)) {
+        ck_threadpool_t *pool = ck_threadpool_global();
+        const int active = ck_attention_pick_active_threads(pool, total_queries, T);
+        if (pool && active > 1) {
+            ck_attention_parallel_args_t args = {
+                .q = q,
+                .k = k,
+                .v = v,
+                .output = output,
+                .num_heads = num_heads,
+                .num_kv_heads = num_kv_heads,
+                .num_tokens = num_tokens,
+                .head_dim = head_dim,
+                .aligned_head_dim = aligned_head_dim,
+                .kv_stride_tokens = kv_stride_tokens,
+                .causal = causal,
+                .scale = scale,
+            };
+            ck_threadpool_dispatch_n(pool, active, ck_attention_full_grid_work, &args);
+            return;
+        }
+    }
 
     for (int h = 0; h < num_heads; ++h) {
         int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);

--- a/tests/test_v8_codegen_bridge.py
+++ b/tests/test_v8_codegen_bridge.py
@@ -395,6 +395,9 @@ class V8CodegenBridgeTests(unittest.TestCase):
             self.assertIn("g_qwen3vl_prefill_prefix_tokens = prefix_tokens;", text)
             self.assertIn("int rc = ck_embed_tokens_at(g_model, tokens_after, tokens_after_count, tokens_before_count + prefix_tokens);", text)
             self.assertIn("ck_prefill_from_embedded(g_model, total_tokens);", text)
+            self.assertIn("uint16_t *kv_cache = (uint16_t*)model->kv_cache_f16;", text)
+            self.assertIn("ck_fp32_to_fp16_soft(ks[d])", text)
+            self.assertIn("ck_fp32_to_fp16_soft(vs[d])", text)
             self.assertIn(
                 "int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;",
                 text,
@@ -663,9 +666,6 @@ class V8CodegenBridgeTests(unittest.TestCase):
             self.assertIn("rope_precompute_cache(", text)
             self.assertNotIn("/* No pre-weights init ops */", text)
             self.assertIn("logits (last-only)", text)
-            self.assertIn("uint16_t *kv_cache = (uint16_t*)model->kv_cache_f16;", text)
-            self.assertIn("ck_fp32_to_fp16_soft(ks[d])", text)
-            self.assertIn("ck_fp32_to_fp16_soft(vs[d])", text)
             self.assertNotIn("copy_last_logits (prefill fixup)", text)
             self.assertNotIn("static void ck_decode_embedded", text)
             self.assertNotIn("static int ck_bridge_forward_staged", text)

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1204,6 +1204,9 @@ def run_pipeline(args: argparse.Namespace) -> int:
             cmd.extend(["--bridge-runtime", str(args.bridge_runtime)])
         if args.bridge_generation_mode is not None:
             cmd.extend(["--bridge-generation-mode", str(args.bridge_generation_mode)])
+        if getattr(args, "profile", False):
+            cmd.append("--profile-decoder")
+            cmd.append("--profile-encoder")
         if args.context_len is not None:
             cmd.extend(["--decoder-context-len", str(int(args.context_len))])
         run_cmd(cmd, cwd=PROJECT_ROOT)

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -1799,6 +1799,7 @@ def _prepare_encoder_runtime(
     activation_overrides: dict[str, str] | None = None,
     image_min_tokens: int | None = None,
     image_max_tokens: int | None = None,
+    profile: bool = False,
 ) -> dict[str, Any]:
     manifest, manifest_path, bump_path, config_path = _run_converter(gguf_path, output_dir)
     config = dict(manifest.get("config", {}) or {})
@@ -1830,12 +1831,14 @@ def _prepare_encoder_runtime(
     lowered_path = output_dir / "lowered.json"
     ir1_path = output_dir / "ir1.json"
     manifest_map = output_dir / "weights_manifest.map"
-    c_path = output_dir / "encoder_v8.c"
-    so_path = output_dir / "libencoder_v8.so"
-    runtime_stamp = output_dir / "encoder_runtime.cache.json"
+    suffix = "_profile" if profile else ""
+    c_path = output_dir / f"encoder_v8{suffix}.c"
+    so_path = output_dir / f"libencoder_v8{suffix}.so"
+    runtime_stamp = output_dir / f"encoder_runtime{suffix}.cache.json"
     runtime_fingerprint = _runtime_fingerprint(
         manifest_path=manifest_path,
         mode="encoder_prefill",
+        profile=profile,
     )
     reusable_outputs = [
         manifest_path,
@@ -1849,8 +1852,8 @@ def _prepare_encoder_runtime(
     ]
 
     if _artifacts_match_fingerprint(runtime_stamp, runtime_fingerprint, reusable_outputs):
-        _log_progress(f"encoder runtime reuse workdir={output_dir}")
-        _compile_generated_model(c_path, so_path)
+        _log_progress(f"encoder runtime reuse workdir={output_dir} profile={int(bool(profile))}")
+        _compile_generated_model(c_path, so_path, profile=profile)
         layout = _load_layout(layout_path)
         return {
             "gguf": str(gguf_path),
@@ -1896,13 +1899,15 @@ def _prepare_encoder_runtime(
             "--output",
             str(c_path),
         ]
+        if profile:
+            sys.argv.append("--profile")
         codegen_rc = codegen_v8.main()
     finally:
         sys.argv = old_argv
     if codegen_rc != 0:
         raise RuntimeError(f"codegen_v8 encoder failed with rc={codegen_rc}")
 
-    _compile_generated_model(c_path, so_path)
+    _compile_generated_model(c_path, so_path, profile=profile)
     _json_write(runtime_stamp, runtime_fingerprint)
     layout = _load_layout(layout_path)
     return {
@@ -2228,15 +2233,32 @@ def _load_decoder_lib(model_so: Path) -> ctypes.CDLL:
     return lib
 
 
-def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | None = None) -> dict[str, Any]:
+def _run_encoder(
+    runtime: dict[str, Any],
+    image_mode: str,
+    image_path: Path | None = None,
+    profile_csv_path: Path | None = None,
+) -> dict[str, Any]:
+    encoder_t0 = time.perf_counter()
+    old_profile_csv_env = os.environ.get("CK_PROFILE_CSV")
+    old_profile_json_env = os.environ.get("CK_PROFILE_JSON")
+    if profile_csv_path is not None:
+        profile_csv_path.parent.mkdir(parents=True, exist_ok=True)
+        profile_csv_path.unlink(missing_ok=True)
+        os.environ["CK_PROFILE_CSV"] = str(profile_csv_path)
+        os.environ.pop("CK_PROFILE_JSON", None)
+    lib_load_t0 = time.perf_counter()
     lib = _load_encoder_lib(runtime["so_path"])
+    lib_load_ms = (time.perf_counter() - lib_load_t0) * 1000.0
     _log_progress("encoder: init start")
+    init_t0 = time.perf_counter()
     rc = lib.ck_model_init_with_manifest(
         str(runtime["weights_bump"]).encode(),
         str(runtime["manifest_map"]).encode(),
     )
     if rc != 0:
         raise RuntimeError(f"encoder init failed with rc={rc}")
+    init_ms = (time.perf_counter() - init_t0) * 1000.0
     try:
         _log_progress("encoder: init done")
         layout = _load_layout(runtime["layout_path"])
@@ -2259,6 +2281,7 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
         prefix_position_policy = _vision_prefix_position_policy(layout_cfg)
         prefix_decode_policy = _vision_prefix_decode_policy(layout_cfg)
 
+        image_prepare_t0 = time.perf_counter()
         if image_path is not None:
             image_report = _load_image_file(
                 image_path,
@@ -2278,14 +2301,17 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
                 "source_image_size": [image_width, image_height],
                 "preprocess": "synthetic_generator",
             }
+        image_prepare_ms = (time.perf_counter() - image_prepare_t0) * 1000.0
         image_len = _buffer_nbytes(image_buf) // ctypes.sizeof(ctypes.c_float)
         if len(planar) != image_len:
             raise RuntimeError(f"encoder planar image length mismatch: {len(planar)} != {image_len}")
 
+        image_copy_t0 = time.perf_counter()
         image_arr = (ctypes.c_float * image_len).from_address(
             base_ptr + _activation_runtime_offset(layout, image_buf)
         )
         image_arr[:] = planar
+        image_copy_ms = (time.perf_counter() - image_copy_t0) * 1000.0
         _log_progress(
             f"encoder: decode start image={image_width}x{image_height} prefix_activation={bridge.get('fallback_buffer_name')}"
         )
@@ -2293,12 +2319,14 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
         rc = lib.ck_model_decode(0, None)
         if rc != 0:
             raise RuntimeError(f"encoder decode failed with rc={rc}")
-        _log_progress(f"encoder: decode done elapsed={time.perf_counter() - decode_t0:.2f}s")
+        decode_ms = (time.perf_counter() - decode_t0) * 1000.0
+        _log_progress(f"encoder: decode done elapsed={decode_ms / 1000.0:.2f}s")
 
         embed_dim = int(bridge["embed_dim"])
         if embed_dim <= 0:
             raise RuntimeError("encoder bridge embed_dim is not available")
 
+        output_copy_t0 = time.perf_counter()
         output_ptr = 0
         output_nbytes = 0
         bridge_name = str(bridge.get("named_activation") or "")
@@ -2324,10 +2352,12 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
             prefix_grid_y,
         )
         output_arr = (ctypes.c_float * output_len).from_address(output_ptr)
+        embeddings = array("f", output_arr)
+        output_copy_ms = (time.perf_counter() - output_copy_t0) * 1000.0
         return {
             "embed_dim": embed_dim,
             "prefix_tokens": prefix_tokens,
-            "embeddings": array("f", output_arr),
+            "embeddings": embeddings,
             "prefix_grid_x": prefix_grid_x,
             "prefix_grid_y": prefix_grid_y,
             "prefix_text_pos": int(local_prefix_text_pos),
@@ -2343,9 +2373,28 @@ def _run_encoder(runtime: dict[str, Any], image_mode: str, image_path: Path | No
             "image_height": image_height,
             "image_width": image_width,
             "interleaved_image": interleaved,
+            "profile_csv_path": None if profile_csv_path is None else str(profile_csv_path),
+            "timings": {
+                "lib_load_ms": lib_load_ms,
+                "init_ms": init_ms,
+                "image_prepare_ms": image_prepare_ms,
+                "image_copy_ms": image_copy_ms,
+                "decode_ms": decode_ms,
+                "output_copy_ms": output_copy_ms,
+                "total_ms": (time.perf_counter() - encoder_t0) * 1000.0,
+            },
         }
     finally:
         lib.ck_model_free()
+        if profile_csv_path is not None:
+            if old_profile_csv_env is None:
+                os.environ.pop("CK_PROFILE_CSV", None)
+            else:
+                os.environ["CK_PROFILE_CSV"] = old_profile_csv_env
+            if old_profile_json_env is None:
+                os.environ.pop("CK_PROFILE_JSON", None)
+            else:
+                os.environ["CK_PROFILE_JSON"] = old_profile_json_env
 
 
 def _summarize_profile_csv(path: Path, *, top_n: int = 12) -> dict[str, Any]:
@@ -2931,6 +2980,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--no-stream-output", action="store_true", help="Disable live text streaming during generation and print only the final response")
     ap.add_argument("--strict-parity", action="store_true", help="Enable strict/reference parity paths in bridge decoder kernels")
     ap.add_argument("--profile-decoder", action="store_true", help="Compile decoder with CK_PROFILE and include mixed-prefill per-op timings")
+    ap.add_argument("--profile-encoder", action="store_true", help="Compile encoder with CK_PROFILE and include encoder per-op timings")
     ap.add_argument("--bridge-runtime", choices=["prefill", "decode-staged"], default=None, help="Override template multimodal bridge runtime; decode-staged enables incremental generation after mixed prefill")
     ap.add_argument(
         "--bridge-generation-mode",
@@ -3029,16 +3079,19 @@ def main(argv: list[str] | None = None) -> int:
             activation_overrides=vision_activation_overrides,
             image_min_tokens=args.image_min_tokens,
             image_max_tokens=args.image_max_tokens,
+            profile=bool(args.profile_encoder),
         )
         encoder_prepare_elapsed = time.perf_counter() - encoder_prep_t0
         timings["encoder_prepare_ms"] = encoder_prepare_elapsed * 1000.0
         _log_progress(f"encoder runtime prepare done elapsed={encoder_prepare_elapsed:.2f}s")
         _log_progress("encoder execution start")
         encoder_exec_t0 = time.perf_counter()
+        encoder_profile_csv_path = (encoder_dir / "encoder_profile_current.csv") if bool(args.profile_encoder) else None
         encoder_report = _run_encoder(
             encoder_runtime,
             args.image_mode,
             image_path=args.image_path.resolve() if args.image_path is not None else None,
+            profile_csv_path=encoder_profile_csv_path,
         )
         timings["encoder_execute_ms"] = (time.perf_counter() - encoder_exec_t0) * 1000.0
         _log_progress(
@@ -3256,6 +3309,9 @@ def main(argv: list[str] | None = None) -> int:
             "prefix_position_policy": str(encoder_report.get("prefix_position_policy", "") or ""),
             "prefix_decode_policy": str(encoder_report.get("prefix_decode_policy", "") or ""),
             "activation_preference_overrides": dict(vision_activation_overrides),
+            "timings": dict(encoder_report.get("timings", {}) or {}),
+            "profile": _summarize_profile_csv(Path(str(encoder_report.get("profile_csv_path"))))
+            if encoder_report.get("profile_csv_path") else {},
         } if encoder_report is not None else None,
         "dim_mismatch": dim_mismatch,
         "logits_dump_path": str(args.dump_logits_f32.resolve()) if args.dump_logits_f32 is not None else None,


### PR DESCRIPTION
## Summary
- Fix/stabilize staged Qwen3-VL OCR bridge behavior around FP16 decode cache compatibility.
- Add encoder and decoder profiling plumbing for multimodal runs.
- Add CK threadpool dispatch for large full-attention query grids.
- Preserve existing opt-in/perf work without making experimental Q4 paths default.

## Validation
- .venv/bin/python -m py_compile version/v8/scripts/codegen_prefill_v8.py tests/test_v8_codegen_bridge.py version/v8/scripts/run_multimodal_bridge_v8.py version/v8/scripts/ck_run_v8.py benchmarks/bench_v8_qwen3vl_ocr.py
- .venv/bin/python -m unittest tests.test_v8_codegen_bridge tests.test_v8_qwen3vl_template
- .venv/bin/python unittest/test_flash_attention.py
- make --no-print-directory build/libckernel_engine.so
- make test-v8-qwen3vl-ocr-smoke with cached Qwen3-VL artifacts, 64 image tokens, 2 max decode tokens
- Direct ck_run_v8.py Qwen3-VL OCR run with --profile confirmed both --profile-decoder and --profile-encoder paths and produced encoder/decoder profile totals
- pre-commit hooks passed
- pre-push hooks passed

## Notes
- unittest/test_attention_full.py still fails its existing strict tolerance even with CK_DISABLE_ATTENTION_THREADPOOL=1, so it was not used as a regression gate for this patch.
- Local unrelated dirty/untracked files were left untouched.