### PR TITLE
perf(v8): add Qwen3-VL OCR speed profile stack

### DIFF
--- a/benchmarks/bench_v8_qwen3vl_ocr.py
+++ b/benchmarks/bench_v8_qwen3vl_ocr.py
@@ -83,6 +83,7 @@ def _apply_qwen3vl_ocr_fast_defaults(env: dict[str, str]) -> None:
     env.setdefault("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", "20")
     env.setdefault("CK_Q4K_X16_CHUNK4", "1")
     env.setdefault("CK_ATTENTION_QBLOCK4", "1")
+    env.setdefault("CK_ATTENTION_THREAD_CAP", "16")
     env.setdefault("CK_Q4K_PACKED_META_X8_MAX_M", "2048")
     env.setdefault("CK_NUM_THREADS", "20")
     env.setdefault("OMP_NUM_THREADS", "1")
@@ -163,6 +164,8 @@ def _run_one(
     report = json.loads(report_path.read_text(encoding="utf-8"))
     timings = report.get("timings") if isinstance(report.get("timings"), dict) else {}
     decoder_profile = report.get("decoder_profile") if isinstance(report.get("decoder_profile"), dict) else {}
+    encoder_report = report.get("encoder_report") if isinstance(report.get("encoder_report"), dict) else {}
+    encoder_profile = encoder_report.get("profile") if isinstance(encoder_report.get("profile"), dict) else {}
     encoder_execute_ms = _num(timings, "encoder_execute_ms")
     decoder_forward_ms = _num(timings, "decoder_forward_mixed_ms")
     decoder_generation_ms = _num(timings, "decoder_generation_ms")
@@ -185,6 +188,7 @@ def _run_one(
             "decoder_generation_tok_s": _num(timings, "decoder_generation_tok_s"),
             "steady_generated_tok_s": (generated_tokens / (steady_state_ms / 1000.0)) if steady_state_ms > 0 and generated_tokens > 0 else 0.0,
             "decoder_profile": decoder_profile,
+            "encoder_profile": encoder_profile,
         }
     )
     return row

--- a/benchmarks/qwen3vl_ocr_perf_pipeline.py
+++ b/benchmarks/qwen3vl_ocr_perf_pipeline.py
@@ -41,6 +41,7 @@ def _apply_qwen3vl_ocr_fast_defaults(env: dict[str, str]) -> None:
     env.setdefault("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", "20")
     env.setdefault("CK_Q4K_X16_CHUNK4", "1")
     env.setdefault("CK_ATTENTION_QBLOCK4", "1")
+    env.setdefault("CK_ATTENTION_THREAD_CAP", "16")
     env.setdefault("CK_Q4K_PACKED_META_X8_MAX_M", "2048")
     env.setdefault("CK_NUM_THREADS", "20")
     env.setdefault("OMP_NUM_THREADS", "1")

--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -425,3 +425,26 @@ set in the benchmark command after applying profile defaults consistently:
 
 Final mixed-prefill delta: about -2.31 s on this generated OCR check. The main
 wins were Q4 `mlp_down` (-1.02 s), `out_proj` (-0.91 s), and `q_proj` (-0.72 s).
+
+## 2026-07-04 Attention Thread-Cap Sweep
+
+After exposing the nested encoder profile in the OCR benchmark JSON, the fresh
+Qwen3-VL OCR profile showed encoder full attention as the largest single
+remaining encoder op. The speed profile already enables the AVX512 qblock4 path
+with `CK_ATTENTION_QBLOCK4=1`, so the next low-risk A/B was active-thread
+capping for attention only.
+
+Generated clean OCR image, `CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512`, 20 CK
+threads, 1024 image tokens:
+
+| Attention Cap | Encoder | Mixed Prefill | Encoder Attention | Decoder Attention | Output |
+|---:|---:|---:|---:|---:|---|
+| default/profile | 37992.6 ms | 31277.2 ms | 12748.6 ms | 1732.3 ms | `CK OCR TEST\nTOTAL 42` |
+| 16 | 37900.0 ms | 30919.4 ms | 12516.7 ms | 2185.8 ms | `CK OCR TEST\nTOTAL 42` |
+| 12 | 39307.2 ms | 31345.7 ms | 13496.2 ms | 2605.7 ms | `CK OCR TEST\nTOTAL 42` |
+
+Cap 16 is the best measured point in this small sweep. It is now part of the
+Qwen3-VL OCR speed profile defaults as `CK_ATTENTION_THREAD_CAP=16`, while
+normal runs and explicit user env settings remain unchanged. This is a modest
+contention/cache tuning win, not a replacement for a better encoder attention
+microkernel.

--- a/docs/site/_pages/cke-throughput-unit.html
+++ b/docs/site/_pages/cke-throughput-unit.html
@@ -40,6 +40,37 @@
     <li>quantized layout conversion, repacking, and dequantization overhead</li>
 </ul>
 
+<h2>Not Just Weights</h2>
+
+<p>
+    A common shortcut is to say, "a 1 TB model at 1 ms/token needs 1 PB/s."
+    That is a useful intuition, but it is not the full CKU definition.
+    CKU is not only parameter bytes divided by token time.
+    It is the <strong>active byte path</strong> divided by token time.
+    The active byte path includes both the model data being read and the runtime
+    data being produced, consumed, stored, and moved while the token is generated.
+</p>
+
+<p>
+    In decode, weights are often the streaming bottleneck because many layers
+    repeatedly read projection and MLP weights for each new token.
+    In prefill, long prompts can make activation and KV/cache writes matter much
+    more because the system processes many token rows at once.
+    In training, activation saves, gradient writes, optimizer state, and backward
+    reads all become part of the active path.
+    In distributed execution, activation transfers, KV/state movement, gradient
+    exchange, and pipeline bubbles must be counted too.
+</p>
+
+<p>
+    This distinction matters because two runs with the same stored model size can
+    have very different CKU. A dense 1 GB model may touch nearly all weights on
+    every decode token. A sparse MoE model may store far more total weights but
+    only touch selected experts. A vision-language prefill run may move less
+    weight than expected but spend heavily on image-token activations and bridge
+    buffers. CKU asks what the system actually had to cycle for this token path.
+</p>
+
 <h2>Why 1 PB/s?</h2>
 
 <p>
@@ -108,6 +139,43 @@
     CKE cares about the measured active path: which weights are actually read, which activations are produced, which cache/state buffers are updated, and which bytes cross sockets or nodes.
 </p>
 
+<table>
+    <thead>
+        <tr>
+            <th>Byte class</th>
+            <th>Examples</th>
+            <th>When it dominates</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Weights</td>
+            <td>Q/K/V projections, MLP gate/up/down, expert weights, output head</td>
+            <td>Decode and small-batch inference, especially dense models</td>
+        </tr>
+        <tr>
+            <td>Activations</td>
+            <td>Layer inputs/outputs, normalized streams, Q8 views, fused scratch</td>
+            <td>Prefill, vision/audio encoders, large token blocks, unfused paths</td>
+        </tr>
+        <tr>
+            <td>Cache and state</td>
+            <td>KV cache reads/writes, recurrent state, Mamba/DeltaNet state</td>
+            <td>Long context, recurrent models, decode with large history</td>
+        </tr>
+        <tr>
+            <td>Training state</td>
+            <td>Saved activations, gradients, optimizer moments, checkpoints</td>
+            <td>Backward pass, fine-tuning, long-context training</td>
+        </tr>
+        <tr>
+            <td>Communication</td>
+            <td>Pipeline activations, tensor-parallel shards, MPI/RDMA transfers</td>
+            <td>Multi-node inference/training and CPU clusters</td>
+        </tr>
+    </tbody>
+</table>
+
 <h2>What CKE Optimizes</h2>
 
 <p>
@@ -131,14 +199,25 @@
     The same run should also show CPU utilization, memory bandwidth, cache behavior, and network transfer if the run spans nodes.
 </p>
 
-<pre><code>active_bytes_per_token = weights_touched
-                       + activations_touched
-                       + cache_or_state_touched
-                       + communication_touched
+<pre><code>active_bytes_per_token = weights_read_or_reused
+                       + activations_read_written
+                       + cache_or_state_read_written
+                       + scratch_and_layout_traffic
+                       + communication_read_written
 
 seconds_per_token      = measured_wall_time / generated_tokens
 
 CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
+
+<p>
+    A stricter report can also split <em>logical active bytes</em> from
+    <em>physical traffic</em>.
+    Logical active bytes describe the model/runtime tensors that participate in
+    the token path. Physical traffic includes cache-line rereads, layout
+    conversion, write-allocate behavior, NUMA hops, and network retransfers.
+    CKE tracks the logical path first, then uses perf, VTune, Advisor, and
+    benchmark counters to find where physical traffic is higher than it should be.
+</p>
 
 <p>
     This is the reason CKE keeps investing in visualizers, memory layouts, kernel maps, perf counters, VTune/Advisor profiles, and future MPI lanes.

--- a/docs/site/_pages/cke-throughput-unit.html
+++ b/docs/site/_pages/cke-throughput-unit.html
@@ -139,6 +139,42 @@
     CKE cares about the measured active path: which weights are actually read, which activations are produced, which cache/state buffers are updated, and which bytes cross sockets or nodes.
 </p>
 
+<h2>Lifecycle Envelope and Concurrency</h2>
+
+<p>
+    CKU is first a <strong>single-stream lifecycle unit</strong>.
+    It asks what the runtime must cycle for one model instance serving one token
+    path at the model's intended operating envelope.
+    If a model advertises a 1 million token context length with an 8K embedding
+    dimension, the lifecycle envelope should include the memory behavior needed
+    to support that context: the active weights, the full KV/cache or recurrent
+    state footprint, the activations needed by prefill/decode, and the load/store
+    traffic required to keep the token path moving.
+</p>
+
+<p>
+    That does not mean every CKU number automatically includes every concurrent
+    user. Concurrency is a separate service-level multiplier.
+    A single-user CKU report answers, "Can this system run one full-context model
+    stream at this token rate?"
+    A service report then asks, "How many such streams can the cluster run at the
+    same time, and what token rate does each user receive?"
+</p>
+
+<pre><code>single_user_cku = active_lifecycle_bytes_per_token / seconds_per_token
+
+service_cku     = single_user_cku * concurrent_streams
+
+per_user_rate   = total_generated_tokens_per_second / concurrent_streams</code></pre>
+
+<p>
+    For example, a cluster might target 1 token/sec for 1000 concurrent users on
+    a very large model. That is a different operating point from 1000 tokens/sec
+    for one user, even if both produce 1000 aggregate tokens/sec.
+    CKU should make both cases explicit: the active lifecycle bytes per user, the
+    concurrency count, the total aggregate byte rate, and the per-user token rate.
+</p>
+
 <table>
     <thead>
         <tr>

--- a/docs/site/_pages/cke-throughput-unit.html
+++ b/docs/site/_pages/cke-throughput-unit.html
@@ -212,6 +212,77 @@ per_user_rate   = total_generated_tokens_per_second / concurrent_streams</code><
     </tbody>
 </table>
 
+<h2>Node Roofline Math</h2>
+
+<p>
+    CKU is not only a memory-bandwidth number and it is not only a FLOPS number.
+    A CPU node can only contribute the useful part of the slowest roof: memory
+    bandwidth, compute throughput, or network movement when the run is
+    distributed. This is why CKU belongs next to roofline analysis.
+</p>
+
+<pre><code>required_service_cku =
+    active_lifecycle_bytes_per_token
+  * tokens_per_second_per_user
+  * concurrent_streams
+
+node_memory_roof =
+    sockets
+  * memory_channels_per_socket
+  * transfer_rate_MTps
+  * 8 bytes_per_channel_transfer
+
+node_compute_roof_bytes =
+    useful_flops_per_second / arithmetic_intensity_flops_per_byte
+
+effective_node_cku =
+    min(node_memory_roof, node_compute_roof_bytes, node_network_roof)
+  * runtime_efficiency
+
+nodes_needed =
+    required_service_cku / effective_node_cku</code></pre>
+
+<p>
+    For DDR memory, a practical first-pass estimate is:
+    <code>channel_GBps = MT/s * 8 bytes / 1000</code>.
+    DDR5-6600 is about 52.8 GB/s per channel.
+    A 12-channel socket is therefore about 633.6 GB/s theoretical, and a
+    dual-socket system is about 1.27 TB/s theoretical before NUMA effects,
+    memory-controller efficiency, page placement, and OS noise.
+    At 8800 MT/s, the same 12-channel socket is about 844.8 GB/s, or about
+    1.69 TB/s for two sockets.
+</p>
+
+<p>
+    Compute has its own roof. For an AVX-512 FP32 FMA path, a rough dense-core
+    estimate is:
+    <code>cores * GHz * FMA_units_per_core * lanes_per_vector * 2 FLOPs_per_FMA</code>.
+    That estimate changes for BF16, INT8, AMX tile paths, VNNI, SVE, or Neon.
+    Quantized Q4/Q6 kernels are often limited by unpacking, metadata,
+    reductions, cache reuse, and memory traffic, so AMX is not automatically the
+    answer. In many CKE paths, AVX-512/VNNI-style layout work is the more direct
+    lever.
+</p>
+
+<p>
+    This also keeps the 1 PB/s north star honest. If a dual-socket CPU node can
+    deliver 1.2 TB/s of useful lifecycle movement, then 1 PB/s requires roughly
+    833 such nodes in the perfect case. At 60-70% useful efficiency, the number
+    is closer to 1200-1400 nodes. If quantization, MoE routing, locality, and
+    cache reuse reduce the active path to 100 GB/token at 100 tokens/sec, the
+    requirement becomes 10 TB/s, which is a very different cluster shape.
+</p>
+
+<p>
+    The CPU thesis is not that one socket beats an H100 at dense tensor math.
+    The thesis is that commodity capacity, many memory channels, many physical
+    cores, SIMD/matrix units, Linux tuning, MPI/RDMA placement, and generated C
+    scheduling can combine into a measurable aggregate byte machine. GPUs can
+    also reach enormous aggregate bandwidth, but a 1 TB resident model may need
+    many expensive HBM devices just for capacity before it even starts serving
+    traffic.
+</p>
+
 <h2>What CKE Optimizes</h2>
 
 <p>

--- a/docs/site/_pages/spec-training-results.html
+++ b/docs/site/_pages/spec-training-results.html
@@ -156,7 +156,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-30 15:55 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-04 23:32 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-06-30 08:55</span>
+        <span class="folder-updated">Updated: 2026-07-04 16:32</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -12973,7 +12973,7 @@ rmsnorm_backward(d_norm_out, input, gamma, rstd_cache, d_input, d_gamma, tokens,
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture-links.html
+++ b/docs/site/architecture-links.html
@@ -1460,7 +1460,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -1220,7 +1220,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-06-30 08:55</span>
+        <span class="folder-updated">Updated: 2026-07-04 16:32</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1590,7 +1590,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/assets/cke-throughput-unit.svg
+++ b/docs/site/assets/cke-throughput-unit.svg
@@ -1,70 +1,179 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
-  <title id="title">CKE Throughput Unit</title>
-  <desc id="desc">A diagram showing how active bytes per token divided by token latency becomes aggregate bytes cycled per second across CPU nodes.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="860" viewBox="0 0 1400 860" role="img" aria-labelledby="title desc">
+  <title id="title">CKU active-byte lifecycle across CPU nodes</title>
+  <desc id="desc">A diagram explaining CKE Throughput Unit as active lifecycle bytes per token divided by token time, with weights, activations, KV cache, CPU cores, memory channels, MPI or RDMA fabric, and service concurrency.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#252525"/>
-      <stop offset="1" stop-color="#171717"/>
+      <stop offset="0" stop-color="#262626"/>
+      <stop offset="0.55" stop-color="#1d1d1d"/>
+      <stop offset="1" stop-color="#111"/>
     </linearGradient>
-    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#ffb400"/>
+    <linearGradient id="orange" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffcf4a"/>
       <stop offset="1" stop-color="#ff7a18"/>
     </linearGradient>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#000" flood-opacity="0.35"/>
+    <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#58c7ff"/>
+      <stop offset="1" stop-color="#087fc5"/>
+    </linearGradient>
+    <linearGradient id="green" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#62d88d"/>
+      <stop offset="1" stop-color="#2c9f63"/>
+    </linearGradient>
+    <linearGradient id="purple" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#c2a0ff"/>
+      <stop offset="1" stop-color="#7957d5"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="145%">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#000" flood-opacity="0.38"/>
     </filter>
+    <marker id="arrowOrange" markerWidth="14" markerHeight="14" refX="11" refY="7" orient="auto">
+      <path d="M1,1 L12,7 L1,13 Z" fill="#ffb400"/>
+    </marker>
+    <marker id="arrowBlue" markerWidth="14" markerHeight="14" refX="11" refY="7" orient="auto">
+      <path d="M1,1 L12,7 L1,13 Z" fill="#07adf8"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="14" markerHeight="14" refX="11" refY="7" orient="auto">
+      <path d="M1,1 L12,7 L1,13 Z" fill="#47b475"/>
+    </marker>
+    <style>
+      .title { font: 800 36px Inter, Arial, sans-serif; fill: #f5f5f5; }
+      .subtitle { font: 500 18px Inter, Arial, sans-serif; fill: #b8b8b8; }
+      .h { font: 800 18px Inter, Arial, sans-serif; fill: #f5f5f5; }
+      .h2 { font: 700 15px Inter, Arial, sans-serif; fill: #f5f5f5; }
+      .body { font: 500 14px Inter, Arial, sans-serif; fill: #cfcfcf; }
+      .muted { font: 500 12px Inter, Arial, sans-serif; fill: #8e8e8e; }
+      .mono { font: 700 18px JetBrains Mono, Consolas, monospace; fill: #f5f5f5; }
+      .monoSmall { font: 700 13px JetBrains Mono, Consolas, monospace; fill: #f5f5f5; }
+      .panel { fill: #292929; stroke: #505050; stroke-width: 1.2; }
+      .soft { fill: #202020; stroke: #3e3e3e; stroke-width: 1; }
+      .chip { fill: #171717; stroke: #555; stroke-width: 1; }
+    </style>
   </defs>
 
-  <rect width="1200" height="620" rx="18" fill="url(#bg)"/>
-  <rect x="26" y="26" width="1148" height="568" rx="14" fill="none" stroke="#454545"/>
+  <rect width="1400" height="860" rx="22" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1344" height="804" rx="18" fill="none" stroke="#484848"/>
 
-  <text x="60" y="78" fill="#f5f5f5" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700">CKE Throughput Unit</text>
-  <text x="60" y="112" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="18">How many bytes can the full system cycle per second to produce tokens?</text>
+  <text x="60" y="78" class="title">CKU: CKE Throughput Unit</text>
+  <text x="60" y="111" class="subtitle">Active lifecycle bytes per token, cycled through CPU memory, cores, and cluster fabric.</text>
 
-  <g filter="url(#shadow)">
-    <rect x="60" y="152" width="310" height="155" rx="10" fill="#303030" stroke="#555"/>
-    <text x="88" y="194" fill="#ffb400" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Active bytes per token</text>
-    <text x="88" y="232" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="30">1 TB</text>
-    <text x="88" y="266" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">Weights + activations + KV</text>
-    <text x="88" y="288" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">+ communication touched</text>
+  <g transform="translate(60 145)" filter="url(#shadow)">
+    <rect width="380" height="470" rx="14" class="panel"/>
+    <text x="28" y="42" fill="#ffb400" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">1. Active lifecycle bytes</text>
+    <text x="28" y="72" class="body">The token path is not only weights.</text>
+
+    <g transform="translate(28 105)">
+      <rect width="324" height="54" rx="8" fill="#332a13" stroke="#ffb400"/>
+      <text x="18" y="23" class="h2">Weights read / reused</text>
+      <text x="18" y="43" class="muted">Q/K/V, MLP, experts, output head</text>
+    </g>
+    <g transform="translate(28 172)">
+      <rect width="324" height="54" rx="8" fill="#132b37" stroke="#07adf8"/>
+      <text x="18" y="23" class="h2">Activations read / written</text>
+      <text x="18" y="43" class="muted">prefill blocks, Q8 views, bridge buffers</text>
+    </g>
+    <g transform="translate(28 239)">
+      <rect width="324" height="54" rx="8" fill="#15301e" stroke="#47b475"/>
+      <text x="18" y="23" class="h2">KV cache / recurrent state</text>
+      <text x="18" y="43" class="muted">full context, decode history, SSM state</text>
+    </g>
+    <g transform="translate(28 306)">
+      <rect width="324" height="54" rx="8" fill="#2a2140" stroke="#a78bfa"/>
+      <text x="18" y="23" class="h2">Scratch + layout traffic</text>
+      <text x="18" y="43" class="muted">packing, dequant, load/store, spills</text>
+    </g>
+    <g transform="translate(28 373)">
+      <rect width="324" height="54" rx="8" fill="#303030" stroke="#777"/>
+      <text x="18" y="23" class="h2">Communication</text>
+      <text x="18" y="43" class="muted">MPI/RDMA, pipeline activations, shards</text>
+    </g>
   </g>
 
-  <g filter="url(#shadow)">
-    <rect x="445" y="152" width="310" height="155" rx="10" fill="#303030" stroke="#555"/>
-    <text x="473" y="194" fill="#07adf8" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Token latency target</text>
-    <text x="473" y="232" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="30">1 ms</text>
-    <text x="473" y="266" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">End-to-end prefill/decode</text>
-    <text x="473" y="288" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">system time per token</text>
+  <path d="M462 380 C515 380 515 380 565 380" stroke="#ffb400" stroke-width="4" fill="none" marker-end="url(#arrowOrange)"/>
+
+  <g transform="translate(565 145)" filter="url(#shadow)">
+    <rect width="310" height="470" rx="14" class="panel"/>
+    <text x="26" y="42" fill="#07adf8" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">2. CKE compiler/runtime</text>
+    <text x="26" y="72" class="body">Plan the byte path before execution.</text>
+
+    <g transform="translate(30 112)">
+      <rect width="250" height="56" rx="8" class="soft"/>
+      <text x="18" y="24" class="h2">Template + IR lowering</text>
+      <text x="18" y="44" class="muted">model circuit → kernel map</text>
+    </g>
+    <g transform="translate(30 188)">
+      <rect width="250" height="56" rx="8" class="soft"/>
+      <text x="18" y="24" class="h2">Memory planner</text>
+      <text x="18" y="44" class="muted">offsets, lifetimes, KV/cache</text>
+    </g>
+    <g transform="translate(30 264)">
+      <rect width="250" height="56" rx="8" class="soft"/>
+      <text x="18" y="24" class="h2">Generated C kernels</text>
+      <text x="18" y="44" class="muted">SIMD/AMX/SVE-friendly loops</text>
+    </g>
+    <g transform="translate(30 340)">
+      <rect width="250" height="56" rx="8" class="soft"/>
+      <text x="18" y="24" class="h2">Runtime schedule</text>
+      <text x="18" y="44" class="muted">prefill, decode, pipeline ranks</text>
+    </g>
+
+    <text x="34" y="440" class="monoSmall">active_bytes / token_time</text>
   </g>
 
-  <g filter="url(#shadow)">
-    <rect x="830" y="152" width="310" height="155" rx="10" fill="#303030" stroke="#555"/>
-    <text x="858" y="194" fill="#47b475" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Aggregate data rate</text>
-    <text x="858" y="232" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="30">1 PB/s</text>
-    <text x="858" y="266" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">1000 TB/s aggregate</text>
-    <text x="858" y="288" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="15">across all compute nodes</text>
+  <path d="M897 380 C940 380 940 380 982 380" stroke="#07adf8" stroke-width="4" fill="none" marker-end="url(#arrowBlue)"/>
+
+  <g transform="translate(982 145)" filter="url(#shadow)">
+    <rect width="338" height="470" rx="14" class="panel"/>
+    <text x="26" y="42" fill="#47b475" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">3. CPU node fabric</text>
+    <text x="26" y="72" class="body">CKU rises by aggregating useful channels.</text>
+
+    <g transform="translate(28 105)">
+      <rect width="282" height="88" rx="10" fill="#1b261f" stroke="#47b475"/>
+      <rect x="16" y="18" width="56" height="52" rx="6" class="chip"/>
+      <text x="31" y="51" class="monoSmall">CPU</text>
+      <g fill="#47b475">
+        <rect x="94" y="20" width="20" height="20" rx="3"/>
+        <rect x="120" y="20" width="20" height="20" rx="3"/>
+        <rect x="146" y="20" width="20" height="20" rx="3"/>
+        <rect x="172" y="20" width="20" height="20" rx="3"/>
+        <rect x="94" y="48" width="20" height="20" rx="3"/>
+        <rect x="120" y="48" width="20" height="20" rx="3"/>
+        <rect x="146" y="48" width="20" height="20" rx="3"/>
+        <rect x="172" y="48" width="20" height="20" rx="3"/>
+      </g>
+      <text x="210" y="36" class="muted">cores</text>
+      <text x="210" y="56" class="muted">SIMD/AMX</text>
+    </g>
+
+    <g transform="translate(28 218)">
+      <rect width="282" height="68" rx="10" fill="#302914" stroke="#ffb400"/>
+      <text x="18" y="28" class="h2">DDR5/DDR6 memory channels</text>
+      <text x="18" y="50" class="muted">weights + activations + cache/state</text>
+    </g>
+
+    <g transform="translate(28 312)">
+      <rect width="282" height="68" rx="10" fill="#132736" stroke="#07adf8"/>
+      <text x="18" y="28" class="h2">NIC / MPI / RDMA fabric</text>
+      <text x="18" y="50" class="muted">pipeline stages, tensor shards, ranks</text>
+    </g>
+
+    <text x="30" y="414" class="monoSmall">node CKU <= min(mem, compute, NIC)</text>
+    <text x="30" y="438" class="monoSmall">cluster CKU = sum(nodes) - stalls</text>
   </g>
 
-  <path d="M386 230 H424" stroke="#ffb400" stroke-width="4" stroke-linecap="round"/>
-  <path d="M424 230 l-12 -8 v16 z" fill="#ffb400"/>
-  <text x="392" y="212" fill="#808080" font-family="Inter, Arial, sans-serif" font-size="15">divided by</text>
+  <g transform="translate(86 662)" filter="url(#shadow)">
+    <rect width="1228" height="122" rx="16" fill="#1f1f1f" stroke="#454545"/>
+    <text x="30" y="40" fill="#ffb400" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">Lifecycle envelope</text>
+    <text x="30" y="70" class="body">Single user at full intended context: weights + activations + full KV/cache/state + load/store + communication.</text>
+    <text x="30" y="100" class="mono">single_user_cku = active_lifecycle_bytes_per_token / seconds_per_token</text>
 
-  <path d="M771 230 H809" stroke="#47b475" stroke-width="4" stroke-linecap="round"/>
-  <path d="M809 230 l-12 -8 v16 z" fill="#47b475"/>
-  <text x="770" y="212" fill="#808080" font-family="Inter, Arial, sans-serif" font-size="15">equals</text>
+    <path d="M690 26 V98" stroke="#454545"/>
+    <text x="720" y="40" fill="#47b475" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">Service envelope</text>
+    <text x="720" y="70" class="body">Concurrency is explicit: 1000 users at 1 tok/s is not the same as 1 user at 1000 tok/s.</text>
+    <text x="720" y="100" class="mono">service_cku = single_user_cku × streams</text>
+  </g>
 
-  <rect x="145" y="360" width="910" height="98" rx="12" fill="#1f1f1f" stroke="#454545"/>
-  <text x="180" y="406" fill="#f5f5f5" font-family="JetBrains Mono, Consolas, monospace" font-size="28">CKU = active_bytes_per_token / seconds_per_token</text>
-  <text x="180" y="438" fill="#b0b0b0" font-family="Inter, Arial, sans-serif" font-size="16">1 PB/s means the system can cycle one terabyte of active token-path data every millisecond.</text>
-
-  <g>
-    <circle cx="235" cy="520" r="16" fill="url(#orange)"/>
-    <text x="265" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">Linux tuning</text>
-    <circle cx="410" cy="520" r="16" fill="#07adf8"/>
-    <text x="440" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">SIMD / AMX kernels</text>
-    <circle cx="630" cy="520" r="16" fill="#47b475"/>
-    <text x="660" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">NUMA + memory channels</text>
-    <circle cx="910" cy="520" r="16" fill="#b48cff"/>
-    <text x="940" y="526" fill="#d0d0d0" font-family="Inter, Arial, sans-serif" font-size="16">MPI / RDMA clusters</text>
+  <g transform="translate(82 805)">
+    <text x="0" y="0" class="muted">North-star example: 1 TB active path at 1 ms/token ⇒ 1 PB/s. Dual socket 12ch DDR5-6600 is ~1.27 TB/s theoretical, so PB/s scale is a cluster roofline problem.</text>
+    <text x="0" y="24" class="muted">nodes_needed ≈ required_CKU / effective_node_CKU, after NUMA, OS jitter, network, and kernel efficiency.</text>
   </g>
 </svg>

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -982,6 +982,37 @@
     <li>quantized layout conversion, repacking, and dequantization overhead</li>
 </ul>
 
+<h2>Not Just Weights</h2>
+
+<p>
+    A common shortcut is to say, "a 1 TB model at 1 ms/token needs 1 PB/s."
+    That is a useful intuition, but it is not the full CKU definition.
+    CKU is not only parameter bytes divided by token time.
+    It is the <strong>active byte path</strong> divided by token time.
+    The active byte path includes both the model data being read and the runtime
+    data being produced, consumed, stored, and moved while the token is generated.
+</p>
+
+<p>
+    In decode, weights are often the streaming bottleneck because many layers
+    repeatedly read projection and MLP weights for each new token.
+    In prefill, long prompts can make activation and KV/cache writes matter much
+    more because the system processes many token rows at once.
+    In training, activation saves, gradient writes, optimizer state, and backward
+    reads all become part of the active path.
+    In distributed execution, activation transfers, KV/state movement, gradient
+    exchange, and pipeline bubbles must be counted too.
+</p>
+
+<p>
+    This distinction matters because two runs with the same stored model size can
+    have very different CKU. A dense 1 GB model may touch nearly all weights on
+    every decode token. A sparse MoE model may store far more total weights but
+    only touch selected experts. A vision-language prefill run may move less
+    weight than expected but spend heavily on image-token activations and bridge
+    buffers. CKU asks what the system actually had to cycle for this token path.
+</p>
+
 <h2>Why 1 PB/s?</h2>
 
 <p>
@@ -1050,6 +1081,43 @@
     CKE cares about the measured active path: which weights are actually read, which activations are produced, which cache/state buffers are updated, and which bytes cross sockets or nodes.
 </p>
 
+<table>
+    <thead>
+        <tr>
+            <th>Byte class</th>
+            <th>Examples</th>
+            <th>When it dominates</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Weights</td>
+            <td>Q/K/V projections, MLP gate/up/down, expert weights, output head</td>
+            <td>Decode and small-batch inference, especially dense models</td>
+        </tr>
+        <tr>
+            <td>Activations</td>
+            <td>Layer inputs/outputs, normalized streams, Q8 views, fused scratch</td>
+            <td>Prefill, vision/audio encoders, large token blocks, unfused paths</td>
+        </tr>
+        <tr>
+            <td>Cache and state</td>
+            <td>KV cache reads/writes, recurrent state, Mamba/DeltaNet state</td>
+            <td>Long context, recurrent models, decode with large history</td>
+        </tr>
+        <tr>
+            <td>Training state</td>
+            <td>Saved activations, gradients, optimizer moments, checkpoints</td>
+            <td>Backward pass, fine-tuning, long-context training</td>
+        </tr>
+        <tr>
+            <td>Communication</td>
+            <td>Pipeline activations, tensor-parallel shards, MPI/RDMA transfers</td>
+            <td>Multi-node inference/training and CPU clusters</td>
+        </tr>
+    </tbody>
+</table>
+
 <h2>What CKE Optimizes</h2>
 
 <p>
@@ -1073,14 +1141,25 @@
     The same run should also show CPU utilization, memory bandwidth, cache behavior, and network transfer if the run spans nodes.
 </p>
 
-<pre><code>active_bytes_per_token = weights_touched
-                       + activations_touched
-                       + cache_or_state_touched
-                       + communication_touched
+<pre><code>active_bytes_per_token = weights_read_or_reused
+                       + activations_read_written
+                       + cache_or_state_read_written
+                       + scratch_and_layout_traffic
+                       + communication_read_written
 
 seconds_per_token      = measured_wall_time / generated_tokens
 
 CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
+
+<p>
+    A stricter report can also split <em>logical active bytes</em> from
+    <em>physical traffic</em>.
+    Logical active bytes describe the model/runtime tensors that participate in
+    the token path. Physical traffic includes cache-line rereads, layout
+    conversion, write-allocate behavior, NUMA hops, and network retransfers.
+    CKE tracks the logical path first, then uses perf, VTune, Advisor, and
+    benchmark counters to find where physical traffic is higher than it should be.
+</p>
 
 <p>
     This is the reason CKE keeps investing in visualizers, memory layouts, kernel maps, perf counters, VTune/Advisor profiles, and future MPI lanes.
@@ -1333,7 +1412,7 @@ CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
             </div>
         </div>
     </footer>

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -1081,6 +1081,42 @@
     CKE cares about the measured active path: which weights are actually read, which activations are produced, which cache/state buffers are updated, and which bytes cross sockets or nodes.
 </p>
 
+<h2>Lifecycle Envelope and Concurrency</h2>
+
+<p>
+    CKU is first a <strong>single-stream lifecycle unit</strong>.
+    It asks what the runtime must cycle for one model instance serving one token
+    path at the model's intended operating envelope.
+    If a model advertises a 1 million token context length with an 8K embedding
+    dimension, the lifecycle envelope should include the memory behavior needed
+    to support that context: the active weights, the full KV/cache or recurrent
+    state footprint, the activations needed by prefill/decode, and the load/store
+    traffic required to keep the token path moving.
+</p>
+
+<p>
+    That does not mean every CKU number automatically includes every concurrent
+    user. Concurrency is a separate service-level multiplier.
+    A single-user CKU report answers, "Can this system run one full-context model
+    stream at this token rate?"
+    A service report then asks, "How many such streams can the cluster run at the
+    same time, and what token rate does each user receive?"
+</p>
+
+<pre><code>single_user_cku = active_lifecycle_bytes_per_token / seconds_per_token
+
+service_cku     = single_user_cku * concurrent_streams
+
+per_user_rate   = total_generated_tokens_per_second / concurrent_streams</code></pre>
+
+<p>
+    For example, a cluster might target 1 token/sec for 1000 concurrent users on
+    a very large model. That is a different operating point from 1000 tokens/sec
+    for one user, even if both produce 1000 aggregate tokens/sec.
+    CKU should make both cases explicit: the active lifecycle bytes per user, the
+    concurrency count, the total aggregate byte rate, and the per-user token rate.
+</p>
+
 <table>
     <thead>
         <tr>

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -1154,6 +1154,77 @@ per_user_rate   = total_generated_tokens_per_second / concurrent_streams</code><
     </tbody>
 </table>
 
+<h2>Node Roofline Math</h2>
+
+<p>
+    CKU is not only a memory-bandwidth number and it is not only a FLOPS number.
+    A CPU node can only contribute the useful part of the slowest roof: memory
+    bandwidth, compute throughput, or network movement when the run is
+    distributed. This is why CKU belongs next to roofline analysis.
+</p>
+
+<pre><code>required_service_cku =
+    active_lifecycle_bytes_per_token
+  * tokens_per_second_per_user
+  * concurrent_streams
+
+node_memory_roof =
+    sockets
+  * memory_channels_per_socket
+  * transfer_rate_MTps
+  * 8 bytes_per_channel_transfer
+
+node_compute_roof_bytes =
+    useful_flops_per_second / arithmetic_intensity_flops_per_byte
+
+effective_node_cku =
+    min(node_memory_roof, node_compute_roof_bytes, node_network_roof)
+  * runtime_efficiency
+
+nodes_needed =
+    required_service_cku / effective_node_cku</code></pre>
+
+<p>
+    For DDR memory, a practical first-pass estimate is:
+    <code>channel_GBps = MT/s * 8 bytes / 1000</code>.
+    DDR5-6600 is about 52.8 GB/s per channel.
+    A 12-channel socket is therefore about 633.6 GB/s theoretical, and a
+    dual-socket system is about 1.27 TB/s theoretical before NUMA effects,
+    memory-controller efficiency, page placement, and OS noise.
+    At 8800 MT/s, the same 12-channel socket is about 844.8 GB/s, or about
+    1.69 TB/s for two sockets.
+</p>
+
+<p>
+    Compute has its own roof. For an AVX-512 FP32 FMA path, a rough dense-core
+    estimate is:
+    <code>cores * GHz * FMA_units_per_core * lanes_per_vector * 2 FLOPs_per_FMA</code>.
+    That estimate changes for BF16, INT8, AMX tile paths, VNNI, SVE, or Neon.
+    Quantized Q4/Q6 kernels are often limited by unpacking, metadata,
+    reductions, cache reuse, and memory traffic, so AMX is not automatically the
+    answer. In many CKE paths, AVX-512/VNNI-style layout work is the more direct
+    lever.
+</p>
+
+<p>
+    This also keeps the 1 PB/s north star honest. If a dual-socket CPU node can
+    deliver 1.2 TB/s of useful lifecycle movement, then 1 PB/s requires roughly
+    833 such nodes in the perfect case. At 60-70% useful efficiency, the number
+    is closer to 1200-1400 nodes. If quantization, MoE routing, locality, and
+    cache reuse reduce the active path to 100 GB/token at 100 tokens/sec, the
+    requirement becomes 10 TB/s, which is a very different cluster shape.
+</p>
+
+<p>
+    The CPU thesis is not that one socket beats an H100 at dense tensor math.
+    The thesis is that commodity capacity, many memory channels, many physical
+    cores, SIMD/matrix units, Linux tuning, MPI/RDMA placement, and generated C
+    scheduling can combine into a measurable aggregate byte machine. GPUs can
+    also reach enormous aggregate bandwidth, but a 1 TB resident model may need
+    many expensive HBM devices just for capacity before it even starts serving
+    traffic.
+</p>
+
 <h2>What CKE Optimizes</h2>
 
 <p>
@@ -1448,7 +1519,7 @@ CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/codegen.html
+++ b/docs/site/codegen.html
@@ -1763,7 +1763,7 @@ static size_t bump(size_t *off, size_t bytes) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -2213,7 +2213,7 @@ With weight tying: W = E  (same matrix!)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/contributing.html
+++ b/docs/site/contributing.html
@@ -1273,7 +1273,7 @@ make test</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions-dynamic.html
+++ b/docs/site/decisions-dynamic.html
@@ -1459,7 +1459,7 @@ details.adr pre {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions.html
+++ b/docs/site/decisions.html
@@ -1933,7 +1933,7 @@ weight_mapping:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deltanet-deep-dive.html
+++ b/docs/site/deltanet-deep-dive.html
@@ -2186,7 +2186,7 @@ void recurrent_conv_state_update_forward(
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deterministic-memory.html
+++ b/docs/site/deterministic-memory.html
@@ -1614,7 +1614,7 @@ class TrainingObserver:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/developer-guide.html
+++ b/docs/site/developer-guide.html
@@ -1733,7 +1733,7 @@ make emit CONFIG=x.json OUT=out.c  # Generate runtime</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/flash_attention.html
+++ b/docs/site/flash_attention.html
@@ -1720,7 +1720,7 @@ pthread_setaffinity_np(pthread_self(),
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout-temp.html
+++ b/docs/site/gemm-memory-layout-temp.html
@@ -1398,7 +1398,7 @@ for (m_tile = 0; m_tile < M; m_tile += MB) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout.html
+++ b/docs/site/gemm-memory-layout.html
@@ -1654,7 +1654,7 @@ Token 2: offset 1972    ✗ Kernel expects 1904!</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-optimization.html
+++ b/docs/site/gemm-optimization.html
@@ -2552,7 +2552,7 @@ gemm_microkernel_packed(A, B, C, M, N, K);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemma4-speculative-pair.html
+++ b/docs/site/gemma4-speculative-pair.html
@@ -1402,7 +1402,7 @@ int ck_gemma4_pair_generate_speculative(...);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-bump.html
+++ b/docs/site/gguf-bump.html
@@ -1834,7 +1834,7 @@ make gguf-to-bump GGUF=models/qwen2.5-3b-instruct-q4_k_m.gguf
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-conversion.html
+++ b/docs/site/gguf-conversion.html
@@ -2182,7 +2182,7 @@ with open(output_path, "w+b") as f:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1562,7 +1562,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-06-30 08:55</span>
+        <span class="folder-updated">Updated: 2026-07-04 16:32</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1932,7 +1932,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-pipeline.html
+++ b/docs/site/ir-pipeline.html
@@ -2263,7 +2263,7 @@ python version/v6.6/tools/open_ir_visualizer.py Qwen--Qwen3-0.6B-GGUF</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-v2.html
+++ b/docs/site/ir-v2.html
@@ -1659,7 +1659,7 @@ Page 2 (2-3GB)   → DRAM Bank 2 (Layer 12-17)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/iteration-philosophy.html
+++ b/docs/site/iteration-philosophy.html
@@ -2577,7 +2577,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernels.html
+++ b/docs/site/kernels.html
@@ -1403,7 +1403,7 @@ out     = S_new^T * q_hat</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/mega_fusion.html
+++ b/docs/site/mega_fusion.html
@@ -1943,7 +1943,7 @@ mega_fused_attention_decode():
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-reality.html
+++ b/docs/site/memory-reality.html
@@ -1715,7 +1715,7 @@ CPU (2TB server): FITS with 1.8TB headroom
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-safety.html
+++ b/docs/site/memory-safety.html
@@ -1922,7 +1922,7 @@ echo "=== All memory safety checks passed ==="</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -2425,7 +2425,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/prefill-performance-roadmap.html
+++ b/docs/site/prefill-performance-roadmap.html
@@ -1357,7 +1357,7 @@ make profile-v8-prefill-perf-stat</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/profiling.html
+++ b/docs/site/profiling.html
@@ -1634,7 +1634,7 @@ make flamegraph       # Generate SVG flamegraph</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/pytorch-parity.html
+++ b/docs/site/pytorch-parity.html
@@ -1336,7 +1336,7 @@ make litmus</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/q6-prefill-roofline.html
+++ b/docs/site/q6-prefill-roofline.html
@@ -1294,7 +1294,7 @@ CK_NUM_THREADS=12 OMP_NUM_THREADS=1 CK_Q6K_Q8K_SIMD=1 \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quant-formats.html
+++ b/docs/site/quant-formats.html
@@ -1616,7 +1616,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-math-temp.html
+++ b/docs/site/quantization-math-temp.html
@@ -1380,7 +1380,7 @@ for (int ib = 0; ib < nb; ib++) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-visuals.html
+++ b/docs/site/quantization-visuals.html
@@ -1512,7 +1512,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization.html
+++ b/docs/site/quantization.html
@@ -2390,7 +2390,7 @@ void matmul_q4(float* out, const float* x, const tensor* W) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -1680,7 +1680,7 @@ firefox build/flamegraph.svg</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/research.html
+++ b/docs/site/research.html
@@ -1628,7 +1628,7 @@ K = [K_rope (with position), K_nope (from latent)]</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -3389,7 +3389,7 @@ That's it. For any model size.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sentencepiece.html
+++ b/docs/site/sentencepiece.html
@@ -1872,7 +1872,7 @@ ck_tokenizer_free(tok);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/simd-architecture.html
+++ b/docs/site/simd-architecture.html
@@ -2365,7 +2365,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,266 +2,266 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-mla-kimi.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-06-30</lastmod>
+    <lastmod>2026-07-04</lastmod>
   </url>
 </urlset>

--- a/docs/site/spec-training-method.html
+++ b/docs/site/spec-training-method.html
@@ -3774,7 +3774,7 @@ Next run:</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -1098,7 +1098,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-06-30 15:55 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-04 23:32 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>
@@ -1416,7 +1416,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec17-curriculum-blueprint.html
+++ b/docs/site/spec17-curriculum-blueprint.html
@@ -1472,7 +1472,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec19-textbook-routing-mixture.html
+++ b/docs/site/spec19-textbook-routing-mixture.html
@@ -1585,7 +1585,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spectrum.html
+++ b/docs/site/spectrum.html
@@ -1763,7 +1763,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -2728,7 +2728,7 @@ document.addEventListener('DOMContentLoaded', loadResults);
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-viewer.html
+++ b/docs/site/test-viewer.html
@@ -1386,7 +1386,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -1880,7 +1880,7 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/threadpool.html
+++ b/docs/site/threadpool.html
@@ -2827,7 +2827,7 @@ make test-threadpool-parity-verbose
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/tokenizer.html
+++ b/docs/site/tokenizer.html
@@ -2314,7 +2314,7 @@ True BPE (merge rules applied in order):
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-curriculum.html
+++ b/docs/site/training-curriculum.html
@@ -1847,7 +1847,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-intuition.html
+++ b/docs/site/training-intuition.html
@@ -2254,7 +2254,7 @@ report:    version/v7/tools/ir_visualizer.html (or generated ir_report*.html)</c
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-lessons-learned.html
+++ b/docs/site/training-lessons-learned.html
@@ -1840,7 +1840,7 @@ AFTER TRAINING:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-backprop-ir.html
+++ b/docs/site/v7-backprop-ir.html
@@ -2009,7 +2009,7 @@ version/v7/scripts/cks-v7-run init \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-cross-entropy-parity.html
+++ b/docs/site/v7-cross-entropy-parity.html
@@ -1396,7 +1396,7 @@ CK_NUM_THREADS=8 python version/v7/scripts/train_parity_epochs_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-grad-accum-windows.html
+++ b/docs/site/v7-grad-accum-windows.html
@@ -1326,7 +1326,7 @@ at accumulation boundary:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-parity-checklist.html
+++ b/docs/site/v7-parity-checklist.html
@@ -1525,7 +1525,7 @@ PY</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-profiling.html
+++ b/docs/site/v7-profiling.html
@@ -1444,7 +1444,7 @@ python3 version/v7/tools/open_ir_visualizer.py --generate --run /tmp/v7_ht_threa
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-python-authoring.html
+++ b/docs/site/v7-python-authoring.html
@@ -1597,7 +1597,7 @@ python3 version/v7/examples/python_module_api_tiny_lm_v7.py --run-name py-module
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-runbook.html
+++ b/docs/site/v7-runbook.html
@@ -5607,7 +5607,7 @@ python3 scripts/ck_chat.py --help</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-svg-dataset-runbook.html
+++ b/docs/site/v7-svg-dataset-runbook.html
@@ -1655,7 +1655,7 @@ tail -n 20 "$RUN/autopilot/summary.jsonl"</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-training-progression-playbook.html
+++ b/docs/site/v7-training-progression-playbook.html
@@ -1575,7 +1575,7 @@ jq -r '.status, (.stages // [])' "$RUN/training_parity_regimen_latest.json" 2>/d
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-visualizer-test-runbook.html
+++ b/docs/site/v7-visualizer-test-runbook.html
@@ -1926,7 +1926,7 @@ document.querySelectorAll('.copy-btn').forEach(btn => {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-mla-kimi.html
+++ b/docs/site/v8-mla-kimi.html
@@ -1399,7 +1399,7 @@ make build/libckernel_engine.so
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -1740,7 +1740,7 @@ make v8-visualizer-vision-artifacts</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -1941,7 +1941,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-02</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/version-history.html
+++ b/docs/site/version-history.html
@@ -2680,7 +2680,7 @@ console.log('Roadmap: ' + versionData.roadmap.map(v => 'v' + v.major).join(' →
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -1327,7 +1327,7 @@ permalink: /vision-encoder-parity/
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-06-30</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
             </div>
         </div>
     </footer>

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1035,6 +1035,7 @@ def _apply_qwen3vl_ocr_fast_defaults(env: dict[str, str]) -> None:
     env.setdefault("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", "20")
     env.setdefault("CK_Q4K_X16_CHUNK4", "1")
     env.setdefault("CK_ATTENTION_QBLOCK4", "1")
+    env.setdefault("CK_ATTENTION_THREAD_CAP", "16")
     env.setdefault("CK_Q4K_PACKED_META_X8_MAX_M", "2048")
     env.setdefault("CK_NUM_THREADS", "20")
     env.setdefault("OMP_NUM_THREADS", "1")


### PR DESCRIPTION
## Why

Add a named Qwen3-VL OCR speed profile stack that captures the proven Xeon/OpenShift OCR optimizations without changing default AVX2 behavior. Also clarify the CKU docs so the throughput unit is understood as active byte path per token, not only model-weight bytes.

## What Changed

- Added opt-in Q4_K gate/up x16 chunk4 reuse and AVX512 attention qblock4 reuse.
- Added `CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512` and `CK_QWEN3VL_OCR_FAST=1` aliases.
- Kept `CK_PROFILE` reserved for profiling instrumentation.
- Raised `CK_Q4K_PACKED_META_X8_MAX_M` to `2048` only under the Qwen3-VL OCR speed profile.
- Default Q4 x8 behavior remains conservative at `M<=64` unless explicitly overridden.
- Aligned speed-profile defaults across OCR benchmarks, perf pipeline, and `ck_run_v8.py`.
- Extended `bench_q4k_dispatch_matrix.c` with x16 packed projection paths and Qwen3-VL-sized shapes.
- Updated Qwen3-VL speed notes and CKU throughput docs.

## CKU Docs Clarification

CKU now explicitly means active byte path per token over measured token time. It includes:

- weights read/reused
- activations read/written
- KV/cache or recurrent state traffic
- scratch/layout traffic
- training state when applicable
- distributed communication when applicable

The docs also distinguish logical active bytes from physical traffic caused by cache-line rereads, write allocation, NUMA hops, and network movement.

## Validation

Latest perf commit validation:

- `git diff --check`
- `.venv/bin/python -m py_compile benchmarks/bench_v8_qwen3vl_ocr.py benchmarks/qwen3vl_ocr_perf_pipeline.py version/v8/scripts/ck_run_v8.py`
- `make build/libckernel_engine.so build/bench_q4k_dispatch_matrix`
- `CK_NUM_THREADS=12 LD_LIBRARY_PATH=build:/opt/intel/oneapi/tcm/1.4/lib:/opt/intel/oneapi/umf/1.0/lib:/opt/intel/oneapi/tbb/2022.3/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mpi/2021.17/opt/mpi/libfabric/lib:/opt/intel/oneapi/mpi/2021.17/lib:/opt/intel/oneapi/mkl/2025.3/lib:/opt/intel/oneapi/ishmem/1.5/lib:/opt/intel/oneapi/ippcp/2025.3/lib/:/opt/intel/oneapi/ipp/2022.3/lib:/opt/intel/oneapi/dnnl/2025.3/lib:/opt/intel/oneapi/debugger/2025.3/opt/debugger/lib:/opt/intel/oneapi/dal/2025.10/lib:/opt/intel/oneapi/compiler/2025.3/opt/compiler/lib:/opt/intel/oneapi/compiler/2025.3/lib:/opt/intel/oneapi/ccl/2021.17/lib/:/usr/local/lib:/home/antshiv/Programs/lib::/home/antshiv/Programs/lib build/bench_q4k_dispatch_matrix --quick --iters 1`
- Pre-commit: v8-regression-fast passed
- Pre-push: build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training smoke, v8 fast regression, v7 training-kernel parity passed

Latest docs commit validation:

- `git diff --check` for the CKU source/generated pages
- Pre-commit skipped runtime regressions as docs-only
- Pre-push passed build, kernel parity, v8 text smoke, v8 contracts, v7 training smoke, training-kernel parity

## High-Memory Xeon Evidence

With `CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512` on clean Qwen3-VL OCR:

- Output stayed: `CK OCR TEST\nTOTAL 42`
- Mixed prefill improved from `33006.0 ms` to `30695.1 ms`
- Net improvement: about `2.31 s` faster for the latest x8 large-M profile change

Earlier default-vs-profile evidence:

- Default steady: `110.6 s`
- Profile steady: `69.0 s`
- Speedup: `1.60x`
- Same OCR output

## Blog-Agent Summary

Read:

- `docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md`
- `docs/site/_pages/cke-throughput-unit.html`

Story: methodical Qwen3-VL OCR prefill hardening plus CKU clarification. CKU is not just parameter bytes; it is the full active byte path through weights, activations, cache/state, scratch/layout traffic, training state, and distributed communication.