### PR TITLE
perf(v8): enable Gemma batched prefill

### DIFF
--- a/benchmarks/profile_v8_prefill_ops.py
+++ b/benchmarks/profile_v8_prefill_ops.py
@@ -71,6 +71,7 @@ def _compile_profile_runtime(
         "--no-chat-template",
     ]
     if force:
+        cmd.append("--force-convert")
         cmd.append("--force-compile")
     env = os.environ.copy()
     env.setdefault("CK_V8_COMPILER", "gcc")

--- a/scripts/validate_submodule_pins.py
+++ b/scripts/validate_submodule_pins.py
@@ -5,9 +5,29 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+
+def clean_git_env() -> dict[str, str]:
+    """Drop hook-local Git env so `git -C submodule` resolves that repo."""
+    env = os.environ.copy()
+    proc = subprocess.run(
+        ["git", "rev-parse", "--local-env-vars"],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    if proc.returncode == 0:
+        for name in proc.stdout.splitlines():
+            env.pop(name.strip(), None)
+    return env
+
+
+GIT_ENV = clean_git_env()
 
 
 def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -17,6 +37,7 @@ def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subproce
         check=check,
         text=True,
         capture_output=True,
+        env=GIT_ENV,
     )
 
 

--- a/src/kernels/attention_kernels_sliding.c
+++ b/src/kernels/attention_kernels_sliding.c
@@ -4,6 +4,7 @@
  */
 
 #include "ckernel_engine.h"
+#include "ck_threadpool.h"
 #include <math.h>
 #include <stdlib.h>
 
@@ -438,6 +439,105 @@ static void attention_flash_query_sliding(const float *q_vec,
     }
 }
 
+typedef struct {
+    const float *q;
+    const float *k;
+    const float *v;
+    float *output;
+    int num_heads;
+    int num_kv_heads;
+    int num_tokens;
+    int head_dim;
+    int aligned_head_dim;
+    int kv_stride_tokens;
+    int sliding_window;
+    float scale;
+} ck_sliding_attention_args_t;
+
+static int ck_env_int_default(const char *name, int fallback)
+{
+    const char *v = getenv(name);
+    if (!v || !v[0]) return fallback;
+    char *end = NULL;
+    long parsed = strtol(v, &end, 10);
+    if (end == v || (end && *end != '\0')) return fallback;
+    if (parsed < 0) parsed = 0;
+    if (parsed > 1 << 20) parsed = 1 << 20;
+    return (int)parsed;
+}
+
+static int ck_sliding_attention_parallel_disabled(void)
+{
+    const char *v = getenv("CK_DISABLE_SLIDING_ATTN_PARALLEL");
+    return v && v[0] && v[0] != '0';
+}
+
+static int ck_sliding_attention_pick_threads(ck_threadpool_t *pool,
+                                             int total_jobs,
+                                             int num_tokens,
+                                             int head_dim)
+{
+    if (!pool || total_jobs <= 0) return 1;
+    if (ck_sliding_attention_parallel_disabled()) return 1;
+    if (ck_threadpool_thread_id(pool) > 0) return 1;
+
+    const int min_tokens = ck_env_int_default("CK_SLIDING_ATTN_PARALLEL_MIN_TOKENS", 128);
+    if (num_tokens < min_tokens || head_dim < 8) return 1;
+
+    int active = ck_threadpool_n_threads(pool);
+    const int cap = ck_env_int_default("CK_SLIDING_ATTN_THREAD_CAP", active);
+    if (cap > 0 && active > cap) active = cap;
+    if (active > total_jobs) active = total_jobs;
+    return active > 1 ? active : 1;
+}
+
+static void ck_sliding_attention_compute_one(const ck_sliding_attention_args_t *a,
+                                             int job)
+{
+    if (!a || job < 0) return;
+
+    const int T = a->num_tokens;
+    const size_t kv_head_stride = (size_t)a->kv_stride_tokens * (size_t)a->aligned_head_dim;
+
+#if defined(__AVX512F__)
+    #define CK_SLIDING_FLASH_IMPL attention_flash_query_sliding_avx512
+#elif defined(__AVX2__)
+    #define CK_SLIDING_FLASH_IMPL attention_flash_query_sliding_avx2
+#elif defined(__AVX__)
+    #define CK_SLIDING_FLASH_IMPL attention_flash_query_sliding_avx
+#else
+    #define CK_SLIDING_FLASH_IMPL attention_flash_query_sliding
+#endif
+
+    const int h = job / T;
+    const int i = job - h * T;
+    const int kv_head = (int)((long long)h * (long long)a->num_kv_heads /
+                              (long long)a->num_heads);
+    const float *k_head = a->k + (size_t)kv_head * kv_head_stride;
+    const float *v_head = a->v + (size_t)kv_head * kv_head_stride;
+    const float *q_vec = a->q + qkv_index(h, i, 0, T, a->aligned_head_dim);
+    float *out_vec = a->output + qkv_index(h, i, 0, T, a->aligned_head_dim);
+
+    CK_SLIDING_FLASH_IMPL(q_vec, k_head, v_head,
+                          /*query_pos=*/i,
+                          /*kv_tokens=*/T,
+                          a->head_dim, a->aligned_head_dim,
+                          a->scale, out_vec,
+                          a->sliding_window);
+
+#undef CK_SLIDING_FLASH_IMPL
+}
+
+static void ck_sliding_attention_work_fn(int ith, int nth, void *args)
+{
+    const ck_sliding_attention_args_t *a = (const ck_sliding_attention_args_t *)args;
+    if (!a || ith < 0 || nth <= 0 || ith >= nth) return;
+    const int total_jobs = a->num_heads * a->num_tokens;
+    for (int job = ith; job < total_jobs; job += nth) {
+        ck_sliding_attention_compute_one(a, job);
+    }
+}
+
 /**
  * Flash attention forward with sliding window (prefill)
  * @test test_attention.py::TestAttentionForward::test_sliding_window_prefill
@@ -485,6 +585,28 @@ void attention_forward_causal_head_major_gqa_flash_strided_sliding(
     const float scale = 1.0f / sqrtf((float)head_dim);
     const int T = num_tokens;
     const size_t kv_head_stride = (size_t)kv_stride_tokens * (size_t)aligned_head_dim;
+
+    const int total_jobs = num_heads * T;
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int active = ck_sliding_attention_pick_threads(pool, total_jobs, T, head_dim);
+    if (pool && active > 1) {
+        ck_sliding_attention_args_t args = {
+            .q = q,
+            .k = k,
+            .v = v,
+            .output = output,
+            .num_heads = num_heads,
+            .num_kv_heads = num_kv_heads,
+            .num_tokens = T,
+            .head_dim = head_dim,
+            .aligned_head_dim = aligned_head_dim,
+            .kv_stride_tokens = kv_stride_tokens,
+            .sliding_window = sliding_window,
+            .scale = scale,
+        };
+        ck_threadpool_dispatch_n(pool, active, ck_sliding_attention_work_fn, &args);
+        return;
+    }
 
 #if defined(__AVX512F__)
     #define SLIDING_FLASH_IMPL attention_flash_query_sliding_avx512
@@ -559,6 +681,28 @@ void attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4(
     const float scale = 1.0f;
     const int T = num_tokens;
     const size_t kv_head_stride = (size_t)kv_stride_tokens * (size_t)aligned_head_dim;
+
+    const int total_jobs = num_heads * T;
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int active = ck_sliding_attention_pick_threads(pool, total_jobs, T, head_dim);
+    if (pool && active > 1) {
+        ck_sliding_attention_args_t args = {
+            .q = q,
+            .k = k,
+            .v = v,
+            .output = output,
+            .num_heads = num_heads,
+            .num_kv_heads = num_kv_heads,
+            .num_tokens = T,
+            .head_dim = head_dim,
+            .aligned_head_dim = aligned_head_dim,
+            .kv_stride_tokens = kv_stride_tokens,
+            .sliding_window = sliding_window,
+            .scale = scale,
+        };
+        ck_threadpool_dispatch_n(pool, active, ck_sliding_attention_work_fn, &args);
+        return;
+    }
 
 #if defined(__AVX512F__)
     #define SLIDING_FLASH_IMPL_GEMMA4 attention_flash_query_sliding_avx512

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -2541,7 +2541,10 @@ CK_EXPORT void ck_model_profile_dump(void) {
     recurrent_reset_lines: list[str] = []
     prefill_policy = str(config.get("prefill_policy") or "").strip().lower()
     force_sequential_prefill = prefill_policy in {"sequential_decode", "decode"}
-    prefill_guard = " && 0" if force_sequential_prefill else " && !(getenv(\"CK_V8_FORCE_DECODE_PREFILL\") && atoi(getenv(\"CK_V8_FORCE_DECODE_PREFILL\")) != 0)"
+    if force_sequential_prefill:
+        prefill_guard = " && (getenv(\"CK_V8_FORCE_BATCHED_PREFILL\") && atoi(getenv(\"CK_V8_FORCE_BATCHED_PREFILL\")) != 0)"
+    else:
+        prefill_guard = " && !(getenv(\"CK_V8_FORCE_DECODE_PREFILL\") && atoi(getenv(\"CK_V8_FORCE_DECODE_PREFILL\")) != 0)"
     for buf_name, macro_name in (
         ("recurrent_conv_state", "A_RECURRENT_CONV_STATE"),
         ("recurrent_ssm_state", "A_RECURRENT_SSM_STATE"),

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -146,15 +146,11 @@ def _last_token_row_offset_expr(func_name: str, embed_dim: int) -> Optional[str]
     fn = str(func_name or "").lower()
     if "q8_k" in fn:
         return f"(size_t)(num_tokens - 1) * (size_t)({embed_dim} / QK_K) * sizeof(block_q8_K)"
-    if "q8_0" in fn:
+    if "q8_0_q8_0" in fn:
         return f"(size_t)(num_tokens - 1) * (size_t)({embed_dim} / QK8_0) * sizeof(block_q8_0)"
     if "fp32" in fn or "f32" in fn or "bf16" in fn:
         return f"(size_t)(num_tokens - 1) * (size_t){embed_dim} * sizeof(float)"
-    # Conservative default for q8_0-style activation packing.
-    row_bytes = _q8_0_row_bytes(embed_dim)
-    if row_bytes is None:
-        return None
-    return f"(size_t)(num_tokens - 1) * (size_t){row_bytes}"
+    return f"(size_t)(num_tokens - 1) * (size_t){embed_dim} * sizeof(float)"
 
 
 def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False, dump: bool = False) -> str:

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -5680,11 +5680,7 @@ def main() -> None:
                 if rope_layout:
                     config["rope_layout"] = rope_layout
                 if arch == "gemma3":
-                    # Gemma 3 decode matches llama.cpp, but the current v8
-                    # batched prefill lowering diverges on first-token logits.
-                    # Replay prompt tokens through decode until Gemma prefill
-                    # has layer-level parity.
-                    config["prefill_policy"] = "sequential_decode"
+                    config["prefill_policy"] = "batched"
                 finetune = meta.get("general.finetune")
                 if isinstance(finetune, str) and finetune.strip():
                     config["finetune"] = finetune
@@ -5893,9 +5889,7 @@ def main() -> None:
         if rope_layout:
             cfg["rope_layout"] = rope_layout
         if arch == "gemma3":
-            # Keep generated runners correct for Gemma 3 while batched prefill
-            # parity is still behind the decode path.
-            cfg["prefill_policy"] = "sequential_decode"
+            cfg["prefill_policy"] = "batched"
         chat_template = meta.get("tokenizer.chat_template")
         if isinstance(chat_template, str) and chat_template.strip():
             cfg["chat_template"] = chat_template


### PR DESCRIPTION
## Summary
- Fix v8 prefill last-token logits row selection so FP32 activation GEMV paths use FP32 row stride, allowing Gemma3 to use batched prefill again.
- Parallelize large sliding-window prefill attention through the existing CK threadpool, with CK_DISABLE_SLIDING_ATTN_PARALLEL as an escape hatch.
- Force reconversion for profiled v8 runtime builds to avoid stale config.json state.
- Harden submodule pin validation inside git hooks by clearing hook-local GIT_* env for nested git commands.

## Validation
- py_compile: changed v8/profile Python scripts and scripts/validate_submodule_pins.py.
- make build/libckernel_engine.so.
- make build/libckernel_attention.so.
- LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH .venv/bin/python -B unittest/test_attention_sliding_contract.py.
- Gemma3 regenerate check: produced config.json with prefill_policy=batched.
- p512 Gemma timing smoke: serial sliding attention ~437 tok/s, parallel sliding attention ~611 tok/s on this host.
- .githooks/pre-commit passed after local .venv and llama.cpp were available.
- git push pre-push hook passed with LD_LIBRARY_PATH including /home/antshiv/Workspace/C-Kernel-Engine/llama.cpp/build/bin for v7 llama replay helper shared libraries.

## Notes
- The larger dynamic scheduler/fusion experiments are intentionally not included here; this PR keeps the production change narrow.
- Pre-push generated local kernel registry files during validation; they were restored and are not part of the branch.
