### PR TITLE
Document Qwen3-VL OCR Q4/Q8 speed research

### DIFF
--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -1,0 +1,145 @@
+# Qwen3-VL OCR Q4/Q8 Prefill Speed Notes - 2026-07-02
+
+This note records the Xeon/OpenShift Qwen3-VL OCR speed investigation so the same
+ideas can be retested on CPUs with different cache/core ratios, especially Ryzen
+or newer Xeon parts with larger effective cache per active core.
+
+## Baseline Context
+
+Target workload:
+
+```text
+Model: Qwen3-VL 8B Instruct GGUF Q4_K_M + Q8_0 mmproj
+Image: SDPR form, 1400 px PPM
+Prompt: Extract visible form fields as compact JSON.
+Image tokens: 1024
+Text+visual mixed prefill: 1028 tokens
+Threads: 20 for the current best Xeon run
+```
+
+Historical steady-state wall-clock on this OpenShift Xeon node:
+
+| Stage | Approx Time | Notes |
+|---|---:|---|
+| Original CK OCR path | ~281 s | Before staged bridge and encoder/kernel fixes. |
+| After staged bridge + attention/FP16 work | ~101 s | Encoder still dominated by Q8/attention work. |
+| After raw `gemm_nt_q8_0` CK threadpool | ~78.3 s | Encoder dropped to ~34.6 s. |
+| After Q4 x16 SwiGLU output-loop cleanup | ~76.7 s | Mixed prefill dropped modestly. |
+| llama.cpp OCR report baseline | ~55.8 s/sample | 40-sample SDPR report; likely noisy and not a theoretical roofline. |
+
+The current CK gap is specific and measurable: decoder mixed prefill remains
+largely Q4_K/Q6_K x Q8_K projection work, not bridge/compiler overhead.
+
+## Current Best CK Split
+
+Latest representative real-image run after Q8 threadpool and Q4 x16 output-loop cleanup:
+
+```text
+steady_state_ms:        76695
+encoder_execute_ms:     34171
+mixed_prefill_ms:       42499
+decode_1_token_ms:         24
+```
+
+Decoder mixed-prefill top ops:
+
+| Op | Time |
+|---|---:|
+| `gemm_nt_q4_k_q8_k_gateup_swiglu_x16` / `mlp_gate_up_swiglu` | ~20.9 s |
+| `mlp_down` total | ~9.1 s |
+| `out_proj` | ~3.6 s |
+| `q_proj` | ~3.6 s |
+| attention | ~1.7 s |
+
+## Q4_K Gate/Up Microbench Results
+
+Representative shape for the hot fused gate/up path:
+
+```text
+M = 1028
+D = 12288
+K = 4096
+weights ~= 54 MiB Q4_K gate+up matrix
+output ~= 48 MiB FP32
+intermediate gate/up scratch equivalent ~= 96 MiB if unfused
+```
+
+The packed x16 benchmark uses the real CK threadpool and compares against the
+existing unfused reference path.
+
+Useful command:
+
+```bash
+CK_NUM_THREADS=20 LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH \
+  build/bench_q4k_gateup_swiglu \
+  --M 1028 --D 12288 --K 4096 --tile-m 8 --mode x16 --warmup 1 --iters 3
+```
+
+Measured Xeon/OpenShift examples:
+
+| Threads | x16 Time | Observation |
+|---:|---:|---|
+| 12 | ~535 ms | Underuses available physical cores for this shape. |
+| 16 | ~444 ms | Strong. |
+| 20 | ~428 ms | Best observed point. |
+| 24 | ~574 ms | Regresses from cache/bandwidth pressure. |
+
+The 20-thread result lines up with the BC server validation argument: the limiter
+is core-to-cache/core-to-memory ratio, not just visible thread count. SMT/48
+threads is not appropriate for this kernel on the current Xeon/OpenShift setup.
+
+## Experiments Kept vs Rejected
+
+Kept:
+
+- Raw `gemm_nt_q8_0` CK-threadpool dispatch for encoder branch/projector GEMMs.
+- Q4_K x16 fused gate/up path as an opt-in path.
+- Q4_K x16 final SwiGLU output loop made vectorization-friendly:
+  - same math: `gate / (1 + expf(-gate)) * up`
+  - removes scalar helper call from the hot lane loop
+  - modest model-level gain: about 1.6 s on the tested SDPR image
+
+Rejected on this Xeon, but should be retested on larger-cache CPUs:
+
+- Dual gate/up accumulator helper that shares one Q8 activation traversal while
+  updating both gate and up accumulators.
+- It was numerically clean, but slower on this Xeon:
+  - vectorized-output-loop x16 best: ~428 ms
+  - dual-accumulator x16: ~442 ms
+- Likely reason: register/instruction pressure outweighed saved Q8 traversal.
+- Retest on Ryzen/X3D or other CPUs with different cache hierarchy and register
+  scheduling behavior before permanently discarding the idea.
+
+## Retest Matrix for Other CPUs
+
+Run this matrix on Ryzen, AVX2-only i7, and any larger-cache Xeon/EPYC host:
+
+| Variable | Values |
+|---|---|
+| Threads | physical cores only, then SMT separately |
+| Tile M | 1, 2, 4, 8, 16 if supported |
+| Scheduler | CK threadpool first; OpenMP only as research comparison |
+| Shape | `M=128/512/1028`, `D=12288`, `K=4096` |
+| Kernel variants | unfused, x16, x16 output-loop cleanup, dual accumulator |
+
+Record:
+
+- wall time median and min over several iterations
+- relative diff and cosine against reference
+- physical-core count and SMT status
+- L1/L2/L3 sizes and cache per active worker
+- NUMA placement, if applicable
+
+## Interpretation
+
+llama.cpp is faster on the current OCR report, but it is probably not at the
+hardware theoretical peak either. It is ahead because its mature layouts,
+packing, and executor scheduling keep the hot quantized projection loops closer
+to the practical cache/memory roofline.
+
+CK is now close enough that the next improvements should be kernel-specific:
+
+1. Better Q4_K/Q6_K packed prefill kernels for mixed prefill.
+2. Load/conversion-time prepacking instead of lazy runtime packing.
+3. Cache-derived active-thread defaults with env overrides.
+4. Separate results by CPU family; do not tune only for this OpenShift Xeon.

--- a/research/q4k_gateup_swiglu/README.md
+++ b/research/q4k_gateup_swiglu/README.md
@@ -98,3 +98,22 @@ python3 research/q4k_gateup_swiglu/cache_model.py --M 79 --D 12288 --K 4096
 ```
 
 This computes `tile_m` and `active_threads` from L1/L2/L3 and physical-core topology. Benchmark sweeps validate the model, but defaults should come from this deterministic cache calculation rather than a single noisy OpenShift timing run.
+
+## 2026-07-02 Qwen3-VL OCR x16 Notes
+
+A companion summary is tracked at:
+
+```text
+docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+```
+
+Important result from the Xeon/OpenShift run: more active threads were not always
+better. For the real Qwen3-VL OCR gate/up shape (`M=1028, D=12288, K=4096`),
+20 physical threads beat 24 and 48. This matches the cache/core-ratio model from
+the BC server validation package: the bottleneck is effective cache and memory
+bandwidth per active worker, not just total visible hardware threads.
+
+The dual gate/up accumulator idea was numerically clean but slower on this Xeon
+(~442 ms versus ~428 ms for the best x16 variant), likely due to register and
+instruction pressure. Keep it as a retest candidate for Ryzen/X3D, EPYC, and
+larger-cache Xeon systems before discarding it globally.


### PR DESCRIPTION
## Summary
- Add Qwen3-VL OCR Q4/Q8 speed research notes from the Xeon/OpenShift run.
- Link the research note from the q4k_gateup_swiglu research README.
- Capture what was kept, what was rejected, current best CK split, and the retest matrix for Ryzen/AVX2/Xeon/EPYC hosts.

## Latest commit
- 1ff19ac0 docs(v8): record q4q8 OCR speed research

## Validation
- git apply --check qwen3vl-q4q8-speed-research-notes.patch
- git diff --check for the touched research docs
- Pre-commit recognized the change as docs-only
- Pre-push passed: visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training smoke, and v7 training-kernel parity

## Notes
- The patch artifact qwen3vl-q4q8-speed-research-notes.patch remains untracked locally; the actual docs changes are committed.