### PR TITLE
Add opt-in Q4 x16 prefill dispatch

### DIFF
--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -75,18 +75,27 @@ CK_NUM_THREADS=20 LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH \
   --M 1028 --D 12288 --K 4096 --tile-m 8 --mode x16 --warmup 1 --iters 3
 ```
 
-Measured Xeon/OpenShift examples:
+Measured Xeon/OpenShift examples before the final output-loop cleanup were noisy:
 
 | Threads | x16 Time | Observation |
 |---:|---:|---|
 | 12 | ~535 ms | Underuses available physical cores for this shape. |
 | 16 | ~444 ms | Strong. |
-| 20 | ~428 ms | Best observed point. |
-| 24 | ~574 ms | Regresses from cache/bandwidth pressure. |
+| 20 | ~428 ms | Best observed point in that sweep. |
+| 24 | ~574 ms | Regressed in that noisy sweep. |
 
-The 20-thread result lines up with the BC server validation argument: the limiter
-is core-to-cache/core-to-memory ratio, not just visible thread count. SMT/48
-threads is not appropriate for this kernel on the current Xeon/OpenShift setup.
+After the vectorization-friendly final SwiGLU loop, a clean sequential CK-threadpool
+run on the same real OCR shape produced near-tied results:
+
+| Threads | x16 Time | Parity |
+|---:|---:|---|
+| 16 | ~352.4 ms | rel diff ~5.7e-7, cosine 1.0 |
+| 20 | ~351.2 ms | rel diff ~5.7e-7, cosine 1.0 |
+| 24 | ~352.7 ms | rel diff ~5.7e-7, cosine 1.0 |
+
+The updated result is better interpreted as: use physical cores, avoid SMT for this
+kernel, and do not overfit the cap to one noisy OpenShift run. The limiter is still
+core-to-cache/core-to-memory ratio, not just visible thread count.
 
 ## Experiments Kept vs Rejected
 
@@ -97,7 +106,8 @@ Kept:
 - Q4_K x16 final SwiGLU output loop made vectorization-friendly:
   - same math: `gate / (1 + expf(-gate)) * up`
   - removes scalar helper call from the hot lane loop
-  - modest model-level gain: about 1.6 s on the tested SDPR image
+  - real-shape standalone timing improved into the ~351-353 ms region on 16-24 physical threads
+  - previous model-level run showed a modest gain of about 1.6 s on the tested SDPR image
 
 Rejected on this Xeon, but should be retested on larger-cache CPUs:
 
@@ -109,6 +119,27 @@ Rejected on this Xeon, but should be retested on larger-cache CPUs:
 - Likely reason: register/instruction pressure outweighed saved Q8 traversal.
 - Retest on Ryzen/X3D or other CPUs with different cache hierarchy and register
   scheduling behavior before permanently discarding the idea.
+
+## Generic Q4 Projection x16 Opt-In Check
+
+A generic packed-meta x16 projection dispatch is available behind:
+
+```bash
+CK_ENABLE_Q4K_PACKED_META_X16_PREFILL=1
+```
+
+It is intentionally opt-in. On the generated fast OCR clean-text asset, enabling
+it together with gate/up x16 did not improve mixed prefill:
+
+| Run | Encoder | Mixed Prefill | Decode | Text |
+|---|---:|---:|---:|---|
+| gate/up x16 only | 2740.7 ms | 4279.4 ms | 960.2 ms | `CK OCR TEST\nTOTAL 42` |
+| gate/up x16 + generic projection x16 | 2729.1 ms | 4308.5 ms | 878.6 ms | `CK OCR TEST\nTOTAL 42` |
+
+Standalone projection microbenchmarks still show small wins for some q/out-style
+shapes, so keep the path for CPU-family sweeps, but do not enable it by default.
+The next default-quality speed work is a better projection/down microkernel or
+conversion-time prepacking, not simply routing every Q4 projection through x16.
 
 ## Retest Matrix for Other CPUs
 

--- a/research/q4k_gateup_swiglu/README.md
+++ b/research/q4k_gateup_swiglu/README.md
@@ -108,12 +108,15 @@ docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
 ```
 
 Important result from the Xeon/OpenShift run: more active threads were not always
-better. For the real Qwen3-VL OCR gate/up shape (`M=1028, D=12288, K=4096`),
-20 physical threads beat 24 and 48. This matches the cache/core-ratio model from
-the BC server validation package: the bottleneck is effective cache and memory
-bandwidth per active worker, not just total visible hardware threads.
+better. Earlier noisy sweeps made 20 physical threads look clearly better than
+24, but after the final SwiGLU lane-loop cleanup clean sequential runs on the
+real Qwen3-VL OCR gate/up shape (`M=1028, D=12288, K=4096`) are effectively tied
+for 16/20/24 physical threads at about 351-353 ms, with rel diff ~5.7e-7 and
+cosine 1.0. This matches the cache/core-ratio model from the BC server
+validation package: use physical cores, avoid SMT for this kernel, and do not
+overfit one noisy OpenShift sweep.
 
 The dual gate/up accumulator idea was numerically clean but slower on this Xeon
-(~442 ms versus ~428 ms for the best x16 variant), likely due to register and
-instruction pressure. Keep it as a retest candidate for Ryzen/X3D, EPYC, and
-larger-cache Xeon systems before discarding it globally.
+(~442 ms versus ~428 ms for the best x16 variant before output-loop cleanup),
+likely due to register and instruction pressure. Keep it as a retest candidate
+for Ryzen/X3D, EPYC, and larger-cache Xeon systems before discarding it globally.

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -1315,10 +1315,6 @@ typedef struct {
     int jobs;
 } gemm_q4_gateup_swiglu_x16_work_t;
 
-static inline float ck_silu_f32(float x)
-{
-    return x / (1.0f + expf(-x));
-}
 
 static void gemm_q4_gateup_swiglu_x16_thread_fn(int ith, int nth, void *args)
 {
@@ -1365,8 +1361,15 @@ static void gemm_q4_gateup_swiglu_x16_thread_fn(int ith, int nth, void *args)
 
         for (int m = m0; m < m1; ++m) {
             float *c_row = a->C + (size_t)m * (size_t)a->D;
+#if defined(__clang__) || defined(__INTEL_LLVM_COMPILER)
+#pragma clang loop vectorize(enable) interleave(enable)
+#elif defined(__GNUC__)
+#pragma GCC ivdep
+#endif
             for (int lane = 0; lane < active; ++lane) {
-                c_row[d0 + lane] = ck_silu_f32(acc_gate[m - m0][lane]) * acc_up[m - m0][lane];
+                const float gate = acc_gate[m - m0][lane];
+                const float up = acc_up[m - m0][lane];
+                c_row[d0 + lane] = (gate / (1.0f + expf(-gate))) * up;
             }
         }
     }

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -82,6 +82,20 @@ extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mtile(const void *A_q8,
                                                             int M, int N, int K,
                                                             int tile_m,
                                                             int threads);
+extern void gemm_nt_q4_k_packed_meta_x16_q8_k_threaded_mreuse(const void *A_q8,
+                                                              const void *B_packed_x16,
+                                                              const float *bias,
+                                                              float *C,
+                                                              int M, int N, int K,
+                                                              int tile_m,
+                                                              int active_threads);
+extern void gemm_nt_q4_k_packed_meta_x16_q8_k_threaded_mtile(const void *A_q8,
+                                                             const void *B_packed_x16,
+                                                             const float *bias,
+                                                             float *C,
+                                                             int M, int N, int K,
+                                                             int tile_m,
+                                                             int active_threads);
 extern void gemm_nt_q4_k_packed_meta_x16_gateup_swiglu_fused_vnni(const void *A_q8,
                                                                    const void *B_packed_x16,
                                                                    const float *bias,
@@ -398,6 +412,24 @@ static int ck_should_use_q4k_packed_meta_prefill(int M, int N, int K)
      * let force/env tuning override this when collecting new hardware data. */
     if (N >= 1024 && K >= 1024) return 1;
     if (K <= 2048 && N >= 1024 && N <= 8192) return 1;
+    return 0;
+}
+
+static int ck_should_use_q4k_packed_meta_x16_prefill(int M, int N, int K)
+{
+    if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_META_X16_PREFILL")) return 0;
+    if (!ck_env_enabled("CK_ENABLE_Q4K_PACKED_META_X16_PREFILL") &&
+        !ck_env_enabled("CK_FORCE_Q4K_PACKED_META_X16_PREFILL")) return 0;
+    if (M <= 1 || N <= 0 || K <= 0 || (K % QK_K) != 0) return 0;
+
+    const int min_m = ck_env_int_or2("CK_Q4K_PACKED_META_X16_MIN_M", NULL, 16);
+    if (M < min_m) return 0;
+    if (ck_env_enabled("CK_FORCE_Q4K_PACKED_META_X16_PREFILL")) return 1;
+
+    /* Experimental generic projection path. It wins on Qwen3-VL q/out style
+     * shapes and is marginal on Q4 MLP-down on this Xeon, so keep it opt-in
+     * until model-level sweeps by CPU family justify default promotion. */
+    if (N >= 1024 && K >= 1024) return 1;
     return 0;
 }
 
@@ -780,6 +812,30 @@ void gemm_nt_q4_k_q8_k_parallel_dispatch(
     int M, int N, int K)
 {
     ck_threadpool_t *pool = ck_threadpool_global();
+    if (pool && ck_should_use_q4k_packed_meta_x16_prefill(M, N, K)) {
+        void *packed_x16 = ck_get_q4k_packed_meta_x16_cached(B, N, K);
+        if (packed_x16) {
+            int active = ck_select_gemm_active_threads(pool, M, N, K);
+            const int cap = ck_env_int_or2("CK_Q4K_PACKED_META_X16_THREAD_CAP", "CK_GEMM_THREAD_CAP", 20);
+            if (cap > 0 && active > cap) active = cap;
+            const int tile_m = ck_env_int_or2("CK_Q4K_PACKED_META_X16_TILE_M", "CK_PREFILL_TILE_M", 8);
+            if (ck_env_enabled("CK_Q4K_PACKED_META_X16_MTILE")) {
+                gemm_nt_q4_k_packed_meta_x16_q8_k_threaded_mtile(
+                    A, packed_x16, bias, C, M, N, K,
+                    tile_m,
+                    active
+                );
+            } else {
+                gemm_nt_q4_k_packed_meta_x16_q8_k_threaded_mreuse(
+                    A, packed_x16, bias, C, M, N, K,
+                    tile_m,
+                    active
+                );
+            }
+            return;
+        }
+    }
+
     if (pool && ck_should_use_q4k_packed_meta_x8mt_prefill(M, N, K)) {
         void *packed_x8 = ck_get_q4k_packed_meta_x8_cached(B, N, K);
         if (packed_x8) {


### PR DESCRIPTION
## Summary
- add an opt-in generic Q4_K packed-meta x16 prefill dispatch lane for v8
- clean up the Q4 x16 SwiGLU lane loop so the compiler can vectorize the final output pass
- update Qwen3-VL OCR Q4/Q8 speed notes with corrected timing and promotion caveats
- keep the new path guarded behind CK_ENABLE_Q4K_PACKED_META_X16_PREFILL / force flags; it is not default yet

## Validation
- git diff --check for the scoped files
- make --no-print-directory build/libckernel_engine.so
- pre-commit: v7-regression-fast passed, v8-regression-fast passed
- pre-push: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, v7/v8 fast regression, and training-kernel parity all passed

## Notes
- this is research/perf infrastructure, not a production default promotion
- docs explain why CPU-family sweeps and shape gates are still needed before enabling broadly
- local unrelated dirty/untracked files were left untouched