### PR TITLE
docs(site): clarify CKU model-math throughput

### DIFF
--- a/docs/site/_pages/cke-throughput-unit.html
+++ b/docs/site/_pages/cke-throughput-unit.html
@@ -14,6 +14,13 @@
         The proposed CKE unit is aggregate bytes cycled per second across the full token path.
         The north-star target is <strong>1 petabyte/sec</strong>, which is the same as <strong>1000 terabytes/sec</strong>, or <strong>1 terabyte every millisecond</strong>.
     </p>
+    <p style="font-size: 1.08em; line-height: 1.7; margin-top: 1.2rem; margin-bottom: 0;">
+        The reference CKU is <strong>useful model-math byte throughput</strong>, not a copy-bandwidth score.
+        A DSA engine can move bytes, but CKU asks whether active weights, activations, and cache/state are
+        fed through GEMM/FMA/attention work to advance the model. The clean upper-bound reference is
+        full-context prefill, where active weights are cycled through mostly GEMM. Decode is a related but
+        different path: mostly GEMV plus KV/cache reads and writes.
+    </p>
 </div>
 
 <div class="img-container svg-viewer" data-title="CKE Throughput Unit">
@@ -27,7 +34,8 @@
 <p>
     CKU means <strong>C-Kernel throughput unit</strong>.
     The unit is not just DRAM bandwidth from one socket and it is not just matrix FLOPS.
-    It is an end-to-end systems rate: how many bytes the runtime must touch, transform, cache, transmit, or reuse in order to produce tokens.
+    It is an end-to-end systems rate: how many bytes the runtime must touch, transform, cache, transmit, or reuse through useful model compute in order to produce tokens.
+    Plain copies are not enough; the bytes have to arrive in the right layout at the right kernel and participate in the model's math.
     Depending on the model and phase, that can include:
 </p>
 
@@ -121,6 +129,17 @@
     if the active token path is one terabyte and the target is one millisecond per token, the cumulative runtime has to behave like a one-petabyte-per-second machine.
     That machine does not have to be one CPU.
     It can be a coordinated set of CPU sockets, memory channels, NUMA domains, and Linux nodes.
+</p>
+
+<p>
+    In CKE, this is intentionally anchored to the hardest clean reference:
+    <strong>full-context prefill over the active model path</strong>.
+    Prefill is mostly GEMM-shaped work over many token rows, so the system must
+    stream active weights, reuse activations, execute reductions, and write the
+    next layer state at high rate. Decode is measured too, but it is usually a
+    different shape: mostly GEMV over one or a few token rows, plus KV/cache
+    reads and writes. That is why CKU should report the phase and workload
+    shape, not only the headline byte rate.
 </p>
 
 <h2>What Counts as Active Bytes?</h2>

--- a/docs/site/assets/cke-throughput-unit.svg
+++ b/docs/site/assets/cke-throughput-unit.svg
@@ -54,12 +54,13 @@
   <rect x="28" y="28" width="1344" height="804" rx="18" fill="none" stroke="#484848"/>
 
   <text x="60" y="78" class="title">CKU: CKE Throughput Unit</text>
-  <text x="60" y="111" class="subtitle">Active lifecycle bytes per token, cycled through CPU memory, cores, and cluster fabric.</text>
+  <text x="60" y="111" class="subtitle">Useful model-math byte throughput, not memcpy bandwidth.</text>
+  <text x="60" y="135" class="muted">Reference: full-context prefill cycles active weights through GEMM/FMA. Decode is mostly GEMV plus KV/cache traffic.</text>
 
   <g transform="translate(60 145)" filter="url(#shadow)">
     <rect width="380" height="470" rx="14" class="panel"/>
     <text x="28" y="42" fill="#ffb400" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">1. Active lifecycle bytes</text>
-    <text x="28" y="72" class="body">The token path is not only weights.</text>
+    <text x="28" y="72" class="body">The token path is not only memcpy.</text>
 
     <g transform="translate(28 105)">
       <rect width="324" height="54" rx="8" fill="#332a13" stroke="#ffb400"/>
@@ -116,7 +117,8 @@
       <text x="18" y="44" class="muted">prefill, decode, pipeline ranks</text>
     </g>
 
-    <text x="34" y="440" class="monoSmall">active_bytes / token_time</text>
+    <text x="34" y="426" class="monoSmall">GEMM/FMA/attention work</text>
+    <text x="34" y="448" class="monoSmall">active_bytes / token_time</text>
   </g>
 
   <path d="M897 380 C940 380 940 380 982 380" stroke="#07adf8" stroke-width="4" fill="none" marker-end="url(#arrowBlue)"/>

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -956,6 +956,13 @@
         The proposed CKE unit is aggregate bytes cycled per second across the full token path.
         The north-star target is <strong>1 petabyte/sec</strong>, which is the same as <strong>1000 terabytes/sec</strong>, or <strong>1 terabyte every millisecond</strong>.
     </p>
+    <p style="font-size: 1.08em; line-height: 1.7; margin-top: 1.2rem; margin-bottom: 0;">
+        The reference CKU is <strong>useful model-math byte throughput</strong>, not a copy-bandwidth score.
+        A DSA engine can move bytes, but CKU asks whether active weights, activations, and cache/state are
+        fed through GEMM/FMA/attention work to advance the model. The clean upper-bound reference is
+        full-context prefill, where active weights are cycled through mostly GEMM. Decode is a related but
+        different path: mostly GEMV plus KV/cache reads and writes.
+    </p>
 </div>
 
 <div class="img-container svg-viewer" data-title="CKE Throughput Unit">
@@ -969,7 +976,8 @@
 <p>
     CKU means <strong>C-Kernel throughput unit</strong>.
     The unit is not just DRAM bandwidth from one socket and it is not just matrix FLOPS.
-    It is an end-to-end systems rate: how many bytes the runtime must touch, transform, cache, transmit, or reuse in order to produce tokens.
+    It is an end-to-end systems rate: how many bytes the runtime must touch, transform, cache, transmit, or reuse through useful model compute in order to produce tokens.
+    Plain copies are not enough; the bytes have to arrive in the right layout at the right kernel and participate in the model's math.
     Depending on the model and phase, that can include:
 </p>
 
@@ -1063,6 +1071,17 @@
     if the active token path is one terabyte and the target is one millisecond per token, the cumulative runtime has to behave like a one-petabyte-per-second machine.
     That machine does not have to be one CPU.
     It can be a coordinated set of CPU sockets, memory channels, NUMA domains, and Linux nodes.
+</p>
+
+<p>
+    In CKE, this is intentionally anchored to the hardest clean reference:
+    <strong>full-context prefill over the active model path</strong>.
+    Prefill is mostly GEMM-shaped work over many token rows, so the system must
+    stream active weights, reuse activations, execute reductions, and write the
+    next layer state at high rate. Decode is measured too, but it is usually a
+    different shape: mostly GEMV over one or a few token rows, plus KV/cache
+    reads and writes. That is why CKU should report the phase and workload
+    shape, not only the headline byte rate.
 </p>
 
 <h2>What Counts as Active Bytes?</h2>


### PR DESCRIPTION
## Summary
- Clarifies CKU as useful model-math byte throughput, not memcpy or DSA copy bandwidth.
- Anchors the 1 PB/s north-star to full-context prefill: active weights and activations cycled through GEMM/FMA/attention work.
- Separates decode as a related but different GEMV plus KV/cache path.
- Updates the CKU SVG headline and runtime panel to make the distinction visible at the top of the page.

## Validation
- git diff --check for CKU docs/SVG files.
- rg verification for DSA, full-context prefill, GEMM/FMA, and GEMV language.
- Pre-commit skipped runtime regression because staged changes are docs-only.
- Pre-push passed: submodule pins, visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, and training-kernel parity.

## Blog-agent summary
CKU should be explained as active model bytes fed through useful model math. DSA can copy bytes; CKU asks whether the runtime can stream active weights, activations, and cache/state into GEMM/FMA/attention work. The reference north-star is full-context prefill; decode is measured separately as GEMV plus KV/cache traffic.