### PR TITLE
Speed up Q4 VNNI gate-up hsum reduction

### DIFF
--- a/benchmarks/bench_q4k_gateup_swiglu.c
+++ b/benchmarks/bench_q4k_gateup_swiglu.c
@@ -31,6 +31,17 @@ extern void gemm_nt_q4_k_q8_k_gateup_swiglu_fused_vnni(const void *A_q8,
                                                         int D,
                                                         int K,
                                                         int threads);
+extern size_t q4_k_packed_meta_x16_block_size(void);
+extern void pack_q4_k_to_packed_meta_x16(const void *src, void *dst, int N, int K);
+extern void gemm_nt_q4_k_packed_meta_x16_gateup_swiglu_fused_vnni(const void *A_q8,
+                                                                   const void *B_packed_x16,
+                                                                   const float *bias,
+                                                                   float *C,
+                                                                   int M,
+                                                                   int D,
+                                                                   int K,
+                                                                   int tile_m,
+                                                                   int active_threads);
 
 static double now_ms(void) {
     struct timespec ts;
@@ -105,6 +116,7 @@ static double bench_ms(bench_fn fn, void *ctx, int warmup, int iters) {
 typedef struct {
     const uint8_t *A_q8;
     const uint8_t *W;
+    const void *W_x16;
     const float *bias;
     float *gate_up;
     float *out;
@@ -112,6 +124,7 @@ typedef struct {
     int D;
     int K;
     int threads;
+    int tile_m;
 } ctx_t;
 
 static void run_unfused(void *p) {
@@ -123,6 +136,11 @@ static void run_fused(void *p) {
     ctx_t *c = (ctx_t *)p;
     gemm_nt_q4_k_q8_k_gateup_swiglu_fused_vnni(c->A_q8, c->W, c->bias, c->out, c->M, c->D, c->K, c->threads);
 }
+static void run_x16(void *p) {
+    ctx_t *c = (ctx_t *)p;
+    gemm_nt_q4_k_packed_meta_x16_gateup_swiglu_fused_vnni(
+        c->A_q8, c->W_x16, c->bias, c->out, c->M, c->D, c->K, c->tile_m, c->threads);
+}
 
 int main(int argc, char **argv) {
     int M = 79;
@@ -130,17 +148,20 @@ int main(int argc, char **argv) {
     int K = 4096;
     int iters = 8;
     int warmup = 2;
-    int mode = 0; /* 0=both, 1=unfused, 2=fused */
+    int mode = 0; /* 0=both, 1=unfused, 2=fused, 3=x16 */
+    int tile_m = 8;
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--iters") == 0 && i + 1 < argc) iters = atoi(argv[++i]);
         else if (strcmp(argv[i], "--warmup") == 0 && i + 1 < argc) warmup = atoi(argv[++i]);
         else if (strcmp(argv[i], "--M") == 0 && i + 1 < argc) M = atoi(argv[++i]);
         else if (strcmp(argv[i], "--D") == 0 && i + 1 < argc) D = atoi(argv[++i]);
         else if (strcmp(argv[i], "--K") == 0 && i + 1 < argc) K = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--tile-m") == 0 && i + 1 < argc) tile_m = atoi(argv[++i]);
         else if (strcmp(argv[i], "--mode") == 0 && i + 1 < argc) {
             const char *m = argv[++i];
             if (strcmp(m, "unfused") == 0) mode = 1;
             else if (strcmp(m, "fused") == 0) mode = 2;
+            else if (strcmp(m, "x16") == 0) mode = 3;
             else mode = 0;
         }
     }
@@ -152,15 +173,18 @@ int main(int argc, char **argv) {
     const size_t q4_bytes = (size_t)(2 * D) * (size_t)(K / QK_K) * sizeof(block_q4_K);
     const size_t gateup_elems = (size_t)M * (size_t)(2 * D);
     const size_t out_elems = (size_t)M * (size_t)D;
+    const size_t x16_blocks = (size_t)((2 * D + 15) / 16) * (size_t)(K / QK_K);
+    const size_t x16_bytes = x16_blocks * q4_k_packed_meta_x16_block_size();
 
     float *A = (float *)malloc((size_t)M * (size_t)K * sizeof(float));
     uint8_t *A_q8 = (uint8_t *)malloc(q8_bytes);
     uint8_t *W = (uint8_t *)malloc(q4_bytes);
+    void *W_x16 = aligned_alloc(64, (x16_bytes + 63u) & ~63u);
     float *bias = (float *)malloc((size_t)(2 * D) * sizeof(float));
     float *gate_up = (float *)malloc(gateup_elems * sizeof(float));
     float *out_ref = (float *)malloc(out_elems * sizeof(float));
     float *out = (float *)malloc(out_elems * sizeof(float));
-    if (!A || !A_q8 || !W || !bias || !gate_up || !out_ref || !out) {
+    if (!A || !A_q8 || !W || !W_x16 || !bias || !gate_up || !out_ref || !out) {
         fprintf(stderr, "allocation failed\n");
         return 2;
     }
@@ -169,20 +193,25 @@ int main(int argc, char **argv) {
     fill_f32(bias, (size_t)(2 * D), 0.01f);
     fill_q4k(W, 2 * D, K);
     quantize_acts_q8k(A, A_q8, M, K);
+    const double pack_t0 = now_ms();
+    pack_q4_k_to_packed_meta_x16(W, W_x16, 2 * D, K);
+    const double pack_ms = now_ms() - pack_t0;
 
-    ctx_t ctx = {.A_q8 = A_q8, .W = W, .bias = bias, .gate_up = gate_up, .out = out_ref,
-                 .M = M, .D = D, .K = K, .threads = threads};
+    ctx_t ctx = {.A_q8 = A_q8, .W = W, .W_x16 = W_x16, .bias = bias, .gate_up = gate_up, .out = out_ref,
+                 .M = M, .D = D, .K = K, .threads = threads, .tile_m = tile_m};
     run_unfused(&ctx);
 
     ctx.out = out;
     memset(out, 0, out_elems * sizeof(float));
-    run_fused(&ctx);
+    if (mode == 3) run_x16(&ctx);
+    else run_fused(&ctx);
     const float diff = max_abs_diff(out_ref, out, out_elems);
     const float max_ref = max_abs_val(out_ref, out_elems);
     const double cos = cosine_sim(out_ref, out, out_elems);
 
     double unfused = 0.0;
     double fused = 0.0;
+    double x16 = 0.0;
     if (mode == 0 || mode == 1) {
         ctx.out = out_ref;
         unfused = bench_ms(run_unfused, &ctx, warmup, iters);
@@ -191,21 +220,30 @@ int main(int argc, char **argv) {
         ctx.out = out;
         fused = bench_ms(run_fused, &ctx, warmup, iters);
     }
+    if (mode == 3) {
+        ctx.out = out;
+        x16 = bench_ms(run_x16, &ctx, warmup, iters);
+    }
 
     const double w_mib = (double)q4_bytes / (1024.0 * 1024.0);
     const double scratch_mib = (double)(gateup_elems * sizeof(float)) / (1024.0 * 1024.0);
-    printf("Q4_K gate_up+SwiGLU M=%d D=%d K=%d threads=%d warmup=%d iters=%d mode=%s\n", M, D, K, threads, warmup, iters, mode == 1 ? "unfused" : (mode == 2 ? "fused" : "both"));
-    printf("weights=%.1f MiB gate_up_scratch=%.1f MiB output=%.1f MiB\n",
-           w_mib, scratch_mib, (double)(out_elems * sizeof(float)) / (1024.0 * 1024.0));
+    printf("Q4_K gate_up+SwiGLU M=%d D=%d K=%d threads=%d warmup=%d iters=%d mode=%s tile_m=%d\n",
+           M, D, K, threads, warmup, iters,
+           mode == 1 ? "unfused" : (mode == 2 ? "fused" : (mode == 3 ? "x16" : "both")), tile_m);
+    printf("weights=%.1f MiB packed_x16=%.1f MiB pack_ms=%.3f gate_up_scratch=%.1f MiB output=%.1f MiB\n",
+           w_mib, (double)x16_bytes / (1024.0 * 1024.0), pack_ms, scratch_mib,
+           (double)(out_elems * sizeof(float)) / (1024.0 * 1024.0));
     printf("unfused_ms %.3f\n", unfused);
     printf("fused_ms   %.3f\n", fused);
-    if (unfused > 0.0 && fused > 0.0) printf("speedup    %.3fx\n", unfused / fused);
+    printf("x16_ms     %.3f\n", x16);
+    if (unfused > 0.0 && fused > 0.0) printf("speedup_fused %.3fx\n", unfused / fused);
+    if (unfused > 0.0 && x16 > 0.0) printf("speedup_x16   %.3fx\n", unfused / x16);
     printf("max_diff   %.6g\n", diff);
     printf("max_ref    %.6g\n", max_ref);
     printf("rel_diff   %.6g\n", max_ref > 0.0f ? diff / max_ref : 0.0f);
     printf("cosine     %.9f\n", cos);
 
-    free(A); free(A_q8); free(W); free(bias); free(gate_up); free(out_ref); free(out);
+    free(A); free(A_q8); free(W); free(W_x16); free(bias); free(gate_up); free(out_ref); free(out);
     ck_threadpool_global_destroy();
     return (diff < 1e-3f || (max_ref > 0.0f && diff / max_ref < 1e-5f) || cos > 0.999999) ? 0 : 1;
 }

--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -141,6 +141,34 @@ shapes, so keep the path for CPU-family sweeps, but do not enable it by default.
 The next default-quality speed work is a better projection/down microkernel or
 conversion-time prepacking, not simply routing every Q4 projection through x16.
 
+## 2026-07-03 VNNI Horizontal-Sum Fix
+
+A VTune software-hotspots run on the packed x16 gate/up path showed the hot work
+was not SiLU/`expf`; it was the Q4_K/Q8_K VNNI dot/accumulation loop. The shared
+`hsum256_epi32` helper in `gemm_kernels_q4k_q8k_vnni.c` used two
+`_mm_hadd_epi32` reductions. Switching it to the standalone research harness'
+shuffle/add reduction closed the gap between the research x16 path and the actual
+shared-library x16 path.
+
+Focused gate/up benchmark, real OCR shape (`M=1028, D=12288, K=4096`, 20 threads):
+
+| Variant | Time | Parity |
+|---|---:|---|
+| library x16 before hsum fix | ~452 ms | rel diff ~5.7e-7, cosine 1.0 |
+| library x16 after hsum fix | ~348 ms | rel diff ~5.7e-7, cosine 1.0 |
+
+Large-prefix OCR A/B on generated clean-text image (`image_tokens=1024`, gate/up
+x16 enabled, generic projection x16 disabled):
+
+| Run | Encoder | Mixed Prefill | Decode | Top improvement |
+|---|---:|---:|---:|---|
+| before hsum fix | 61444.7 ms | 42908.0 ms | 1239.9 ms | `mlp_gate_up_swiglu` 21086.0 ms |
+| after hsum fix | 60881.0 ms | 39578.6 ms | 1324.1 ms | `mlp_gate_up_swiglu` 17390.7 ms |
+
+Net: mixed prefill improved by about 3.3 s on this large-prefix OCR check. This
+reduces the dominant Q4 gate/up cost, but CK is still slower than llama.cpp due
+to remaining encoder cost plus Q4/Q6 down/projection work.
+
 ## Retest Matrix for Other CPUs
 
 Run this matrix on Ryzen, AVX2-only i7, and any larger-cache Xeon/EPYC host:

--- a/research/q4k_gateup_swiglu/README.md
+++ b/research/q4k_gateup_swiglu/README.md
@@ -120,3 +120,15 @@ The dual gate/up accumulator idea was numerically clean but slower on this Xeon
 (~442 ms versus ~428 ms for the best x16 variant before output-loop cleanup),
 likely due to register and instruction pressure. Keep it as a retest candidate
 for Ryzen/X3D, EPYC, and larger-cache Xeon systems before discarding it globally.
+
+## 2026-07-03 Shared VNNI hsum Fix
+
+The standalone research harness was faster than the shared-library x16 path until
+`hsum256_epi32` in `src/kernels/gemm_kernels_q4k_q8k_vnni.c` was changed from
+`_mm_hadd_epi32` reductions to shuffle/add reductions. On the real OCR gate/up
+shape (`M=1028, D=12288, K=4096`, 20 threads), the library-backed x16 benchmark
+now reports about 348 ms with rel diff ~5.7e-7 and cosine 1.0.
+
+Large-prefix Qwen3-VL OCR mixed prefill improved from about 42.9 s to about 39.6 s
+on the generated clean-text 1024-image-token check. The improvement lands mostly
+in `mlp_gate_up_swiglu` (`~21.1 s -> ~17.4 s`).

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -53,8 +53,8 @@ static inline int32_t hsum256_epi32(__m256i v) {
     __m128i lo = _mm256_castsi256_si128(v);
     __m128i hi = _mm256_extracti128_si256(v, 1);
     __m128i sum = _mm_add_epi32(lo, hi);
-    sum = _mm_hadd_epi32(sum, sum);
-    sum = _mm_hadd_epi32(sum, sum);
+    sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4e));
+    sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xb1));
     return _mm_cvtsi128_si32(sum);
 }
 #endif


### PR DESCRIPTION
## Summary
- replace the shared Q4_K/Q8_K VNNI hsum helper with the faster shuffle/add reduction
- extend the Q4 gate/up SwiGLU benchmark so it can run the packed x16 path directly
- document the large-prefix Qwen3-VL OCR A/B result and remaining bottlenecks

## Validation
- git diff --check for scoped files
- make --no-print-directory build/libckernel_engine.so
- make --no-print-directory build/bench_q4k_gateup_swiglu
- CK_NUM_THREADS=4 build/bench_q4k_gateup_swiglu --M 16 --D 512 --K 1024 --threads 4 --tile-m 8 --warmup 1 --iters 2 --mode x16
- pre-commit: v7-regression-fast and v8-regression-fast passed
- pre-push: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training smoke, v7/v8 fast regression, and training-kernel parity passed

## Notes
- measured research note records mlp_gate_up_swiglu moving from ~21.1s to ~17.4s and mixed prefill from ~42.9s to ~39.6s on the large-prefix Qwen3-VL OCR check
- next targets remain Q4/Q6 mlp_down, Q4 q_proj/out_proj, encoder visual attention/projector, and conversion/load-time prepacking
- local unrelated dirty/untracked files were left untouched