### PR TITLE
perf(v8): add opt-in Qwen3-VL chunked kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2510,6 +2510,12 @@ bench-q4k-gateup-swiglu: $(Q4K_GATEUP_SWIGLU_BIN)
 	@echo "Running Q4_K gate_up+SwiGLU fused benchmark..."
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(Q4K_GATEUP_SWIGLU_BIN)
 
+bench-q4k-gateup-swiglu-x16-chunk4-quick: $(Q4K_GATEUP_SWIGLU_BIN)
+	@echo "Running Q4_K gate_up+SwiGLU x16 chunk4 benchmark (quick)..."
+	CK_Q4K_X16_CHUNK4=1 CK_NUM_THREADS=$${CK_NUM_THREADS:-4} \
+		LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(Q4K_GATEUP_SWIGLU_BIN) \
+		--M 16 --D 512 --K 1024 --tile-m 8 --warmup 1 --iters 2 --mode x16
+
 $(Q4K_GATEUP_SWIGLU_OMP_BIN): $(LIB) research/q4k_gateup_swiglu/bench_q4k_gateup_swiglu_omp_standalone.c
 	@mkdir -p $(BUILD_DIR)
 	$(CC) -O3 -march=native -fopenmp -Iinclude -I$(V8_SRC_DIR) \
@@ -2759,6 +2765,8 @@ qwen3vl-ocr-perf-pipeline:
 		--max-tokens $${CK_QWEN3VL_OCR_MAX_TOKENS:-8} \
 		$${CK_ENABLE_Q80_FP32_M4N4:+--enable-q80-m4n4} \
 		$${CK_ENABLE_Q4K_GATEUP_SWIGLU_X16:+--enable-q4-gateup-x16} \
+		$${CK_Q4K_X16_CHUNK4:+--enable-q4-chunk4} \
+		$${CK_ATTENTION_QBLOCK4:+--enable-attention-qblock4} \
 		$${CK_QWEN3VL_OCR_BASELINE:+--baseline $$CK_QWEN3VL_OCR_BASELINE} \
 		--json-out build/qwen3vl_ocr_perf_pipeline.json \
 		--md-out build/qwen3vl_ocr_perf_pipeline.md
@@ -2771,7 +2779,7 @@ qwen3vl-ocr-perf-analyze:
 		--json-out build/qwen3vl_ocr_perf_pipeline.json \
 		--md-out build/qwen3vl_ocr_perf_pipeline.md
 
-.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick bench-q8-0-fp32-gemm bench-q8-0-fp32-gemm-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick bench-v8-qwen3vl-ocr-fast profile-v8-prefill-ops profile-v8-prefill-ops-quick qwen3vl-ocr-perf-pipeline qwen3vl-ocr-perf-analyze
+.PHONY: test-threadpool-parity test-threadpool-parity-quick test-threadpool-parity-verbose bench-q4k-dispatch-matrix bench-q4k-dispatch-matrix-quick bench-q4k-gateup-swiglu-x16-chunk4-quick bench-q8-0-fp32-gemm bench-q8-0-fp32-gemm-quick test-q6k-prefill-tile-bench test-q6k-prefill-tile-bench-quick test-q6k-prefill-dispatch-sweep test-q6k-prefill-dispatch-sweep-quick test-q6k-prefill-dispatch-sweep-avx2 test-q6k-prefill-thread-sweep-quick test-q4-q5-prefill-dispatch-sweep test-q4-q5-prefill-thread-sweep-quick profile-v8-prefill-perf-stat test-v8-decoder-matrix test-v8-decoder-matrix-quick test-v8-template-circuit-audit v8-model-kernel-inspect test-v8-gemma4-assistant-e2e test-v8-qwen3vl-e2e-smoke test-v8-qwen3vl-ocr-smoke test-v8-gemma4-vision-smoke test-v8-vision-smoke test-v8-model-smoke test-v8-gemma4-highmem test-v8-nemotron9-highmem bench-v8-qwen3vl-ocr bench-v8-qwen3vl-ocr-quick bench-v8-qwen3vl-ocr-fast profile-v8-prefill-ops profile-v8-prefill-ops-quick qwen3vl-ocr-perf-pipeline qwen3vl-ocr-perf-analyze
 
 # =============================================================================
 # GEMM AVX Benchmark: _avx (SSE4.1) vs _ref (scalar)

--- a/benchmarks/bench_q4k_gateup_swiglu.c
+++ b/benchmarks/bench_q4k_gateup_swiglu.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
     double unfused = 0.0;
     double fused = 0.0;
     double x16 = 0.0;
-    if (mode == 0 || mode == 1) {
+    if (mode == 0 || mode == 1 || mode == 3) {
         ctx.out = out_ref;
         unfused = bench_ms(run_unfused, &ctx, warmup, iters);
     }

--- a/benchmarks/qwen3vl_ocr_perf_pipeline.py
+++ b/benchmarks/qwen3vl_ocr_perf_pipeline.py
@@ -255,6 +255,8 @@ def _vtune_commands(args: argparse.Namespace) -> list[str]:
     env_prefix = [
         f"CK_ENABLE_Q80_FP32_M4N4={int(bool(args.enable_q80_m4n4))}",
         f"CK_ENABLE_Q4K_GATEUP_SWIGLU_X16={int(bool(args.enable_q4_gateup_x16))}",
+        f"CK_Q4K_X16_CHUNK4={int(bool(args.enable_q4_chunk4))}",
+        f"CK_ATTENTION_QBLOCK4={int(bool(args.enable_attention_qblock4))}",
         f"CK_NUM_THREADS={args.threads}",
         "OMP_NUM_THREADS=1",
     ]
@@ -291,6 +293,8 @@ def main() -> int:
     ap.add_argument("--timeout", type=int, default=1800)
     ap.add_argument("--enable-q80-m4n4", action="store_true")
     ap.add_argument("--enable-q4-gateup-x16", action="store_true")
+    ap.add_argument("--enable-q4-chunk4", action="store_true")
+    ap.add_argument("--enable-attention-qblock4", action="store_true")
     ap.add_argument("--emit-vtune", action="store_true")
     args = ap.parse_args()
 
@@ -302,6 +306,10 @@ def main() -> int:
     if args.enable_q4_gateup_x16:
         env["CK_ENABLE_Q4K_GATEUP_SWIGLU_X16"] = "1"
         env.setdefault("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", str(args.threads))
+    if args.enable_q4_chunk4:
+        env["CK_Q4K_X16_CHUNK4"] = "1"
+    if args.enable_attention_qblock4:
+        env["CK_ATTENTION_QBLOCK4"] = "1"
 
     if args.analyze_existing is None:
         cmd = [
@@ -355,6 +363,8 @@ def main() -> int:
             "max_tokens": int(args.max_tokens),
             "enable_q80_m4n4": bool(args.enable_q80_m4n4),
             "enable_q4_gateup_x16": bool(args.enable_q4_gateup_x16),
+            "enable_q4_chunk4": bool(args.enable_q4_chunk4),
+            "enable_attention_qblock4": bool(args.enable_attention_qblock4),
         },
         **summary,
         "comparison": comparison,

--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -203,6 +203,71 @@ about 77.2 s steady-state while preserving the OCR answer. The new encoder top
 bottleneck is visual attention (`attention_forward_full_head_major_gqa_flash_strided`,
 about 15.0 s), followed by Q8_0/Q8_0 MLP/QKV and remaining fp32 branch FC work.
 
+
+## 2026-07-03 Q4_K Gate/Up x16 Chunk4 Reuse
+
+After the fp32 x Q8_0 M4N4 encoder fix, the largest decoder-side mixed-prefill
+projection remained `mlp_gate_up_swiglu`. The x16 packed Q4_K path still loaded
+the same Q8_K activation block once per output lane. An opt-in chunked reuse path
+behind `CK_Q4K_X16_CHUNK4=1` processes up to four x16 lanes per activation load,
+so the Q8_K row stays hot while several Q4_K output lanes consume it.
+
+Focused gate/up benchmark (`M=1028, D=12288, K=4096`, 20 CK threads):
+
+| Variant | Time | Parity |
+|---|---:|---|
+| x16 baseline | ~403 ms | reference |
+| x16 chunk4 | ~274 ms | rel diff ~1.0e-6, cosine 1.0 |
+
+Large-prefix Qwen3-VL OCR with `CK_ENABLE_Q80_FP32_M4N4=1`,
+`CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1`, and `CK_Q4K_X16_CHUNK4=1`:
+
+| Run | Encoder | Mixed Prefill | Decode | Steady | Output |
+|---|---:|---:|---:|---:|---|
+| M4N4 + gate/up x16 | 37419.3 ms | 38479.5 ms | 1299.6 ms | 77198.3 ms | `CK OCR TEST\nTOTAL 42` |
+| + Q4 chunk4 reuse | 37474.0 ms | 35169.9 ms | 1285.7 ms | 73929.6 ms | `CK OCR TEST\nTOTAL 42` |
+
+Net: chunk4 is a correctness-clean opt-in improvement for this workload, reducing
+mixed prefill by about 3.3 s and the steady OCR run by about 4.4%. The next
+measured bottleneck moves to Qwen3-VL encoder full attention
+(`attention_forward_full_head_major_gqa_flash_strided`, about 15.0 s). A quick
+attention-thread-cap sweep did not produce a stable scheduler-only win, and the
+existing tiled/ggml full-attention path is much slower at the real encoder shape
+(`T=4232, H=16, D=72`).
+
+
+## 2026-07-03 AVX512 Full-Attention QBlock4 Reuse
+
+After Q4 chunk4 reuse, the largest encoder-side cost was full visual attention
+at the real Qwen3-VL encoder shape (`T=4232, H=16, D=72`). The existing full
+attention path computes one query row at a time, so each nearby query rereads the
+same K/V rows. An opt-in AVX512 path behind `CK_ATTENTION_QBLOCK4=1` processes
+four query rows together for non-causal full attention with `head_dim=72`,
+keeping K/V rows hotter across the four query accumulators. The path is guarded
+by shape and ISA checks and falls back to the existing kernel otherwise.
+
+Focused exact-shape attention benchmark (`T=4232, H=16, KV=16, D=72`, 20 CK
+threads):
+
+| Variant | Time | Parity |
+|---|---:|---|
+| existing full attention | ~622.9 ms | reference |
+| opt-in qblock4 | ~598.0 ms | max diff 0, cosine 1.0 |
+
+Large-prefix Qwen3-VL OCR with `CK_ENABLE_Q80_FP32_M4N4=1`,
+`CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1`, `CK_Q4K_X16_CHUNK4=1`, and
+`CK_ATTENTION_QBLOCK4=1`:
+
+| Run | Encoder | Mixed Prefill | Decode | Steady | Output |
+|---|---:|---:|---:|---:|---|
+| chunk4 baseline | 37908.6 ms | 34832.3 ms | 1370.4 ms | 74111.4 ms | `CK OCR TEST\nTOTAL 42` |
+| + attention qblock4 | 33803.1 ms | 34260.0 ms | 1328.2 ms | 69391.3 ms | `CK OCR TEST\nTOTAL 42` |
+
+Net: qblock4 is a correctness-clean opt-in model-level win on this Xeon/OpenShift
+node, saving about 4.7 s on the clean OCR workload. The next measured bottleneck
+moves back to decoder mixed prefill, especially `mlp_gate_up_swiglu` through
+`gemm_nt_q4_k_q8_k_gateup_swiglu_x16` at about 12.2 s in the latest profile.
+
 ## Retest Matrix for Other CPUs
 
 Run this matrix on Ryzen, AVX2-only i7, and any larger-cache Xeon/EPYC host:

--- a/docs/notes/VISION_PERF_HARDENING_PIPELINE.md
+++ b/docs/notes/VISION_PERF_HARDENING_PIPELINE.md
@@ -59,13 +59,29 @@ If correctness fails, stop performance work and debug stitching/kernel parity fi
 Optimized flags currently used for the heavy 1024 visual-token smoke:
 
 ```bash
-CK_ENABLE_Q80_FP32_M4N4=1 CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1 CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP=20 CK_NUM_THREADS=20 OMP_NUM_THREADS=1
+CK_ENABLE_Q80_FP32_M4N4=1 \
+CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1 \
+CK_Q4K_X16_CHUNK4=1 \
+CK_ATTENTION_QBLOCK4=1 \
+CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP=20 \
+CK_NUM_THREADS=20 \
+OMP_NUM_THREADS=1
 ```
 
 Pipeline command:
 
 ```bash
-.venv/bin/python -B benchmarks/qwen3vl_ocr_perf_pipeline.py   --image version/v8/test_assets/v8_ocr_clean_text.ppm   --threads 20   --image-tokens 1024   --context-len 1536   --max-tokens 8   --enable-q80-m4n4   --enable-q4-gateup-x16   --emit-vtune
+.venv/bin/python -B benchmarks/qwen3vl_ocr_perf_pipeline.py \
+  --image version/v8/test_assets/v8_ocr_clean_text.ppm \
+  --threads 20 \
+  --image-tokens 1024 \
+  --context-len 1536 \
+  --max-tokens 8 \
+  --enable-q80-m4n4 \
+  --enable-q4-gateup-x16 \
+  --enable-q4-chunk4 \
+  --enable-attention-qblock4 \
+  --emit-vtune
 ```
 
 Expected text:
@@ -77,16 +93,57 @@ TOTAL 42
 
 Current optimized reference from this Xeon/OpenShift host:
 
-- Encoder: about 37.4 s
-- Decoder mixed prefill: about 38.5 s
+- Encoder: about 33.8 s
+- Decoder mixed prefill: about 34.3 s
 - Generation: about 1.3 s
-- Steady total: about 77.2 s
+- Steady total: about 69.4 s
 
-The current pipeline recommendation after the fp32 x Q8_0 M4N4 encoder fix is:
+The current pipeline recommendation after Q4 chunk4 reuse and attention qblock4 is:
 
 ```text
 decoder mlp_gate_up_swiglu / gemm_nt_q4_k_q8_k_gateup_swiglu_x16
 ```
+
+That op is still the largest measured mixed-prefill hotspot at about 12.2 s in
+the latest profile. The next work should improve Q4_K/Q8_K prefill reuse or
+prepacking, not enable the opt-in AVX512 paths globally without shape and host
+sweeps.
+
+## Local and Nightly Coverage
+
+The lightweight gate for the current Q4_K opt-in speed path is:
+
+```bash
+CK_Q4K_X16_CHUNK4=1 CK_NUM_THREADS=4 make bench-q4k-gateup-swiglu-x16-chunk4-quick
+```
+
+The chunk4 benchmark emits `speedup_x16`, so nightly can render it as a
+performance lane.
+
+The full OCR pipeline is the model-level proof:
+
+```bash
+CK_ENABLE_Q80_FP32_M4N4=1 \
+CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1 \
+CK_Q4K_X16_CHUNK4=1 \
+CK_ATTENTION_QBLOCK4=1 \
+CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP=20 \
+CK_NUM_THREADS=20 \
+OMP_NUM_THREADS=1 \
+make qwen3vl-ocr-perf-pipeline
+```
+
+Keep the full pipeline on high-memory runners or dedicated Xeon boxes with the
+Qwen3-VL artifacts cached. It is too expensive for every default CI pass, but it
+is the contract that proves the quick kernel gates translate into end-to-end OCR
+speed without text corruption.
+
+`CK_ATTENTION_QBLOCK4=1` is intentionally validated through the full OCR pipeline
+for now. The existing standalone `unittest/test_attention_full.py` flash tests
+currently fail their strict PyTorch tolerance on this AVX2 laptop even without
+qblock4 enabled, so promoting that suite as a qblock4 nightly gate would add
+noise rather than signal. Add a dedicated qblock4 parity microbench before making
+that dispatch a default nightly correctness lane.
 
 ## Current Known Rejections
 

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -511,6 +511,14 @@ BENCH_TARGETS = {
         "perf_pattern": r"speedup\s+(\d+\.?\d*)x",
         "perf_unit": "speedup",
     },
+    "q4k_gateup_x16_chunk4": {
+        "name": "Q4_K Gate/Up x16 Chunk4",
+        "category": "bench",
+        "target": "bench-q4k-gateup-swiglu-x16-chunk4-quick",
+        "timeout_sec": 300,
+        "perf_pattern": r"speedup_x16\s+(\d+\.?\d*)x",
+        "perf_unit": "speedup",
+    },
 }
 
 # Quick subset for fast validation

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -2894,6 +2894,148 @@ static inline void ck_attention_flash_query_auto(const float *q_vec,
 #endif
 }
 
+
+static int ck_attention_qblock4_enabled(void)
+{
+    static int cached = -1;
+    if (cached < 0) {
+        const char *env = getenv("CK_ATTENTION_QBLOCK4");
+        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+    }
+    return cached;
+}
+
+#if defined(__AVX512F__)
+static inline float ck_attention_dot72_avx512(const float *q_vec, const float *k_vec)
+{
+    __m512 acc = _mm512_setzero_ps();
+    acc = _mm512_fmadd_ps(_mm512_loadu_ps(q_vec + 0),  _mm512_loadu_ps(k_vec + 0),  acc);
+    acc = _mm512_fmadd_ps(_mm512_loadu_ps(q_vec + 16), _mm512_loadu_ps(k_vec + 16), acc);
+    acc = _mm512_fmadd_ps(_mm512_loadu_ps(q_vec + 32), _mm512_loadu_ps(k_vec + 32), acc);
+    acc = _mm512_fmadd_ps(_mm512_loadu_ps(q_vec + 48), _mm512_loadu_ps(k_vec + 48), acc);
+    float dot = _mm512_reduce_add_ps(acc);
+    for (int d = 64; d < 72; ++d) {
+        dot += q_vec[d] * k_vec[d];
+    }
+    return dot;
+}
+
+static void attention_flash_query4_full_avx512(const float *q_head,
+                                                const float *k_head,
+                                                const float *v_head,
+                                                int q0,
+                                                int q_count,
+                                                int kv_tokens,
+                                                int aligned_head_dim,
+                                                float scale,
+                                                float *out_head)
+{
+    float m[4] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
+    float ssum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    float out[4][72];
+    for (int r = 0; r < q_count; ++r) {
+        for (int d = 0; d < 72; ++d) out[r][d] = 0.0f;
+    }
+
+    const float *qv[4] = { NULL, NULL, NULL, NULL };
+    for (int r = 0; r < q_count; ++r) {
+        qv[r] = q_head + (size_t)(q0 + r) * (size_t)aligned_head_dim;
+    }
+
+    for (int j = 0; j < kv_tokens; ++j) {
+        const float *k_vec = k_head + (size_t)j * (size_t)aligned_head_dim;
+        const float *v_vec = v_head + (size_t)j * (size_t)aligned_head_dim;
+        float score[4];
+        float scale_old[4];
+        float scale_v[4];
+
+        for (int r = 0; r < q_count; ++r) {
+            score[r] = ck_attention_dot72_avx512(qv[r], k_vec) * scale;
+            if (score[r] > m[r]) {
+                scale_old[r] = (m[r] == -INFINITY) ? 0.0f : expf(m[r] - score[r]);
+                scale_v[r] = 1.0f;
+                ssum[r] *= scale_old[r];
+                ssum[r] += 1.0f;
+                m[r] = score[r];
+            } else {
+                scale_old[r] = 1.0f;
+                scale_v[r] = expf(score[r] - m[r]);
+                ssum[r] += scale_v[r];
+            }
+        }
+
+        for (int d = 0; d < 72; d += 16) {
+            const int width = (d + 16 <= 72) ? 16 : (72 - d);
+            if (width == 16) {
+                const __m512 vv = _mm512_loadu_ps(v_vec + d);
+                for (int r = 0; r < q_count; ++r) {
+                    __m512 ov = _mm512_loadu_ps(out[r] + d);
+                    ov = _mm512_fmadd_ps(ov, _mm512_set1_ps(scale_old[r]), _mm512_mul_ps(_mm512_set1_ps(scale_v[r]), vv));
+                    _mm512_storeu_ps(out[r] + d, ov);
+                }
+            } else {
+                for (int r = 0; r < q_count; ++r) {
+                    for (int t = 0; t < width; ++t) {
+                        out[r][d + t] = out[r][d + t] * scale_old[r] + scale_v[r] * v_vec[d + t];
+                    }
+                }
+            }
+        }
+    }
+
+    for (int r = 0; r < q_count; ++r) {
+        float *dst = out_head + (size_t)(q0 + r) * (size_t)aligned_head_dim;
+        const float inv = ssum[r] == 0.0f ? 0.0f : (1.0f / ssum[r]);
+        const __m512 invv = _mm512_set1_ps(inv);
+        for (int d = 0; d + 16 <= 72; d += 16) {
+            _mm512_storeu_ps(dst + d, _mm512_mul_ps(_mm512_loadu_ps(out[r] + d), invv));
+        }
+        for (int d = 64; d < 72; ++d) dst[d] = out[r][d] * inv;
+        for (int d = 72; d < aligned_head_dim; ++d) dst[d] = 0.0f;
+    }
+}
+
+typedef struct {
+    const float *q;
+    const float *k;
+    const float *v;
+    float *output;
+    int num_heads;
+    int num_kv_heads;
+    int num_tokens;
+    int aligned_head_dim;
+    int kv_stride_tokens;
+    float scale;
+} ck_attention_qblock4_args_t;
+
+static void ck_attention_full_qblock4_work(int ith, int nth, void *opaque)
+{
+    ck_attention_qblock4_args_t *args = (ck_attention_qblock4_args_t *) opaque;
+    const int T = args->num_tokens;
+    const int q_blocks = (T + 3) / 4;
+    const int total = args->num_heads * q_blocks;
+    const size_t head_stride = (size_t)T * (size_t)args->aligned_head_dim;
+    const size_t kv_head_stride = (size_t)args->kv_stride_tokens * (size_t)args->aligned_head_dim;
+
+    for (int idx = ith; idx < total; idx += nth) {
+        const int h = idx / q_blocks;
+        const int qb = idx - h * q_blocks;
+        const int q0 = qb * 4;
+        const int q_count = (q0 + 4 <= T) ? 4 : (T - q0);
+        const int kv_head = (int)((long long)h * (long long)args->num_kv_heads / (long long)args->num_heads);
+        const float *q_head = args->q + (size_t)h * head_stride;
+        const float *k_head = args->k + (size_t)kv_head * kv_head_stride;
+        const float *v_head = args->v + (size_t)kv_head * kv_head_stride;
+        float *out_head = args->output + (size_t)h * head_stride;
+        attention_flash_query4_full_avx512(q_head, k_head, v_head,
+                                           q0, q_count, T,
+                                           args->aligned_head_dim,
+                                           args->scale,
+                                           out_head);
+    }
+}
+#endif
+
 static void ck_attention_full_grid_work(int ith, int nth, void *opaque)
 {
     ck_attention_parallel_args_t *args = (ck_attention_parallel_args_t *) opaque;
@@ -2999,6 +3141,30 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
 #endif
 
     const int total_queries = num_heads * T;
+#if defined(__AVX512F__)
+    if (!causal && head_dim == 72 && aligned_head_dim >= 72 && ck_attention_qblock4_enabled()) {
+        ck_threadpool_t *pool = ck_threadpool_global();
+        const int q_blocks = (T + 3) / 4;
+        const int total_blocks = num_heads * q_blocks;
+        int active = ck_attention_pick_active_threads(pool, total_blocks, T);
+        if (pool && active > 1) {
+            ck_attention_qblock4_args_t args = {
+                .q = q,
+                .k = k,
+                .v = v,
+                .output = output,
+                .num_heads = num_heads,
+                .num_kv_heads = num_kv_heads,
+                .num_tokens = num_tokens,
+                .aligned_head_dim = aligned_head_dim,
+                .kv_stride_tokens = kv_stride_tokens,
+                .scale = scale,
+            };
+            ck_threadpool_dispatch_n(pool, active, ck_attention_full_qblock4_work, &args);
+            return;
+        }
+    }
+#endif
     if (ck_attention_parallel_enabled(total_queries, T, head_dim)) {
         ck_threadpool_t *pool = ck_threadpool_global();
         const int active = ck_attention_pick_active_threads(pool, total_queries, T);

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -34,6 +34,16 @@
 #include "ck_threadpool.h"
 #include "ckernel_quant.h"
 
+static int ck_q4k_x16_chunk4_enabled(void)
+{
+    static int cached = -1;
+    if (cached < 0) {
+        const char *env = getenv("CK_Q4K_X16_CHUNK4");
+        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+    }
+    return cached;
+}
+
 #if (defined(__AVX512VNNI__) && defined(__AVX512VL__)) || defined(__AVX2__)
 #include <immintrin.h>
 #endif
@@ -587,6 +597,65 @@ static inline void accum_q4_k_packed_meta_x16_q8_k_block_mreuse(float acc[8][16]
             }
         }
     }
+}
+
+static inline void accum_q4_k_packed_meta_x16_q8_k_block_mreuse_chunk4(float acc[8][16],
+                                                                        const block_q4_K_packed_meta_x16 *w,
+                                                                        int active,
+                                                                        const block_q8_K *A,
+                                                                        int blocks_per_vec,
+                                                                        int block_index,
+                                                                        int m0,
+                                                                        int m_count)
+{
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+    for (int j = 0, is = 0, q_offset = 0; j < QK_K; j += 64, is += 2, q_offset += 32) {
+        for (int lane0 = 0; lane0 < active; lane0 += 4) {
+            const int lanes = (lane0 + 4 <= active) ? 4 : (active - lane0);
+            __m256i q4_lo[4];
+            __m256i q4_hi[4];
+            float wd[4], wdmin[4], sc_lo[4], sc_hi[4], min_lo[4], min_hi[4];
+
+            for (int l = 0; l < lanes; ++l) {
+                const int lane = lane0 + l;
+                const uint8_t *qs = &w->qs[lane][q_offset];
+                const __m256i packed = _mm256_loadu_si256((const __m256i *)qs);
+                q4_lo[l] = q4_k_unpack_32_vnni_bytes(packed, 0);
+                q4_hi[l] = q4_k_unpack_32_vnni_bytes(packed, 1);
+                wd[l] = CK_FP16_TO_FP32(w->d[lane]);
+                wdmin[l] = CK_FP16_TO_FP32(w->dmin[lane]);
+                sc_lo[l] = (float)w->sc[lane][is];
+                sc_hi[l] = (float)w->sc[lane][is + 1];
+                min_lo[l] = (float)w->m[lane][is];
+                min_hi[l] = (float)w->m[lane][is + 1];
+            }
+
+            for (int mt = 0; mt < m_count; ++mt) {
+                const block_q8_K *x = A + (size_t)(m0 + mt) * (size_t)blocks_per_vec + (size_t)block_index;
+                const int32_t bsum_lo = (int32_t)x->bsums[j / 16] +
+                                        (int32_t)x->bsums[j / 16 + 1];
+                const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
+                                        (int32_t)x->bsums[(j + 32) / 16 + 1];
+                const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)&x->qs[j]);
+                const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)&x->qs[j + 32]);
+                const float xd = x->d;
+                for (int l = 0; l < lanes; ++l) {
+                    const int lane = lane0 + l;
+                    const int32_t sum_lo = dot_q4_k_q8_k_32_vnni_q4v_q8v(q4_lo[l], q8_lo);
+                    const int32_t sum_hi = dot_q4_k_q8_k_32_vnni_q4v_q8v(q4_hi[l], q8_hi);
+                    const float d = wd[l] * xd;
+                    const float dmin = wdmin[l] * xd;
+                    acc[mt][lane] += d * sc_lo[l] * (float)sum_lo;
+                    acc[mt][lane] -= dmin * min_lo[l] * (float)bsum_lo;
+                    acc[mt][lane] += d * sc_hi[l] * (float)sum_hi;
+                    acc[mt][lane] -= dmin * min_hi[l] * (float)bsum_hi;
+                }
+            }
+        }
+    }
+#else
+    accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc, w, active, A, blocks_per_vec, block_index, m0, m_count);
+#endif
 }
 
 static inline void accum_q4_k_packed_meta_x16_q8_k_block(float acc[16],
@@ -1353,10 +1422,17 @@ static void gemm_q4_gateup_swiglu_x16_thread_fn(int ith, int nth, void *args)
                 a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
             const block_q4_K_packed_meta_x16 *w_up =
                 a->W + (size_t)(a->groups_d + g) * (size_t)a->blocks_per_row + (size_t)b;
-            accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc_gate, w_gate, active, a->A,
-                                                          a->blocks_per_vec, b, m0, m_count);
-            accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc_up, w_up, active, a->A,
-                                                          a->blocks_per_vec, b, m0, m_count);
+            if (ck_q4k_x16_chunk4_enabled()) {
+                accum_q4_k_packed_meta_x16_q8_k_block_mreuse_chunk4(acc_gate, w_gate, active, a->A,
+                                                                     a->blocks_per_vec, b, m0, m_count);
+                accum_q4_k_packed_meta_x16_q8_k_block_mreuse_chunk4(acc_up, w_up, active, a->A,
+                                                                     a->blocks_per_vec, b, m0, m_count);
+            } else {
+                accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc_gate, w_gate, active, a->A,
+                                                              a->blocks_per_vec, b, m0, m_count);
+                accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc_up, w_up, active, a->A,
+                                                              a->blocks_per_vec, b, m0, m_count);
+            }
         }
 
         for (int m = m0; m < m1; ++m) {


### PR DESCRIPTION
## Why

Close more of the Qwen3-VL OCR prefill/encoder performance gap with correctness-preserving opt-in kernels while keeping default AVX2 behavior unchanged.

## What Changed

- Added opt-in Q4_K gate/up x16 chunk4 activation reuse via CK_Q4K_X16_CHUNK4=1.
- Added opt-in AVX512 full-attention qblock4 reuse for the Qwen3-VL head_dim=72 visual attention shape via CK_ATTENTION_QBLOCK4=1.
- Wired CK_Q4K_X16_CHUNK4 and CK_ATTENTION_QBLOCK4 through benchmarks/qwen3vl_ocr_perf_pipeline.py and the Makefile OCR perf pipeline.
- Added bench-q4k-gateup-swiglu-x16-chunk4-quick and a nightly benchmark row that parses speedup_x16.
- Updated Qwen3-VL speed research notes and the vision performance hardening runbook.

## Measured Result

On the Xeon/OpenShift 1024 visual-token OCR contract, preserving expected output:

CK OCR TEST
TOTAL 42

Speed chain documented in docs/notes:

- ~77.2s after prior M4N4/gate-up work
- ~74.1s with Q4 chunk4 reuse
- ~69.4s with attention qblock4

## Validation

- git diff --check
- .venv/bin/python -m py_compile benchmarks/qwen3vl_ocr_perf_pipeline.py scripts/nightly_runner.py
- make build/libckernel_engine.so
- make build/bench_q4k_gateup_swiglu
- CK_Q4K_X16_CHUNK4=1 CK_NUM_THREADS=4 make bench-q4k-gateup-swiglu-x16-chunk4-quick
- pre-commit: v7-kernel-map-contracts, v7-regression-fast, v8-regression-fast
- pre-push: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, v7/v8 fast regression, v7 training-kernel parity

## Nightly / Coverage

- Q4 chunk4 has a quick nightly benchmark lane.
- qblock4 remains validated by the high-memory OCR pipeline until a dedicated standalone attention microbench exists. The current standalone unittest/test_attention_full.py flash tests fail their strict tolerance on this AVX2 host even without qblock4 enabled, so promoting that as a qblock4 nightly gate would add noise.

## Blog-Agent Summary

Read:

- docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
- docs/notes/VISION_PERF_HARDENING_PIPELINE.md

Story: fixed OCR contract, profile, reject incorrect faster quantization, add Q8 M4N4, Q4 x16 hsum, Q4 chunk4 reuse, and AVX512 qblock4 attention. Next bottleneck is decoder Q4_K gate/up prefill.