### PR TITLE
perf(v7): gate packed q4 prefill paths

### DIFF
--- a/benchmarks/bench_q4k_dispatch_matrix.c
+++ b/benchmarks/bench_q4k_dispatch_matrix.c
@@ -269,6 +269,7 @@ int main(int argc, char **argv) {
     int quick = 0;
     int iters = 20;
     int warmup = 3;
+    shape_t custom_shape = {NULL, 0, 0, 0, NULL};
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--quick") == 0) {
             quick = 1;
@@ -276,6 +277,12 @@ int main(int argc, char **argv) {
             warmup = 2;
         } else if (strcmp(argv[i], "--iters") == 0 && i + 1 < argc) {
             iters = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--shape") == 0 && i + 3 < argc) {
+            custom_shape.name = "custom";
+            custom_shape.M = atoi(argv[++i]);
+            custom_shape.N = atoi(argv[++i]);
+            custom_shape.K = atoi(argv[++i]);
+            custom_shape.comment = "custom";
         }
     }
 
@@ -309,7 +316,11 @@ int main(int argc, char **argv) {
         {"qwen3vl_down", 1028, 4096, 11008, "Qwen3-VL mlp down"},
         {NULL, 0, 0, 0, NULL},
     };
-    const shape_t *shapes = quick ? quick_shapes : full_shapes;
+    const shape_t custom_shapes[] = {
+        {custom_shape.name, custom_shape.M, custom_shape.N, custom_shape.K, custom_shape.comment},
+        {NULL, 0, 0, 0, NULL},
+    };
+    const shape_t *shapes = custom_shape.name ? custom_shapes : (quick ? quick_shapes : full_shapes);
 
     printf("Q4_K x Q8_K prefill dispatch matrix; lower ms is better\n");
     printf("threads=%d warmup=%d iters=%d x8mt_tile_m=%d x16_tile_m=%d llama=%s\n", threads, warmup, iters, x8mt_tile_m, x16_tile_m, llama_fn ? "yes" : "no");

--- a/docs/notes/NANBEIGE_V7_ROOFLINE_REPORT_2026-07-06.md
+++ b/docs/notes/NANBEIGE_V7_ROOFLINE_REPORT_2026-07-06.md
@@ -1,0 +1,168 @@
+# Nanbeige v7 AVX2 Roofline Report - 2026-07-06
+
+## Scope
+
+Model:
+`Nanbeige4.1-3B.Q4_K_M.gguf`
+
+Runtime:
+v7 native CLI, Intel Core i7-14700T, AVX2/FMA, no AVX-512/AMX, `OMP_NUM_THREADS=1`.
+
+Change tested:
+Nanbeige prefill now uses last-only logits through the generic `llama` template path used by
+this GGUF. The old full prefill logits path computed
+`[prompt_tokens x vocab]` logits, then copied the last row. Native generation consumes only
+the last prefill logits row, so last-only logits removes unnecessary footer GEMM work.
+
+## Direct Runtime Scaling
+
+Prompt: `The quick brown fox`
+Generation: 32 max tokens, 31 decoded tokens, 14 prompt tokens after template.
+
+| CK threads | Total wall ms | Prefill ms | Decode ms | Decode tok/s |
+|---:|---:|---:|---:|---:|
+| 1 | 31965.0 | 4491.2 | 27473.8 | 1.1 |
+| 8 | 3125.2 | 668.8 | 2456.4 | 12.6 |
+| 16 | 2857.0 | 576.4 | 2280.5 | 13.6 |
+| 20 | 2774.8 | 579.5 | 2195.4 | 14.1 |
+| 24 | 2666.3 | 486.1 | 2180.2 | 14.2 |
+| 28 | 2935.1 | 608.0 | 2327.0 | 13.3 |
+
+Best observed total: 24 CK threads. Decode saturates around 16-24 threads; 28 regresses.
+
+Prior full-logits baseline from the same profiling session:
+
+| Build | Total wall ms | Prefill ms | Decode ms | Decode tok/s |
+|---|---:|---:|---:|---:|
+| full prefill logits | 7790.3 | 3540.5 | 4249.8 | 7.3 |
+| last-only prefill logits | 2666.3 | 486.1 | 2180.2 | 14.2 |
+| last-only logits, Q4 packed paths gated | 2589.3 | 432.3 | 2157.0 | 14.4 |
+
+Observed end-to-end speedup: about 2.9x on this prompt. Most of that comes from removing
+full prefill logits work and using the better 24-thread point.
+
+llama.cpp comparison on the same GGUF and CPU-only AVX2 path:
+
+| Framework | Threads | Prompt tokens | Prompt ms | Prompt tok/s | Decode tokens | Decode ms | Decode tok/s |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| CK v7 | 24 | 11 | 432.3 | 25.4 | 31 | 2157.0 | 14.4 |
+| llama.cpp `llama-bench` | 24 | 14 | 135.4 | 103.4 | 31 | 1908.7 | 16.2 |
+
+Decode is now close to llama.cpp on this tiny prompt. Prefill remains materially slower, which
+points at quantized small-M GEMM/layout rather than memory bandwidth alone.
+
+## Q4_K Packed Dispatch Probe
+
+The Q4_K hot shape from Nanbeige MLP gate/up was benchmarked directly:
+`M=14, N=20992, K=2560`.
+
+| Path | Time ms |
+|---|---:|
+| serial baseline | 9.891 |
+| thread pool baseline | 9.816 |
+| packed-M | 7.373 |
+| packed-N | 5.730 |
+| packed-x8 | 3.263 |
+
+The packed-x8 layout is about 3.0x faster than the baseline for this isolated shape when the
+weights are already packed. Lazy packing during the first prefill call is not acceptable for
+smoke/pre-commit runs because it adds one-time conversion cost inside inference. Current v7/v8
+behavior keeps these packed Q4_K paths opt-in/profile-gated until packing is moved to model
+initialization or a persistent sidecar cache.
+
+## CK Profile Hotspots
+
+Best direct run: 24 CK threads.
+
+| Kernel | Time ms | Percent |
+|---|---:|---:|
+| `gemv_q4_k_q8_k` | 1283.17 | 48.3% |
+| `gemv_q6_k_q8_k` | 640.16 | 24.1% |
+| `gemm_nt_q4_k_q8_k` | 364.73 | 13.7% |
+| `attention_forward_decode_head_major_gqa_flash_f16kv` | 204.96 | 7.7% |
+| `swiglu_forward` | 60.15 | 2.3% |
+| `gemm_nt_q6_k_q8_k` | 50.46 | 1.9% |
+
+Top op/kernel pairs:
+
+| Mode | Op | Kernel | Time ms | Percent |
+|---|---|---|---:|---:|
+| decode | `mlp_gate_up` | `gemv_q4_k_q8_k` | 787.43 | 29.6% |
+| decode | `mlp_down` | `gemv_q6_k_q8_k` | 324.66 | 12.2% |
+| decode | `logits` | `gemv_q6_k_q8_k` | 297.81 | 11.2% |
+| prefill | `mlp_gate_up` | `gemm_nt_q4_k_q8_k` | 225.03 | 8.5% |
+| decode | `mlp_down` | `gemv_q4_k_q8_k` | 220.37 | 8.3% |
+| decode | `attn` | decode attention | 204.96 | 7.7% |
+
+After the last-logits change, logits prefill is no longer a major hotspot. The remaining
+roofline target is quantized decode GEMV and prefill MLP GEMM.
+
+## VTune Hotspots
+
+VTune warning:
+microarchitecture performance insights were unavailable because the sampling driver is not
+enabled. Hotspot attribution was still collected.
+
+| Function | CPU time |
+|---|---:|
+| `gemv_q4_k_q8_k_parallel_simd` | 24.308 s |
+| `gemv_q4_k_q8_k_avx2` | 11.229 s |
+| `gemv_q6_k_q8_k_parallel_simd` | 10.051 s |
+| `worker_main` | 4.392 s |
+| `__intel_avx_rep_memset` | 0.800 s |
+| `gemm_nt_q6_k_q8_k` | 0.450 s |
+| `attention_forward_decode_head_major_gqa_flash_f16kv` | 0.340 s |
+| `ck_threadpool_dispatch_n` | 0.290 s |
+
+## Advisor Roofline
+
+Advisor summary:
+
+| Metric | Value |
+|---|---:|
+| Program elapsed | 6.571 s |
+| CPU threads | 24 |
+| Total CPU time | 53.140 s |
+| Time in vectorized loops | 44.620 s |
+| Time in scalar loops | 7.026 s |
+| GFLOPS | 4.23 |
+| GINTOPS | 49.21 |
+| Mixed ops/s | 53.44 |
+| DRAM bandwidth | 39.13 GB/s |
+| L1 bandwidth | 6973.12 GB/s |
+| L2 bandwidth | 3241.25 GB/s |
+| L3 bandwidth | 847.73 GB/s |
+| Float arithmetic intensity | 0.086 |
+| Int arithmetic intensity | 1.003 |
+| Mixed arithmetic intensity | 1.090 |
+| ISA used | AVX2, AVX, SSE4, SSE2 |
+
+Vectorization hotspots:
+
+| Routine | Vectorized | Self time |
+|---|---:|---:|
+| `gemv_q4_k_q8_k_parallel_simd` | yes | 23.727 s |
+| `gemv_q4_k_q8_k_avx2` | yes | 10.217 s |
+| `gemv_q6_k_q8_k_parallel_simd` | yes | 9.657 s |
+| `worker_main` | no | 4.251 s |
+
+Interpretation:
+the core compute loops are vectorized, but arithmetic intensity is low and DRAM bandwidth is
+about 39 GB/s. The next speed work should reduce quantized GEMV memory traffic and unpack cost,
+not focus on attention first.
+
+## Next Targets
+
+1. Prepack Q4_K/Q6_K weights at model load or into a persistent sidecar cache, then route prefill
+   GEMM through packed layouts without first-token conversion cost.
+2. Repacked Q4_K/Q6_K decode layouts for `gemv_q4_k_q8_k` and `gemv_q6_k_q8_k`.
+3. Fused/decode MLP gate-up plus SwiGLU where layout allows it.
+4. Q6 logits GEMV, which remains about 11% of direct CK profile time.
+5. Keep thread cap around 20-24 on this CPU; 28 threads regressed.
+
+Artifacts:
+
+- `build/nanbeige_v7_roofline/last_threads_24.csv`
+- `build/nanbeige_v7_roofline/last_vtune_hotspots.txt`
+- `build/nanbeige_v7_roofline/last_advisor_roofline.txt`
+- `/home/antshiv/.cache/ck-engine-v7/models/Nanbeige4.1-3B.Q4_K_M/advisor_summary.json`

--- a/version/v7/scripts/build_ir_train_v7.py
+++ b/version/v7/scripts/build_ir_train_v7.py
@@ -215,6 +215,58 @@ def _shape_numel(shape: Any) -> Optional[int]:
     return int(n)
 
 
+def _infer_weight_shape_numel(name: str, config: Dict[str, Any]) -> Tuple[Optional[List[int]], Optional[int]]:
+    d_model = int(config.get("embed_dim") or config.get("hidden_size") or 0)
+    vocab = int(config.get("vocab_size") or 0)
+    ff = int(config.get("intermediate_size") or config.get("ffn_dim") or 0)
+    head_dim = int(config.get("head_dim") or 0)
+    kv_heads = int(config.get("num_kv_heads") or config.get("num_heads") or 0)
+    kv_dim = int(kv_heads * head_dim) if kv_heads > 0 and head_dim > 0 else 0
+
+    shape: Optional[List[int]] = None
+    if name in {"token_emb", "output.weight", "output_weight", "lm_head.weight"} and vocab > 0 and d_model > 0:
+        shape = [vocab, d_model]
+    elif name in {"final_ln_weight", "final_norm.weight"} and d_model > 0:
+        shape = [d_model]
+    elif name.startswith("layer."):
+        parts = name.split(".")
+        suffix = parts[-1] if parts else ""
+        if suffix in {"ln1_gamma", "ln2_gamma", "post_attention_norm", "post_ffn_norm"} and d_model > 0:
+            shape = [d_model]
+        elif suffix in {"wq", "wo"} and d_model > 0:
+            shape = [d_model, d_model]
+        elif suffix in {"wk", "wv"} and kv_dim > 0 and d_model > 0:
+            shape = [kv_dim, d_model]
+        elif suffix in {"w1", "w3"} and ff > 0 and d_model > 0:
+            shape = [ff, d_model]
+        elif suffix == "w2" and d_model > 0 and ff > 0:
+            shape = [d_model, ff]
+        elif suffix in {"bq", "bo"} and d_model > 0:
+            shape = [d_model]
+        elif suffix in {"bk", "bv"} and kv_dim > 0:
+            shape = [kv_dim]
+        elif suffix == "b1" and ff > 0:
+            shape = [ff]
+        elif suffix == "b2" and d_model > 0:
+            shape = [d_model]
+
+    numel = _shape_numel(shape)
+    return shape, numel
+
+
+def _entry_shape_numel(entry: Dict[str, Any], config: Optional[Dict[str, Any]] = None) -> Tuple[Optional[List[int]], Optional[int]]:
+    shape = entry.get("shape")
+    if isinstance(shape, list):
+        n = _shape_numel(shape)
+        if isinstance(n, int) and n > 0:
+            return list(shape), n
+    if isinstance(config, dict):
+        inferred_shape, inferred_numel = _infer_weight_shape_numel(str(entry.get("name", "") or ""), config)
+        if isinstance(inferred_numel, int) and inferred_numel > 0:
+            return inferred_shape, inferred_numel
+    return None, _entry_numel(entry)
+
+
 def _entry_numel(entry: Dict[str, Any]) -> Optional[int]:
     n = _shape_numel(entry.get("shape"))
     if isinstance(n, int) and n > 0:
@@ -711,8 +763,7 @@ def build_ir1_train(
                 continue
             entry = weight_index[weight_name]
             dtype = str(entry.get("dtype", "fp32")).lower()
-            shape = entry.get("shape")
-            numel = _entry_numel(entry)
+            shape, numel = _entry_shape_numel(entry, config)
             tensor_id = "weight.%s" % weight_name
             ensure_tensor(
                 tensor_id=tensor_id,
@@ -721,14 +772,14 @@ def build_ir1_train(
                 requires_grad=_is_trainable_dtype(dtype),
                 persistent=True,
                 producer=None,
-                shape=shape if isinstance(shape, list) else None,
+                shape=shape,
                 numel=numel,
             )
             resolved[kernel_alias] = {
                 "name": weight_name,
                 "tensor": tensor_id,
                 "dtype": dtype,
-                "shape": shape if isinstance(shape, list) else None,
+                "shape": shape,
                 "numel": int(numel) if isinstance(numel, int) and numel > 0 else None,
                 "kind": "weight",
                 "requires_grad": _is_trainable_dtype(dtype),

--- a/version/v7/scripts/build_ir_v7.py
+++ b/version/v7/scripts/build_ir_v7.py
@@ -1306,7 +1306,7 @@ def _align_up(value: int, align: int) -> int:
 
 def _resolve_logits_layout(config: Dict[str, Any], mode: str) -> str:
     """Resolve logits layout policy for this mode: 'last' or 'full'."""
-    layout = str(config.get("logits_layout", "auto")).lower()
+    layout = str(config.get("logits_layout", "auto") or "auto").lower()
     if layout not in {"auto", "last", "full"}:
         layout = "auto"
     if layout == "auto":
@@ -7141,8 +7141,8 @@ def main(args: List[str]) -> int:
     parser.add_argument(
         "--logits-layout",
         choices=["auto", "last", "full"],
-        default="auto",
-        help="Logits buffer layout (auto=decode last/prefill full)"
+        default=None,
+        help="Override logits buffer layout (default: manifest/template policy)"
     )
     parser.add_argument(
         "--no-fusion",
@@ -7209,8 +7209,9 @@ def main(args: List[str]) -> int:
     manifest["config"] = _normalize_manifest_config(manifest.get("config", {}))
     if parsed_args.prefer_q8_activation:
         manifest.setdefault("config", {})["prefer_q8_activation"] = True
-    # Override logits layout if requested (propagates into layout + codegen config)
-    manifest.setdefault("config", {})["logits_layout"] = parsed_args.logits_layout
+    # Override logits layout only when requested; otherwise preserve manifest/template policy.
+    if parsed_args.logits_layout is not None:
+        manifest.setdefault("config", {})["logits_layout"] = parsed_args.logits_layout
 
     # Build IR1
     registry = load_kernel_registry()

--- a/version/v7/scripts/ck_run_v7.py
+++ b/version/v7/scripts/ck_run_v7.py
@@ -1748,9 +1748,10 @@ def detect_input_type(model_input: str) -> tuple[str, dict]:
     if model_input.endswith('.json') and Path(model_input).exists():
         return 'local_config', {'path': Path(model_input).resolve()}
 
-    # Local directory with config.json
+    # Local directory. GGUF cache dirs may only contain *.gguf plus tokenizer
+    # files, so classify existing directories before Hugging Face repo IDs.
     local_path = Path(model_input)
-    if local_path.is_dir() and (local_path / "config.json").exists():
+    if local_path.is_dir():
         return 'local_dir', {'path': local_path.resolve()}
 
     # HuggingFace URL
@@ -9503,6 +9504,15 @@ def _template_audit_prepare_artifacts(
                 manifest_path = work_dir / "weights_manifest.json"
             else:
                 weights_path, config_path, manifest_path = _prepare_runtime_dir_from_local_ck_artifacts(model_dir, work_dir)
+        elif local_gguf is not None:
+            gguf_path = local_gguf
+            weights_path, config_path = step_convert_gguf(
+                local_gguf,
+                work_dir,
+                force=getattr(args, "force_convert", False),
+                validate=True,
+            )
+            manifest_path = work_dir / "weights_manifest.json"
         else:
             tokenizer_json = model_dir / "tokenizer.json"
             weights_path = step_convert_hf(
@@ -10096,6 +10106,19 @@ def run_pipeline(args: argparse.Namespace):
             if args.inspect_only:
                 log(f"  Local CK runtime manifest: {manifest_path}", C_GREEN)
                 return
+        elif local_gguf is not None:
+            if v7_mode:
+                manifest_input_path = step_inspect_weights_v7(
+                    input_type, None, local_gguf, work_dir, force=args.force_inspect
+                )
+                if args.inspect_only:
+                    return
+            weights_path, config_path = step_convert_gguf(
+                local_gguf,
+                work_dir,
+                force=args.force_convert,
+            )
+            manifest_path = work_dir / "weights_manifest.json"
         else:
             # Convert local HF checkpoint weights
             if v7_mode:

--- a/version/v7/scripts/ck_run_v7.py
+++ b/version/v7/scripts/ck_run_v7.py
@@ -1016,6 +1016,12 @@ def _merge_template_defaults(
     for key, value in override_doc.items():
         if value is None:
             continue
+        if (
+            key == "logits_layout"
+            and str(value).strip().lower() == "auto"
+            and str(merged.get(key, "")).strip().lower() in {"last", "full"}
+        ):
+            continue
         if isinstance(merged.get(key), dict) and isinstance(value, dict):
             merged[key] = _merge_template_defaults(merged[key], value)
         else:
@@ -1091,6 +1097,25 @@ def _normalize_manifest_template_contract(
     return patched
 
 
+def _apply_template_logits_layout(cfg: dict[str, Any], template_doc: dict[str, Any] | None) -> dict[str, Any]:
+    """Use the template logits layout unless the manifest/CLI already set one."""
+    current = str(cfg.get("logits_layout", "") or "").strip().lower()
+    if current and current != "auto":
+        return cfg
+    if not isinstance(template_doc, dict):
+        return cfg
+    contract = template_doc.get("contract")
+    if not isinstance(contract, dict):
+        return cfg
+    logits_contract = contract.get("logits_contract")
+    if not isinstance(logits_contract, dict):
+        return cfg
+    layout = str(logits_contract.get("logits_layout", "") or "").strip().lower()
+    if layout in {"last", "full"} or (layout == "auto" and not current):
+        cfg["logits_layout"] = layout
+    return cfg
+
+
 def _normalize_manifest_for_inference(src_manifest: dict) -> dict:
     """
     Normalize train/runtime manifests into build_ir_v7-compatible shape.
@@ -1163,6 +1188,8 @@ def _normalize_manifest_for_inference(src_manifest: dict) -> dict:
         out["template"] = template
     if isinstance(template, dict):
         out["template"] = _normalize_manifest_template_contract(template, cfg, entry_names)
+        cfg = _apply_template_logits_layout(cfg, out["template"])
+        out["config"] = cfg
 
     quant_summary = out.get("quant_summary")
     if not isinstance(quant_summary, dict) or not quant_summary:
@@ -10711,8 +10738,8 @@ Examples:
     run_parser.add_argument('--context-len', type=int, default=None,
                            help='Context length for generation (default: from model config, max 32768). '
                                 'All buffers (KV cache, activations, RoPE) sized accordingly.')
-    run_parser.add_argument('--logits-layout', choices=['auto', 'last', 'full'], default='auto',
-                           help='Logits buffer layout (auto=decode last/prefill full)')
+    run_parser.add_argument('--logits-layout', choices=['auto', 'last', 'full'], default=None,
+                           help='Override logits buffer layout (default: template policy)')
     run_parser.add_argument('--temperature', type=float, default=0.7,
                            help='Sampling temperature (default: 0.7)')
     run_parser.add_argument('--max-tokens', type=int, default=512,

--- a/version/v7/scripts/resolve_model_dir_v7.py
+++ b/version/v7/scripts/resolve_model_dir_v7.py
@@ -2,7 +2,7 @@
 """
 Resolve v7 model input into concrete model cache directory.
 
-This is used by Make targets that need direct paths for ck-cli-v7:
+This is used by Make targets that need direct paths for generated v7 artifacts:
   <model_dir>/libmodel.so
   <model_dir>/weights.bump
 """
@@ -25,7 +25,12 @@ def resolve_model_dir(model_input: str) -> Path:
     if input_type == "gguf":
         return CACHE_DIR / info["path"].stem
     if input_type == "local_dir":
-        return Path(info["path"]).resolve()
+        local_dir = Path(info["path"]).resolve()
+        if (local_dir / "weights.bump").exists() and (local_dir / "weights_manifest.json").exists():
+            return local_dir
+        # ck_run_v7.py builds local directory inputs into <local_dir>/.ck_build
+        # unless an explicit --run directory is supplied.
+        return local_dir / ".ck_build"
     if input_type == "local_config":
         return Path(info["path"]).resolve().parent
 
@@ -44,4 +49,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/version/v7/src/ck_parallel_prefill.c
+++ b/version/v7/src/ck_parallel_prefill.c
@@ -24,11 +24,14 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <pthread.h>
 
 /* Serial GEMM kernels (defined in src/kernels/) */
 extern void gemm_nt_q5_0_q8_0(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemm_nt_q8_0_q8_0(const void *A, const void *B, const float *bias,
+                                float *C, int M, int N, int K);
+extern void gemm_nt_q4_k_q8_k(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemm_nt_q6_k_q8_k(const void *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
@@ -36,6 +39,23 @@ extern void gemm_nt_q5_1_q8_1(const float *A, const void *B, const float *bias,
                                 float *C, int M, int N, int K);
 extern void gemm_nt_q5_k(const float *A, const void *B, const float *bias,
                           float *C, int M, int N, int K);
+
+extern size_t q4_k_packed_meta_x8_block_size(void);
+extern void pack_q4_k_to_packed_meta_x8(const void *src, void *dst, int N, int K);
+extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(
+    const void *A_q8, const void *B_packed_x8, const float *bias, float *C,
+    int M, int N, int K, int threads);
+
+typedef struct ck_q4k_packed_x8_cache_entry {
+    const void *src;
+    int N;
+    int K;
+    void *packed;
+    struct ck_q4k_packed_x8_cache_entry *next;
+} ck_q4k_packed_x8_cache_entry_t;
+
+static pthread_mutex_t ck_q4k_packed_x8_cache_mu = PTHREAD_MUTEX_INITIALIZER;
+static ck_q4k_packed_x8_cache_entry_t *ck_q4k_packed_x8_cache_head = NULL;
 
 /* ============================================================================
  * Lifecycle
@@ -78,6 +98,49 @@ static int ck_env_enabled(const char *name)
 {
     const char *v = getenv(name);
     return v && v[0] && strcmp(v, "0") != 0;
+}
+
+static void *ck_get_q4k_packed_x8_cached(const void *B, int N, int K)
+{
+    if (!B || N <= 0 || K <= 0 || (K % QK_K) != 0) return NULL;
+
+    pthread_mutex_lock(&ck_q4k_packed_x8_cache_mu);
+    for (ck_q4k_packed_x8_cache_entry_t *e = ck_q4k_packed_x8_cache_head; e; e = e->next) {
+        if (e->src == B && e->N == N && e->K == K) {
+            pthread_mutex_unlock(&ck_q4k_packed_x8_cache_mu);
+            return e->packed;
+        }
+    }
+
+    const size_t blocks = (size_t)((N + 7) / 8) * (size_t)(K / QK_K);
+    const size_t bytes = blocks * q4_k_packed_meta_x8_block_size();
+    ck_q4k_packed_x8_cache_entry_t *entry =
+        (ck_q4k_packed_x8_cache_entry_t *)malloc(sizeof(*entry));
+    void *packed = malloc(bytes);
+    if (!entry || !packed) {
+        free(entry);
+        free(packed);
+        pthread_mutex_unlock(&ck_q4k_packed_x8_cache_mu);
+        return NULL;
+    }
+
+    pack_q4_k_to_packed_meta_x8(B, packed, N, K);
+    entry->src = B;
+    entry->N = N;
+    entry->K = K;
+    entry->packed = packed;
+    entry->next = ck_q4k_packed_x8_cache_head;
+    ck_q4k_packed_x8_cache_head = entry;
+    pthread_mutex_unlock(&ck_q4k_packed_x8_cache_mu);
+    return packed;
+}
+
+static int ck_should_use_q4k_packed_x8_prefill(int M, int N, int K)
+{
+    if (!ck_env_enabled("CK_ENABLE_Q4K_PACKED_X8_PREFILL")) return 0;
+    if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_X8_PREFILL")) return 0;
+    if (M <= 1 || N < 1024 || K < QK_K || (K % QK_K) != 0) return 0;
+    return (size_t)M * (size_t)N >= 4096u;
 }
 
 static int ck_env_int_or2(const char *primary, const char *secondary, int fallback)
@@ -253,6 +316,25 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
         .A_row_bytes = A_row_bytes
     };
     ck_threadpool_dispatch_n(pool, ck_select_gemm_active_threads(pool, M, N, K), work_gemm_nt_q8_0_q8_0, &args);
+}
+
+void gemm_nt_q4_k_q8_k_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K)
+{
+    ck_threadpool_t *pool = ck_threadpool_global();
+    if (pool && ck_should_use_q4k_packed_x8_prefill(M, N, K)) {
+        void *packed = ck_get_q4k_packed_x8_cached(B, N, K);
+        if (packed) {
+            int active = ck_select_gemm_active_threads(pool, M, N, K);
+            const int cap = ck_env_int_or2("CK_Q4K_PACKED_X8_THREAD_CAP", "CK_GEMM_THREAD_CAP", 24);
+            if (cap > 0 && active > cap) active = cap;
+            gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_nsplit(A, packed, bias, C, M, N, K, active);
+            return;
+        }
+    }
+
+    gemm_nt_q4_k_q8_k(A, B, bias, C, M, N, K);
 }
 
 void gemm_nt_q6_k_q8_k_parallel_dispatch(

--- a/version/v7/src/ck_parallel_prefill.h
+++ b/version/v7/src/ck_parallel_prefill.h
@@ -18,6 +18,7 @@
  * Kernel types:
  *   - gemm_nt_q5_0_q8_0: Q8_0 activations x Q5_0 weights (Q/K proj, out proj, MLP gate+up)
  *   - gemm_nt_q8_0_q8_0: Q8_0 activations x Q8_0 weights (V proj)
+ *   - gemm_nt_q4_k_q8_k: Q8_K activations x Q4_K weights (Q/K/out/MLP proj)
  *   - gemm_nt_q6_k_q8_k: Q8_K activations x Q6_K weights (MLP down proj)
  *   - gemm_nt_q5_1_q8_1: FP32 activations x Q5_1 weights
  *   - gemm_nt_q5_k:      FP32 activations x Q5_K weights
@@ -45,6 +46,10 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K);
 
+void gemm_nt_q4_k_q8_k_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K);
+
 void gemm_nt_q6_k_q8_k_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K);
@@ -66,6 +71,9 @@ void gemm_nt_q5_k_parallel_dispatch(
 
 #define gemm_nt_q8_0_q8_0(A, B, bias, C, M, N, K) \
     gemm_nt_q8_0_q8_0_parallel_dispatch(A, B, bias, C, M, N, K)
+
+#define gemm_nt_q4_k_q8_k(A, B, bias, C, M, N, K) \
+    gemm_nt_q4_k_q8_k_parallel_dispatch(A, B, bias, C, M, N, K)
 
 #define gemm_nt_q6_k_q8_k(A, B, bias, C, M, N, K) \
     gemm_nt_q6_k_q8_k_parallel_dispatch(A, B, bias, C, M, N, K)

--- a/version/v7/templates/llama.json
+++ b/version/v7/templates/llama.json
@@ -38,7 +38,7 @@
     "logits_contract": {
       "final_norm": "rmsnorm",
       "lm_head": "weight_tying",
-      "logits_layout": "auto"
+      "logits_layout": "last"
     },
     "quant_contract": {
       "kernel_select": "weight_dtype_registry",

--- a/version/v7/templates/nanbeige.json
+++ b/version/v7/templates/nanbeige.json
@@ -62,7 +62,7 @@
     "logits_contract": {
       "final_norm": "rmsnorm",
       "lm_head": "weight_tying",
-      "logits_layout": "auto"
+      "logits_layout": "last"
     },
     "quant_contract": {
       "kernel_select": "weight_dtype_registry",

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -387,6 +387,9 @@ static void *ck_get_q4k_packed_meta_x16_cached(const void *B, int N, int K)
 static int ck_should_use_q4k_packed_meta_prefill(int M, int N, int K)
 {
     if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_META_PREFILL")) return 0;
+    if (!ck_env_enabled("CK_ENABLE_Q4K_PACKED_META_PREFILL") &&
+        !ck_env_enabled("CK_FORCE_Q4K_PACKED_META_PREFILL") &&
+        !ck_speed_profile_qwen3vl_ocr_fast()) return 0;
     if (M <= 1 || N <= 0 || K <= 0 || (K % QK_K) != 0) return 0;
 
     const int min_m = ck_env_int_or2("CK_Q4K_PACKED_META_MIN_M", NULL, 32);
@@ -464,6 +467,9 @@ static int ck_should_use_q4k_packed_meta_x8_mreuse_prefill(int M, int N, int K)
 static int ck_should_use_q4k_packed_meta_x8_prefill(int M, int N, int K)
 {
     if (ck_env_enabled("CK_DISABLE_Q4K_PACKED_META_X8_PREFILL")) return 0;
+    if (!ck_env_enabled("CK_ENABLE_Q4K_PACKED_META_X8_PREFILL") &&
+        !ck_env_enabled("CK_FORCE_Q4K_PACKED_META_X8_PREFILL") &&
+        !ck_speed_profile_qwen3vl_ocr_fast()) return 0;
     if (M <= 1 || N <= 0 || K <= 0 || (K % QK_K) != 0) return 0;
 
     const int min_m = ck_env_int_or2("CK_Q4K_PACKED_META_X8_MIN_M", NULL, 16);

--- a/version/v8/templates/llama.json
+++ b/version/v8/templates/llama.json
@@ -33,7 +33,7 @@
     "logits_contract": {
       "final_norm": "rmsnorm",
       "lm_head": "weight_tying",
-      "logits_layout": "auto"
+      "logits_layout": "last"
     },
     "quant_contract": {
       "kernel_select": "weight_dtype_registry",


### PR DESCRIPTION
## Summary
- Preserve v7 template logits-layout policy so Nanbeige/llama prefill uses last-row logits by default.
- Add opt-in v7 Q4_K packed-x8 prefill dispatch and gate v8 packed Q4_K lazy paths behind explicit profile/env flags.
- Harden v7 train IR numel metadata for quantized cached manifests and sync the v8 llama template contract.
- Add Nanbeige AVX2 roofline notes with llama.cpp comparison and Q4_K dispatch probe results.

## Validation
- py_compile for v7/v8 build scripts
- make ck-cli-v7 build/bench_q4k_dispatch_matrix
- make test-threadpool-parity-quick
- make v7-regression-fast
- make v8-kernel-map-contracts
- make v7-train-ir-smoke
- commit hook passed v7-regression-fast and v8-regression-fast
- pre-push hook passed build, kernel parity, v8 E2E, v8 inference contracts, v7 training contract smoke, v7/v8 fast regression, and v7 training-kernel parity

## Notes
Packed Q4_K prefill is intentionally opt-in/profile-gated until model-load or persistent sidecar prepacking avoids first-prompt conversion cost.
