### PR TITLE
Harden v8 inference, vision artifacts, and visualizer docs

### DIFF
--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -404,9 +404,9 @@
     <div class="regression-section">
       <h2>Visualizer Contract Matrix</h2>
       <p class="regression-meta">
-        v7 remains the promoted training/backprop visualizer lane. v8 carries the same health-check contract style
-        forward for inference and adds the multimodal vision artifact lane for encoder &rarr; bridge &rarr; decoder
-        graph rendering.
+        v7 remains the promoted training/backprop visualizer lane. v8 is the promoted inference and multimodal
+        observability lane: decoder-only reports, v8 run hub discovery, dataset viewer contracts, and encoder
+        &rarr; bridge &rarr; decoder graph rendering for vision artifacts.
       </p>
 
       <table class="results-table">
@@ -445,14 +445,14 @@
             <td><span class="coverage-lane v8">v8</span></td>
             <td>Visualizer health</td>
             <td><code>make v8-visualizer-health</code></td>
-            <td class="coverage-detail">Runs the same contract-driven source and JS utility checks against the v8 visualizer/tool paths.</td>
-            <td>v8 IR Visualizer and Dataset Viewer contracts</td>
+            <td class="coverage-detail">Contract-driven source and JS utility checks against v8 IR Visualizer, Dataset Viewer, and tool-path contracts.</td>
+            <td>v8 IR Visualizer, Dataset Viewer, IR Hub</td>
           </tr>
           <tr>
             <td><span class="coverage-lane v8">v8</span></td>
             <td>Generated E2E</td>
             <td><code>make v8-visualizer-generated-e2e</code></td>
-            <td class="coverage-detail">Validates generated v8 report and hub artifacts, including embedded JSON and cross-artifact structure.</td>
+            <td class="coverage-detail">Generates and validates v8 <code>ir_report.html</code>, <code>dataset_viewer.html</code>, <code>ir_hub_v8.html</code>, embedded JSON, and cross-artifact structure.</td>
             <td>Nightly generated-file chain</td>
           </tr>
           <tr>
@@ -801,8 +801,9 @@
     Contract-driven test coverage for the IR Visualizer and Dataset Viewer.
     Each component declares its tab/function/DOM contracts in JSON; tests
     validate against those contracts at every push. v7 owns the promoted
-    training/backprop visualizer lane; v8 mirrors the health checks and adds
-    dedicated multimodal vision artifact coverage.
+    training/backprop visualizer lane; v8 owns the inference and multimodal
+    observability lane with its own IR report, run hub, dataset viewer, and
+    dedicated vision artifact coverage.
     See the <a href="v7-visualizer-test-runbook.html">full test runbook</a>.
   </p>
 
@@ -974,8 +975,10 @@
   <h3>Level 3 — Generated-File E2E (Nightly)</h3>
   <p>
     Validates the full generation → validation chain: generate all three
-    visualizer HTML files from the latest training run, then run L1 health
-    checks + embedded JSON structure + cross-artifact consistency on the output.
+    visualizer HTML files from the latest run, then run L1 health checks +
+    embedded JSON structure + cross-artifact consistency on the output. The v7
+    version uses a training-capable run; the v8 version uses the v8 inference
+    cache and hub/tool wrappers.
   </p>
   <p style="font-size: 0.85rem; color: var(--text-muted);">
     Run locally: <code>make v7-visualizer-generated-e2e</code>
@@ -990,13 +993,13 @@
     <tbody>
       <tr><td class="viz-component">Generate</td><td>ir_report.html via <code>open_ir_visualizer.py</code></td><td>ir_report.html</td></tr>
       <tr><td class="viz-component">Generate</td><td>dataset_viewer.html via <code>prepare_run_viewer.py</code></td><td>dataset_viewer.html</td></tr>
-      <tr><td class="viz-component">Generate</td><td>ir_hub.html via <code>open_ir_hub.py</code></td><td>ir_hub.html</td></tr>
+      <tr><td class="viz-component">Generate</td><td>ir_hub.html / ir_hub_v8.html via <code>open_ir_hub.py</code> or <code>open_ir_hub_v8.py</code></td><td>run hub HTML</td></tr>
       <tr><td class="viz-component">L1 Health</td><td>Tabs, functions, DOM targets in generated output</td><td>All three files</td></tr>
       <tr><td class="viz-component">JSON Structure</td><td>Embedded JSON blobs (run_config, ir1_decode, layout_decode)</td><td>ir_report.html</td></tr>
       <tr><td class="viz-component">Panel Structure</td><td>Panel IDs, attnColor presence, file size</td><td>dataset_viewer.html</td></tr>
       <tr><td class="viz-component">Hub Structure</td><td>Run cards, ir_report links, navigation</td><td>ir_hub.html</td></tr>
       <tr><td class="viz-component">Cross-artifact</td><td>Run name in hub, vocab consistency, config.json</td><td>All three files</td></tr>
-      <tr><td class="viz-component">v8 Vision</td><td>Encoder, bridge, decoder, unified kernel flow, logical memory, and embedded HTML helpers</td><td>vision visualizer artifact HTML</td></tr>
+      <tr><td class="viz-component">v8 Vision</td><td>Encoder, bridge, decoder, unified kernel flow, logical memory, bridge report wiring, and embedded HTML helpers</td><td>vision visualizer artifact HTML</td></tr>
     </tbody>
   </table>
 </div>

--- a/docs/site/_pages/v8-runbook.html
+++ b/docs/site/_pages/v8-runbook.html
@@ -72,6 +72,28 @@
     color: var(--text-muted);
     font-size: 0.88rem;
 }
+.v8-artifact-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.8rem;
+    margin: 0.9rem 0 1rem;
+}
+.v8-artifact-tile {
+    border: 1px solid var(--grey);
+    border-radius: 8px;
+    background: rgba(7,173,248,0.045);
+    padding: 0.85rem;
+}
+.v8-artifact-tile strong {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--text-primary);
+}
+.v8-artifact-tile p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.86rem;
+}
 @media (max-width: 900px) {
     .v8-runbook-hero {
         grid-template-columns: 1fr;
@@ -408,11 +430,42 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
 <h2>Artifacts To Inspect</h2>
 
 <div class="card">
+    <p>
+        v8 has its own operator artifact surface. It is not only a decoder dump:
+        text runs can emit an <code>ir_report.html</code>, the v8 hub indexes run directories,
+        and multimodal runs carry encoder &rarr; bridge &rarr; decoder artifacts that the visualizer can render as a single circuit.
+    </p>
+    <div class="v8-artifact-grid">
+        <div class="v8-artifact-tile">
+            <strong>IR Visualizer</strong>
+            <p><code>ir_report.html</code> shows lowered ops, memory layout, kernel flow, profile artifacts, parity notes, and generated commands for a single v8 run.</p>
+        </div>
+        <div class="v8-artifact-tile">
+            <strong>v8 IR Hub</strong>
+            <p><code>ir_hub_v8.html</code> indexes cache-backed v8 runs and links reports, bridge outputs, dataset viewers, embeddings, attention exports, and probe reports.</p>
+        </div>
+        <div class="v8-artifact-tile">
+            <strong>Vision Artifacts</strong>
+            <p>Qwen3-VL/Gemma4V bridge reports expose encoder runtime, projected visual prefix, decoder mixed prefill, generated text, and profiler summaries.</p>
+        </div>
+        <div class="v8-artifact-tile">
+            <strong>Dataset Viewer</strong>
+            <p>The v8 viewer reuses the contract-tested tab model for staged data, tokenizer, vocabulary, quality, embeddings, and attention inspection.</p>
+        </div>
+    </div>
     <table class="table v8-path-table">
         <thead>
             <tr><th>Artifact</th><th>Purpose</th></tr>
         </thead>
         <tbody>
+            <tr>
+                <td><code>~/.cache/ck-engine-v8/models/.../ir_report.html</code></td>
+                <td>Single-run v8 IR visualizer report. Generated automatically by <code>--generate-visualizer</code> or explicitly with <code>open_ir_visualizer_v8.py</code>.</td>
+            </tr>
+            <tr>
+                <td><code>~/.cache/ck-engine-v8/models/ir_hub_v8.html</code></td>
+                <td>v8 run hub for scanning all cache-backed inference, bridge, probe, and viewer artifacts.</td>
+            </tr>
             <tr>
                 <td><code>~/.cache/ck-engine-v8/models/.../multimodal_bridge/bridge_report.json</code></td>
                 <td>Final bridge status, prompt accounting, prefix grid, and generated text.</td>
@@ -429,8 +482,43 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
     </table>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
-<pre>./build/ck-cli-v8 --list</pre>
+<pre># Generate or refresh a v8 IR visualizer report for one run.
+.venv/bin/python version/v8/tools/open_ir_visualizer_v8.py \
+  --generate --run "$RUN" --html-only --strict-run-artifacts \
+  --output "$RUN/ir_report.html"
+
+# Refresh the v8 run hub.
+.venv/bin/python version/v8/tools/open_ir_hub_v8.py \
+  --models-root "${CK_CACHE_DIR:-$HOME/.cache/ck-engine-v8/models}" \
+  --output "${CK_CACHE_DIR:-$HOME/.cache/ck-engine-v8/models}/ir_hub_v8.html"
+
+# List local v8 runtimes.
+./build/ck-cli-v8 --list</pre>
     </div>
+</div>
+
+<h2>Visualizer And Hub Gates</h2>
+
+<div class="card card-blue">
+    <p>
+        Use these gates when changing v8 visualizer tabs, embedded JSON, run-hub discovery, dataset viewer contracts,
+        or multimodal bridge artifacts. They are intentionally fast enough to run locally before a PR.
+    </p>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre># Source-level tab/function/DOM contracts plus pure JS utility checks.
+make v8-visualizer-health
+
+# Generate and validate ir_report.html, dataset_viewer.html, and ir_hub_v8.html.
+make v8-visualizer-generated-e2e
+
+# Validate encoder + bridge + decoder visualizer rendering for a synthetic vision run.
+make v8-visualizer-vision-artifacts</pre>
+    </div>
+    <p class="v8-note" style="margin-bottom: 0;">
+        v7 still owns the promoted training/backprop visualizer lane. v8 now owns inference and multimodal observability:
+        lowered decoder graphs, generated C metadata, logical memory, kernel-flow summaries, bridge reports, and vision-prefix dataflow.
+    </p>
 </div>
 
 <h2>Troubleshooting</h2>

--- a/docs/site/_pages/v8-vision-encoder.html
+++ b/docs/site/_pages/v8-vision-encoder.html
@@ -624,38 +624,52 @@
 
 <div class="card">
     <p>
-        The latest Qwen3-VL OCR bridge speed work changes <code>decode-staged</code> into a hybrid decoder runtime:
+        The Qwen3-VL OCR speed work is now moving through measured bottlenecks instead of guessing.
+        The first large win changed <code>decode-staged</code> into a hybrid decoder runtime:
         decode IR with prefill-sized activations for the mixed image/text prefix, followed by safe incremental decode.
-        On the current Xeon sweep with 24 threads, 64 image tokens, and 8 decode tokens, the mixed-prefix phase dropped
-        from roughly <strong>6.8-7.2 seconds</strong> to roughly <strong>3.86-4.03 seconds</strong>.
+        The current patch adds CK threadpool dispatch inside <code>gemm_nt_f16</code> for large FP16 vision-encoder GEMMs.
     </p>
     <table>
         <thead>
             <tr>
                 <th>Stage</th>
-                <th>Current signal</th>
+                <th>Measured signal</th>
+                <th>What changed</th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <td>Vision encoder</td>
-                <td>About 4.7-5.3 seconds for the four-image OCR sweep</td>
+                <td>Original OCR path</td>
+                <td>Multiple-minute end-to-end run on real SDPR-style OCR images</td>
+                <td>Correctness-first Qwen3-VL bridge and decoder path</td>
             </tr>
             <tr>
-                <td>Mixed prefix</td>
-                <td>About 3.9-4.0 seconds after staged prefill hardening</td>
+                <td>Staged bridge</td>
+                <td>Encoder about <strong>212.7s -&gt; 85.8s</strong>; mixed prefill about <strong>68.3s -&gt; 47.5s</strong>; steady path about <strong>281s -&gt; 133s</strong></td>
+                <td>Hybrid decoder runtime, staged mixed visual/text prefix, FP16 KV cache correctness, and encoder/decoder profiling</td>
             </tr>
             <tr>
-                <td>Incremental generation</td>
-                <td>About 10 tokens/second for the short 8-token OCR smoke</td>
+                <td>FP16 encoder GEMM threadpool</td>
+                <td>Encoder about <strong>85.8s -&gt; 59.0s</strong>; mixed prefill still about <strong>47s</strong>; one-token path about <strong>106s</strong></td>
+                <td>Threadpool dispatch for large <code>gemm_nt_f16</code> vision-encoder GEMMs</td>
+            </tr>
+            <tr>
+                <td>Small OCR smoke</td>
+                <td>Output remains coherent (<code>CK</code>), encoder about <strong>6.7s</strong> on the small local smoke</td>
+                <td>Regression guard for the fast path without requiring the full SDPR image workload</td>
             </tr>
         </tbody>
     </table>
+    <p>
+        This is still not llama.cpp-speed OCR, but the shape is encouraging: the path moved from many minutes toward
+        roughly a minute-class real-image run by fixing one measured bottleneck at a time. A tested Q8-contract
+        threadpool idea for the next encoder bottleneck did not materially move the real profile, so it was dropped
+        instead of carrying complexity.
+    </p>
     <p style="margin-bottom: 0;">
-        The profiler now points at quantized projection kernels, especially <code>gemm_nt_q4_k_q8_k</code>
-        in <code>mlp_gate_up</code>, <code>mlp_down</code>, <code>q_proj</code>, and <code>out_proj</code>.
-        Attention is not the dominant cost in this run. The next speed target is packed/reused
-        Q4_K/Q6_K x Q8_K batched GEMM for decoder prefill.
+        The next dominant cost is no longer the vision encoder scheduler. The profile now points at decoder mixed
+        prefill, especially <code>gemm_nt_q4_k_q8_k</code> in <code>mlp_gate_up</code> at about <strong>23.7s</strong>
+        on the real OCR image. That needs packed/reused Q4_K prefill microkernel work, not another scheduler-only patch.
     </p>
 </div>
 

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1347,9 +1347,9 @@
     <div class="regression-section">
       <h2>Visualizer Contract Matrix</h2>
       <p class="regression-meta">
-        v7 remains the promoted training/backprop visualizer lane. v8 carries the same health-check contract style
-        forward for inference and adds the multimodal vision artifact lane for encoder &rarr; bridge &rarr; decoder
-        graph rendering.
+        v7 remains the promoted training/backprop visualizer lane. v8 is the promoted inference and multimodal
+        observability lane: decoder-only reports, v8 run hub discovery, dataset viewer contracts, and encoder
+        &rarr; bridge &rarr; decoder graph rendering for vision artifacts.
       </p>
 
       <table class="results-table">
@@ -1388,14 +1388,14 @@
             <td><span class="coverage-lane v8">v8</span></td>
             <td>Visualizer health</td>
             <td><code>make v8-visualizer-health</code></td>
-            <td class="coverage-detail">Runs the same contract-driven source and JS utility checks against the v8 visualizer/tool paths.</td>
-            <td>v8 IR Visualizer and Dataset Viewer contracts</td>
+            <td class="coverage-detail">Contract-driven source and JS utility checks against v8 IR Visualizer, Dataset Viewer, and tool-path contracts.</td>
+            <td>v8 IR Visualizer, Dataset Viewer, IR Hub</td>
           </tr>
           <tr>
             <td><span class="coverage-lane v8">v8</span></td>
             <td>Generated E2E</td>
             <td><code>make v8-visualizer-generated-e2e</code></td>
-            <td class="coverage-detail">Validates generated v8 report and hub artifacts, including embedded JSON and cross-artifact structure.</td>
+            <td class="coverage-detail">Generates and validates v8 <code>ir_report.html</code>, <code>dataset_viewer.html</code>, <code>ir_hub_v8.html</code>, embedded JSON, and cross-artifact structure.</td>
             <td>Nightly generated-file chain</td>
           </tr>
           <tr>
@@ -1744,8 +1744,9 @@
     Contract-driven test coverage for the IR Visualizer and Dataset Viewer.
     Each component declares its tab/function/DOM contracts in JSON; tests
     validate against those contracts at every push. v7 owns the promoted
-    training/backprop visualizer lane; v8 mirrors the health checks and adds
-    dedicated multimodal vision artifact coverage.
+    training/backprop visualizer lane; v8 owns the inference and multimodal
+    observability lane with its own IR report, run hub, dataset viewer, and
+    dedicated vision artifact coverage.
     See the <a href="v7-visualizer-test-runbook.html">full test runbook</a>.
   </p>
 
@@ -1917,8 +1918,10 @@
   <h3>Level 3 — Generated-File E2E (Nightly)</h3>
   <p>
     Validates the full generation → validation chain: generate all three
-    visualizer HTML files from the latest training run, then run L1 health
-    checks + embedded JSON structure + cross-artifact consistency on the output.
+    visualizer HTML files from the latest run, then run L1 health checks +
+    embedded JSON structure + cross-artifact consistency on the output. The v7
+    version uses a training-capable run; the v8 version uses the v8 inference
+    cache and hub/tool wrappers.
   </p>
   <p style="font-size: 0.85rem; color: var(--text-muted);">
     Run locally: <code>make v7-visualizer-generated-e2e</code>
@@ -1933,13 +1936,13 @@
     <tbody>
       <tr><td class="viz-component">Generate</td><td>ir_report.html via <code>open_ir_visualizer.py</code></td><td>ir_report.html</td></tr>
       <tr><td class="viz-component">Generate</td><td>dataset_viewer.html via <code>prepare_run_viewer.py</code></td><td>dataset_viewer.html</td></tr>
-      <tr><td class="viz-component">Generate</td><td>ir_hub.html via <code>open_ir_hub.py</code></td><td>ir_hub.html</td></tr>
+      <tr><td class="viz-component">Generate</td><td>ir_hub.html / ir_hub_v8.html via <code>open_ir_hub.py</code> or <code>open_ir_hub_v8.py</code></td><td>run hub HTML</td></tr>
       <tr><td class="viz-component">L1 Health</td><td>Tabs, functions, DOM targets in generated output</td><td>All three files</td></tr>
       <tr><td class="viz-component">JSON Structure</td><td>Embedded JSON blobs (run_config, ir1_decode, layout_decode)</td><td>ir_report.html</td></tr>
       <tr><td class="viz-component">Panel Structure</td><td>Panel IDs, attnColor presence, file size</td><td>dataset_viewer.html</td></tr>
       <tr><td class="viz-component">Hub Structure</td><td>Run cards, ir_report links, navigation</td><td>ir_hub.html</td></tr>
       <tr><td class="viz-component">Cross-artifact</td><td>Run name in hub, vocab consistency, config.json</td><td>All three files</td></tr>
-      <tr><td class="viz-component">v8 Vision</td><td>Encoder, bridge, decoder, unified kernel flow, logical memory, and embedded HTML helpers</td><td>vision visualizer artifact HTML</td></tr>
+      <tr><td class="viz-component">v8 Vision</td><td>Encoder, bridge, decoder, unified kernel flow, logical memory, bridge report wiring, and embedded HTML helpers</td><td>vision visualizer artifact HTML</td></tr>
     </tbody>
   </table>
 </div>
@@ -2725,7 +2728,7 @@ document.addEventListener('DOMContentLoaded', loadResults);
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -1014,6 +1014,28 @@
     color: var(--text-muted);
     font-size: 0.88rem;
 }
+.v8-artifact-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.8rem;
+    margin: 0.9rem 0 1rem;
+}
+.v8-artifact-tile {
+    border: 1px solid var(--grey);
+    border-radius: 8px;
+    background: rgba(7,173,248,0.045);
+    padding: 0.85rem;
+}
+.v8-artifact-tile strong {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--text-primary);
+}
+.v8-artifact-tile p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.86rem;
+}
 @media (max-width: 900px) {
     .v8-runbook-hero {
         grid-template-columns: 1fr;
@@ -1350,11 +1372,42 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
 <h2>Artifacts To Inspect</h2>
 
 <div class="card">
+    <p>
+        v8 has its own operator artifact surface. It is not only a decoder dump:
+        text runs can emit an <code>ir_report.html</code>, the v8 hub indexes run directories,
+        and multimodal runs carry encoder &rarr; bridge &rarr; decoder artifacts that the visualizer can render as a single circuit.
+    </p>
+    <div class="v8-artifact-grid">
+        <div class="v8-artifact-tile">
+            <strong>IR Visualizer</strong>
+            <p><code>ir_report.html</code> shows lowered ops, memory layout, kernel flow, profile artifacts, parity notes, and generated commands for a single v8 run.</p>
+        </div>
+        <div class="v8-artifact-tile">
+            <strong>v8 IR Hub</strong>
+            <p><code>ir_hub_v8.html</code> indexes cache-backed v8 runs and links reports, bridge outputs, dataset viewers, embeddings, attention exports, and probe reports.</p>
+        </div>
+        <div class="v8-artifact-tile">
+            <strong>Vision Artifacts</strong>
+            <p>Qwen3-VL/Gemma4V bridge reports expose encoder runtime, projected visual prefix, decoder mixed prefill, generated text, and profiler summaries.</p>
+        </div>
+        <div class="v8-artifact-tile">
+            <strong>Dataset Viewer</strong>
+            <p>The v8 viewer reuses the contract-tested tab model for staged data, tokenizer, vocabulary, quality, embeddings, and attention inspection.</p>
+        </div>
+    </div>
     <table class="table v8-path-table">
         <thead>
             <tr><th>Artifact</th><th>Purpose</th></tr>
         </thead>
         <tbody>
+            <tr>
+                <td><code>~/.cache/ck-engine-v8/models/.../ir_report.html</code></td>
+                <td>Single-run v8 IR visualizer report. Generated automatically by <code>--generate-visualizer</code> or explicitly with <code>open_ir_visualizer_v8.py</code>.</td>
+            </tr>
+            <tr>
+                <td><code>~/.cache/ck-engine-v8/models/ir_hub_v8.html</code></td>
+                <td>v8 run hub for scanning all cache-backed inference, bridge, probe, and viewer artifacts.</td>
+            </tr>
             <tr>
                 <td><code>~/.cache/ck-engine-v8/models/.../multimodal_bridge/bridge_report.json</code></td>
                 <td>Final bridge status, prompt accounting, prefix grid, and generated text.</td>
@@ -1371,8 +1424,43 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
     </table>
     <div class="cmd-block">
         <button class="copy-btn" type="button">Copy</button>
-<pre>./build/ck-cli-v8 --list</pre>
+<pre># Generate or refresh a v8 IR visualizer report for one run.
+.venv/bin/python version/v8/tools/open_ir_visualizer_v8.py \
+  --generate --run "$RUN" --html-only --strict-run-artifacts \
+  --output "$RUN/ir_report.html"
+
+# Refresh the v8 run hub.
+.venv/bin/python version/v8/tools/open_ir_hub_v8.py \
+  --models-root "${CK_CACHE_DIR:-$HOME/.cache/ck-engine-v8/models}" \
+  --output "${CK_CACHE_DIR:-$HOME/.cache/ck-engine-v8/models}/ir_hub_v8.html"
+
+# List local v8 runtimes.
+./build/ck-cli-v8 --list</pre>
     </div>
+</div>
+
+<h2>Visualizer And Hub Gates</h2>
+
+<div class="card card-blue">
+    <p>
+        Use these gates when changing v8 visualizer tabs, embedded JSON, run-hub discovery, dataset viewer contracts,
+        or multimodal bridge artifacts. They are intentionally fast enough to run locally before a PR.
+    </p>
+    <div class="cmd-block">
+        <button class="copy-btn" type="button">Copy</button>
+<pre># Source-level tab/function/DOM contracts plus pure JS utility checks.
+make v8-visualizer-health
+
+# Generate and validate ir_report.html, dataset_viewer.html, and ir_hub_v8.html.
+make v8-visualizer-generated-e2e
+
+# Validate encoder + bridge + decoder visualizer rendering for a synthetic vision run.
+make v8-visualizer-vision-artifacts</pre>
+    </div>
+    <p class="v8-note" style="margin-bottom: 0;">
+        v7 still owns the promoted training/backprop visualizer lane. v8 now owns inference and multimodal observability:
+        lowered decoder graphs, generated C metadata, logical memory, kernel-flow summaries, bridge reports, and vision-prefix dataflow.
+    </p>
 </div>
 
 <h2>Troubleshooting</h2>
@@ -1652,7 +1740,7 @@ V8_NEMOTRON9_MIN_MEM_GB=24 make test-v8-nemotron9-highmem</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -1566,38 +1566,52 @@
 
 <div class="card">
     <p>
-        The latest Qwen3-VL OCR bridge speed work changes <code>decode-staged</code> into a hybrid decoder runtime:
+        The Qwen3-VL OCR speed work is now moving through measured bottlenecks instead of guessing.
+        The first large win changed <code>decode-staged</code> into a hybrid decoder runtime:
         decode IR with prefill-sized activations for the mixed image/text prefix, followed by safe incremental decode.
-        On the current Xeon sweep with 24 threads, 64 image tokens, and 8 decode tokens, the mixed-prefix phase dropped
-        from roughly <strong>6.8-7.2 seconds</strong> to roughly <strong>3.86-4.03 seconds</strong>.
+        The current patch adds CK threadpool dispatch inside <code>gemm_nt_f16</code> for large FP16 vision-encoder GEMMs.
     </p>
     <table>
         <thead>
             <tr>
                 <th>Stage</th>
-                <th>Current signal</th>
+                <th>Measured signal</th>
+                <th>What changed</th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <td>Vision encoder</td>
-                <td>About 4.7-5.3 seconds for the four-image OCR sweep</td>
+                <td>Original OCR path</td>
+                <td>Multiple-minute end-to-end run on real SDPR-style OCR images</td>
+                <td>Correctness-first Qwen3-VL bridge and decoder path</td>
             </tr>
             <tr>
-                <td>Mixed prefix</td>
-                <td>About 3.9-4.0 seconds after staged prefill hardening</td>
+                <td>Staged bridge</td>
+                <td>Encoder about <strong>212.7s -&gt; 85.8s</strong>; mixed prefill about <strong>68.3s -&gt; 47.5s</strong>; steady path about <strong>281s -&gt; 133s</strong></td>
+                <td>Hybrid decoder runtime, staged mixed visual/text prefix, FP16 KV cache correctness, and encoder/decoder profiling</td>
             </tr>
             <tr>
-                <td>Incremental generation</td>
-                <td>About 10 tokens/second for the short 8-token OCR smoke</td>
+                <td>FP16 encoder GEMM threadpool</td>
+                <td>Encoder about <strong>85.8s -&gt; 59.0s</strong>; mixed prefill still about <strong>47s</strong>; one-token path about <strong>106s</strong></td>
+                <td>Threadpool dispatch for large <code>gemm_nt_f16</code> vision-encoder GEMMs</td>
+            </tr>
+            <tr>
+                <td>Small OCR smoke</td>
+                <td>Output remains coherent (<code>CK</code>), encoder about <strong>6.7s</strong> on the small local smoke</td>
+                <td>Regression guard for the fast path without requiring the full SDPR image workload</td>
             </tr>
         </tbody>
     </table>
+    <p>
+        This is still not llama.cpp-speed OCR, but the shape is encouraging: the path moved from many minutes toward
+        roughly a minute-class real-image run by fixing one measured bottleneck at a time. A tested Q8-contract
+        threadpool idea for the next encoder bottleneck did not materially move the real profile, so it was dropped
+        instead of carrying complexity.
+    </p>
     <p style="margin-bottom: 0;">
-        The profiler now points at quantized projection kernels, especially <code>gemm_nt_q4_k_q8_k</code>
-        in <code>mlp_gate_up</code>, <code>mlp_down</code>, <code>q_proj</code>, and <code>out_proj</code>.
-        Attention is not the dominant cost in this run. The next speed target is packed/reused
-        Q4_K/Q6_K x Q8_K batched GEMM for decoder prefill.
+        The next dominant cost is no longer the vision encoder scheduler. The profile now points at decoder mixed
+        prefill, especially <code>gemm_nt_q4_k_q8_k</code> in <code>mlp_gate_up</code> at about <strong>23.7s</strong>
+        on the real OCR image. That needs packed/reused Q4_K prefill microkernel work, not another scheduler-only patch.
     </p>
 </div>
 
@@ -1840,7 +1854,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
             </div>
         </div>
     </footer>

--- a/src/kernels/gemm_kernels_f16.c
+++ b/src/kernels/gemm_kernels_f16.c
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 #include "ckernel_quant.h"  /* For ck_fp16_to_fp32 */
 #include "ckernel_engine.h"
+#include "ck_threadpool.h"
 #include "ggml_runtime_compat.h"
 
 #include <dlfcn.h>
@@ -474,6 +475,95 @@ static void gemm_f16_input_fp16_ref(float *Y,
     }
 }
 
+typedef struct {
+    float *Y;
+    const uint16_t *W;
+    const float *X;
+    int M;
+    int N;
+    int K;
+} ck_gemm_f16_input_fp16_args_t;
+
+static void ck_gemm_f16_input_fp16_work(int ith, int nth, void *opaque)
+{
+    ck_gemm_f16_input_fp16_args_t *args = (ck_gemm_f16_input_fp16_args_t *) opaque;
+    const int M = args->M;
+    const int N = args->N;
+    const int K = args->K;
+
+    for (int n = ith; n < N; n += nth) {
+        const float *x_row = args->X + (size_t)n * (size_t)K;
+        uint16_t x_f16[K];
+
+        for (int k = 0; k < K; ++k) {
+            x_f16[k] = fp32_to_fp16(x_row[k]);
+        }
+
+        for (int row = 0; row < M; ++row) {
+            float sum = 0.0f;
+            const uint16_t *w_row = args->W + (size_t)row * (size_t)K;
+
+            for (int k = 0; k < K; ++k) {
+                sum += fp16_to_fp32(w_row[k]) * fp16_to_fp32(x_f16[k]);
+            }
+
+            args->Y[(size_t)n * (size_t)M + (size_t)row] = sum;
+        }
+    }
+}
+
+static int ck_gemm_f16_threadpool_enabled(int M, int N, int K)
+{
+    const char *disable = getenv("CK_DISABLE_F16_GEMM_THREADPOOL");
+    if (disable && disable[0] && strcmp(disable, "0") != 0) return 0;
+    if (M < 256 || N < 16 || K < 256) return 0;
+    return 1;
+}
+
+static int ck_gemm_f16_pick_active_threads(const ck_threadpool_t *pool, int M, int N, int K)
+{
+    int nth = pool ? ck_threadpool_n_threads(pool) : 1;
+    if (nth <= 1) return 1;
+
+    const char *cap_env = getenv("CK_F16_GEMM_THREAD_CAP");
+    int cap = cap_env && cap_env[0] ? atoi(cap_env) : 24;
+    if (cap < 1) cap = 1;
+    if (cap > nth) cap = nth;
+
+    int active = N;
+    if (M >= 1024 && K >= 1024 && active < 8) active = 8;
+    if (active > cap) active = cap;
+    if (active > nth) active = nth;
+    return active < 1 ? 1 : active;
+}
+
+static int gemm_f16_input_fp16_threadpool(float *Y,
+                                          const uint16_t *W,
+                                          const float *X,
+                                          int M, int N, int K)
+{
+    if (!ck_gemm_f16_threadpool_enabled(M, N, K)) {
+        return 0;
+    }
+
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int active = ck_gemm_f16_pick_active_threads(pool, M, N, K);
+    if (!pool || active <= 1) {
+        return 0;
+    }
+
+    ck_gemm_f16_input_fp16_args_t args = {
+        .Y = Y,
+        .W = W,
+        .X = X,
+        .M = M,
+        .N = N,
+        .K = K,
+    };
+    ck_threadpool_dispatch_n(pool, active, ck_gemm_f16_input_fp16_work, &args);
+    return 1;
+}
+
 /**
  * @brief NT GEMM wrapper for FP16 weights with the engine's standard ABI.
  *
@@ -498,7 +588,9 @@ void gemm_nt_f16(const float *A,
         return;
     }
 
-    gemm_f16_input_fp16_ref(C, (const uint16_t *)B, A, N, M, K);
+    if (!gemm_f16_input_fp16_threadpool(C, (const uint16_t *)B, A, N, M, K)) {
+        gemm_f16_input_fp16_ref(C, (const uint16_t *)B, A, N, M, K);
+    }
 
     if (!bias) {
         return;


### PR DESCRIPTION
## Summary
- Harden v8 inference and vision work on this branch, including Qwen3-VL OCR bridge profiling and attention threading from prior commits.
- Promote the v8 visualizer and hub story in docs: v8 IR report, v8 IR hub, dataset viewer, bridge reports, and vision artifact gates.
- Clarify the dashboard split: v7 owns promoted training/backprop visualization; v8 owns inference and multimodal observability.

## Latest docs commit
- 1c0f0545 docs(v8): promote visualizer and hub artifacts

## Validation
- bash docs/site/build.sh
- git diff --check for the scoped docs files
- make v8-visualizer-health passed: 180 checks, 10 warnings, 109 JS unit tests
- make v8-visualizer-generated-e2e passed in no-cached-runs mode on this laptop
- make v8-visualizer-vision-artifacts passed synthetic encoder/bridge/decoder artifact harness
- Pre-push passed: visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training smoke, and v7 training-kernel parity

## Notes
- The local worktree still has unrelated dirty/untracked files; only the scoped docs files were staged for the latest commit.
- v8-visualizer-generated-e2e reports no cached v8 train/run fixture on this laptop, so it validates the skip/pass path locally. CI/nightly can run it against populated cache artifacts.