### PR TITLE
docs(site): surface CKU in navigation

### DIFF
--- a/docs/site/_pages/index.html
+++ b/docs/site/_pages/index.html
@@ -195,6 +195,7 @@
         <span class="hero-stat"><strong>9+</strong> fwd + bwd kernels</span>
         <span class="hero-stat"><strong>IR1 → IR2 → IR3</strong> codegen</span>
         <span class="hero-stat"><strong>VTune / Advisor</strong> profiling</span>
+        <span class="hero-stat"><strong>CKU</strong> PB/s byte-path metric</span>
         <span class="hero-stat"><strong>C-first</strong> execution</span>
     </div>
 </div>
@@ -212,6 +213,14 @@
     <h3 style="margin-top: 0;">Long-Horizon Commodity Compute Bet</h3>
     <p>CKE assumes AI execution will not remain permanently locked inside expensive accelerator stacks, because the underlying workload is still math, memory movement, and systems software. Accelerators matter, but they do not change the shape of the problem: tensors must live somewhere, bytes must move through memory hierarchies, kernels must execute, and distributed systems must coordinate the work.</p>
     <p style="margin-bottom: 0;">If CPUs keep gaining cores, SIMD and matrix units, memory channels, NUMA controls, and fast interconnects, then a clean generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly interesting. The bet is not that one CPU beats every GPU. The bet is that commodity CPU clusters can become a practical, auditable, incrementally scalable execution substrate for a large class of AI inference and training workloads.</p>
+</div>
+
+<div class="card card-blue">
+    <h3 style="margin-top: 0;">CKU: CKE Throughput Unit</h3>
+    <p>CKU is the project’s north-star systems metric: active model bytes cycled through useful model math per second. It is not memcpy or DSA copy bandwidth. The reference workload is full-context prefill, where active weights and activations flow through GEMM/FMA/attention; decode is tracked separately as GEMV plus KV/cache traffic.</p>
+    <p style="margin-bottom: 0;">
+        <a href="cke-throughput-unit.html" class="btn btn-sm">Read the CKU page →</a>
+    </p>
 </div>
 
 <div class="card card-green">

--- a/docs/site/_pages/spec-training-results.html
+++ b/docs/site/_pages/spec-training-results.html
@@ -156,7 +156,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-04 23:32 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-05 03:36 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-04 16:32</span>
+        <span class="folder-updated">Updated: 2026-07-04 20:36</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/_partials/header.html
+++ b/docs/site/_partials/header.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="{{NAV_QUICKSTART}}">Getting Started</a>
             <a href="developer-guide.html" class="{{NAV_DEVGUIDE}}">Developer Guide</a>
             <a href="scaling.html" class="{{NAV_SCALING}}">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/architecture-links.html
+++ b/docs/site/architecture-links.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1220,7 +1221,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-04 16:32</span>
+        <span class="folder-updated">Updated: 2026-07-04 20:36</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="active" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/codegen.html
+++ b/docs/site/codegen.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/contributing.html
+++ b/docs/site/contributing.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/decisions-dynamic.html
+++ b/docs/site/decisions-dynamic.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/decisions.html
+++ b/docs/site/decisions.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/deltanet-deep-dive.html
+++ b/docs/site/deltanet-deep-dive.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/deterministic-memory.html
+++ b/docs/site/deterministic-memory.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/developer-guide.html
+++ b/docs/site/developer-guide.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/flash_attention.html
+++ b/docs/site/flash_attention.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/gemm-memory-layout-temp.html
+++ b/docs/site/gemm-memory-layout-temp.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/gemm-memory-layout.html
+++ b/docs/site/gemm-memory-layout.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/gemm-optimization.html
+++ b/docs/site/gemm-optimization.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/gemma4-speculative-pair.html
+++ b/docs/site/gemma4-speculative-pair.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/gguf-bump.html
+++ b/docs/site/gguf-bump.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/gguf-conversion.html
+++ b/docs/site/gguf-conversion.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1137,6 +1138,7 @@
         <span class="hero-stat"><strong>9+</strong> fwd + bwd kernels</span>
         <span class="hero-stat"><strong>IR1 → IR2 → IR3</strong> codegen</span>
         <span class="hero-stat"><strong>VTune / Advisor</strong> profiling</span>
+        <span class="hero-stat"><strong>CKU</strong> PB/s byte-path metric</span>
         <span class="hero-stat"><strong>C-first</strong> execution</span>
     </div>
 </div>
@@ -1154,6 +1156,14 @@
     <h3 style="margin-top: 0;">Long-Horizon Commodity Compute Bet</h3>
     <p>CKE assumes AI execution will not remain permanently locked inside expensive accelerator stacks, because the underlying workload is still math, memory movement, and systems software. Accelerators matter, but they do not change the shape of the problem: tensors must live somewhere, bytes must move through memory hierarchies, kernels must execute, and distributed systems must coordinate the work.</p>
     <p style="margin-bottom: 0;">If CPUs keep gaining cores, SIMD and matrix units, memory channels, NUMA controls, and fast interconnects, then a clean generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly interesting. The bet is not that one CPU beats every GPU. The bet is that commodity CPU clusters can become a practical, auditable, incrementally scalable execution substrate for a large class of AI inference and training workloads.</p>
+</div>
+
+<div class="card card-blue">
+    <h3 style="margin-top: 0;">CKU: CKE Throughput Unit</h3>
+    <p>CKU is the project’s north-star systems metric: active model bytes cycled through useful model math per second. It is not memcpy or DSA copy bandwidth. The reference workload is full-context prefill, where active weights and activations flow through GEMM/FMA/attention; decode is tracked separately as GEMV plus KV/cache traffic.</p>
+    <p style="margin-bottom: 0;">
+        <a href="cke-throughput-unit.html" class="btn btn-sm">Read the CKU page →</a>
+    </p>
 </div>
 
 <div class="card card-green">
@@ -1562,7 +1572,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-04 16:32</span>
+        <span class="folder-updated">Updated: 2026-07-04 20:36</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/ir-pipeline.html
+++ b/docs/site/ir-pipeline.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/ir-v2.html
+++ b/docs/site/ir-v2.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/iteration-philosophy.html
+++ b/docs/site/iteration-philosophy.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/kernels.html
+++ b/docs/site/kernels.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/mega_fusion.html
+++ b/docs/site/mega_fusion.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/memory-reality.html
+++ b/docs/site/memory-reality.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/memory-safety.html
+++ b/docs/site/memory-safety.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/prefill-performance-roadmap.html
+++ b/docs/site/prefill-performance-roadmap.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/profiling.html
+++ b/docs/site/profiling.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/pytorch-parity.html
+++ b/docs/site/pytorch-parity.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/q6-prefill-roofline.html
+++ b/docs/site/q6-prefill-roofline.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/quant-formats.html
+++ b/docs/site/quant-formats.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/quantization-math-temp.html
+++ b/docs/site/quantization-math-temp.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/quantization-visuals.html
+++ b/docs/site/quantization-visuals.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/quantization.html
+++ b/docs/site/quantization.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/research.html
+++ b/docs/site/research.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/sentencepiece.html
+++ b/docs/site/sentencepiece.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/simd-architecture.html
+++ b/docs/site/simd-architecture.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/spec-training-method.html
+++ b/docs/site/spec-training-method.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1098,7 +1099,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-04 23:32 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-05 03:36 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>

--- a/docs/site/spec17-curriculum-blueprint.html
+++ b/docs/site/spec17-curriculum-blueprint.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/spec19-textbook-routing-mixture.html
+++ b/docs/site/spec19-textbook-routing-mixture.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/spectrum.html
+++ b/docs/site/spectrum.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/test-viewer.html
+++ b/docs/site/test-viewer.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/threadpool.html
+++ b/docs/site/threadpool.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/tokenizer.html
+++ b/docs/site/tokenizer.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/training-curriculum.html
+++ b/docs/site/training-curriculum.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/training-intuition.html
+++ b/docs/site/training-intuition.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/training-lessons-learned.html
+++ b/docs/site/training-lessons-learned.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-backprop-ir.html
+++ b/docs/site/v7-backprop-ir.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-cross-entropy-parity.html
+++ b/docs/site/v7-cross-entropy-parity.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-grad-accum-windows.html
+++ b/docs/site/v7-grad-accum-windows.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-parity-checklist.html
+++ b/docs/site/v7-parity-checklist.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-profiling.html
+++ b/docs/site/v7-profiling.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-python-authoring.html
+++ b/docs/site/v7-python-authoring.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-runbook.html
+++ b/docs/site/v7-runbook.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-svg-dataset-runbook.html
+++ b/docs/site/v7-svg-dataset-runbook.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-training-progression-playbook.html
+++ b/docs/site/v7-training-progression-playbook.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v7-visualizer-test-runbook.html
+++ b/docs/site/v7-visualizer-test-runbook.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v8-mla-kimi.html
+++ b/docs/site/v8-mla-kimi.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/version-history.html
+++ b/docs/site/version-history.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -863,6 +863,7 @@
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">


### PR DESCRIPTION
## Summary
- Adds a direct CKU link to the top navigation.
- Adds a CKU hero stat and homepage card linking to the CKE Throughput Unit page.
- Rebuilds generated docs/site pages so the nav link appears across the site.
- Includes the current branch stack with the Qwen3-VL Q6 cap and CKU SVG XML fix.

## Where CKU Was Before
The CKU page was already reachable under Architecture > Optimization > CKE Throughput Unit, but that was too buried for a north-star metric.

## Validation
- docs/site/build.sh completed; existing spec-training ledger warning remains.
- git diff --check passed for staged docs changes.
- rg verified CKU nav link, active CKU page state, homepage stat, and homepage card in generated output.
- Pre-push passed: submodule pins, visualizer health, build, kernel parity, v8 E2E text smoke, v8 inference contracts, v7 training contract smoke, and training-kernel parity.

## Blog-agent summary
CKU is now first-class in docs navigation. The homepage and top nav directly point to the CKE Throughput Unit page instead of hiding it inside Architecture > Optimization.