### PR TITLE
perf(v8): add AVX2 Qwen3-VL parity and f16 path

### DIFF
--- a/docs/notes/QWEN3VL_ENCODER_MTMD_PARITY_2026-07-06.md
+++ b/docs/notes/QWEN3VL_ENCODER_MTMD_PARITY_2026-07-06.md
@@ -1,0 +1,60 @@
+# Qwen3-VL Encoder vs llama.cpp mtmd Prefix Parity - 2026-07-06
+
+## Scope
+
+Compared CK v8 Qwen3-VL encoder bridge prefixes against llama.cpp `libmtmd`
+image embeddings for several local images.
+
+Reference helper:
+
+```bash
+build/mtmd_dump_embeddings \
+  --model models/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
+  --mmproj models/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
+  --image <image> \
+  --out <llama_prefix.f32> \
+  --threads 20
+```
+
+CK prefix source:
+
+```bash
+CK_NUM_THREADS=20 OMP_NUM_THREADS=20 \
+.venv/bin/python version/v8/scripts/run_multimodal_bridge_v8.py \
+  --decoder-gguf models/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
+  --encoder-gguf models/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
+  --image-path <image> \
+  --prompt 'OCR TEST' \
+  --decoder-context-len 512 \
+  --max-tokens 0 \
+  --workdir <ck_workdir> \
+  --dump-prefix-f32 <ck_prefix.f32> \
+  --no-stream-output
+```
+
+## Results
+
+| sample | shape | CK grid | cosine | RMSE | MAE | max abs |
+|---|---:|---:|---:|---:|---:|---:|
+| clean_text | 2097152 / 2097152 | 16x8 | 0.999259174 | 0.00627279 | 0.00353828 | 0.170078 |
+| receipt | 2097152 / 2097152 | 16x8 | 0.999641299 | 0.00428494 | 0.00282775 | 0.0712301 |
+| table | 2097152 / 2097152 | 16x8 | 0.999097347 | 0.00723644 | 0.00317368 | 0.66362 |
+| paragraph | 3932160 / 3932160 | 24x10 | 0.996389270 | 0.0130378 | 0.00343413 | 1.01251 |
+| card72 | 147456 / 147456 | 3x3 | 0.799037158 | 0.180574 | 0.109638 | 2.64726 |
+
+## Interpretation
+
+CK and llama.cpp agree on prefix shape/token count for all tested images, including
+dynamic grids (`24x10`, `3x3`). The prefix values are not exact.
+
+For OCR-sized inputs the difference is small but not negligible. This is enough
+to explain why decoder step 0 logits are already looser than normal Qwen text
+parity. For the tiny `card72` input, encoder parity is poor and should be treated
+as a preprocessing/resize/normalization or mmproj lowering issue before judging
+decoder accuracy.
+
+## Current Takeaway
+
+The Qwen3-VL issue is not only an autoregressive step-23 problem. Drift exists in
+the visual prefix before decode starts. Decoder drift then accumulates until the
+first visible greedy-token mismatch at generated step 23 on the ctx512 OCR run.

--- a/docs/notes/XEON_FIXES_AVX2_APPLICABILITY_2026-07-06.md
+++ b/docs/notes/XEON_FIXES_AVX2_APPLICABILITY_2026-07-06.md
@@ -1,0 +1,146 @@
+# Xeon Qwen3-VL Fixes vs AVX2 Applicability - 2026-07-06
+
+## Scope
+
+This note maps the recent Qwen3-VL/Xeon performance fixes in local `main` to
+the AVX2 path. There is no local branch literally named `xeon`; the relevant
+history is the July 2026 `perf(v8)` Qwen3-VL OCR speed stack and the local
+VTune/Advisor artifacts under `build/`.
+
+## What The Xeon Stack Fixed
+
+The speed work is mostly performance/profile policy, not the Qwen3-VL long-token
+accuracy issue.
+
+Relevant commits:
+
+| Commit | Area | Result from local notes |
+|---|---|---|
+| `884e90af` | Thread large F16 vision GEMM | Moves vision FP16 GEMM to CK threadpool for large shapes. |
+| `484e7f48` | Q4_K/Q8_K VNNI hsum | Gate/up x16 focused benchmark improved from about 452 ms to 348 ms. |
+| `a2e40265` | FP32 activation x Q8_0 encoder GEMM | Encoder-heavy OCR dropped from about 101.8 s to 77.2 s with OCR answer preserved. |
+| `6014ddea` | Q4 x16 chunk4 reuse | Mixed prefill improved by about 3.3 s on large OCR. |
+| `03d84f40` | `CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512` | Collapsed per-kernel flags into one profile; default-vs-profile improved about 1.60x on Xeon. |
+| `e41140d1` | Q4 x8 profile gate widened | Mixed prefill improved by about 2.3 s on generated OCR. |
+| `2102a9ef` | Attention thread cap | Profile-scoped attention cap set to 16. |
+| `945d8f49` | AVX512 qblock8 attention + Q4 x8 M-reuse | Focused encoder attention improved about 1.38x; OCR stayed correct on clean sample. |
+| `9cfd80ed` | Q6_K thread cap | Q6 row-split benchmark improved from 161.41 ms to 142.18 ms. |
+| `b34e7438` | Qblock fast exp | Profile-scoped fast exp inside AVX512 qblock attention only. |
+
+Best logged Xeon OCR profile result in the note is about `61.6 s` steady-state
+for the large clean OCR check, with expected output:
+
+```text
+CK OCR TEST
+TOTAL 42
+```
+
+The older llama.cpp SDPR reference in the notes is about `55.8 s/sample`, so the
+logged Xeon profile was roughly 10 percent behind that reference, not yet a
+clear win.
+
+## Already Useful On AVX2
+
+These changes are architecture-neutral or have AVX2 code paths already present:
+
+| Fix | AVX2 status | Evidence |
+|---|---|---|
+| `CK_SPEED_PROFILE` plumbing | Applies directly | `include/ck_speed_profiles.h` enables the profile aliases. |
+| Thread defaults/caps | Applies directly | `ck_run_v8.py`, OCR bench wrappers, attention cap, and Q6 cap are not ISA-specific. |
+| Q4 packed-meta x8/x8-M-reuse dispatch policy | Likely applies | `ck_parallel_prefill_v8.c` routes profile Q4 large-prefill shapes through x8/x8reuse gates. The underlying file has AVX2 guarded code for packed-meta dot paths. |
+| Q6_K profile thread cap | Applies directly | Shape-specific cap for `M>=512,N=4096,K=12288` is independent of AVX512. |
+| Focused benchmarks/perf pipeline | Applies directly | `bench_qwen3vl_encoder_attention`, `bench_q4k_dispatch_matrix`, and `qwen3vl_ocr_perf_pipeline.py` all build/run on AVX2 fallback. |
+| Local F16C/AVX F16 GEMM adaptation | Applies to AVX2 | Current workspace adds F16C conversion and AVX/FMA dot loops in `gemm_kernels_f16.c`. This is the clearest AVX2-port of a Xeon-side win. |
+
+## Xeon-Only Or Mostly Xeon-Only Today
+
+These compile out or lose their main acceleration on AVX2:
+
+| Fix | Why it does not directly transfer |
+|---|---|
+| FP32 x Q8_0 M4N4 encoder GEMM | Current fast body is guarded by `#if defined(__AVX512F__)`; AVX2 falls back to row-loop GEMV. |
+| Qblock4/qblock8 encoder attention | Current qblock bodies are guarded by `#if defined(__AVX512F__)`; AVX2 uses the generic threaded full-grid path and AVX2 per-query attention. |
+| Qblock fast exp | Only used inside the AVX512 qblock paths. |
+| VNNI horizontal-sum win | The exact `_mm256_dpbusd_epi32` path requires AVX512-VNNI/VL. AVX2 has to emulate int8 dot products with unpack/madd pairs. |
+| Q4 x16 chunk4 VNNI reuse | The chunk4 body is AVX512-VNNI-only and falls back to the existing m-reuse function otherwise. |
+
+## AVX2 Port Candidates
+
+Priority for AVX2 should be:
+
+1. Keep and validate the local F16C/AVX F16 GEMM patch.
+   This attacks the `ck_gemm_f16_input_fp16_work` hotspot visible in the current
+   AVX2 VTune output.
+
+2. Add an AVX2 version of FP32 x Q8_0 M4N4 or M4N2.
+   The Xeon M4N4 result is the largest encoder-side single win, but the current
+   implementation is AVX512-only. An AVX2 version should reuse 4 activation rows
+   and 2 or 4 Q8 rows, using 8-wide float lanes.
+
+3. Add AVX2 qblock full-attention for Qwen3-VL encoder shape.
+   The shape is fixed and friendly: full attention, `head_dim=72`, aligned head
+   dim around 80. A qblock4 AVX2 path is more realistic than qblock8 because ymm
+   registers are fewer and narrower.
+
+4. Port Q4_K/Q8_K packed-meta reuse to true AVX2 dot kernels.
+   Use the existing packed layout and shape gates, but replace VNNI dpbusd with
+   AVX2 unpack/subtract/maddubs/madd or a parity-clean scalar-assisted variant.
+
+5. Keep thread caps as tunable, not universal defaults.
+   The Xeon notes repeatedly show 16/20/24 thread results shifting by kernel and
+   machine. AVX2 should sweep `1,8,16,20,24` before accepting a default.
+
+## Accuracy Caveat
+
+The inspected Xeon commits are speed/profile commits. They do not explain the
+Qwen3-VL long-token drift we saw locally.
+
+Current AVX2 diagnostic state from the parity work:
+
+| Check | Current read |
+|---|---|
+| Normal Qwen decoder | Good parity in the available v8 checks. |
+| Qwen3-VL multimodal decoder | First visible greedy token mismatch around generated step 23, but numeric drift exists at step 0. |
+| Encoder/bridge vs llama.cpp mtmd | Prefix shape/token count matches; values are close on OCR-sized images but not exact. |
+| First concrete decoder dump failure | Layer-0 attention/residual boundary before MLP (`ffn_inp`) in the wide step-23 dump. |
+
+So for AVX2, do not treat the Xeon speed stack as an accuracy fix. Keep the
+parity harness enabled while porting speed kernels.
+
+## Recommended AVX2 Validation Command
+
+Use the profile for measurement, but remember AVX512-only pieces compile out:
+
+```bash
+CK_SPEED_PROFILE=qwen3vl_ocr_xeon_avx512 \
+CK_NUM_THREADS=20 \
+OMP_NUM_THREADS=1 \
+.venv/bin/python benchmarks/qwen3vl_ocr_perf_pipeline.py \
+  --emit-vtune \
+  --json-out build/qwen3vl_ocr_perf_pipeline_avx2.json \
+  --md-out build/qwen3vl_ocr_perf_pipeline_avx2.md \
+  --raw-json-out build/qwen3vl_ocr_perf_raw_avx2.json
+```
+
+For focused AVX2 port work, start with:
+
+```bash
+CK_NUM_THREADS=20 LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH \
+  build/bench_q8_0_fp32_gemm --M 1028 --N 4096 --K 4096 --warmup 1 --iters 3
+
+CK_NUM_THREADS=20 LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH \
+  build/bench_qwen3vl_encoder_attention --threads 20 --warmup 1 --iters 3
+
+CK_NUM_THREADS=20 LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH \
+  build/bench_q4k_dispatch_matrix
+```
+
+## Bottom Line
+
+The Xeon agent fixed a large part of Qwen3-VL OCR speed by combining profile
+policy, thread caps, packed Q4/Q6 prefill routing, AVX512 Q8 encoder GEMM, and
+AVX512 qblock attention. The profile and dispatch policy are already in `main`
+and are safe to use for AVX2 measurement. The largest remaining AVX2 work is not
+applying commits mechanically; it is writing AVX2 equivalents for the AVX512
+encoder GEMM and qblock-attention kernels, while keeping the long-token parity
+harness as a gate.

--- a/src/kernels/gemm_kernels_f16.c
+++ b/src/kernels/gemm_kernels_f16.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef __AVX512F__
+#if defined(__AVX512F__) || defined(__AVX__) || defined(__F16C__)
 #include <immintrin.h>
 #endif
 
@@ -278,6 +278,85 @@ static inline uint16_t fp32_to_fp16(float f) {
 }
 #endif
 
+static inline void ck_f32_to_f16_row_local(uint16_t *dst, const float *src, int n)
+{
+#ifdef __AVX512F__
+    int i = 0;
+    const int n16 = (n / 16) * 16;
+    for (; i < n16; i += 16) {
+        const __m512 v = _mm512_loadu_ps(src + i);
+        const __m256i h = _mm512_cvtps_ph(v, 0);
+        _mm256_storeu_si256((__m256i *)(dst + i), h);
+    }
+    for (; i < n; ++i) {
+        dst[i] = fp32_to_fp16(src[i]);
+    }
+#elif defined(__F16C__) && defined(__AVX__)
+    int i = 0;
+    const int n8 = (n / 8) * 8;
+    for (; i < n8; i += 8) {
+        const __m256 v = _mm256_loadu_ps(src + i);
+        const __m128i h = _mm256_cvtps_ph(v, 0);
+        _mm_storeu_si128((__m128i *)(dst + i), h);
+    }
+    for (; i < n; ++i) {
+        dst[i] = fp32_to_fp16(src[i]);
+    }
+#else
+    for (int i = 0; i < n; ++i) {
+        dst[i] = fp32_to_fp16(src[i]);
+    }
+#endif
+}
+
+#if defined(__F16C__) && defined(__AVX__)
+static inline float ck_hsum256_ps(__m256 v)
+{
+    __m128 lo = _mm256_castps256_ps128(v);
+    __m128 hi = _mm256_extractf128_ps(v, 1);
+    __m128 sum = _mm_add_ps(lo, hi);
+    sum = _mm_hadd_ps(sum, sum);
+    sum = _mm_hadd_ps(sum, sum);
+    return _mm_cvtss_f32(sum);
+}
+
+static inline float ck_dot_f16_f16_avx(const uint16_t *w, const uint16_t *x, int k)
+{
+    int i = 0;
+    const int k8 = (k / 8) * 8;
+    __m256 acc = _mm256_setzero_ps();
+    for (; i < k8; i += 8) {
+        const __m128i wh = _mm_loadu_si128((const __m128i *)(w + i));
+        const __m128i xh = _mm_loadu_si128((const __m128i *)(x + i));
+        const __m256 wf = _mm256_cvtph_ps(wh);
+        const __m256 xf = _mm256_cvtph_ps(xh);
+#ifdef __FMA__
+        acc = _mm256_fmadd_ps(wf, xf, acc);
+#else
+        acc = _mm256_add_ps(acc, _mm256_mul_ps(wf, xf));
+#endif
+    }
+    float sum = ck_hsum256_ps(acc);
+    for (; i < k; ++i) {
+        sum += fp16_to_fp32(w[i]) * fp16_to_fp32(x[i]);
+    }
+    return sum;
+}
+#endif
+
+static inline float ck_dot_f16_f16_local(const uint16_t *w, const uint16_t *x, int k)
+{
+#if defined(__F16C__) && defined(__AVX__)
+    return ck_dot_f16_f16_avx(w, x, k);
+#else
+    float sum = 0.0f;
+    for (int i = 0; i < k; ++i) {
+        sum += fp16_to_fp32(w[i]) * fp16_to_fp32(x[i]);
+    }
+    return sum;
+#endif
+}
+
 /* ============================================================================
  * GEMV: y = W @ x  (W is FP16, x and y are FP32)
  * ============================================================================ */
@@ -458,18 +537,11 @@ static void gemm_f16_input_fp16_ref(float *Y,
         const float *x_row = &X[(size_t)n * (size_t)K];
         uint16_t x_f16[K];
 
-        for (int k = 0; k < K; ++k) {
-            x_f16[k] = fp32_to_fp16(x_row[k]);
-        }
+        ck_f32_to_f16_row_local(x_f16, x_row, K);
 
         for (int row = 0; row < M; ++row) {
-            float sum = 0.0f;
             const uint16_t *w_row = &W[(size_t)row * (size_t)K];
-
-            for (int k = 0; k < K; ++k) {
-                sum += fp16_to_fp32(w_row[k]) * fp16_to_fp32(x_f16[k]);
-            }
-
+            const float sum = ck_dot_f16_f16_local(w_row, x_f16, K);
             Y[(size_t)n * (size_t)M + (size_t)row] = sum;
         }
     }
@@ -495,18 +567,11 @@ static void ck_gemm_f16_input_fp16_work(int ith, int nth, void *opaque)
         const float *x_row = args->X + (size_t)n * (size_t)K;
         uint16_t x_f16[K];
 
-        for (int k = 0; k < K; ++k) {
-            x_f16[k] = fp32_to_fp16(x_row[k]);
-        }
+        ck_f32_to_f16_row_local(x_f16, x_row, K);
 
         for (int row = 0; row < M; ++row) {
-            float sum = 0.0f;
             const uint16_t *w_row = args->W + (size_t)row * (size_t)K;
-
-            for (int k = 0; k < K; ++k) {
-                sum += fp16_to_fp32(w_row[k]) * fp16_to_fp32(x_f16[k]);
-            }
-
+            const float sum = ck_dot_f16_f16_local(w_row, x_f16, K);
             args->Y[(size_t)n * (size_t)M + (size_t)row] = sum;
         }
     }

--- a/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
+++ b/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""
+Tokenizer-free multimodal multi-token greedy parity probe.
+
+This is the multimodal counterpart to compare_multitoken_logits_v8.py.  It
+starts from a bridge_report.json + prefix.f32 produced by run_multimodal_bridge_v8,
+does one CK mixed visual/text prefill, then advances CK through real
+ck_model_decode calls while llama.cpp replays the same generated suffix.
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from array import array
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import decoder_first_token_parity_v8 as first_token  # type: ignore  # noqa: E402
+from gguf_tokenizer import GGUFTokenizer  # type: ignore  # noqa: E402
+
+
+def _ck_logits_from_buffer(buf: Any, vocab_size: int) -> np.ndarray:
+    return np.ctypeslib.as_array(buf, shape=(int(vocab_size),)).astype(np.float32, copy=True)
+
+
+def _decode_topk(logits: np.ndarray, tokenizer: GGUFTokenizer, top_k: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    n = int(logits.size)
+    k = max(1, min(int(top_k), n))
+    top = np.argpartition(-logits, k - 1)[:k]
+    top = top[np.argsort(-logits[top])]
+    for idx in top.tolist():
+        rows.append(
+            {
+                "token_id": int(idx),
+                "logit": float(logits[int(idx)]),
+                "token_text": tokenizer.decode([int(idx)], skip_special=False),
+            }
+        )
+    return rows
+
+
+
+def _run_llama_greedy_sequence(inputs: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    helper = first_token.compare_first_token_logits_v7.ensure_llama_helper()
+    with tempfile.TemporaryDirectory(prefix="llama_token_replay_v8_seq_") as td:
+        tmp = Path(td)
+        logits_out = tmp / "llama_final.f32"
+        seq_out = tmp / "llama_seq.f32"
+        cmd = [
+            str(helper),
+            "--model",
+            str(inputs["gguf_path"]),
+            "--ctx",
+            str(int(inputs["ctx_len"])),
+            "--top-k",
+            str(int(args.top_k)),
+            "--decode-mode",
+            str(args.llama_decode_mode),
+            "--logits-out",
+            str(logits_out),
+            "--logits-seq-out",
+            str(seq_out),
+            "--greedy-steps",
+            str(int(args.max_new_tokens)),
+        ]
+        if inputs["tokens_before"]:
+            cmd.extend(["--tokens-before", ",".join(str(t) for t in inputs["tokens_before"])])
+            if inputs["tokens_after"]:
+                cmd.extend(["--tokens-after", ",".join(str(t) for t in inputs["tokens_after"])])
+        elif inputs["tokens_after"]:
+            cmd.extend(["--tokens", ",".join(str(t) for t in inputs["tokens_after"])])
+        if inputs["llama_prefix_path"] is not None:
+            cmd.extend(["--prefix-f32", str(inputs["llama_prefix_path"])])
+        if inputs["prefix_grid"] is not None:
+            gx, gy = inputs["prefix_grid"]
+            cmd.extend(["--prefix-grid-x", str(int(gx)), "--prefix-grid-y", str(int(gy))])
+        if int(inputs["prefix_row_dim"]) > 0:
+            cmd.extend(["--prefix-row-dim", str(int(inputs["prefix_row_dim"]))])
+        cmd.extend(["--prefix-text-pos", str(int(inputs["prefix_text_pos"]))])
+        if int(args.threads) > 0:
+            cmd.extend(["--threads", str(int(args.threads))])
+        if bool(args.llama_no_repack):
+            cmd.append("--no-repack")
+        proc = subprocess.run(cmd, cwd=str(REPO_ROOT), text=True, capture_output=True, check=False)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "llama_token_replay greedy sequence failed\n"
+                f"cmd: {' '.join(cmd)}\nrc: {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}\n"
+            )
+        payload = proc.stdout.strip().splitlines()[-1]
+        meta = json.loads(payload)
+        if not isinstance(meta, dict) or not meta.get("ok"):
+            raise RuntimeError(f"llama_token_replay returned invalid payload: {payload}")
+        n_vocab = int(meta.get("n_vocab", 0))
+        steps = int(meta.get("greedy_steps", args.max_new_tokens) or 0)
+        logits = np.fromfile(seq_out, dtype=np.float32)
+        expected = int(steps) * int(n_vocab)
+        if logits.size != expected:
+            raise RuntimeError(f"llama sequence logits size mismatch: got={logits.size} expected={expected}")
+        return {
+            "meta": meta,
+            "logits": logits.reshape((steps, n_vocab)),
+        }
+
+def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> dict[str, Any]:
+    bridge_report = first_token._load_bridge_report(args.bridge_report.resolve())
+    gguf_value = str(((bridge_report.get("decoder_runtime") or {}).get("gguf") or "")).strip()
+    if not gguf_value:
+        raise ValueError("bridge report does not include decoder_runtime.gguf; pass a fresh report")
+    gguf_path = Path(gguf_value).resolve()
+    workdir = args.workdir.resolve()
+    workdir.mkdir(parents=True, exist_ok=True)
+    decoder_dir = workdir / "decoder"
+
+    requested_ctx_len = int(args.ctx_len or bridge_report.get("decoder_context_len") or 256)
+    runtime = first_token.bridge_runner_v8._prepare_decoder_runtime(
+        gguf_path,
+        decoder_dir,
+        parity_dump=bool(parity_dump),
+        context_override=max(1, requested_ctx_len),
+    )
+    tokenizer = GGUFTokenizer.from_gguf(str(gguf_path))
+    _, tokens_before, tokens_after, prompt_meta = first_token._resolve_prompt_token_segments(
+        tokenizer,
+        prompt=None,
+        tokens_csv=None,
+        tokens_before_csv=None,
+        tokens_after_csv=None,
+        bridge_report=bridge_report,
+    )
+    prefix_path = args.prefix_f32.resolve() if args.prefix_f32 is not None else None
+    if prefix_path is None:
+        report_prefix = str(bridge_report.get("prefix_dump_path") or "").strip()
+        if report_prefix:
+            prefix_path = Path(report_prefix).resolve()
+    prefix_embeddings, prefix_tokens, prefix_row_dim, prefix_source = first_token._load_prefix_embeddings(
+        prefix_path,
+        0,
+        int(runtime["embed_dim"]),
+        int(runtime.get("input_embed_dim", 0) or 0),
+        int(args.prefix_row_dim) if args.prefix_row_dim is not None else None,
+    )
+    total_prompt_tokens = len(tokens_before) + len(tokens_after)
+    resolved_ctx_len = max(int(requested_ctx_len), int(prefix_tokens) + total_prompt_tokens, 1)
+    if resolved_ctx_len != requested_ctx_len:
+        runtime = first_token.bridge_runner_v8._prepare_decoder_runtime(
+            gguf_path,
+            decoder_dir,
+            parity_dump=bool(parity_dump),
+            context_override=resolved_ctx_len,
+        )
+
+    bridge_grid_x = None if bridge_report.get("prefix_grid_x") is None else int(bridge_report.get("prefix_grid_x"))
+    bridge_grid_y = None if bridge_report.get("prefix_grid_y") is None else int(bridge_report.get("prefix_grid_y"))
+    prefix_grid = first_token._resolve_prefix_grid(
+        int(prefix_tokens),
+        int(args.prefix_grid_x) if args.prefix_grid_x is not None else bridge_grid_x,
+        int(args.prefix_grid_y) if args.prefix_grid_y is not None else bridge_grid_y,
+    )
+    prefix_text_pos = (
+        int(args.prefix_text_pos)
+        if args.prefix_text_pos is not None
+        else (
+            int(bridge_report.get("prefix_text_pos"))
+            if bridge_report.get("prefix_text_pos") is not None
+            else (
+                len(tokens_before) + max(int(prefix_grid[0]), int(prefix_grid[1]))
+                if prefix_grid is not None
+                else len(tokens_before) + int(prefix_tokens)
+            )
+        )
+    )
+    llama_prefix_path = first_token._materialize_llama_prefix(
+        prefix_embeddings,
+        int(prefix_tokens),
+        workdir,
+        prefix_path=prefix_path,
+    )
+    return {
+        "bridge_report": bridge_report,
+        "gguf_path": gguf_path,
+        "workdir": workdir,
+        "runtime": runtime,
+        "tokenizer": tokenizer,
+        "tokens_before": [int(t) for t in tokens_before],
+        "tokens_after": [int(t) for t in tokens_after],
+        "prompt_meta": prompt_meta,
+        "prefix_embeddings": prefix_embeddings,
+        "prefix_tokens": int(prefix_tokens),
+        "prefix_row_dim": int(prefix_row_dim),
+        "prefix_source": prefix_source,
+        "prefix_path": prefix_path,
+        "llama_prefix_path": llama_prefix_path,
+        "prefix_grid": prefix_grid,
+        "prefix_text_pos": int(prefix_text_pos),
+        "ctx_len": int(resolved_ctx_len),
+        "requested_ctx_len": int(requested_ctx_len),
+    }
+
+
+def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    step_index = int(args.dump_step)
+    steps = list(report.get("steps") or [])
+    if step_index < 0 or step_index >= len(steps):
+        raise ValueError(f"--dump-step {step_index} is outside captured steps [0, {max(0, len(steps) - 1)}]")
+    dump_dir = args.dump_dir
+    if dump_dir is None:
+        dump_dir = args.workdir / f"dump_step_{step_index:04d}"
+
+    inputs = _prepare_inputs(args, parity_dump=True)
+    row = dict(steps[step_index])
+    generated_prefix = [int(t) for t in list(row.get("generated_prefix") or [])]
+    replay_tokens_after = [int(t) for t in inputs["tokens_after"]] + generated_prefix
+    ck, dump_report = first_token._capture_dump_compare(
+        inputs["gguf_path"],
+        inputs["runtime"],
+        inputs["prefix_embeddings"],
+        int(inputs["prefix_tokens"]),
+        replay_tokens_after,
+        tokens_before=inputs["tokens_before"],
+        prefix_row_dim=int(inputs["prefix_row_dim"]),
+        ctx_len=int(inputs["ctx_len"]),
+        top_k=int(args.top_k),
+        threads=int(args.threads),
+        dump_root=dump_dir.resolve(),
+        dump_names=str(args.dump_names),
+        dump_pass=str(args.dump_pass),
+        dump_atol=float(args.dump_atol),
+        dump_rtol=float(args.dump_rtol),
+        prefix_grid=inputs["prefix_grid"],
+        prefix_text_pos=int(inputs["prefix_text_pos"]),
+        ck_strict_parity=bool(args.ck_strict_parity),
+    )
+    return {
+        "step": int(step_index),
+        "step_row": row,
+        "dump_dir": str(dump_dir.resolve()),
+        "replay_tokens_after_count": int(len(replay_tokens_after)),
+        "generated_prefix": generated_prefix,
+        "ck_top1": int((ck.get("comparison") or {}).get("top1_ck", ck.get("ck_top1", -1))),
+        "dump": dump_report,
+    }
+
+
+def _init_ck_state(inputs: dict[str, Any], strict_parity: bool) -> tuple[Any, Any, int]:
+    runtime = inputs["runtime"]
+    model_so = Path(runtime["so_path"])
+    lib = first_token.bridge_runner_v8._load_decoder_lib(model_so)
+    rc = lib.ck_model_init_with_manifest(
+        str(runtime["weights_bump"]).encode(),
+        str(runtime["manifest_map"]).encode(),
+    )
+    if rc != 0:
+        raise RuntimeError(f"decoder init failed with rc={rc}")
+    if hasattr(lib, "ck_set_strict_parity"):
+        lib.ck_set_strict_parity(1 if strict_parity else 0)
+
+    vocab_size = int(lib.ck_model_get_vocab_size())
+    if vocab_size <= 0:
+        vocab_size = int(runtime["vocab_size"])
+    logits = (ctypes.c_float * vocab_size)()
+
+    tokens_before = inputs["tokens_before"]
+    tokens_after = inputs["tokens_after"]
+    prefix_tokens = int(inputs["prefix_tokens"])
+    prefix_row_dim = int(inputs["prefix_row_dim"])
+    prefix_embeddings: array = inputs["prefix_embeddings"]
+
+    prefix_ptr = None
+    if prefix_tokens > 0:
+        expected = prefix_tokens * prefix_row_dim
+        if len(prefix_embeddings) != expected:
+            raise RuntimeError(f"prefix float count mismatch: got={len(prefix_embeddings)} expected={expected}")
+        prefix_ptr = (ctypes.c_float * len(prefix_embeddings))(*prefix_embeddings)
+    before_arr = (ctypes.c_int32 * len(tokens_before))(*tokens_before) if tokens_before else None
+    after_arr = (ctypes.c_int32 * len(tokens_after))(*tokens_after) if tokens_after else None
+    grid = inputs["prefix_grid"]
+    if tokens_before and hasattr(lib, "ck_model_forward_segments_grid_ex"):
+        grid_x, grid_y = grid if grid is not None else (0, 0)
+        rc = lib.ck_model_forward_segments_grid_ex(
+            before_arr,
+            len(tokens_before),
+            prefix_ptr,
+            prefix_tokens,
+            prefix_row_dim,
+            int(grid_x),
+            int(grid_y),
+            int(inputs["prefix_text_pos"]),
+            after_arr,
+            len(tokens_after),
+            logits,
+        )
+    elif hasattr(lib, "ck_model_forward_mixed_grid_ex") and grid is not None:
+        grid_x, grid_y = grid
+        rc = lib.ck_model_forward_mixed_grid_ex(
+            prefix_ptr,
+            prefix_tokens,
+            prefix_row_dim,
+            int(grid_x),
+            int(grid_y),
+            int(inputs["prefix_text_pos"]),
+            after_arr,
+            len(tokens_after),
+            logits,
+        )
+    elif hasattr(lib, "ck_model_forward_mixed_ex"):
+        rc = lib.ck_model_forward_mixed_ex(prefix_ptr, prefix_tokens, prefix_row_dim, after_arr, len(tokens_after), logits)
+    else:
+        rc = lib.ck_model_forward_mixed(prefix_ptr, prefix_tokens, after_arr, len(tokens_after), logits)
+    if rc != 0:
+        raise RuntimeError(f"decoder forward_mixed failed rc={rc}")
+    return lib, logits, vocab_size
+
+
+def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]:
+    inputs = _prepare_inputs(args)
+    tokenizer: GGUFTokenizer = inputs["tokenizer"]
+    llama_seq = _run_llama_greedy_sequence(inputs, args)
+    lib, logits_buf, vocab_size = _init_ck_state(inputs, bool(args.ck_strict_parity))
+    generated: list[int] = []
+    llama_generated = [int(t) for t in list((llama_seq.get("meta") or {}).get("greedy_generated", []))]
+    steps: list[dict[str, Any]] = []
+    first_divergence: dict[str, Any] | None = None
+    try:
+        for step in range(max(1, int(args.max_new_tokens))):
+            ck_logits = _ck_logits_from_buffer(logits_buf, vocab_size)
+            if step >= int(llama_seq["logits"].shape[0]):
+                raise RuntimeError(f"llama sequence ended before step={step}")
+            llama_logits = llama_seq["logits"][step]
+            cmp = first_token.compare_first_token_logits_v7.compare_logits(ck_logits, llama_logits, int(args.top_k))
+            ck_next = int(cmp["top1_ck"])
+            llama_next = int(llama_generated[step]) if step < len(llama_generated) else int(cmp["top1_llama"])
+            top1_match = ck_next == llama_next
+            row = {
+                "step": int(step),
+                "generated_prefix": [int(t) for t in generated],
+                "prefix_len_after_image": int(len(inputs["tokens_after"]) + len(generated)),
+                "ck_next": ck_next,
+                "llama_next": llama_next,
+                "ck_next_text": tokenizer.decode([ck_next], skip_special=False),
+                "llama_next_text": tokenizer.decode([llama_next], skip_special=False),
+                "top1_match": bool(top1_match),
+                "llama_no_repack": bool(args.llama_no_repack),
+                "cosine": float(cmp["cosine"]),
+                "rmse": float(cmp["rmse"]),
+                "mean_abs_diff": float(cmp["mean_abs_diff"]),
+                "max_abs_diff": float(cmp["max_abs_diff"]),
+                "ck_top1_margin": float(cmp.get("ck_top1_margin", 0.0)),
+                "llama_top1_margin": float(cmp.get("llama_top1_margin", 0.0)),
+                "topk_overlap_count": int(cmp["topk_overlap_count"]),
+                "topk_overlap_ratio": float(cmp["topk_overlap_ratio"]),
+                "ck_topk_ids": list(cmp["ck_topk_ids"]),
+                "llama_topk_ids": list(cmp["llama_topk_ids"]),
+                "ck_topk": _decode_topk(ck_logits, tokenizer, int(args.top_k)),
+                "llama_topk": _decode_topk(llama_logits, tokenizer, int(args.top_k)),
+                "topk_logits": list(cmp.get("topk_logits", [])),
+            }
+            steps.append(row)
+            if not top1_match and first_divergence is None:
+                first_divergence = row
+                if args.append_on_divergence == "stop":
+                    break
+            if top1_match or args.append_on_divergence == "llama":
+                next_token = llama_next
+            elif args.append_on_divergence == "ck":
+                next_token = ck_next
+            else:
+                break
+            generated.append(int(next_token))
+            if step + 1 >= int(args.max_new_tokens):
+                break
+            rc = lib.ck_model_decode(ctypes.c_int32(int(next_token)), logits_buf)
+            if rc != 0:
+                raise RuntimeError(f"ck_model_decode failed rc={rc} at step={step}")
+    finally:
+        if hasattr(lib, "ck_model_free"):
+            try:
+                lib.ck_model_free()
+            except Exception:
+                pass
+
+    return {
+        "status": "pass" if first_divergence is None else "fail",
+        "pass": first_divergence is None,
+        "bridge_report_path": str(args.bridge_report.resolve()),
+        "gguf_path": str(inputs["gguf_path"]),
+        "workdir": str(inputs["workdir"]),
+        "ctx_len": int(inputs["ctx_len"]),
+        "requested_ctx_len": int(inputs["requested_ctx_len"]),
+        "threads": int(args.threads),
+        "top_k": int(args.top_k),
+        "llama_decode_mode": str(args.llama_decode_mode),
+        "llama_greedy_generated": llama_generated,
+        "append_on_divergence": str(args.append_on_divergence),
+        "prompt_tokens_before_image": inputs["tokens_before"],
+        "prompt_tokens_after_image": inputs["tokens_after"],
+        "prefix": {
+            "source": str(inputs["prefix_source"]),
+            "tokens": int(inputs["prefix_tokens"]),
+            "row_dim": int(inputs["prefix_row_dim"]),
+            "path": None if inputs["prefix_path"] is None else str(inputs["prefix_path"]),
+            "grid": None if inputs["prefix_grid"] is None else [int(inputs["prefix_grid"][0]), int(inputs["prefix_grid"][1])],
+            "text_pos": int(inputs["prefix_text_pos"]),
+        },
+        "generated_shared_tokens": [int(t) for t in generated],
+        "generated_shared_text": tokenizer.decode(generated, skip_special=False) if generated else "",
+        "first_divergence": first_divergence,
+        "steps": steps,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Multimodal multi-token greedy parity (CK vs llama.cpp)")
+    ap.add_argument("--bridge-report", required=True, type=Path)
+    ap.add_argument("--prefix-f32", type=Path, default=None)
+    ap.add_argument("--prefix-row-dim", type=int, default=None)
+    ap.add_argument("--prefix-grid-x", type=int, default=None)
+    ap.add_argument("--prefix-grid-y", type=int, default=None)
+    ap.add_argument("--prefix-text-pos", type=int, default=None)
+    ap.add_argument("--workdir", required=True, type=Path)
+    ap.add_argument("--ctx-len", type=int, default=None)
+    ap.add_argument("--max-new-tokens", type=int, default=16)
+    ap.add_argument("--top-k", type=int, default=16)
+    ap.add_argument("--threads", type=int, default=0)
+    ap.add_argument("--llama-decode-mode", choices=["batched", "sequential"], default="sequential")
+    ap.add_argument("--llama-no-repack", action="store_true", help="Disable llama.cpp CPU tensor repacking in the replay helper")
+    ap.add_argument("--llama-repack-fallback", action=argparse.BooleanOptionalAction, default=True, help="Retry a failed llama replay step with --no-repack")
+    ap.add_argument("--append-on-divergence", choices=["stop", "llama", "ck"], default="stop")
+    ap.add_argument("--ck-strict-parity", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--json-out", type=Path, default=None)
+    ap.add_argument("--dump-step", type=int, default=None, help="Capture CK-vs-llama tensor dumps at this generated step")
+    ap.add_argument("--dump-dir", type=Path, default=None, help="Directory for --dump-step tensor dumps")
+    ap.add_argument(
+        "--dump-names",
+        type=str,
+        default="Qcur-0,Kcur-0,Vcur-0,Qcur_normed-0,Kcur_normed-0,kqv_out-0",
+        help="Comma-separated llama dump names for --dump-step",
+    )
+    ap.add_argument("--dump-pass", choices=("all", "prefill", "decode"), default="decode")
+    ap.add_argument("--dump-atol", type=float, default=1.0e-4)
+    ap.add_argument("--dump-rtol", type=float, default=1.0e-3)
+    ap.add_argument("--summary", action="store_true")
+    args = ap.parse_args()
+
+    if args.threads > 0:
+        os.environ["CK_NUM_THREADS"] = str(int(args.threads))
+        os.environ["OMP_NUM_THREADS"] = str(int(args.threads))
+    report = run_multimodal_multitoken_parity(args)
+    if args.dump_step is not None:
+        report["step_dump"] = _capture_step_dump(report, args)
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    if args.summary:
+        first = report.get("first_divergence")
+        if first:
+            print(
+                "status=fail "
+                f"step={first['step']} ck_next={first['ck_next']}({first['ck_next_text']!r}) "
+                f"llama_next={first['llama_next']}({first['llama_next_text']!r}) "
+                f"cosine={first['cosine']:.6f} rmse={first['rmse']:.6f} "
+                f"topk_overlap={first['topk_overlap_count']}/{args.top_k}"
+            )
+        else:
+            print(
+                "status=pass "
+                f"steps={len(report.get('steps', []))} "
+                f"generated={report.get('generated_shared_text', '')!r}"
+            )
+        if report.get("step_dump"):
+            dump = (report["step_dump"] or {}).get("dump") or {}
+            first_issue = dump.get("first_issue")
+            summary = dump.get("summary") or {}
+            if first_issue:
+                print(
+                    "dump=fail "
+                    f"step={report['step_dump']['step']} "
+                    f"layer={first_issue.get('layer')} op={first_issue.get('op')} "
+                    f"status={first_issue.get('status')} "
+                    f"max_abs_diff={float(first_issue.get('max_abs_diff', 0.0)):.6g} "
+                    f"summary={summary}"
+                )
+            else:
+                print(f"dump={dump.get('status', 'ok')} step={report['step_dump']['step']} summary={summary}")
+    else:
+        print(json.dumps(report, indent=2))
+    return 0 if report.get("pass") else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/decoder_first_token_parity_v8.py
+++ b/version/v8/scripts/decoder_first_token_parity_v8.py
@@ -241,6 +241,7 @@ def _run_llama_capture(
     decode_mode: str = "batched",
     dump_dir: Path | None = None,
     dump_names: str | None = None,
+    no_repack: bool = False,
 ) -> dict[str, Any]:
     helper = compare_first_token_logits_v7.ensure_llama_helper()
     if dump_dir is not None:
@@ -283,6 +284,8 @@ def _run_llama_capture(
             cmd.extend(["--prefix-text-pos", str(int(prefix_text_pos))])
         if threads > 0:
             cmd.extend(["--threads", str(int(threads))])
+        if no_repack:
+            cmd.append("--no-repack")
         if dump_dir is not None:
             cmd.extend(["--dump-dir", str(dump_dir)])
             if dump_names:
@@ -990,6 +993,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--ck-strict-parity", action=argparse.BooleanOptionalAction, default=True)
     ap.add_argument("--json-out", type=Path, default=None, help="Optional explicit JSON report path")
     args = ap.parse_args(argv)
+
+    if int(args.threads) > 0:
+        os.environ["CK_NUM_THREADS"] = str(int(args.threads))
+        os.environ["OMP_NUM_THREADS"] = str(int(args.threads))
 
     bridge_report = _load_bridge_report(args.bridge_report.resolve()) if args.bridge_report is not None else None
     if args.gguf is not None:

--- a/version/v8/scripts/llama_token_replay_v8.cpp
+++ b/version/v8/scripts/llama_token_replay_v8.cpp
@@ -23,6 +23,7 @@ struct Args {
     std::string prompt;
     std::string prefix_f32_path;
     std::string logits_out_path;
+    std::string logits_seq_out_path;
     std::string embeddings_out_path;
     std::string dump_dir;
     std::vector<std::string> dump_names;
@@ -35,7 +36,9 @@ struct Args {
     int prefix_grid_y = 0;
     int prefix_row_dim = 0;
     int prefix_text_pos = -1;
+    int greedy_steps = 0;
     bool no_repack = false;
+    bool dump_list_only = false;
 };
 
 struct DumpState {
@@ -44,6 +47,7 @@ struct DumpState {
     std::unordered_set<std::string> names;
     bool dump_all = false;
     int dumped = 0;
+    bool list_only = false;
     int32_t current_token_id = 0;
     std::unordered_map<std::string, int> occurrences;
 };
@@ -185,6 +189,18 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
             args.logits_out_path = v;
             continue;
         }
+        if (a == "--logits-seq-out") {
+            const char * v = need_value("--logits-seq-out");
+            if (!v) return false;
+            args.logits_seq_out_path = v;
+            continue;
+        }
+        if (a == "--greedy-steps") {
+            const char * v = need_value("--greedy-steps");
+            if (!v) return false;
+            args.greedy_steps = std::max(0, std::atoi(v));
+            continue;
+        }
         if (a == "--embeddings-out") {
             const char * v = need_value("--embeddings-out");
             if (!v) return false;
@@ -201,6 +217,10 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
             const char * v = need_value("--dump-names");
             if (!v) return false;
             args.dump_names = split_csv(v);
+            continue;
+        }
+        if (a == "--dump-list-only") {
+            args.dump_list_only = true;
             continue;
         }
         if (a == "--decode-mode") {
@@ -231,10 +251,10 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
             std::cout
                 << "Usage: llama_token_replay --model <path.gguf> "
                 << "(--tokens <id,id,...> | --prompt <text> | [--tokens-before <id,id,...>] [--tokens-after <id,id,...>]) "
-                << "--logits-out <path.bin> [--embeddings-out <path.f32>] [--prefix-f32 <path.f32>] "
+                << "--logits-out <path.bin> [--logits-seq-out <path.bin> --greedy-steps N] [--embeddings-out <path.f32>] [--prefix-f32 <path.f32>] "
                 << "[--prefix-grid-x N --prefix-grid-y N] [--prefix-row-dim N] [--prefix-text-pos N] [--ctx N] [--top-k K] [--threads N] "
                 << "[--decode-mode batched|sequential] [--prefix-decode-mode batched|sequential] "
-                << "[--dump-dir dir --dump-names a,b,c] [--no-repack]\n";
+                << "[--dump-dir dir --dump-names a,b,c] [--dump-list-only] [--no-repack]\n";
             std::exit(0);
         }
         err = "unknown arg: " + a;
@@ -464,22 +484,23 @@ static bool dump_eval_callback(struct ggml_tensor * t, bool ask, void * user_dat
         return true;
     }
 
-    std::vector<uint8_t> raw(static_cast<size_t>(nbytes));
-    ggml_backend_tensor_get(t, raw.data(), 0, static_cast<size_t>(nbytes));
-
     DumpState * mut = static_cast<DumpState *>(user_data);
     const int occurrence = mut->occurrences[base_name]++;
     const std::string dump_name = make_dump_name(base_name, mut->current_token_id, occurrence);
 
     std::filesystem::create_directories(mut->dump_dir);
-    const std::filesystem::path bin_path = mut->dump_dir / (dump_name + ".bin");
-    std::ofstream f(bin_path, std::ios::binary | std::ios::trunc);
-    if (!f) {
-        return false;
-    }
-    f.write(reinterpret_cast<const char *>(raw.data()), static_cast<std::streamsize>(raw.size()));
-    if (!f.good()) {
-        return false;
+    if (!mut->list_only) {
+        std::vector<uint8_t> raw(static_cast<size_t>(nbytes));
+        ggml_backend_tensor_get(t, raw.data(), 0, static_cast<size_t>(nbytes));
+        const std::filesystem::path bin_path = mut->dump_dir / (dump_name + ".bin");
+        std::ofstream f(bin_path, std::ios::binary | std::ios::trunc);
+        if (!f) {
+            return false;
+        }
+        f.write(reinterpret_cast<const char *>(raw.data()), static_cast<std::streamsize>(raw.size()));
+        if (!f.good()) {
+            return false;
+        }
     }
 
     const std::filesystem::path meta_path = mut->dump_dir / (dump_name + ".json");
@@ -771,6 +792,7 @@ int main(int argc, char ** argv) {
     if (!args.dump_dir.empty()) {
         dump_state.dump_dir = args.dump_dir;
         dump_state.index_path = dump_state.dump_dir / "index.json";
+        dump_state.list_only = args.dump_list_only;
         dump_state.dump_all = args.dump_names.empty();
         for (const std::string & name : args.dump_names) {
             if (!name.empty()) {
@@ -921,6 +943,64 @@ int main(int argc, char ** argv) {
         }
     }
 
+    std::vector<llama_token> greedy_generated;
+    if (!args.logits_seq_out_path.empty() && args.greedy_steps > 0) {
+        std::ofstream seq(args.logits_seq_out_path, std::ios::binary | std::ios::trunc);
+        if (!seq) {
+            print_json_error("failed opening logits-seq-out file");
+            llama_free(ctx);
+            llama_model_free(model);
+            llama_backend_free();
+            return 18;
+        }
+        for (int step = 0; step < args.greedy_steps; ++step) {
+            seq.write(reinterpret_cast<const char *>(logits), static_cast<std::streamsize>(n_vocab) * sizeof(float));
+            if (!seq.good()) {
+                print_json_error("failed writing logits-seq-out file");
+                llama_free(ctx);
+                llama_model_free(model);
+                llama_backend_free();
+                return 19;
+            }
+            const float * best_it = std::max_element(logits, logits + n_vocab);
+            llama_token next = static_cast<llama_token>(best_it - logits);
+            greedy_generated.push_back(next);
+            if (step + 1 >= args.greedy_steps) {
+                break;
+            }
+            begin_dump_batch(dump_state.dump_dir.empty() ? nullptr : &dump_state, prefix_text_pos + static_cast<int32_t>(tokens_after.size()) + step);
+            llama_batch batch = llama_batch_init(1, 0, 1);
+            batch.n_tokens = 1;
+            batch.token[0] = next;
+            batch.pos[0] = prefix_text_pos + static_cast<int32_t>(tokens_after.size()) + step;
+            batch.n_seq_id[0] = 1;
+            batch.seq_id[0][0] = 0;
+            batch.logits[0] = 1;
+            const int32_t rc = llama_decode(ctx, batch);
+            llama_batch_free(batch);
+            if (rc != 0) {
+                std::ostringstream oss;
+                oss << "llama_decode failed rc=" << rc << " during greedy step " << step;
+                print_json_error(oss.str());
+                llama_free(ctx);
+                llama_model_free(model);
+                llama_backend_free();
+                return 20;
+            }
+            logits = llama_get_logits_ith(ctx, -1);
+            if (!logits) {
+                logits = llama_get_logits(ctx);
+            }
+            if (!logits) {
+                print_json_error("llama logits pointer is null during greedy replay");
+                llama_free(ctx);
+                llama_model_free(model);
+                llama_backend_free();
+                return 21;
+            }
+        }
+    }
+
     {
         std::ofstream f(args.logits_out_path, std::ios::binary | std::ios::trunc);
         if (!f) {
@@ -984,6 +1064,13 @@ int main(int argc, char ** argv) {
     }
     std::cout << "],";
     std::cout << "\"decode_mode\":\"" << args.decode_mode << "\",";
+    std::cout << "\"greedy_steps\":" << args.greedy_steps << ",";
+    std::cout << "\"greedy_generated\":[";
+    for (size_t i = 0; i < greedy_generated.size(); ++i) {
+        if (i) std::cout << ",";
+        std::cout << greedy_generated[i];
+    }
+    std::cout << "],";
     std::cout << "\"dumped\":" << dump_state.dumped << ",";
     std::cout << "\"topk\":[";
     for (int i = 0; i < k; ++i) {


### PR DESCRIPTION
## Summary
- add deterministic Qwen3-VL multimodal multi-token parity harness against llama.cpp replay
- add llama replay sequence logits/dump-list support and thread propagation for reproducible parity runs
- speed up F16 vision GEMM on AVX/F16C paths while preserving scalar fallback
- document encoder mtmd parity and Xeon-to-AVX2 applicability findings

## Validation
- .venv/bin/python -m py_compile version/v8/scripts/decoder_first_token_parity_v8.py version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
- git diff --cached --check
- make --no-print-directory -B build/libckernel_engine.so