### PR TITLE
Harden v7/v8 local model setup and regression hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -271,24 +271,35 @@ if [ "$should_run_v7_regression" = "1" ]; then
     echo -e "${GREEN}✓ v7-kernel-map-contracts passed${NC}"
 fi
 
+regression_pids=()
+regression_names=()
 if [ "$should_run_v7_regression" = "1" ]; then
-    if ! CK_CACHE_DIR="${CACHE_ROOT}" make -C "$SNAPSHOT_DIR" v7-regression-fast REGRESSION_ARGS="--run-root ${RUN_ROOT}/v7 --report-root ${REPORT_ROOT}/v7" > /tmp/ck_precommit_regression_v7.log 2>&1; then
-        echo -e "${RED}✗ v7-regression-fast failed${NC}"
-        echo "  See /tmp/ck_precommit_regression_v7.log for details"
-        tail -40 /tmp/ck_precommit_regression_v7.log || true
-        exit 1
-    fi
-    echo -e "${GREEN}✓ v7-regression-fast passed${NC}"
+    CK_CACHE_DIR="${CACHE_ROOT}" make -C "$SNAPSHOT_DIR" v7-regression-fast REGRESSION_ARGS="--run-root ${RUN_ROOT}/v7 --report-root ${REPORT_ROOT}/v7" > /tmp/ck_precommit_regression_v7.log 2>&1 &
+    regression_pids+=("$!")
+    regression_names+=("v7")
 fi
 
 if [ "$should_run_v8_regression" = "1" ]; then
-    if ! CK_CACHE_DIR="${CACHE_ROOT}" make -C "$SNAPSHOT_DIR" v8-regression-fast REGRESSION_ARGS="--run-root ${RUN_ROOT}/v8 --report-root ${REPORT_ROOT}/v8" > /tmp/ck_precommit_regression_v8.log 2>&1; then
-        echo -e "${RED}✗ v8-regression-fast failed${NC}"
-        echo "  See /tmp/ck_precommit_regression_v8.log for details"
-        tail -40 /tmp/ck_precommit_regression_v8.log || true
-        exit 1
+    CK_CACHE_DIR="${CACHE_ROOT}" make -C "$SNAPSHOT_DIR" v8-regression-fast REGRESSION_ARGS="--run-root ${RUN_ROOT}/v8 --report-root ${REPORT_ROOT}/v8" > /tmp/ck_precommit_regression_v8.log 2>&1 &
+    regression_pids+=("$!")
+    regression_names+=("v8")
+fi
+
+regression_failed=0
+for idx in "${!regression_pids[@]}"; do
+    regression_name="${regression_names[$idx]}"
+    if wait "${regression_pids[$idx]}"; then
+        echo -e "${GREEN}✓ ${regression_name}-regression-fast passed${NC}"
+    else
+        echo -e "${RED}✗ ${regression_name}-regression-fast failed${NC}"
+        echo "  See /tmp/ck_precommit_regression_${regression_name}.log for details"
+        tail -40 "/tmp/ck_precommit_regression_${regression_name}.log" || true
+        regression_failed=1
     fi
-    echo -e "${GREEN}✓ v8-regression-fast passed${NC}"
+done
+
+if [ "$regression_failed" = "1" ]; then
+    exit 1
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -464,24 +464,28 @@ fi
 # =============================================================================
 if [ "$ck_should_run_v7_regression_fast" = "1" ] || [ "$ck_should_run_v8_regression_fast" = "1" ]; then
     echo -e "${YELLOW}[5.5/6]${NC} Running fast regression..."
+    regression_pids=()
+    regression_names=()
     if [ "$ck_should_run_v7_regression_fast" = "1" ]; then
-        if make --no-print-directory v7-regression-fast REGRESSION_ARGS="--run-root /tmp/ck-prepush-regression/runs/v7 --report-root /tmp/ck-prepush-regression/reports/v7" > /tmp/ck_regression_fast_v7.log 2>&1; then
-            echo -e "${GREEN}  ✓ v7 fast regression passed${NC}"
-        else
-            echo -e "${RED}  ✗ v7 fast regression failed${NC}"
-            echo "    See /tmp/ck_regression_fast_v7.log for details"
-            failed=1
-        fi
+        make --no-print-directory v7-regression-fast REGRESSION_ARGS="--run-root /tmp/ck-prepush-regression/runs/v7 --report-root /tmp/ck-prepush-regression/reports/v7" > /tmp/ck_regression_fast_v7.log 2>&1 &
+        regression_pids+=("$!")
+        regression_names+=("v7")
     fi
     if [ "$ck_should_run_v8_regression_fast" = "1" ]; then
-        if make --no-print-directory v8-regression-fast REGRESSION_ARGS="--run-root /tmp/ck-prepush-regression/runs/v8 --report-root /tmp/ck-prepush-regression/reports/v8" > /tmp/ck_regression_fast_v8.log 2>&1; then
-            echo -e "${GREEN}  ✓ v8 fast regression passed${NC}"
+        make --no-print-directory v8-regression-fast REGRESSION_ARGS="--run-root /tmp/ck-prepush-regression/runs/v8 --report-root /tmp/ck-prepush-regression/reports/v8" > /tmp/ck_regression_fast_v8.log 2>&1 &
+        regression_pids+=("$!")
+        regression_names+=("v8")
+    fi
+    for idx in "${!regression_pids[@]}"; do
+        regression_name="${regression_names[$idx]}"
+        if wait "${regression_pids[$idx]}"; then
+            echo -e "${GREEN}  ✓ ${regression_name} fast regression passed${NC}"
         else
-            echo -e "${RED}  ✗ v8 fast regression failed${NC}"
-            echo "    See /tmp/ck_regression_fast_v8.log for details"
+            echo -e "${RED}  ✗ ${regression_name} fast regression failed${NC}"
+            echo "    See /tmp/ck_regression_fast_${regression_name}.log for details"
             failed=1
         fi
-    fi
+    done
 fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -2660,7 +2660,7 @@ test-v8-decoder-matrix-quick: ck-cli-v8
 	@echo "Running v8 decoder matrix benchmark (quick, CKE vs llama.cpp)..."
 	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
 		$(PYTHON) $(PYTHONFLAGS) benchmarks/bench_v8_decoder_matrix.py \
-		--models $${CK_V8_DECODER_MODELS:-qwen35-0.8b-q4_k_m,qwen2-0.5b-q4_k_m} \
+		--models $${CK_V8_DECODER_MODELS:-qwen35-0.8b-q4_k_m,nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m} \
 		--threads $${CK_NUM_THREADS:-12} \
 		--prompt $${CK_V8_DECODER_PROMPT:-128} \
 		--decode $${CK_V8_DECODER_DECODE:-32} \
@@ -2749,7 +2749,7 @@ profile-v8-prefill-ops: ck-cli-v8
 	@echo "Profiling v8 prefill operator costs..."
 	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
 		$(PYTHON) $(PYTHONFLAGS) benchmarks/profile_v8_prefill_ops.py \
-		--models $${CK_V8_PROFILE_MODELS:-qwen35-0.8b-q4_k_m,qwen2-0.5b-q4_k_m} \
+		--models $${CK_V8_PROFILE_MODELS:-qwen35-0.8b-q4_k_m,nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m} \
 		--threads $${CK_NUM_THREADS:-12} \
 		--prompt $${CK_V8_PROFILE_PROMPT:-512} \
 		--decode $${CK_V8_PROFILE_DECODE:-1} \
@@ -2761,7 +2761,7 @@ profile-v8-prefill-ops-quick: ck-cli-v8
 	@echo "Profiling v8 prefill operator costs (quick)..."
 	CK_NUM_THREADS=$${CK_NUM_THREADS:-12} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
 		$(PYTHON) $(PYTHONFLAGS) benchmarks/profile_v8_prefill_ops.py \
-		--models $${CK_V8_PROFILE_MODELS:-qwen35-0.8b-q4_k_m,qwen2-0.5b-q4_k_m} \
+		--models $${CK_V8_PROFILE_MODELS:-qwen35-0.8b-q4_k_m,nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m} \
 		--threads $${CK_NUM_THREADS:-12} \
 		--prompt $${CK_V8_PROFILE_PROMPT:-128} \
 		--decode $${CK_V8_PROFILE_DECODE:-1} \

--- a/benchmarks/bench_v8_decoder_matrix.py
+++ b/benchmarks/bench_v8_decoder_matrix.py
@@ -56,6 +56,12 @@ MODELS: dict[str, dict[str, str]] = {
         "run": "Qwen3.5-0.8B-Q4_K_M",
         "gguf": "unsloth--Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf",
     },
+    "nanbeige4.1-3b-q4_k_m": {
+        "label": "Nanbeige 4.1 3B",
+        "quant": "Q4_K_M",
+        "run": "mradermacher--Nanbeige4.1-3B-GGUF/.ck_build_v8",
+        "gguf": "mradermacher--Nanbeige4.1-3B-GGUF/Nanbeige4.1-3B.Q4_K_M.gguf",
+    },
     "gemma4-e4b-q4_k_m": {
         "label": "Gemma4 E4B",
         "quant": "Q4_K_M",

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1141,7 +1141,10 @@ def _resolve_run_dir(model_input: str, input_type: str, info: dict[str, Any], re
     if input_type == "gguf":
         return CACHE_DIR / info["path"].stem
     if input_type == "local_dir":
-        return info["path"] / ".ck_build_v8"
+        local_dir = info["path"]
+        if _is_runtime_dir(local_dir):
+            return local_dir
+        return local_dir / ".ck_build_v8"
     if input_type == "local_config":
         return info["path"].parent / ".ck_build_v8"
     return CACHE_DIR / "unknown"

--- a/version/v8/scripts/memory_signoff_v8.py
+++ b/version/v8/scripts/memory_signoff_v8.py
@@ -45,9 +45,12 @@ def detect_model_dir_from_input(model_input: str) -> Optional[Path]:
     if input_type == "gguf":
         return CACHE_DIR / info["path"].stem
     if input_type == "local_dir":
-        return Path(info["path"]) / ".ck_build"
+        local_dir = Path(info["path"])
+        if (local_dir / "weights.bump").exists() and (local_dir / "weights_manifest.json").exists():
+            return local_dir
+        return local_dir / ".ck_build_v8"
     if input_type == "local_config":
-        return Path(info["path"]).parent / ".ck_build"
+        return Path(info["path"]).parent / ".ck_build_v8"
     return None
 
 

--- a/version/v8/scripts/resolve_model_dir_v8.py
+++ b/version/v8/scripts/resolve_model_dir_v8.py
@@ -24,7 +24,10 @@ def resolve_model_dir(model_input: str) -> Path:
     if input_type == "gguf":
         return CACHE_DIR / info["path"].stem
     if input_type == "local_dir":
-        return Path(info["path"]).resolve()
+        local_dir = Path(info["path"]).resolve()
+        if (local_dir / "weights.bump").exists() and (local_dir / "weights_manifest.json").exists():
+            return local_dir
+        return local_dir / ".ck_build_v8"
     if input_type == "local_config":
         return Path(info["path"]).resolve().parent
 


### PR DESCRIPTION
## Summary
- harden v7 local GGUF/runtime directory handling for visualizer/nightly paths
- include Nanbeige 4.1 3B in v8 decoder and prefill profiling defaults
- harden v8 local GGUF source/runtime directory resolution
- keep clean rebuild/regeneration coverage while running v7/v8 fast regression lanes concurrently in hooks

## Validation
- pre-commit passed v7 and v8 fast regressions with the parallelized hook path
- pre-push passed build, kernel parity, v8 E2E, v8 contracts, v7 training smoke, v7/v8 fast regressions, and v7 training-kernel parity
- v8 Nanbeige smoke/profile checks were run locally before commit

## Notes
This does not relax tolerances or skip rebuilds. The hook change only schedules independent v7/v8 regression lanes concurrently so local machines use available CPU better.