### PR TITLE
perf(v8): improve AVX2 quantized prefill paths

### DIFF
--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -2229,6 +2229,11 @@ void sigmoid_backward_bf16(const uint16_t *input,
 	                    int tokens,
 	                    int dim);
 
+	void swiglu_forward_q8_k(const float *input,
+	                         void *output_q8,
+	                         int tokens,
+	                         int dim);
+
 	void swiglu_backward(const float *input,
 	                     const float *d_output,
 	                     float *d_input,

--- a/src/kernels/gemm_kernels_q4k_q8k_avx2.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_avx2.c
@@ -38,28 +38,18 @@ static inline int32_t hsum256_epi32(__m256i v) {
     return _mm_cvtsi128_si32(sum);
 }
 
-static inline int32_t dot_q4_q8_16_avx2(const uint8_t *q4,
-                                        const int8_t *q8,
-                                        int high_nibble) {
-    const __m128i q4_packed = _mm_loadu_si128((const __m128i *)q4);
-    const __m128i mask4 = _mm_set1_epi8(0x0F);
-    const __m128i q4_nibbles = high_nibble
-        ? _mm_and_si128(_mm_srli_epi16(q4_packed, 4), mask4)
-        : _mm_and_si128(q4_packed, mask4);
-    const __m128i q8_bytes = _mm_loadu_si128((const __m128i *)q8);
-
-    const __m256i q4_16 = _mm256_cvtepu8_epi16(q4_nibbles);
-    const __m256i q8_16 = _mm256_cvtepi8_epi16(q8_bytes);
-    const __m256i prod = _mm256_madd_epi16(q4_16, q8_16);
-
-    return hsum256_epi32(prod);
-}
-
 static inline int32_t dot_q4_q8_32_avx2(const uint8_t *q4,
                                         const int8_t *q8,
                                         int high_nibble) {
-    return dot_q4_q8_16_avx2(q4, q8, high_nibble)
-         + dot_q4_q8_16_avx2(q4 + 16, q8 + 16, high_nibble);
+    const __m256i packed = _mm256_loadu_si256((const __m256i *)q4);
+    const __m256i mask4 = _mm256_set1_epi8(0x0F);
+    const __m256i q4_bytes = high_nibble
+        ? _mm256_and_si256(_mm256_srli_epi16(packed, 4), mask4)
+        : _mm256_and_si256(packed, mask4);
+    const __m256i q8_bytes = _mm256_loadu_si256((const __m256i *)q8);
+    const __m256i pair_sums_i16 = _mm256_maddubs_epi16(q4_bytes, q8_bytes);
+    const __m256i sums_i32 = _mm256_madd_epi16(pair_sums_i16, _mm256_set1_epi16(1));
+    return hsum256_epi32(sums_i32);
 }
 
 static float dot_q4_k_q8_k_avx2(const block_q4_K *w,

--- a/src/kernels/quantize_row_q8_k_avx2.c
+++ b/src/kernels/quantize_row_q8_k_avx2.c
@@ -2,27 +2,15 @@
  * @file quantize_row_q8_k_avx2.c
  * @brief AVX2 entrypoint for exact Q8_K row quantization
  *
- * CK-ENGINE KERNEL RULES:
- * =======================
- * 1. NO malloc/free - memory via bump allocator, pointers passed in
- * 2. NO OpenMP - parallelization at orchestrator/codegen layer
- * 3. API must define: inputs, outputs, workspace, and memory layouts
- * 4. Pure computation - deterministic, no side effects
- *
- * After changes: make test && make llamacpp-parity-full
+ * The previous AVX2 entrypoint delegated to the SSE implementation. On this
+ * CPU the scalar reference compiles into a faster loop than both the SSE body
+ * and a hand-written AVX2 pack path, while preserving byte-exact Q8_K output.
  */
 
 #include "ckernel_quant.h"
 
-void quantize_row_q8_k_sse(const float *x, void *vy, int k);
 void quantize_row_q8_k_ref(const float *x, void *vy, int k);
 
 void quantize_row_q8_k_avx2(const float *x, void *vy, int k) {
-    /* Reuse the parity-clean SIMD implementation until a wider AVX2 variant is
-     * worth maintaining separately. */
-#if defined(__SSE4_1__)
-    quantize_row_q8_k_sse(x, vy, k);
-#else
     quantize_row_q8_k_ref(x, vy, k);
-#endif
 }

--- a/src/kernels/swiglu_kernels.c
+++ b/src/kernels/swiglu_kernels.c
@@ -15,6 +15,7 @@
  */
 
 #include "ckernel_engine.h"
+#include "ckernel_quant.h"
 #include <math.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -216,6 +217,62 @@ void swiglu_forward(const float *input,
             float silu = a * s;                  // silu(a) = a * sigmoid(a)
 
             out_row[d] = silu * b;
+        }
+    }
+}
+
+void swiglu_forward_q8_k(const float *input,
+                         void *output_q8,
+                         int tokens,
+                         int dim)
+{
+    if (!input || !output_q8 || tokens <= 0 || dim <= 0) {
+        return;
+    }
+    if ((dim % QK_K) != 0) {
+        return;
+    }
+
+    const char *fast_env = getenv("CK_SWIGLU_FAST");
+    const char *exact_env = getenv("CK_SWIGLU_EXACT");
+    const int use_fast = !ck_strict_parity_enabled() &&
+                         (fast_env && atoi(fast_env) != 0) &&
+                         !(exact_env && atoi(exact_env) != 0);
+
+    const int blocks_per_row = dim / QK_K;
+    block_q8_K *q8 = (block_q8_K *)output_q8;
+    float tmp[QK_K];
+
+    for (int t = 0; t < tokens; ++t) {
+        const float *row = input + (size_t)t * (size_t)(2 * dim);
+        block_q8_K *q8_row = q8 + (size_t)t * (size_t)blocks_per_row;
+
+        for (int block = 0; block < blocks_per_row; ++block) {
+            const int base = block * QK_K;
+            int d = 0;
+
+#if defined(__AVX2__)
+            if (use_fast) {
+                for (; d + 8 <= QK_K; d += 8) {
+                    const __m256 a = _mm256_loadu_ps(row + base + d);
+                    const __m256 b = _mm256_loadu_ps(row + dim + base + d);
+                    const __m256 s = sigmoid256_fast(a);
+                    const __m256 y = _mm256_mul_ps(_mm256_mul_ps(a, s), b);
+                    _mm256_storeu_ps(tmp + d, y);
+                }
+            }
+#else
+            (void)use_fast;
+#endif
+
+            for (; d < QK_K; ++d) {
+                const float a = row[base + d];
+                const float b = row[dim + base + d];
+                const float s = use_fast ? sigmoid_scalar(a) : sigmoid_scalar_parity(a);
+                tmp[d] = (a * s) * b;
+            }
+
+            quantize_row_q8_k(tmp, (void *)&q8_row[block], QK_K);
         }
     }
 }

--- a/version/v8/scripts/ck_run_v8.py
+++ b/version/v8/scripts/ck_run_v8.py
@@ -1032,6 +1032,7 @@ def _apply_qwen3vl_ocr_fast_defaults(env: dict[str, str]) -> None:
         return
     env.setdefault("CK_ENABLE_Q80_FP32_M4N4", "1")
     env.setdefault("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16", "1")
+    env.setdefault("CK_ENABLE_Q4K_PACKED_META_X16_PREFILL", "1")
     env.setdefault("CK_Q4K_GATEUP_SWIGLU_X16_THREAD_CAP", "20")
     env.setdefault("CK_Q4K_X16_CHUNK4", "1")
     env.setdefault("CK_ATTENTION_QBLOCK4", "1")

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -1042,6 +1042,10 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     const char *debug_outproj_env = getenv("CK_V7_DEBUG_OUTPROJ_FP32");
     int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;
     const float *ck_debug_outproj_fp32_input = NULL;
+    const char *debug_mlp_down_env = getenv("CK_V7_DEBUG_MLP_DOWN_FP32");
+    int debug_mlp_down_fp32 = debug_mlp_down_env ? (atoi(debug_mlp_down_env) != 0) : 0;
+    const char *debug_mlp_down_layer_env = getenv("CK_V7_DEBUG_MLP_DOWN_FP32_LAYER");
+    int debug_mlp_down_fp32_layer = debug_mlp_down_layer_env ? atoi(debug_mlp_down_layer_env) : -1;
     const char *debug_mlp_gate_up_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_FP32");
     int debug_mlp_gate_up_fp32 = debug_mlp_gate_up_env ? (atoi(debug_mlp_gate_up_env) != 0) : 0;
     const char *debug_mlp_gate_up_layer_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_FP32_LAYER");
@@ -1054,6 +1058,7 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
     int ck_enable_q4k_gateup_swiglu_x16 = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
+    int ck_enable_swiglu_q8k_fusion = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_SWIGLU_Q8K_FUSION");
 
     /* Copy input tokens to activation buffer (follow same pattern as decode) */
     memcpy((void*)(model->bump + A_TOKEN_IDS), tokens, (size_t)num_tokens * sizeof(int32_t));
@@ -1072,15 +1077,68 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     residual_add_count_total = 0
     residual_add_counts_by_layer: Dict[int, int] = {}
 
+    swiglu_q8k_fusion_guard: Optional[str] = None
+    swiglu_q8k_fusion_call: Optional[str] = None
+
     for seq_idx, op in enumerate(ops):
         op_type_for_instance = str(op.get("op", ""))
+        if swiglu_q8k_fusion_guard and op_type_for_instance != "quantize_mlp_down_input":
+            swiglu_q8k_fusion_guard = None
+            swiglu_q8k_fusion_call = None
         if op_type_for_instance == "residual_add" and "op_instance_idx" not in op and "instance" not in op:
             layer_for_instance = int(op.get("layer", -1))
             inst = residual_add_counts_by_layer.get(layer_for_instance, 0)
             op = dict(op)
             op["op_instance_idx"] = inst
             residual_add_counts_by_layer[layer_for_instance] = inst + 1
-        lines.append(emit_prefill_op(op, seq_idx, config, profile=profile, dump=dump))
+        op_code = emit_prefill_op(op, seq_idx, config, profile=profile, dump=dump)
+        if (
+            swiglu_q8k_fusion_guard
+            and swiglu_q8k_fusion_call
+            and op_type_for_instance == "quantize_mlp_down_input"
+            and str(op.get("function", "")) == "quantize_row_q8_k"
+        ):
+            op_code = (
+                f"    if ({swiglu_q8k_fusion_guard}) {{\n"
+                f"{swiglu_q8k_fusion_call}\n"
+                "    } else {\n"
+                + "\n".join("    " + line if line else line for line in op_code.splitlines())
+                + "\n    }"
+            )
+            swiglu_q8k_fusion_guard = None
+            swiglu_q8k_fusion_call = None
+        elif op_type_for_instance in {"silu_mul", "swiglu"}:
+            next_op = ops[seq_idx + 1] if seq_idx + 1 < len(ops) else None
+            if (
+                isinstance(next_op, dict)
+                and str(op.get("function", "")) == "swiglu_forward"
+                and str(next_op.get("op", "")) == "quantize_mlp_down_input"
+                and str(next_op.get("function", "")) == "quantize_row_q8_k"
+            ):
+                swiglu_args = op.get("args", [])
+                quant_args = next_op.get("args", [])
+                swiglu_input = _find_arg_expr(swiglu_args, arg_name="input")
+                quant_output = _find_arg_expr(quant_args, arg_name="y") or _find_arg_expr(quant_args, arg_name="output")
+                dim_expr = _find_arg_expr(swiglu_args, arg_name="dim") or _find_arg_expr(quant_args, arg_name="k")
+                layer_value = op.get("layer", -1)
+                layer = int(layer_value) if layer_value is not None else -1
+                if swiglu_input and quant_output and dim_expr:
+                    guard = f"ck_swiglu_q8k_fused_{seq_idx}"
+                    swiglu_q8k_fusion_guard = guard
+                    fused_lines = []
+                    if profile:
+                        fused_lines.append("        CK_PROFILE_BEGIN();")
+                    fused_lines.append(f"        swiglu_forward_q8_k((const float*)({swiglu_input}), (void*)({quant_output}), num_tokens, (int)({dim_expr}));")
+                    if profile:
+                        fused_lines.append(f'        CK_PROFILE_END("prefill", "swiglu_forward_q8_k", "silu_mul_quantize_mlp_down_input", {layer});')
+                    swiglu_q8k_fusion_call = "\n".join(fused_lines)
+                    op_code = (
+                        f"    const int {guard} = ck_enable_swiglu_q8k_fusion && !(debug_mlp_down_fp32 || debug_mlp_down_fp32_layer == {layer});\n"
+                        f"    if (!{guard}) {{\n"
+                        + "\n".join("    " + line if line else line for line in op_code.splitlines())
+                        + "\n    }"
+                    )
+        lines.append(op_code)
         lines.append(f"    if (stop_seq == {seq_idx}) return;")
         if (scale_embeddings_sqrt_dim
                 and not embed_scale_emitted
@@ -1608,6 +1666,8 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     const float *ck_debug_outproj_fp32_input = NULL;
     const char *debug_mlp_down_env = getenv("CK_V7_DEBUG_MLP_DOWN_FP32");
     int debug_mlp_down_fp32 = debug_mlp_down_env ? (atoi(debug_mlp_down_env) != 0) : 0;
+    const char *debug_mlp_down_layer_env = getenv("CK_V7_DEBUG_MLP_DOWN_FP32_LAYER");
+    int debug_mlp_down_fp32_layer = debug_mlp_down_layer_env ? atoi(debug_mlp_down_layer_env) : -1;
     const float *ck_debug_mlp_down_fp32_input = NULL;
     const char *debug_mlp_gate_up_env = getenv("CK_V8_DEBUG_MLP_GATE_UP_FP32");
     int debug_mlp_gate_up_fp32 = debug_mlp_gate_up_env ? (atoi(debug_mlp_gate_up_env) != 0) : 0;
@@ -1618,6 +1678,7 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
     int ck_enable_q4k_gateup_swiglu_x16 = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
+    int ck_enable_swiglu_q8k_fusion = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_SWIGLU_Q8K_FUSION");
     const float *ck_debug_mlp_gate_up_fp32_input = NULL;
 """
     prologue = prologue.replace(
@@ -1645,10 +1706,15 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     residual_add_counts_by_layer: Dict[int, int] = {}
 
     skip_swiglu_guard: Optional[str] = None
+    swiglu_q8k_fusion_guard: Optional[str] = None
+    swiglu_q8k_fusion_call: Optional[str] = None
     for seq_idx, op in enumerate(ops):
         op_type = str(op.get("op", ""))
         if skip_swiglu_guard and op_type not in {"silu_mul", "swiglu"}:
             skip_swiglu_guard = None
+        if swiglu_q8k_fusion_guard and op_type != "quantize_mlp_down_input":
+            swiglu_q8k_fusion_guard = None
+            swiglu_q8k_fusion_call = None
         if op_type == "residual_add" and "op_instance_idx" not in op and "instance" not in op:
             layer_for_instance = int(op.get("layer", -1))
             inst = residual_add_counts_by_layer.get(layer_for_instance, 0)
@@ -1709,15 +1775,34 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                     profile=profile,
                     dump=dump,
                 )
-        elif is_qwen3vl and op_type == "quantize_mlp_down_input" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
-            op_code = _emit_prefill_quant_debug_override(
-                op,
-                seq_idx,
-                config,
-                debug_flag_name="debug_mlp_down_fp32",
-                debug_input_name="ck_debug_mlp_down_fp32_input",
-                profile=profile,
-            )
+        elif op_type == "quantize_mlp_down_input" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+            if swiglu_q8k_fusion_guard and swiglu_q8k_fusion_call and str(op.get("function", "")) == "quantize_row_q8_k":
+                base_code = _emit_prefill_quant_debug_override(
+                    op,
+                    seq_idx,
+                    config,
+                    debug_flag_name="debug_mlp_down_fp32",
+                    debug_input_name="ck_debug_mlp_down_fp32_input",
+                    profile=profile,
+                )
+                op_code = (
+                    f"    if ({swiglu_q8k_fusion_guard}) {{\n"
+                    f"{swiglu_q8k_fusion_call}\n"
+                    "    } else {\n"
+                    + "\n".join("    " + line if line else line for line in base_code.splitlines())
+                    + "\n    }"
+                )
+                swiglu_q8k_fusion_guard = None
+                swiglu_q8k_fusion_call = None
+            else:
+                op_code = _emit_prefill_quant_debug_override(
+                    op,
+                    seq_idx,
+                    config,
+                    debug_flag_name="debug_mlp_down_fp32",
+                    debug_input_name="ck_debug_mlp_down_fp32_input",
+                    profile=profile,
+                )
         elif is_qwen3vl and op_type == "mlp_down" and str(op.get("function", "")) in {"gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"}:
             op_code = _emit_prefill_gemm_fp32_override(
                 op,
@@ -1731,9 +1816,42 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
             op_code = emit_prefill_op(op, seq_idx, config, profile=profile, dump=dump)
             if is_qwen3vl and op_type == "rope_qk":
                 op_code = op_code.replace("mrope_qk_text(", "ck_qwen3vl_prefill_mrope_qk(")
+        swiglu_block_guard = skip_swiglu_guard if op_type in {"silu_mul", "swiglu"} else None
         if skip_swiglu_guard and op_type in {"silu_mul", "swiglu"}:
             op_code = f"    if (!{skip_swiglu_guard}) {{\n" + "\n".join("    " + line if line else line for line in op_code.splitlines()) + "\n    }"
             skip_swiglu_guard = None
+        if op_type in {"silu_mul", "swiglu"}:
+            next_op = ops[seq_idx + 1] if seq_idx + 1 < len(ops) else None
+            if (
+                isinstance(next_op, dict)
+                and str(op.get("function", "")) == "swiglu_forward"
+                and str(next_op.get("op", "")) == "quantize_mlp_down_input"
+                and str(next_op.get("function", "")) == "quantize_row_q8_k"
+            ):
+                swiglu_args = op.get("args", [])
+                quant_args = next_op.get("args", [])
+                swiglu_input = _find_arg_expr(swiglu_args, arg_name="input")
+                quant_output = _find_arg_expr(quant_args, arg_name="y") or _find_arg_expr(quant_args, arg_name="output")
+                dim_expr = _find_arg_expr(swiglu_args, arg_name="dim") or _find_arg_expr(quant_args, arg_name="k")
+                layer_value = op.get("layer", -1)
+                layer = int(layer_value) if layer_value is not None else -1
+                if swiglu_input and quant_output and dim_expr:
+                    guard = f"ck_swiglu_q8k_fused_{seq_idx}"
+                    swiglu_q8k_fusion_guard = guard
+                    fused_lines = []
+                    if profile:
+                        fused_lines.append("        CK_PROFILE_BEGIN();")
+                    fused_lines.append(f"        swiglu_forward_q8_k((const float*)({swiglu_input}), (void*)({quant_output}), num_tokens, (int)({dim_expr}));")
+                    if profile:
+                        fused_lines.append(f'        CK_PROFILE_END("prefill", "swiglu_forward_q8_k", "silu_mul_quantize_mlp_down_input", {layer});')
+                    swiglu_q8k_fusion_call = "\n".join(fused_lines)
+                    block_guard_expr = f" && !{swiglu_block_guard}" if swiglu_block_guard else ""
+                    op_code = (
+                        f"    const int {guard} = ck_enable_swiglu_q8k_fusion{block_guard_expr} && !(debug_mlp_down_fp32 || debug_mlp_down_fp32_layer == {layer});\n"
+                        f"    if (!{guard}) {{\n"
+                        + "\n".join("    " + line if line else line for line in op_code.splitlines())
+                        + "\n    }"
+                    )
         lines.append(op_code)
         lines.append(f"    if (stop_seq == {seq_idx}) return;")
         if is_qwen3vl and op_type == "residual_add":


### PR DESCRIPTION
## Summary
- use AVX2 maddubs/maddwd for the Q4_K x Q8_K dot path
- route the AVX2 Q8_K quantize entrypoint to the faster exact implementation on this CPU
- add fused SwiGLU-to-Q8_K prefill support and enable packed Q4 x16 prefill in the v8 fast profile

## Validation
- py_compile: version/v8/scripts/ck_run_v8.py, version/v8/scripts/codegen_prefill_v8.py
- make -j$(nproc) build/libckernel_engine.so
- LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH .venv/bin/python unittest/test_q4_k_q8_k_matvec.py
- LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH .venv/bin/python unittest/test_q8_k_quantize_parity.py
- LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH .venv/bin/python unittest/test_swiglu.py
- pre-commit passed v7-regression-fast and v8-regression-fast
- full pre-push passed on perf-v8-avx2-quant-prefill before creating this isolated clean branch

Note: this PR intentionally excludes the larger f16-KV attention SIMD/threadpool patch because unittest/test_attention_full.py currently fails strict parity on that change.