### PR TITLE
perf(v8): add qwen3vl qblock8 attention path

### DIFF
--- a/docs/site/assets/cke-throughput-unit.svg
+++ b/docs/site/assets/cke-throughput-unit.svg
@@ -158,7 +158,7 @@
       <text x="18" y="50" class="muted">pipeline stages, tensor shards, ranks</text>
     </g>
 
-    <text x="30" y="414" class="monoSmall">node CKU <= min(mem, compute, NIC)</text>
+    <text x="30" y="414" class="monoSmall">node CKU &lt;= min(mem, compute, NIC)</text>
     <text x="30" y="438" class="monoSmall">cluster CKU = sum(nodes) - stalls</text>
   </g>
 


### PR DESCRIPTION
## Summary
- Adds the Qwen3-VL qblock8 attention and x8 M-reuse mixed-prefill speed work.
- Adds focused encoder-attention benchmark coverage and Q4 dispatch matrix x8reuse reporting.
- Updates Qwen3-VL OCR speed research notes.
- Fixes the CKU SVG render bug by escaping the less-than sign in the node CKU formula.

## SVG Image Fix
The CKU image existed, but the SVG had raw <= inside a text node. SVG is XML, so raw < breaks parsing and browsers can refuse to render it. This branch changes it to escaped XML text so the image parses correctly.

## Validation
- Python XML parser successfully parsed docs/site/assets/cke-throughput-unit.svg.
- git diff --check passed for the SVG.
- Default build and benchmark builds passed before the qblock8 commit.
- AVX512 compile-only check passed with avx512f, avx512vl, avx512vnni, avx512bw, avx512dq, avx2, and fma enabled.
- Pre-push passed: submodule pins, visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, and training-kernel parity.

## Production Note
The production page will keep showing the old broken SVG until this branch is merged and GitHub Pages redeploys the asset. Browser/CDN cache may also take a few minutes after deploy.