### PR TITLE
Add opt-in Q8_0 FP32 encoder GEMM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2749,7 +2749,29 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick bench-q8-0-fp32-gemm bench-q8-0-fp32-gemm-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick bench-v8-qwen3vl-ocr-fast profile-v8-prefill-ops profile-v8-prefill-ops-quick
+qwen3vl-ocr-perf-pipeline:
+	@echo "Running deterministic Qwen3-VL OCR perf pipeline..."
+	CK_NUM_THREADS=$${CK_NUM_THREADS:-20} OMP_NUM_THREADS=1 \
+		$(PYTHON) $(PYTHONFLAGS) benchmarks/qwen3vl_ocr_perf_pipeline.py \
+		--threads $${CK_NUM_THREADS:-20} \
+		--image-tokens $${CK_QWEN3VL_OCR_IMAGE_TOKENS:-1024} \
+		--context-len $${CK_QWEN3VL_OCR_CONTEXT:-1536} \
+		--max-tokens $${CK_QWEN3VL_OCR_MAX_TOKENS:-8} \
+		$${CK_ENABLE_Q80_FP32_M4N4:+--enable-q80-m4n4} \
+		$${CK_ENABLE_Q4K_GATEUP_SWIGLU_X16:+--enable-q4-gateup-x16} \
+		$${CK_QWEN3VL_OCR_BASELINE:+--baseline $$CK_QWEN3VL_OCR_BASELINE} \
+		--json-out build/qwen3vl_ocr_perf_pipeline.json \
+		--md-out build/qwen3vl_ocr_perf_pipeline.md
+
+qwen3vl-ocr-perf-analyze:
+	@echo "Analyzing existing Qwen3-VL OCR perf JSON..."
+	$(PYTHON) $(PYTHONFLAGS) benchmarks/qwen3vl_ocr_perf_pipeline.py \
+		--analyze-existing $${CK_QWEN3VL_OCR_ANALYZE_JSON:-build/v8_qwen3vl_ocr_large_q80m4n4_gatex16_t20.json} \
+		$${CK_QWEN3VL_OCR_BASELINE:+--baseline $$CK_QWEN3VL_OCR_BASELINE} \
+		--json-out build/qwen3vl_ocr_perf_pipeline.json \
+		--md-out build/qwen3vl_ocr_perf_pipeline.md
+
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick bench-q8-0-fp32-gemm bench-q8-0-fp32-gemm-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick bench-v8-qwen3vl-ocr-fast profile-v8-prefill-ops profile-v8-prefill-ops-quick qwen3vl-ocr-perf-pipeline qwen3vl-ocr-perf-analyze
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/Makefile
+++ b/Makefile
@@ -2454,6 +2454,7 @@ THREADPOOL_BIN := $(BUILD_DIR)/test_threadpool_parity
 Q4K_DISPATCH_MATRIX_BIN := $(BUILD_DIR)/bench_q4k_dispatch_matrix
 Q4K_GATEUP_SWIGLU_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu
 Q4K_GATEUP_SWIGLU_OMP_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu_omp_standalone
+Q80_FP32_GEMM_BIN := $(BUILD_DIR)/bench_q8_0_fp32_gemm
 V66_SRC_DIR    := version/v6.6/src
 V8_SRC_DIR     := version/v8/src
 
@@ -2520,6 +2521,22 @@ $(Q4K_GATEUP_SWIGLU_OMP_BIN): $(LIB) research/q4k_gateup_swiglu/bench_q4k_gateup
 bench-q4k-gateup-swiglu-omp: $(Q4K_GATEUP_SWIGLU_OMP_BIN)
 	@echo "Running standalone OpenMP Q4_K gate_up+SwiGLU benchmark..."
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(Q4K_GATEUP_SWIGLU_OMP_BIN)
+
+$(Q80_FP32_GEMM_BIN): $(LIB) benchmarks/bench_q8_0_fp32_gemm.c
+	@mkdir -p $(BUILD_DIR)
+	$(CC) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) \
+		benchmarks/bench_q8_0_fp32_gemm.c \
+		-L$(BUILD_DIR) -lckernel_engine -lm -lpthread \
+		-Wl,-rpath,$(BUILD_DIR) \
+		-o $(Q80_FP32_GEMM_BIN)
+
+bench-q8-0-fp32-gemm: $(Q80_FP32_GEMM_BIN)
+	@echo "Running fp32 x Q8_0 GEMM benchmark..."
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(Q80_FP32_GEMM_BIN)
+
+bench-q8-0-fp32-gemm-quick: $(Q80_FP32_GEMM_BIN)
+	@echo "Running fp32 x Q8_0 GEMM benchmark (quick)..."
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(Q80_FP32_GEMM_BIN) --M 128 --N 1024 --K 1024 --iters 2 --warmup 1
 
 # Representative Gemma4-sized Q6_K x Q8_K prefill dispatch benchmark.
 # This is benchmark/dispatch coverage, not a correctness gate for every PR.
@@ -2732,7 +2749,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 		$${CK_V8_PROFILE_REUSE:+--reuse-runtime} \
 		--json-out build/v8_prefill_ops_profile_quick_t$${CK_NUM_THREADS:-12}_p$${CK_V8_PROFILE_PROMPT:-128}.json
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick bench-v8-qwen3vl-ocr-fast profile-v8-prefill-ops profile-v8-prefill-ops-quick
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick bench-q8-0-fp32-gemm bench-q8-0-fp32-gemm-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick bench-v8-qwen3vl-ocr-fast profile-v8-prefill-ops profile-v8-prefill-ops-quick
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/benchmarks/bench_q8_0_fp32_gemm.c
+++ b/benchmarks/bench_q8_0_fp32_gemm.c
@@ -1,0 +1,150 @@
+/*
+ * bench_q8_0_fp32_gemm.c
+ *
+ * Focused fp32 activation x Q8_0 weight GEMM benchmark for Qwen3-VL
+ * vision encoder branch/projector FC shapes.
+ */
+
+#include "ckernel_quant.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+extern void gemm_nt_q8_0(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);
+extern void gemv_q8_0(float *y, const void *W, const float *x, int M, int K);
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1.0e6;
+}
+
+static uint32_t rng_state = 0x91e10da5u;
+static uint32_t rng_u32(void) {
+    rng_state = rng_state * 1664525u + 1013904223u;
+    return rng_state;
+}
+static float rng_f32(float scale) {
+    const uint32_t v = rng_u32() >> 8;
+    const float u = (float)v / (float)0x00ffffffu;
+    return (u * 2.0f - 1.0f) * scale;
+}
+static void fill_f32(float *p, size_t n, float scale) {
+    for (size_t i = 0; i < n; ++i) p[i] = rng_f32(scale);
+}
+static void fill_q8_0(uint8_t *dst, int N, int K) {
+    const int nb = K / QK8_0;
+    for (int n = 0; n < N; ++n) {
+        for (int b = 0; b < nb; ++b) {
+            block_q8_0 *blk = (block_q8_0 *)(void *)(dst + ((size_t)n * nb + b) * sizeof(block_q8_0));
+            blk->d = 0x3800; /* 0.5 */
+            for (int i = 0; i < QK8_0; ++i) blk->qs[i] = (int8_t)((int)(rng_u32() % 255u) - 127);
+        }
+    }
+}
+static void gemm_nt_q8_0_reference(const float *A, const void *B, const float *bias, float *C, int M, int N, int K) {
+    for (int m = 0; m < M; ++m) {
+        gemv_q8_0(C + (size_t)m * N, B, A + (size_t)m * K, N, K);
+        if (bias) {
+            for (int n = 0; n < N; ++n) C[(size_t)m * N + n] += bias[n];
+        }
+    }
+}
+static float max_abs_diff(const float *a, const float *b, size_t n) {
+    float mx = 0.0f;
+    for (size_t i = 0; i < n; ++i) {
+        const float d = fabsf(a[i] - b[i]);
+        if (d > mx) mx = d;
+    }
+    return mx;
+}
+static float max_abs_val(const float *a, size_t n) {
+    float mx = 0.0f;
+    for (size_t i = 0; i < n; ++i) {
+        const float v = fabsf(a[i]);
+        if (v > mx) mx = v;
+    }
+    return mx;
+}
+static double cosine_sim(const float *a, const float *b, size_t n) {
+    double dot = 0.0, aa = 0.0, bb = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+        dot += (double)a[i] * (double)b[i];
+        aa += (double)a[i] * (double)a[i];
+        bb += (double)b[i] * (double)b[i];
+    }
+    return (aa > 0.0 && bb > 0.0) ? dot / sqrt(aa * bb) : 0.0;
+}
+
+typedef void (*bench_fn)(const float *, const void *, const float *, float *, int, int, int);
+static double bench_ms(bench_fn fn, const float *A, const void *B, const float *bias, float *C,
+                       int M, int N, int K, int warmup, int iters) {
+    for (int i = 0; i < warmup; ++i) fn(A, B, bias, C, M, N, K);
+    const double t0 = now_ms();
+    for (int i = 0; i < iters; ++i) fn(A, B, bias, C, M, N, K);
+    return (now_ms() - t0) / (double)iters;
+}
+
+int main(int argc, char **argv) {
+    int M = 1028;
+    int N = 4096;
+    int K = 4096;
+    int iters = 5;
+    int warmup = 2;
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--M") == 0 && i + 1 < argc) M = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--N") == 0 && i + 1 < argc) N = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--K") == 0 && i + 1 < argc) K = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--iters") == 0 && i + 1 < argc) iters = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--warmup") == 0 && i + 1 < argc) warmup = atoi(argv[++i]);
+    }
+    if (K % QK8_0 != 0) {
+        fprintf(stderr, "K must be divisible by %d\n", QK8_0);
+        return 2;
+    }
+
+    const size_t a_elems = (size_t)M * K;
+    const size_t c_elems = (size_t)M * N;
+    const size_t w_bytes = (size_t)N * (size_t)(K / QK8_0) * sizeof(block_q8_0);
+    float *A = (float *)malloc(a_elems * sizeof(float));
+    uint8_t *B = (uint8_t *)malloc(w_bytes);
+    float *bias = (float *)malloc((size_t)N * sizeof(float));
+    float *C_ref = (float *)malloc(c_elems * sizeof(float));
+    float *C = (float *)malloc(c_elems * sizeof(float));
+    if (!A || !B || !bias || !C_ref || !C) {
+        fprintf(stderr, "allocation failed\n");
+        return 2;
+    }
+    fill_f32(A, a_elems, 0.05f);
+    fill_f32(bias, (size_t)N, 0.01f);
+    fill_q8_0(B, N, K);
+
+    gemm_nt_q8_0_reference(A, B, bias, C_ref, M, N, K);
+    gemm_nt_q8_0(A, B, bias, C, M, N, K);
+    const float diff = max_abs_diff(C_ref, C, c_elems);
+    const float max_ref = max_abs_val(C_ref, c_elems);
+    const double cos = cosine_sim(C_ref, C, c_elems);
+
+    const double ref_ms = bench_ms(gemm_nt_q8_0_reference, A, B, bias, C_ref, M, N, K, warmup, iters);
+    const double opt_ms = bench_ms(gemm_nt_q8_0, A, B, bias, C, M, N, K, warmup, iters);
+
+    printf("fp32 x Q8_0 GEMM M=%d N=%d K=%d warmup=%d iters=%d\n", M, N, K, warmup, iters);
+    printf("weights=%.1f MiB A=%.1f MiB C=%.1f MiB\n",
+           (double)w_bytes / (1024.0 * 1024.0),
+           (double)(a_elems * sizeof(float)) / (1024.0 * 1024.0),
+           (double)(c_elems * sizeof(float)) / (1024.0 * 1024.0));
+    printf("ref_ms     %.3f\n", ref_ms);
+    printf("opt_ms     %.3f\n", opt_ms);
+    if (opt_ms > 0.0) printf("speedup    %.3fx\n", ref_ms / opt_ms);
+    printf("max_diff   %.6g\n", diff);
+    printf("max_ref    %.6g\n", max_ref);
+    printf("rel_diff   %.6g\n", max_ref > 0.0f ? diff / max_ref : 0.0f);
+    printf("cosine     %.9f\n", cos);
+
+    free(A); free(B); free(bias); free(C_ref); free(C);
+    return (diff < 1e-3f || (max_ref > 0.0f && diff / max_ref < 1e-5f) || cos > 0.999999) ? 0 : 1;
+}

--- a/benchmarks/qwen3vl_ocr_perf_pipeline.py
+++ b/benchmarks/qwen3vl_ocr_perf_pipeline.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Deterministic Qwen3-VL OCR accuracy/performance pipeline.
+
+This wraps ``bench_v8_qwen3vl_ocr.py`` with repeatable defaults, correctness
+checks, hotspot aggregation, baseline comparison, and optional VTune command
+emission. It is intentionally wall-clock first so it works on OpenShift/no-sudo;
+VTune/Advisor artifacts can be attached later without changing the workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCH = ROOT / "benchmarks" / "bench_v8_qwen3vl_ocr.py"
+DEFAULT_IMAGE = ROOT / "version" / "v8" / "test_assets" / "v8_ocr_clean_text.ppm"
+DEFAULT_EXPECT = "CK OCR TEST\nTOTAL 42"
+
+
+def _run(cmd: list[str], *, env: dict[str, str], timeout: int) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    return int(proc.returncode), proc.stdout
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = payload.get("results") or payload.get("rows") or []
+    return rows if isinstance(rows, list) else []
+
+
+def _num(obj: dict[str, Any], key: str) -> float:
+    try:
+        return float(obj.get(key, 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _read_encoder_profile(report_path: Path) -> list[dict[str, Any]]:
+    csv_path = report_path.parent / "encoder" / "encoder_profile_current.csv"
+    if not csv_path.exists():
+        csv_path = report_path.parent / "encoder" / "encoder_profile.csv"
+    if not csv_path.exists():
+        return []
+    agg: dict[tuple[str, str], float] = defaultdict(float)
+    cnt: Counter[tuple[str, str]] = Counter()
+    with csv_path.open(encoding="utf-8") as f:
+        for r in csv.DictReader(f):
+            op = str(r.get("op") or "")
+            kernel = str(r.get("kernel") or "")
+            try:
+                ms = float(r.get("time_us") or 0.0) / 1000.0
+            except ValueError:
+                ms = 0.0
+            key = (op, kernel)
+            agg[key] += ms
+            cnt[key] += 1
+    return [
+        {"op": op, "kernel": kernel, "total_ms": ms, "count": int(cnt[(op, kernel)])}
+        for (op, kernel), ms in sorted(agg.items(), key=lambda item: item[1], reverse=True)
+    ]
+
+
+def _aggregate_profile_csv(csv_path: Path) -> list[dict[str, Any]]:
+    if not csv_path.exists():
+        return []
+    agg: dict[tuple[str, str], float] = defaultdict(float)
+    cnt: Counter[tuple[str, str]] = Counter()
+    with csv_path.open(encoding="utf-8") as f:
+        for r in csv.DictReader(f):
+            op = str(r.get("op") or "")
+            kernel = str(r.get("kernel") or "")
+            try:
+                ms = float(r.get("time_us") or 0.0) / 1000.0
+            except ValueError:
+                ms = 0.0
+            key = (op, kernel)
+            agg[key] += ms
+            cnt[key] += 1
+    return [
+        {"op": op, "kernel": kernel, "total_ms": ms, "count": int(cnt[(op, kernel)])}
+        for (op, kernel), ms in sorted(agg.items(), key=lambda item: item[1], reverse=True)
+    ]
+
+
+def _read_decoder_profile(row: dict[str, Any], report_path: Path) -> list[dict[str, Any]]:
+    csv_path = report_path.parent / "decoder" / "decoder_mixed_prefill_profile.csv"
+    csv_items = _aggregate_profile_csv(csv_path)
+    if csv_items:
+        return csv_items
+    prof = row.get("decoder_profile") if isinstance(row.get("decoder_profile"), dict) else {}
+    by_op = prof.get("by_op") if isinstance(prof, dict) else {}
+    if not isinstance(by_op, dict):
+        return []
+    out = []
+    for op, v in by_op.items():
+        if not isinstance(v, dict):
+            continue
+        out.append(
+            {
+                "op": str(op),
+                "kernel": str(v.get("kernel") or ""),
+                "total_ms": float(v.get("total_ms") or v.get("ms") or 0.0),
+                "count": int(v.get("count") or 0),
+            }
+        )
+    return sorted(out, key=lambda item: float(item["total_ms"]), reverse=True)
+
+
+def _summarize(payload: dict[str, Any], *, expect_text: str | None) -> dict[str, Any]:
+    rows = _rows(payload)
+    summaries = []
+    for row in rows:
+        report_path = Path(str(row.get("report_path") or ""))
+        generated = str(row.get("generated_text") or "")
+        ok = str(row.get("status") or "") == "ok"
+        text_ok = True if expect_text is None else generated.strip() == expect_text.strip()
+        enc_top = _read_encoder_profile(report_path) if report_path.exists() else []
+        dec_top = _read_decoder_profile(row, report_path)
+        summaries.append(
+            {
+                "image_name": str(row.get("image_name") or ""),
+                "status": str(row.get("status") or ""),
+                "correct": bool(ok and text_ok),
+                "expected_text": expect_text,
+                "generated_text": generated,
+                "prefix_tokens": int(row.get("prefix_tokens") or 0),
+                "total_prefill_tokens": int(row.get("total_prefill_tokens") or 0),
+                "encoder_execute_ms": _num(row, "encoder_execute_ms"),
+                "decoder_forward_mixed_ms": _num(row, "decoder_forward_mixed_ms"),
+                "decoder_generation_ms": _num(row, "decoder_generation_ms"),
+                "steady_state_ms": _num(row, "steady_state_ms"),
+                "encoder_top_ops": enc_top[:15],
+                "decoder_top_ops": dec_top[:15],
+                "report_path": str(report_path) if report_path else "",
+            }
+        )
+    return {"results": summaries}
+
+
+def _compare(cur: dict[str, Any], base: dict[str, Any]) -> dict[str, Any]:
+    cur_rows = cur.get("results") or []
+    base_rows = {str(r.get("image_name")): r for r in (base.get("results") or [])}
+    out = []
+    for row in cur_rows:
+        name = str(row.get("image_name"))
+        b = base_rows.get(name)
+        if not b:
+            continue
+        cur_ms = float(row.get("steady_state_ms") or 0.0)
+        base_ms = float(b.get("steady_state_ms") or 0.0)
+        enc = float(row.get("encoder_execute_ms") or 0.0) - float(b.get("encoder_execute_ms") or 0.0)
+        mixed = float(row.get("decoder_forward_mixed_ms") or 0.0) - float(b.get("decoder_forward_mixed_ms") or 0.0)
+        gen = float(row.get("decoder_generation_ms") or 0.0) - float(b.get("decoder_generation_ms") or 0.0)
+        out.append(
+            {
+                "image_name": name,
+                "steady_delta_ms": cur_ms - base_ms,
+                "steady_speedup": (base_ms / cur_ms) if cur_ms > 0.0 else 0.0,
+                "encoder_delta_ms": enc,
+                "mixed_delta_ms": mixed,
+                "generation_delta_ms": gen,
+            }
+        )
+    return {"comparisons": out}
+
+
+def _recommend(summary: dict[str, Any]) -> list[str]:
+    rows = summary.get("results") or []
+    if not rows:
+        return ["No successful rows to analyze."]
+    first = rows[0]
+    enc = float(first.get("encoder_execute_ms") or 0.0)
+    mixed = float(first.get("decoder_forward_mixed_ms") or 0.0)
+    enc_top = first.get("encoder_top_ops") or []
+    dec_top = first.get("decoder_top_ops") or []
+    recs = []
+    if not first.get("correct"):
+        recs.append("Correctness failed: stop performance work and inspect bridge/model output first.")
+        return recs
+    if enc >= mixed and enc_top:
+        top = enc_top[0]
+        recs.append(f"Next target: encoder {top.get('op')} / {top.get('kernel')} ({float(top.get('total_ms') or 0.0):.1f} ms).")
+    elif dec_top:
+        top = dec_top[0]
+        recs.append(f"Next target: decoder {top.get('op')} / {top.get('kernel')} ({float(top.get('total_ms') or 0.0):.1f} ms).")
+    elif enc_top:
+        top = enc_top[0]
+        recs.append(f"Decoder profile missing; next measured target: encoder {top.get('op')} / {top.get('kernel')} ({float(top.get('total_ms') or 0.0):.1f} ms).")
+    else:
+        recs.append("Next target unclear: enable encoder and decoder profiling.")
+    recs.append("Reject any change that improves time but changes expected OCR text or layer/logit parity.")
+    return recs
+
+
+def _write_markdown(path: Path, summary: dict[str, Any], comparison: dict[str, Any] | None, recs: list[str]) -> None:
+    lines = ["# Qwen3-VL OCR Perf Pipeline", ""]
+    lines.append("| Image | Correct | Prefix | Encoder ms | Mixed ms | Gen ms | Steady ms | Text |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---|")
+    for row in summary.get("results") or []:
+        text = str(row.get("generated_text") or "").replace("\n", "\\n")
+        if len(text) > 48:
+            text = text[:45] + "..."
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(row.get("image_name") or ""),
+                    "yes" if row.get("correct") else "no",
+                    str(row.get("prefix_tokens") or 0),
+                    f"{float(row.get('encoder_execute_ms') or 0.0):.1f}",
+                    f"{float(row.get('decoder_forward_mixed_ms') or 0.0):.1f}",
+                    f"{float(row.get('decoder_generation_ms') or 0.0):.1f}",
+                    f"{float(row.get('steady_state_ms') or 0.0):.1f}",
+                    f"`{text}`",
+                ]
+            )
+            + " |"
+        )
+    if comparison and comparison.get("comparisons"):
+        lines += ["", "## Baseline Comparison", "", "| Image | Steady delta ms | Speedup | Encoder delta | Mixed delta | Gen delta |", "|---|---:|---:|---:|---:|---:|"]
+        for row in comparison["comparisons"]:
+            lines.append(
+                f"| {row['image_name']} | {row['steady_delta_ms']:.1f} | {row['steady_speedup']:.3f}x | "
+                f"{row['encoder_delta_ms']:.1f} | {row['mixed_delta_ms']:.1f} | {row['generation_delta_ms']:.1f} |"
+            )
+    lines += ["", "## Top Encoder Ops", "", "| Op | Kernel | ms | count |", "|---|---|---:|---:|"]
+    for row in (summary.get("results") or [{}])[0].get("encoder_top_ops", [])[:10]:
+        lines.append(f"| {row.get('op')} | {row.get('kernel')} | {float(row.get('total_ms') or 0.0):.1f} | {row.get('count')} |")
+    lines += ["", "## Recommendations", ""]
+    lines += [f"- {r}" for r in recs]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _vtune_commands(args: argparse.Namespace) -> list[str]:
+    env_prefix = [
+        f"CK_ENABLE_Q80_FP32_M4N4={int(bool(args.enable_q80_m4n4))}",
+        f"CK_ENABLE_Q4K_GATEUP_SWIGLU_X16={int(bool(args.enable_q4_gateup_x16))}",
+        f"CK_NUM_THREADS={args.threads}",
+        "OMP_NUM_THREADS=1",
+    ]
+    base = [
+        "vtune -collect hotspots -result-dir build/vtune-qwen3vl-ocr-hotspots --",
+        "env",
+        *env_prefix,
+        f"{sys.executable} -B benchmarks/bench_v8_qwen3vl_ocr.py",
+        f"--images {args.image}",
+        f"--threads {args.threads}",
+        f"--max-tokens {args.max_tokens}",
+        f"--context-len {args.context_len}",
+        f"--image-min-tokens {args.image_tokens}",
+        f"--image-max-tokens {args.image_tokens}",
+        "--bridge-runtime decode-staged --bridge-generation-mode incremental-decode --profile-decoder --force-compile",
+    ]
+    return [" ".join(base)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--image", type=Path, default=DEFAULT_IMAGE)
+    ap.add_argument("--threads", type=int, default=20)
+    ap.add_argument("--image-tokens", type=int, default=1024)
+    ap.add_argument("--context-len", type=int, default=1536)
+    ap.add_argument("--max-tokens", type=int, default=8)
+    ap.add_argument("--expected-text", default=DEFAULT_EXPECT)
+    ap.add_argument("--allow-any-text", action="store_true", help="Treat status=ok as correct without matching generated text.")
+    ap.add_argument("--json-out", type=Path, default=ROOT / "build" / "qwen3vl_ocr_perf_pipeline.json")
+    ap.add_argument("--md-out", type=Path, default=ROOT / "build" / "qwen3vl_ocr_perf_pipeline.md")
+    ap.add_argument("--raw-json-out", type=Path, default=ROOT / "build" / "qwen3vl_ocr_perf_raw.json")
+    ap.add_argument("--analyze-existing", type=Path, default=None, help="Analyze an existing bench_v8_qwen3vl_ocr.py JSON instead of running.")
+    ap.add_argument("--baseline", type=Path, default=None, help="Previous pipeline JSON or raw benchmark JSON for comparison.")
+    ap.add_argument("--timeout", type=int, default=1800)
+    ap.add_argument("--enable-q80-m4n4", action="store_true")
+    ap.add_argument("--enable-q4-gateup-x16", action="store_true")
+    ap.add_argument("--emit-vtune", action="store_true")
+    args = ap.parse_args()
+
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(args.threads)
+    env["OMP_NUM_THREADS"] = "1"
+    if args.enable_q80_m4n4:
+        env["CK_ENABLE_Q80_FP32_M4N4"] = "1"
+    if args.enable_q4_gateup_x16:
+        env["CK_ENABLE_Q4K_GATEUP_SWIGLU_X16"] = "1"
+        env.setdefault("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", str(args.threads))
+
+    if args.analyze_existing is None:
+        cmd = [
+            sys.executable,
+            "-B",
+            str(BENCH),
+            "--images",
+            str(args.image),
+            "--threads",
+            str(args.threads),
+            "--max-tokens",
+            str(args.max_tokens),
+            "--context-len",
+            str(args.context_len),
+            "--image-min-tokens",
+            str(args.image_tokens),
+            "--image-max-tokens",
+            str(args.image_tokens),
+            "--bridge-runtime",
+            "decode-staged",
+            "--bridge-generation-mode",
+            "incremental-decode",
+            "--profile-decoder",
+            "--force-compile",
+            "--json-out",
+            str(args.raw_json_out),
+        ]
+        rc, out = _run(cmd, env=env, timeout=args.timeout)
+        print(out, end="")
+        if rc != 0:
+            return rc
+        raw = _load_json(args.raw_json_out)
+    else:
+        raw = _load_json(args.analyze_existing)
+
+    summary = _summarize(raw, expect_text=None if args.allow_any_text else args.expected_text)
+    comparison = None
+    if args.baseline:
+        base_payload = _load_json(args.baseline)
+        if "results" in base_payload and base_payload["results"] and "encoder_top_ops" in base_payload["results"][0]:
+            base_summary = base_payload
+        else:
+            base_summary = _summarize(base_payload, expect_text=args.expected_text)
+        comparison = _compare(summary, base_summary)
+    recs = _recommend(summary)
+    payload = {
+        "config": {
+            "threads": int(args.threads),
+            "image_tokens": int(args.image_tokens),
+            "context_len": int(args.context_len),
+            "max_tokens": int(args.max_tokens),
+            "enable_q80_m4n4": bool(args.enable_q80_m4n4),
+            "enable_q4_gateup_x16": bool(args.enable_q4_gateup_x16),
+        },
+        **summary,
+        "comparison": comparison,
+        "recommendations": recs,
+        "vtune_commands": _vtune_commands(args) if args.emit_vtune else [],
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _write_markdown(args.md_out, summary, comparison, recs)
+    print(f"Wrote {args.json_out}")
+    print(f"Wrote {args.md_out}")
+    for rec in recs:
+        print(f"NEXT: {rec}")
+    if args.emit_vtune:
+        print("\nVTune commands:")
+        for cmd in payload["vtune_commands"]:
+            print(cmd)
+    return 0 if all(r.get("correct") for r in summary.get("results", [])) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -169,6 +169,40 @@ Net: mixed prefill improved by about 3.3 s on this large-prefix OCR check. This
 reduces the dominant Q4 gate/up cost, but CK is still slower than llama.cpp due
 to remaining encoder cost plus Q4/Q6 down/projection work.
 
+Encoder activation-policy follow-up: forcing Qwen3-VL vision `branch_fc1` and
+`branch_fc2` from fp32 activation to Q8_0 activation made the encoder much
+faster, but it broke OCR output on the clean-text image. Split tests showed both
+`branch_fc1=q8_0` and `branch_fc2=q8_0` individually degraded the answer. Keep
+the branch FC path fp32-activation until a parity-clean fp32 x Q8_0 kernel or
+more precise activation policy is available.
+
+## 2026-07-03 Opt-In FP32 x Q8_0 M4N4 Encoder GEMM
+
+Because Qwen3-VL branch FC layers are not correctness-clean with Q8_0
+activations, the safe speed path is a better fp32-activation x Q8_0-weight GEMM.
+An opt-in AVX512 M4xN4 kernel behind `CK_ENABLE_Q80_FP32_M4N4=1` keeps four FP32
+activation rows and four Q8_0 weight rows live together, reducing repeated
+weight dequant/reduction work while preserving the fp32 activation contract.
+
+Focused benchmark (`M=1028, N=4096, K=4096`):
+
+| Variant | Time | Parity |
+|---|---:|---|
+| existing row-GEMV fp32 x Q8_0 | ~3084 ms | reference |
+| opt-in M4N4 fp32 x Q8_0 | ~366 ms | max diff 0, cosine 1.0 |
+
+Large-prefix Qwen3-VL OCR with `CK_ENABLE_Q80_FP32_M4N4=1` plus gate/up x16:
+
+| Run | Encoder | Mixed Prefill | Decode | Output |
+|---|---:|---:|---:|---|
+| hsum + gate/up x16 baseline | 60881.0 ms | 39578.6 ms | 1324.1 ms | `CK OCR TEST\nTOTAL 42` |
+| + fp32 x Q8_0 M4N4 | 37419.3 ms | 38479.5 ms | 1299.6 ms | `CK OCR TEST\nTOTAL 42` |
+
+Net: the heavy 1024-visual-token clean OCR check improved from about 101.8 s to
+about 77.2 s steady-state while preserving the OCR answer. The new encoder top
+bottleneck is visual attention (`attention_forward_full_head_major_gqa_flash_strided`,
+about 15.0 s), followed by Q8_0/Q8_0 MLP/QKV and remaining fp32 branch FC work.
+
 ## Retest Matrix for Other CPUs
 
 Run this matrix on Ryzen, AVX2-only i7, and any larger-cache Xeon/EPYC host:

--- a/docs/notes/VISION_PERF_HARDENING_PIPELINE.md
+++ b/docs/notes/VISION_PERF_HARDENING_PIPELINE.md
@@ -1,0 +1,145 @@
+# Vision Performance Hardening Pipeline
+
+This runbook describes the repeatable CK workflow for closing vision-model performance gaps without breaking model correctness. It is intentionally model-agnostic: Qwen3-VL OCR is the first concrete contract, but the same loop applies to Gemma4V, Qwen3.5-VL, Kimi-VL, GLM-VL, and future encoder/decoder bridge models.
+
+## Core Rule
+
+Do not accept a speed patch unless the correctness contract still passes.
+
+Correctness can be one of:
+
+- exact generated text, e.g. `CK OCR TEST
+TOTAL 42`
+- top-1/top-k logits parity
+- layer-boundary tensor parity
+- OCR field/JSON score
+- model-specific semantic smoke output
+
+If correctness fails, stop performance work and debug stitching/kernel parity first.
+
+## Deterministic Loop
+
+1. Pick one fixed workload.
+   - Same model artifact.
+   - Same prompt/image/tokens/context.
+   - Same thread count and environment flags.
+
+2. Run the benchmark with profiling enabled.
+   - For Qwen3-VL OCR, use `benchmarks/qwen3vl_ocr_perf_pipeline.py`.
+   - Store raw benchmark JSON and pipeline summary JSON/Markdown.
+
+3. Check correctness.
+   - If expected text/logits/parity fails, reject the speed change.
+
+4. Aggregate hotspots by section/op/kernel.
+   - Encoder CSV.
+   - Decoder mixed-prefill CSV.
+   - Generation/decode CSV if available.
+
+5. Compare against a known baseline.
+   - Report encoder delta, mixed-prefill delta, generation delta, and total steady-state delta.
+
+6. Choose only the next largest correctness-clean bottleneck.
+   - Do not tune broad thread policy before identifying the actual hot op.
+   - Do not change activation quantization policy unless parity proves it is safe.
+
+7. Make one focused change.
+   - Kernel implementation.
+   - Prepacking/layout.
+   - Tile size.
+   - Thread cap for that kernel/shape.
+
+8. Re-run the exact same pipeline.
+   - Keep if correctness passes and model-level timing improves.
+   - Reject if faster but wrong.
+   - Keep as research only if microbench improves but model-level timing does not.
+
+## Current Qwen3-VL OCR Contract
+
+Optimized flags currently used for the heavy 1024 visual-token smoke:
+
+```bash
+CK_ENABLE_Q80_FP32_M4N4=1 CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1 CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP=20 CK_NUM_THREADS=20 OMP_NUM_THREADS=1
+```
+
+Pipeline command:
+
+```bash
+.venv/bin/python -B benchmarks/qwen3vl_ocr_perf_pipeline.py   --image version/v8/test_assets/v8_ocr_clean_text.ppm   --threads 20   --image-tokens 1024   --context-len 1536   --max-tokens 8   --enable-q80-m4n4   --enable-q4-gateup-x16   --emit-vtune
+```
+
+Expected text:
+
+```text
+CK OCR TEST
+TOTAL 42
+```
+
+Current optimized reference from this Xeon/OpenShift host:
+
+- Encoder: about 37.4 s
+- Decoder mixed prefill: about 38.5 s
+- Generation: about 1.3 s
+- Steady total: about 77.2 s
+
+The current pipeline recommendation after the fp32 x Q8_0 M4N4 encoder fix is:
+
+```text
+decoder mlp_gate_up_swiglu / gemm_nt_q4_k_q8_k_gateup_swiglu_x16
+```
+
+## Current Known Rejections
+
+These were faster but not correctness-clean:
+
+- `branch_fc1=q8_0`
+- `branch_fc2=q8_0`
+- `branch_fc1=q8_0` plus `branch_fc2=q8_0`
+
+Reason: Qwen3-VL OCR output changed even though encoder time improved. Keep Qwen3-VL branch FC as fp32 activation unless a future parity-clean policy or kernel proves otherwise.
+
+## VTune/Advisor Agent Instructions
+
+Run the same pipeline workload under VTune/Advisor. Capture:
+
+- hotspots
+- memory access
+- microarchitecture exploration
+- threading analysis
+- vectorization/advisor roofline if available
+
+Answer these questions for the current top op:
+
+- Is it memory-bandwidth limited or compute limited?
+- What are L1/L2/L3 miss rates?
+- Are VNNI/FMA units well utilized?
+- Are reductions or scalar unpack/metadata paths hot?
+- Is thread scaling worse after physical cores?
+- Is there false sharing or output cache-line contention?
+- Is the kernel rereading weights or activations unnecessarily across M/N tiles?
+
+For Q4_K/Q8_K gate/up, test at least:
+
+```bash
+CK_NUM_THREADS=20 build/bench_q4k_gateup_swiglu   --M 1028 --D 12288 --K 4096   --threads 20 --tile-m 8   --iters 5 --warmup 2 --mode x16
+```
+
+Thread/tile sweeps should include:
+
+- threads: 12, 16, 20, 24, 32, 48
+- tile_m: 4, 8, 16 where supported
+- physical cores before SMT
+
+## Generalizing Beyond Qwen3-VL
+
+The generic version of this pipeline should take a model contract file with:
+
+- runner command
+- input assets/prompts/token IDs
+- correctness policy
+- expected output or parity target
+- profile artifact paths
+- baseline JSON
+- enabled feature flags
+
+The process is the same for every CK model family because the CK architecture is kernel stitching plus explicit circuit contracts. The only model-specific part should be the contract, not the profiling/decision loop.

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -503,6 +503,14 @@ BENCH_TARGETS = {
         "perf_pattern": r"qwen35_down\s+\d+\s+\d+\s+\d+\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\S+\s+\d+\.?\d*x\s+(\d+\.?\d*)x",
         "perf_unit": "packed-N speedup",
     },
+    "q8_0_fp32_gemm": {
+        "name": "Q8_0 FP32 GEMM",
+        "category": "bench",
+        "target": "bench-q8-0-fp32-gemm-quick",
+        "timeout_sec": 300,
+        "perf_pattern": r"speedup\s+(\d+\.?\d*)x",
+        "perf_unit": "speedup",
+    },
 }
 
 # Quick subset for fast validation

--- a/src/kernels/gemm_kernels_q8_0.c
+++ b/src/kernels/gemm_kernels_q8_0.c
@@ -62,6 +62,16 @@ static int ck_q8_0_q8_0_debug_ref(void)
     return cached;
 }
 
+static int ck_q8_0_fp32_m4n4_enabled(void)
+{
+    static int cached = -1;
+    if (cached < 0) {
+        const char *env = getenv("CK_ENABLE_Q80_FP32_M4N4");
+        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+    }
+    return cached;
+}
+
 static inline int ck_nearest_int_q8_0(float fval) {
     /* Match llama.cpp's deterministic nearest-even helper. */
     float val = fval + 12582912.f;
@@ -706,43 +716,148 @@ void gemm_q8_0(float *Y,
  * @param N Output dimension (number of rows in B)
  * @param K Input dimension
  */
+static void gemm_nt_q8_0_rowloop(const float *A,
+                                  const void *B,
+                                  const float *bias,
+                                  float *C,
+                                  int M, int N, int K)
+{
+    for (int m = 0; m < M; m++) {
+        gemv_q8_0(&C[(size_t)m * N], B, &A[(size_t)m * K], N, K);
+        if (bias) {
+            for (int n = 0; n < N; n++) C[(size_t)m * N + n] += bias[n];
+        }
+    }
+}
+
+#if defined(__AVX512F__)
+static inline float hsum512_ps_q80(__m512 v)
+{
+    return _mm512_reduce_add_ps(v);
+}
+
+static void gemm_nt_q8_0_m4n4_avx512(const float *A,
+                                      const void *B,
+                                      const float *bias,
+                                      float *C,
+                                      int M, int N, int K)
+{
+    const block_q8_0 *blocks = (const block_q8_0 *)B;
+    const int blocks_per_row = K / QK8_0;
+    const int M4 = M & ~3;
+    const int N4 = N & ~3;
+
+    for (int m = 0; m < M4; m += 4) {
+        for (int n = 0; n < N4; n += 4) {
+            __m512 acc00 = _mm512_setzero_ps(), acc01 = _mm512_setzero_ps();
+            __m512 acc02 = _mm512_setzero_ps(), acc03 = _mm512_setzero_ps();
+            __m512 acc10 = _mm512_setzero_ps(), acc11 = _mm512_setzero_ps();
+            __m512 acc12 = _mm512_setzero_ps(), acc13 = _mm512_setzero_ps();
+            __m512 acc20 = _mm512_setzero_ps(), acc21 = _mm512_setzero_ps();
+            __m512 acc22 = _mm512_setzero_ps(), acc23 = _mm512_setzero_ps();
+            __m512 acc30 = _mm512_setzero_ps(), acc31 = _mm512_setzero_ps();
+            __m512 acc32 = _mm512_setzero_ps(), acc33 = _mm512_setzero_ps();
+
+            const block_q8_0 *b0 = blocks + (size_t)(n + 0) * blocks_per_row;
+            const block_q8_0 *b1 = blocks + (size_t)(n + 1) * blocks_per_row;
+            const block_q8_0 *b2 = blocks + (size_t)(n + 2) * blocks_per_row;
+            const block_q8_0 *b3 = blocks + (size_t)(n + 3) * blocks_per_row;
+            const float *a0 = A + (size_t)(m + 0) * K;
+            const float *a1 = A + (size_t)(m + 1) * K;
+            const float *a2 = A + (size_t)(m + 2) * K;
+            const float *a3 = A + (size_t)(m + 3) * K;
+
+            for (int ib = 0; ib < blocks_per_row; ++ib) {
+                const int k0 = ib * QK8_0;
+                for (int chunk = 0; chunk < 2; ++chunk) {
+                    const int off = chunk * 16;
+                    const __m512 x0 = _mm512_loadu_ps(a0 + k0 + off);
+                    const __m512 x1 = _mm512_loadu_ps(a1 + k0 + off);
+                    const __m512 x2 = _mm512_loadu_ps(a2 + k0 + off);
+                    const __m512 x3 = _mm512_loadu_ps(a3 + k0 + off);
+
+                    __m128i q0 = _mm_loadu_si128((const __m128i *)&b0[ib].qs[off]);
+                    __m128i q1 = _mm_loadu_si128((const __m128i *)&b1[ib].qs[off]);
+                    __m128i q2 = _mm_loadu_si128((const __m128i *)&b2[ib].qs[off]);
+                    __m128i q3 = _mm_loadu_si128((const __m128i *)&b3[ib].qs[off]);
+
+                    __m512 w0 = _mm512_mul_ps(_mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(q0)),
+                                              _mm512_set1_ps(CK_FP16_TO_FP32(b0[ib].d)));
+                    __m512 w1 = _mm512_mul_ps(_mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(q1)),
+                                              _mm512_set1_ps(CK_FP16_TO_FP32(b1[ib].d)));
+                    __m512 w2 = _mm512_mul_ps(_mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(q2)),
+                                              _mm512_set1_ps(CK_FP16_TO_FP32(b2[ib].d)));
+                    __m512 w3 = _mm512_mul_ps(_mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(q3)),
+                                              _mm512_set1_ps(CK_FP16_TO_FP32(b3[ib].d)));
+
+                    acc00 = _mm512_fmadd_ps(w0, x0, acc00);
+                    acc01 = _mm512_fmadd_ps(w1, x0, acc01);
+                    acc02 = _mm512_fmadd_ps(w2, x0, acc02);
+                    acc03 = _mm512_fmadd_ps(w3, x0, acc03);
+                    acc10 = _mm512_fmadd_ps(w0, x1, acc10);
+                    acc11 = _mm512_fmadd_ps(w1, x1, acc11);
+                    acc12 = _mm512_fmadd_ps(w2, x1, acc12);
+                    acc13 = _mm512_fmadd_ps(w3, x1, acc13);
+                    acc20 = _mm512_fmadd_ps(w0, x2, acc20);
+                    acc21 = _mm512_fmadd_ps(w1, x2, acc21);
+                    acc22 = _mm512_fmadd_ps(w2, x2, acc22);
+                    acc23 = _mm512_fmadd_ps(w3, x2, acc23);
+                    acc30 = _mm512_fmadd_ps(w0, x3, acc30);
+                    acc31 = _mm512_fmadd_ps(w1, x3, acc31);
+                    acc32 = _mm512_fmadd_ps(w2, x3, acc32);
+                    acc33 = _mm512_fmadd_ps(w3, x3, acc33);
+                }
+            }
+
+            const float b00 = bias ? bias[n + 0] : 0.0f;
+            const float b01 = bias ? bias[n + 1] : 0.0f;
+            const float b02 = bias ? bias[n + 2] : 0.0f;
+            const float b03 = bias ? bias[n + 3] : 0.0f;
+            C[(size_t)(m + 0) * N + n + 0] = hsum512_ps_q80(acc00) + b00;
+            C[(size_t)(m + 0) * N + n + 1] = hsum512_ps_q80(acc01) + b01;
+            C[(size_t)(m + 0) * N + n + 2] = hsum512_ps_q80(acc02) + b02;
+            C[(size_t)(m + 0) * N + n + 3] = hsum512_ps_q80(acc03) + b03;
+            C[(size_t)(m + 1) * N + n + 0] = hsum512_ps_q80(acc10) + b00;
+            C[(size_t)(m + 1) * N + n + 1] = hsum512_ps_q80(acc11) + b01;
+            C[(size_t)(m + 1) * N + n + 2] = hsum512_ps_q80(acc12) + b02;
+            C[(size_t)(m + 1) * N + n + 3] = hsum512_ps_q80(acc13) + b03;
+            C[(size_t)(m + 2) * N + n + 0] = hsum512_ps_q80(acc20) + b00;
+            C[(size_t)(m + 2) * N + n + 1] = hsum512_ps_q80(acc21) + b01;
+            C[(size_t)(m + 2) * N + n + 2] = hsum512_ps_q80(acc22) + b02;
+            C[(size_t)(m + 2) * N + n + 3] = hsum512_ps_q80(acc23) + b03;
+            C[(size_t)(m + 3) * N + n + 0] = hsum512_ps_q80(acc30) + b00;
+            C[(size_t)(m + 3) * N + n + 1] = hsum512_ps_q80(acc31) + b01;
+            C[(size_t)(m + 3) * N + n + 2] = hsum512_ps_q80(acc32) + b02;
+            C[(size_t)(m + 3) * N + n + 3] = hsum512_ps_q80(acc33) + b03;
+        }
+    }
+
+    if (N4 < N) {
+        gemm_nt_q8_0_rowloop(A, B, bias, C, M, N, K);
+        return;
+    }
+    for (int m = M4; m < M; ++m) {
+        gemv_q8_0(&C[(size_t)m * N], B, &A[(size_t)m * K], N, K);
+        if (bias) {
+            for (int n = 0; n < N; ++n) C[(size_t)m * N + n] += bias[n];
+        }
+    }
+}
+#endif
+
 void gemm_nt_q8_0(const float *A,
                   const void *B,
                   const float *bias,
                   float *C,
                   int M, int N, int K)
 {
-    /* Use GEMV dispatch which selects AVX/SSE/scalar based on CPU */
-    for (int m = 0; m < M; m++) {
-        gemv_q8_0(&C[m * N], B, &A[m * K], N, K);
-        if (bias) {
-            for (int n = 0; n < N; n++) C[m * N + n] += bias[n];
-        }
+#if defined(__AVX512F__)
+    if (ck_q8_0_fp32_m4n4_enabled() && M >= 4 && N >= 4 && K % QK8_0 == 0) {
+        gemm_nt_q8_0_m4n4_avx512(A, B, bias, C, M, N, K);
+        return;
     }
-    return;
-
-    const block_q8_0 *blocks = (const block_q8_0 *)B;
-    const int blocks_per_row = K / QK8_0;
-
-    for (int m = 0; m < M; m++) {
-        const float *a_row = &A[m * K];
-
-        for (int n = 0; n < N; n++) {
-            float sum = 0.0f;
-
-            for (int b = 0; b < blocks_per_row; b++) {
-                const block_q8_0 *block = &blocks[n * blocks_per_row + b];
-                const float d = CK_FP16_TO_FP32(block->d);
-                const float *ap = &a_row[b * QK8_0];
-
-                for (int i = 0; i < QK8_0; i++) {
-                    sum += d * (float)block->qs[i] * ap[i];
-                }
-            }
-
-            C[m * N + n] = sum + (bias ? bias[n] : 0.0f);
-        }
-    }
+#endif
+    gemm_nt_q8_0_rowloop(A, B, bias, C, M, N, K);
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary
- add an opt-in AVX512 M4xN4 fp32-activation x Q8_0-weight GEMM path behind CK_ENABLE_Q80_FP32_M4N4=1
- add a focused fp32 x Q8_0 reference/parity benchmark and Makefile targets
- add the quick benchmark to nightly bench reporting
- document the heavy 1024 visual-token Qwen3-VL OCR baseline chain and M4N4 encoder speed result
- add a deterministic Qwen3-VL OCR perf hardening pipeline and model-agnostic vision perf runbook

## Validation
- make --no-print-directory build/libckernel_engine.so build/bench_q8_0_fp32_gemm
- .venv/bin/python -m py_compile scripts/nightly_runner.py
- CK_ENABLE_Q80_FP32_M4N4=1 make --no-print-directory bench-q8-0-fp32-gemm-quick
- .venv/bin/python -m py_compile benchmarks/qwen3vl_ocr_perf_pipeline.py
- .venv/bin/python -B benchmarks/qwen3vl_ocr_perf_pipeline.py --analyze-existing build/v8_qwen3vl_ocr_fast_t24.json --allow-any-text --json-out /tmp/qwen3vl_ocr_perf_pipeline_test.json --md-out /tmp/qwen3vl_ocr_perf_pipeline_test.md --emit-vtune
- make --no-print-directory -n qwen3vl-ocr-perf-analyze
- git diff --check for scoped files
- pre-commit: v7-regression-fast and v8-regression-fast passed
- pre-push: build, kernel parity, v8 E2E text smoke, v8 contracts, v7 training smoke, v7/v8 fast regression, and training-kernel parity passed

## Notes
- correctness coverage uses the local scalar/reference fp32 x Q8_0 implementation with max_diff/rel_diff/cosine checks
- llama.cpp comparison remains useful for end-to-end context, but this patch targets Qwen3-VL encoder/projector fp32 activation x Q8_0 weight GEMM rather than decoder Q4 hot paths
- Xeon result in docs records heavy OCR steady-state moving from about 101.8s to about 77.2s, mainly by reducing encoder time from about 60.9s to about 37.4s
- full 1024 visual-token OCR pipeline is manual/high-memory, not automatic nightly
- local unrelated dirty/untracked files were left untouched