### PR TITLE
perf(v8): add Qwen3-VL OCR speed profile

### DIFF
--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -268,6 +268,72 @@ node, saving about 4.7 s on the clean OCR workload. The next measured bottleneck
 moves back to decoder mixed prefill, especially `mlp_gate_up_swiglu` through
 `gemm_nt_q4_k_q8_k_gateup_swiglu_x16` at about 12.2 s in the latest profile.
 
+## 2026-07-04 Speed Profile Flag Collapse
+
+The tuned Xeon/OpenShift OCR stack can now be enabled with one high-level speed
+profile instead of listing every low-level kernel flag:
+
+```bash
+CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512
+```
+
+Equivalent short alias:
+
+```bash
+CK_QWEN3VL_OCR_FAST=1
+```
+
+`CK_PROFILE` is intentionally not used here because it already means
+profiling/timing instrumentation in CK scripts and Make targets. Speed policy is
+kept separate as `CK_SPEED_PROFILE`, so OCR tuning can coexist with `CK_PROFILE=1`
+or `--profile` runs.
+
+The speed profile defaults these settings when they are not explicitly set:
+
+| Setting | Profile default |
+|---|---|
+| `CK_ENABLE_Q80_FP32_M4N4` | `1` |
+| `CK_ENABLE_Q4K_GATEUP_SWIGLU_X16` | `1` |
+| `CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP` | `20` |
+| `CK_Q4K_X16_CHUNK4` | `1` |
+| `CK_ATTENTION_QBLOCK4` | `1` |
+| `CK_NUM_THREADS` | `20` in `ck_run_v8.py` if unset |
+| `OMP_NUM_THREADS` | `1` in `ck_run_v8.py` if unset |
+
+Explicit low-level env values still override the profile, so individual kernels
+can be disabled for A/B testing, for example `CK_ATTENTION_QBLOCK4=0`.
+
+Validation on this Xeon node after rebasing onto `accec0fa`:
+
+| Check | Result |
+|---|---|
+| Native AVX512 build | passed |
+| AVX2-only build with `AVX_FLAGS='-mavx2 -mfma'` | passed; AVX512 qblock4 compiles out |
+| Q4 gate/up profile-only microbench | rel diff ~1.0e-6, cosine 1.0 |
+| Attention profile-only microbench | max diff 0, cosine 1.0 |
+| Rebased `CK_SPEED_PROFILE` clean OCR E2E | `CK OCR TEST\nTOTAL 42`; encoder 33865.4 ms, mixed 33591.0 ms, gen 1461.5 ms |
+
+Clean OCR E2E default-vs-profile check, same image/prompt/settings and both
+`--force-compile`:
+
+| Stage | Default ms | Speed profile ms | Speedup | Delta ms |
+|---|---:|---:|---:|---:|
+| Encoder execute | 60300.1 | 34328.0 | 1.76x | 25972.1 |
+| Mixed prefill | 48907.7 | 33295.4 | 1.47x | 15612.3 |
+| Generation | 1395.6 | 1331.8 | 1.05x | 63.8 |
+| Steady total | 110603.4 | 68955.3 | 1.60x | 41648.2 |
+
+Correctness output for both runs:
+
+```text
+CK OCR TEST
+TOTAL 42
+```
+
+This is still a profile, not a universal default. Promote it to automatic behavior
+only after CPU-family sweeps confirm that the same choices are neutral or
+positive on AVX2-only laptops, Ryzen/EPYC, and other Xeon cache/core ratios.
+
 ## Retest Matrix for Other CPUs
 
 Run this matrix on Ryzen, AVX2-only i7, and any larger-cache Xeon/EPYC host:

--- a/include/ck_speed_profiles.h
+++ b/include/ck_speed_profiles.h
@@ -1,0 +1,34 @@
+#ifndef CK_SPEED_PROFILES_H
+#define CK_SPEED_PROFILES_H
+
+#include <stdlib.h>
+#include <string.h>
+
+static inline int ck_env_value_truthy(const char *v)
+{
+    return (v && v[0] && v[0] != '0') ? 1 : 0;
+}
+
+static inline int ck_speed_profile_qwen3vl_ocr_fast(void)
+{
+    const char *alias = getenv("CK_QWEN3VL_OCR_FAST");
+    if (ck_env_value_truthy(alias)) return 1;
+
+    /* CK_PROFILE is already used for timing/profiling instrumentation.
+     * Keep speed policy separate so OCR tuning can coexist with CK_PROFILE=1.
+     */
+    const char *profile = getenv("CK_SPEED_PROFILE");
+    if (!profile || !profile[0]) return 0;
+    return strcmp(profile, "qwen3vl_ocr_xeon_avx512") == 0 ||
+           strcmp(profile, "qwen3vl_ocr_fast") == 0 ||
+           strcmp(profile, "qwen3vl_ocr") == 0;
+}
+
+static inline int ck_env_truthy_or_qwen3vl_ocr_profile(const char *name)
+{
+    const char *env = getenv(name);
+    if (env) return ck_env_value_truthy(env);
+    return ck_speed_profile_qwen3vl_ocr_fast();
+}
+
+#endif /* CK_SPEED_PROFILES_H */

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -33,6 +33,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "ck_speed_profiles.h"
 #include <string.h>
 
 #if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSE2__)
@@ -2895,17 +2896,16 @@ static inline void ck_attention_flash_query_auto(const float *q_vec,
 }
 
 
+#if defined(__AVX512F__)
 static int ck_attention_qblock4_enabled(void)
 {
     static int cached = -1;
     if (cached < 0) {
-        const char *env = getenv("CK_ATTENTION_QBLOCK4");
-        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+        cached = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ATTENTION_QBLOCK4");
     }
     return cached;
 }
 
-#if defined(__AVX512F__)
 static inline float ck_attention_dot72_avx512(const float *q_vec, const float *k_vec)
 {
     __m512 acc = _mm512_setzero_ps();

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -33,13 +33,13 @@
 #include "ckernel_engine.h"
 #include "ck_threadpool.h"
 #include "ckernel_quant.h"
+#include "ck_speed_profiles.h"
 
 static int ck_q4k_x16_chunk4_enabled(void)
 {
     static int cached = -1;
     if (cached < 0) {
-        const char *env = getenv("CK_Q4K_X16_CHUNK4");
-        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+        cached = ck_env_truthy_or_qwen3vl_ocr_profile("CK_Q4K_X16_CHUNK4");
     }
     return cached;
 }

--- a/src/kernels/gemm_kernels_q8_0.c
+++ b/src/kernels/gemm_kernels_q8_0.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include "ckernel_quant.h"
 #include "ck_features.h"
+#include "ck_speed_profiles.h"
 
 /* Include SIMD headers based on available extensions */
 #if defined(__AVX512F__) || defined(__AVX2__) || defined(__AVX__) || defined(__SSE4_1__)
@@ -66,8 +67,7 @@ static int ck_q8_0_fp32_m4n4_enabled(void)
 {
     static int cached = -1;
     if (cached < 0) {
-        const char *env = getenv("CK_ENABLE_Q80_FP32_M4N4");
-        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+        cached = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_Q80_FP32_M4N4");
     }
     return cached;
 }

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1017,6 +1017,28 @@ def step_sweep_kernels(work_dir: Path, ir_paths: dict[str, Path], *, quick: bool
     return report_path
 
 
+
+def _qwen3vl_ocr_fast_profile_enabled(env: dict[str, str] | None = None) -> bool:
+    env = env or os.environ
+    alias = env.get("CK_QWEN3VL_OCR_FAST", "")
+    if alias and alias != "0":
+        return True
+    profile = env.get("CK_SPEED_PROFILE", "")
+    return profile in {"qwen3vl_ocr_xeon_avx512", "qwen3vl_ocr_fast", "qwen3vl_ocr"}
+
+
+def _apply_qwen3vl_ocr_fast_defaults(env: dict[str, str]) -> None:
+    if not _qwen3vl_ocr_fast_profile_enabled(env):
+        return
+    env.setdefault("CK_ENABLE_Q80_FP32_M4N4", "1")
+    env.setdefault("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16", "1")
+    env.setdefault("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", "20")
+    env.setdefault("CK_Q4K_X16_CHUNK4", "1")
+    env.setdefault("CK_ATTENTION_QBLOCK4", "1")
+    env.setdefault("CK_NUM_THREADS", "20")
+    env.setdefault("OMP_NUM_THREADS", "1")
+    env.setdefault("OMP_DYNAMIC", "FALSE")
+
 def step_run_chat(work_dir: Path, args: argparse.Namespace, *, gguf_path: Path | None) -> None:
     log_step(6, "Starting chat")
     kernel_lib = BUILD_DIR / "libckernel_engine.so"
@@ -1029,6 +1051,7 @@ def step_run_chat(work_dir: Path, args: argparse.Namespace, *, gguf_path: Path |
     if env.get("LD_LIBRARY_PATH"):
         ld_items.append(env["LD_LIBRARY_PATH"])
     env["LD_LIBRARY_PATH"] = ":".join(ld_items)
+    _apply_qwen3vl_ocr_fast_defaults(env)
     env.setdefault("CK_NUM_THREADS", str(_detect_default_ck_threads()))
     env.setdefault("OMP_NUM_THREADS", "1")
     env.setdefault("OMP_DYNAMIC", "FALSE")

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -3048,6 +3048,7 @@ def generate(
 #include "ckernel_alloc.h"
 #include "ckernel_model_load_v8.h"
 #include "ckernel_engine.h"  /* Kernel declarations */
+#include "ck_speed_profiles.h"
 {tokenizer_include}
 
 /* Parity dump instrumentation for llama.cpp comparison */

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -1053,8 +1053,7 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
-    const char *q4k_gateup_swiglu_x16_env = getenv("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
-    int ck_enable_q4k_gateup_swiglu_x16 = q4k_gateup_swiglu_x16_env ? (atoi(q4k_gateup_swiglu_x16_env) != 0) : 0;
+    int ck_enable_q4k_gateup_swiglu_x16 = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
 
     /* Copy input tokens to activation buffer (follow same pattern as decode) */
     memcpy((void*)(model->bump + A_TOKEN_IDS), tokens, (size_t)num_tokens * sizeof(int32_t));
@@ -1618,8 +1617,7 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
-    const char *q4k_gateup_swiglu_x16_env = getenv("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
-    int ck_enable_q4k_gateup_swiglu_x16 = q4k_gateup_swiglu_x16_env ? (atoi(q4k_gateup_swiglu_x16_env) != 0) : 0;
+    int ck_enable_q4k_gateup_swiglu_x16 = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
     const float *ck_debug_mlp_gate_up_fp32_input = NULL;
 """
     prologue = prologue.replace(

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -37,6 +37,7 @@
 #include "ck_parallel_prefill_v8.h"
 #include "ck_threadpool.h"
 #include "ckernel_quant.h"
+#include "ck_speed_profiles.h"
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
## Why

Add a high-level Qwen3-VL OCR speed profile on top of the existing chunk4/qblock4 kernel work. This avoids forcing users and agents to remember a pile of low-level flags, while keeping CK_PROFILE reserved for profiling instrumentation.

## Important Naming

Use:

```bash
CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512
```

Short alias:

```bash
CK_QWEN3VL_OCR_FAST=1
```

Do not use CK_PROFILE for speed policy; CK_PROFILE already means profiling/timing instrumentation in this repo.

## What Changed

- Added `include/ck_speed_profiles.h`.
- Q8 M4N4, Q4 x16 chunk4, attention qblock4, generated prefill, and `ck_run_v8.py` now respect the speed profile.
- Low-level env vars still override the profile for A/B testing, e.g. `CK_ATTENTION_QBLOCK4=0`.
- Updated the Qwen3-VL OCR speed research note with commands, rationale, AVX2 compile-out validation, and Xeon E2E evidence.

## Validation Run Here

- `git diff --check`
- `.venv/bin/python -m py_compile version/v8/scripts/ck_run_v8.py version/v8/scripts/codegen_core_v8.py version/v8/scripts/codegen_prefill_v8.py`
- `make --no-print-directory build/libckernel_engine.so`
- `make --no-print-directory CC=gcc BUILD_DIR=build_avx2_profile_check AVX_FLAGS='-mavx2 -mfma' build_avx2_profile_check/libckernel_engine.so`
- `CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512 CK_NUM_THREADS=4 LD_LIBRARY_PATH=build:/opt/intel/oneapi/tcm/1.4/lib:/opt/intel/oneapi/umf/1.0/lib:/opt/intel/oneapi/tbb/2022.3/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mpi/2021.17/opt/mpi/libfabric/lib:/opt/intel/oneapi/mpi/2021.17/lib:/opt/intel/oneapi/mkl/2025.3/lib:/opt/intel/oneapi/ishmem/1.5/lib:/opt/intel/oneapi/ippcp/2025.3/lib/:/opt/intel/oneapi/ipp/2022.3/lib:/opt/intel/oneapi/dnnl/2025.3/lib:/opt/intel/oneapi/debugger/2025.3/opt/debugger/lib:/opt/intel/oneapi/dal/2025.10/lib:/opt/intel/oneapi/compiler/2025.3/opt/compiler/lib:/opt/intel/oneapi/compiler/2025.3/lib:/opt/intel/oneapi/ccl/2021.17/lib/:/usr/local/lib:/home/antshiv/Programs/lib::/home/antshiv/Programs/lib build/bench_q4k_gateup_swiglu --M 16 --D 512 --K 1024 --tile-m 8 --warmup 1 --iters 2 --mode x16`
- Pre-commit: v7-kernel-map-contracts, v7-regression-fast, v8-regression-fast
- Pre-push: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, v7/v8 fast regression, v7 training-kernel parity

## Expected AVX2 Agent Result

- AVX2-only build should pass.
- AVX512 qblock4 should compile out on AVX2.
- Default behavior should not change unless `CK_SPEED_PROFILE` or `CK_QWEN3VL_OCR_FAST` is set.
- Low-level env vars still override the profile.

## Xeon Evidence

On Xeon/OpenShift, clean Qwen3-VL OCR with `CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512` produced:

- Output: `CK OCR TEST\nTOTAL 42`
- Encoder: 33.9s
- Mixed prefill: 33.6s
- Generation: 1.46s

Earlier clean default-vs-profile run showed:

- Default steady: 110.6s
- Profile steady: 69.0s
- Speedup: 1.60x
- Same OCR output

## Blog-Agent Summary

Read `docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md`. Story: we moved from many fragile per-kernel env flags to one auditable speed profile, preserved deterministic low-level overrides, and avoided the CK_PROFILE naming collision.