### PR TITLE
perf(v8): cap qwen3vl q6 prefill threads

### DIFF
--- a/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
+++ b/docs/notes/QWEN3VL_OCR_Q4Q8_SPEED_RESEARCH_2026-07-02.md
@@ -527,3 +527,63 @@ reported next bottleneck improved from about 11.2 s to about 10.95 s for
 `attention_forward_full_head_major_gqa_flash_strided`. The focused benchmark is
 the cleaner read: qblock8 gives about a 1.38x speedup for the isolated encoder
 attention shape while preserving output correctness.
+
+## 2026-07-05 QBlock16 Rejection And Q6 Thread Cap
+
+A qblock16 encoder-attention candidate was tested as an explicit-only path after
+qblock8. It preserved the checksum but was slower on this Xeon shape:
+
+| Path | Avg Time | Checksum | Read |
+|---|---:|---:|---|
+| qblock8 profile default | 289.564 ms | 0.01810321 | keep |
+| qblock16 explicit candidate | 301.966 ms | 0.01810321 | reject |
+
+The qblock16 experiment was removed. The qblock8 thread sweep also confirmed the
+existing attention cap direction:
+
+| Threads | Avg Time | Checksum |
+|---:|---:|---:|
+| 12 | 305.845 ms | 0.01810321 |
+| 16 | 279.521 ms | 0.01810321 |
+| 20 | 281.027 ms | 0.01810321 |
+| 24 | 321.124 ms | 0.01810321 |
+
+For mixed prefill, the exact Qwen3-VL Q6_K `mlp_down` shape was extracted from
+`lowered_prefill.json`: runtime `M=1082`, `N=4096`, `K=12288`. The existing 2D
+Q6 scheduler is not a stable win for this shape, so it was not promoted:
+
+| Threads | Row Split | 2D Tile | Checksum |
+|---:|---:|---:|---:|
+| 16 | 137.00 ms | 132.10 ms best / 160.98 ms avg | match |
+| 20 | 161.41 ms | 176.13 ms | match |
+
+The useful action was a narrow Qwen3-VL OCR profile cap for this Q6 shape:
+`CK_Q6K_Q8K_THREAD_CAP` defaults to 16 only for large Q6_K x Q8_K OCR prefill
+(`M>=512`, `N=4096`, `K=12288`). Explicit `CK_GEMM_THREAD_CAP` and
+`CK_Q6K_Q8K_THREAD_CAP` still override this policy.
+
+Verification with a 20-thread pool and the speed profile:
+
+| Case | Best Time | Checksum |
+|---|---:|---:|
+| before cap, row split | 161.41 ms | -157.749893 |
+| after cap, row split | 142.18 ms | -157.749893 |
+
+Latest end-to-end large clean OCR pipeline, profile only, 20 CK threads:
+
+| Encoder | Mixed Prefill | Decode | Steady | Output |
+|---:|---:|---:|---:|---|
+| 32780.8 ms | 27410.7 ms | 1373.3 ms | 61564.8 ms | `CK OCR TEST\nTOTAL 42` |
+
+Latest top ops after this pass:
+
+| Area | Op / Kernel | Time |
+|---|---|---:|
+| encoder | `attn` / `attention_forward_full_head_major_gqa_flash_strided` | 10464.9 ms |
+| decoder | `mlp_gate_up_swiglu` / `gemm_nt_q4_k_q8_k_gateup_swiglu_x16` | 11594.0 ms |
+| decoder | `mlp_down` / `gemm_nt_q6_k_q8_k` | 3493.3 ms |
+| decoder | `mlp_down` / `gemm_nt_q4_k_q8_k` | 3095.9 ms |
+
+Next target remains split between encoder full attention and decoder Q4 gate/up.
+The qblock16 result suggests the next encoder-attention win needs a different
+algorithmic implementation, not just a larger query block.

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -975,7 +975,12 @@ void gemm_nt_q6_k_q8_k_parallel_dispatch(
         .tile_m = ck_env_int_or2("CK_PREFILL_TILE_M", NULL, 16),
         .tile_n = ck_env_int_or2("CK_PREFILL_TILE_N", NULL, 256)
     };
-    const int active = ck_select_gemm_active_threads(pool, M, N, K);
+    int active = ck_select_gemm_active_threads(pool, M, N, K);
+    if (!getenv("CK_GEMM_THREAD_CAP") && !getenv("CK_GEMV_THREAD_CAP")) {
+        const int q6_profile_cap = (ck_speed_profile_qwen3vl_ocr_fast() && M >= 512 && N == 4096 && K == 12288) ? 16 : active;
+        const int q6_cap = ck_env_int_or2("CK_Q6K_Q8K_THREAD_CAP", NULL, q6_profile_cap);
+        active = ck_min_int(active, q6_cap);
+    }
     if (ck_should_use_q6k_q8k_2d_prefill(pool, M, N, K, args.tile_m, args.tile_n)) {
         ck_threadpool_dispatch_n(pool, active, work_gemm_nt_q6_k_q8_k_2d, &args);
     } else {


### PR DESCRIPTION
## Summary
- Adds a narrow Qwen3-VL OCR speed-profile cap for the large Q6_K x Q8_K mlp_down prefill shape.
- Keeps user overrides intact: CK_GEMM_THREAD_CAP, CK_GEMV_THREAD_CAP, and CK_Q6K_Q8K_THREAD_CAP win over the profile default.
- Documents qblock16 rejection, qblock8 thread sweep, Q6 shape extraction, latest OCR timings, and remaining hotspots.
- Includes the previous qblock8 attention path, x8 M-reuse mixed-prefill path, and CKU SVG XML fix already on this branch.

## Validation
- git diff --check for changed files.
- make build/libckernel_engine.so passed.
- make build/bench_q4k_dispatch_matrix build/bench_qwen3vl_encoder_attention passed.
- Quick Q4 dispatch matrix passed.
- Quick Qwen3-VL encoder attention benchmark passed on this machine.
- Pre-commit v8-regression-fast passed.
- Pre-push passed: submodule pins, visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, v8 fast regression, and training-kernel parity.

## Performance Evidence
- Current best CK Qwen3-VL OCR: about 61.6s.
- Earlier llama.cpp SDPR baseline: about 55.8s/sample.
- CK is roughly 10 percent behind on this noisy measured workload.
- Q6 mlp_down row-split benchmark improved from 161.41 ms to 142.18 ms with matching checksum.
- qblock16 was tested and rejected: correct checksum but slower than qblock8.

## Blog-agent summary
The recent Qwen3-VL OCR patches compound into a major speedup: from roughly 280s early in the pipeline to about 61.6s now, close to the measured llama.cpp baseline around 55.8s. This patch adds the last small profile-scoped Q6 cap and documents why qblock-size tuning is mostly exhausted; the next real targets are decoder Q4 gate/up microkernel quality and deeper encoder-attention algorithm work.