### PR TITLE
perf(v8): record kernel tuning methodology and 4096-context retest

### DIFF
--- a/benchmarks/bench_v8_decoder_matrix.py
+++ b/benchmarks/bench_v8_decoder_matrix.py
@@ -53,7 +53,7 @@ MODELS: dict[str, dict[str, str]] = {
     "qwen35-0.8b-q4_k_m": {
         "label": "Qwen3.5 0.8B",
         "quant": "Q4_K_M",
-        "run": "Qwen3.5-0.8B-Q4_K_M",
+        "run": "unsloth--Qwen3.5-0.8B-GGUF",
         "gguf": "unsloth--Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf",
     },
     "nanbeige4.1-3b-q4_k_m": {

--- a/benchmarks/compare_ck_llama_v8.py
+++ b/benchmarks/compare_ck_llama_v8.py
@@ -58,7 +58,7 @@ MODELS: list[ModelSpec] = [
         "Qwen3 0.6B",
         "Q8_0",
         Path.home() / ".cache/ck-engine-v8/models/Qwen--Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf",
-        "Qwen3-0.6B-Q8_0",
+        "Qwen--Qwen3-0.6B-GGUF",
     ),
     ModelSpec(
         "qwen35_08b",

--- a/benchmarks/profile_v8_prefill_ops.py
+++ b/benchmarks/profile_v8_prefill_ops.py
@@ -71,6 +71,7 @@ def _compile_profile_runtime(
         "--no-chat-template",
     ]
     if force:
+        cmd.append("--force-convert")
         cmd.append("--force-compile")
     env = os.environ.copy()
     env.setdefault("CK_V8_COMPILER", "gcc")

--- a/docs/site/_pages/architecture-links.html
+++ b/docs/site/_pages/architecture-links.html
@@ -110,6 +110,16 @@
         <a class="runbook-link" href="v7-profiling.html">Open v7 Profiling</a>
     </div>
     <div class="runbook-card">
+        <h3>Kernel Tuning Methodology</h3>
+        <p>CPU-node tuning loop for v8/v7 kernels: practical coherence, fixed-token throughput, CK profile CSV, VTune, Advisor roofline, microkernel labs, and PR logs.</p>
+        <div class="runbook-tags">
+            <span class="runbook-tag">VTune</span>
+            <span class="runbook-tag">Advisor roofline</span>
+            <span class="runbook-tag">CK_PROFILE</span>
+        </div>
+        <a class="runbook-link" href="kernel-tuning-methodology.html">Open Methodology</a>
+    </div>
+    <div class="runbook-card">
         <h3>v7 SVG Dataset Runbook</h3>
         <p>Operator workflow to generate Stage A pretraining and Stage B midtraining SVG corpora from <code>docs/site/assets/*.svg</code>, then hand off to v7 training.</p>
         <div class="runbook-tags">
@@ -197,6 +207,8 @@
                 <span class="subtitle">IR3 memory + parallel execution plan</span></li>
             <li><a href="gemm-optimization.html#v7-threadpool-playbook">Threadpool GEMM Playbook</a>
                 <span class="subtitle">Split M/N/K policy for training</span></li>
+            <li><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>
+                <span class="subtitle">VTune, Advisor, roofline, CK profile, parity, and benchmark log discipline</span></li>
             <li><a href="simd-architecture.html">SIMD Architecture</a>
                 <span class="subtitle">AVX-512, VNNI, AMX</span></li>
             <li><a href="flash_attention.html">Flash Attention Analysis</a>
@@ -213,6 +225,8 @@
                 <span class="subtitle">RDMA, interpretability</span></li>
             <li><a href="profiling.html">Profiling Guide</a>
                 <span class="subtitle">Valgrind, perf, flamegraphs</span></li>
+            <li><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>
+                <span class="subtitle">CPU-node roofline workflow for v8/v7 kernel performance work</span></li>
             <li><a href="v8-runbook.html">v8 Qwen3-VL Runbook</a>
                 <span class="subtitle">Validated decoder/mmproj workflow for multimodal inference</span></li>
             <li><a href="v8-vision-encoder.html">v8 Vision Encoder Architecture</a>
@@ -278,11 +292,11 @@
         </tr>
         <tr>
             <td><strong>Performance optimization</strong></td>
-            <td><a href="gemm-memory-layout.html">GEMM Layout</a>, <a href="gemm-memory-layout.html#v7-train-parallel-plan">v7 Train Layout+Dispatch</a>, <a href="gemm-optimization.html#v7-threadpool-playbook">Threadpool Playbook</a>, <a href="simd-architecture.html">SIMD</a></td>
+            <td><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>, <a href="gemm-memory-layout.html">GEMM Layout</a>, <a href="gemm-memory-layout.html#v7-train-parallel-plan">v7 Train Layout+Dispatch</a>, <a href="gemm-optimization.html#v7-threadpool-playbook">Threadpool Playbook</a>, <a href="simd-architecture.html">SIMD</a></td>
         </tr>
             <tr>
                 <td><strong>Debugging & profiling</strong></td>
-                <td><a href="profiling.html">Profiling</a>, <a href="v7-profiling.html">v7 Profiling Runbook</a>, <a href="testing.html">Testing</a>, <a href="v7-cross-entropy-parity.html">v7 CE Parity Deep Dive</a>, <a href="v7-backprop-ir.html#v7-runtime-stitch-graph">v7 Runtime Stitch Graph</a>, <a href="v7-runbook.html">v7 Runbook</a>, <a href="v7-python-authoring.html">v7 Python Authoring Guide</a></td>
+                <td><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>, <a href="profiling.html">Profiling</a>, <a href="v7-profiling.html">v7 Profiling Runbook</a>, <a href="testing.html">Testing</a>, <a href="v7-cross-entropy-parity.html">v7 CE Parity Deep Dive</a>, <a href="v7-backprop-ir.html#v7-runtime-stitch-graph">v7 Runtime Stitch Graph</a>, <a href="v7-runbook.html">v7 Runbook</a>, <a href="v7-python-authoring.html">v7 Python Authoring Guide</a></td>
             </tr>
             <tr>
                 <td><strong>Operator train + compute workflow</strong></td>

--- a/docs/site/_pages/architecture.html
+++ b/docs/site/_pages/architecture.html
@@ -9,6 +9,10 @@
     <p style="margin: 0;"><strong>New:</strong> See the <a href="ir-pipeline.html">IR Pipeline v6.6</a> page for end-to-end visuals of templates, IR1/IR2, lowering, memory layout, and dumb codegen.</p>
 </div>
 
+<div class="card card-accent">
+    <p style="margin: 0;"><strong>Performance Methodology:</strong> See <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a> for the VTune, Advisor, roofline, CK profile, parity, and E2E workflow used to push generated kernels toward CPU-node limits.</p>
+</div>
+
 <div class="card">
     <h3 style="margin-top: 0;">The "Website" Metaphor</h3>
     <p>The engine treats LLMs like a website generator treats pages. This allows us to unroll the "Block" section efficiently in C without complex control flow.</p>
@@ -67,6 +71,7 @@
         <h3 style="margin-top: 0;">Computation Runbook Links</h3>
         <ul>
             <li><a href="ir-pipeline.html">IR Pipeline</a> (IR1/IR2/lowering and memory mapping)</li>
+            <li><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a> (VTune, Advisor, roofline, CK profile, and parity gates)</li>
             <li><a href="v7-profiling.html">v7 Profiling</a> (perf, flamegraph, cache, VTune/Advisor)</li>
             <li><a href="v7-backprop-ir.html">v7 Backprop IR</a> (gradient path and training runtime checks)</li>
         </ul>

--- a/docs/site/_pages/kernel-tuning-methodology.html
+++ b/docs/site/_pages/kernel-tuning-methodology.html
@@ -1,0 +1,405 @@
+<!-- TITLE: Kernel Tuning Methodology -->
+<!-- NAV: architecture -->
+
+<style>
+.method-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+    gap: 1rem;
+    align-items: stretch;
+    margin: 1rem 0 1.4rem;
+}
+.method-panel {
+    border: 1px solid var(--grey);
+    border-radius: 8px;
+    background: linear-gradient(145deg, rgba(255,180,0,0.10), rgba(7,173,248,0.06));
+    padding: 1rem 1.1rem;
+}
+.method-panel h3 {
+    margin-top: 0;
+}
+.method-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+}
+.method-card {
+    border: 1px solid var(--grey);
+    border-left: 4px solid var(--orange);
+    border-radius: 8px;
+    background: rgba(255,255,255,0.02);
+    padding: 1rem;
+}
+.method-card h3 {
+    margin-top: 0;
+}
+.metric-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: 0.75rem;
+    margin: 1rem 0;
+}
+.metric-box {
+    border: 1px solid rgba(148,163,184,0.35);
+    border-radius: 8px;
+    padding: 0.85rem;
+    background: rgba(15,23,42,0.35);
+}
+.metric-box strong {
+    display: block;
+    color: var(--orange);
+    font-size: 1.35rem;
+    margin-bottom: 0.25rem;
+}
+.check-list li {
+    margin-bottom: 0.45rem;
+}
+.phase-table td:first-child {
+    white-space: nowrap;
+    font-weight: 600;
+}
+@media (max-width: 860px) {
+    .method-hero {
+        grid-template-columns: 1fr;
+    }
+}
+</style>
+
+<h1>Kernel Tuning Methodology</h1>
+
+<p>C-Kernel-Engine performance work is not a benchmark stunt. The goal is to make a CPU node behave like a serious
+compute device: correct first, measurable at every layer, then pushed toward the roofline one kernel at a time.</p>
+
+<div class="method-hero">
+    <div class="method-panel">
+        <h3>North Star</h3>
+        <p>CK should make each CPU node run as close as practical to its hardware limits, then compose those nodes into
+        larger CPU-native systems. The engine is written from the ground up in C so the team can inspect, replace,
+        profile, and verify each transformer stage instead of treating inference as a black box.</p>
+        <p>The methodology is simple: prove the model is still coherent and numerically connected, profile the exact hot
+        path, isolate the slow kernel, improve one bottleneck, and rerun the same gates. No speed patch is accepted
+        because it "looks fast" in isolation.</p>
+    </div>
+    <div class="method-panel">
+        <h3>Hard Rule</h3>
+        <p>Performance changes must keep the model path valid.</p>
+        <ul class="check-list">
+            <li>First-token parity must not regress.</li>
+            <li>Multi-token mismatch must not move earlier without explanation.</li>
+            <li>Practical prompts must remain coherent, not just syntactically alive.</li>
+            <li>OCR, vision, and long-context paths must be tested with real artifacts when available.</li>
+            <li>Every meaningful PR should link benchmark logs and profiler artifacts.</li>
+        </ul>
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="CKE Node Roofline Math">
+    <img src="assets/cke-node-roofline-math.svg" alt="CKE node roofline math">
+</div>
+
+<h2>Measurement Lanes</h2>
+
+<p>The work is split into lanes so we do not confuse different questions. A short chat prompt, a 4096-token prefill
+test, an Intel Advisor dot, and a VTune hotspot report are all useful, but they answer different things.</p>
+
+<div class="method-grid">
+    <div class="method-card">
+        <h3>Practical E2E Lane</h3>
+        <p>Run real prompts through <code>cks-v8-run</code> with the correct chat template, tokenizer, context length,
+        and decode budget. This lane answers: does the model still speak coherently, follow the prompt, and produce
+        useful output?</p>
+    </div>
+    <div class="method-card">
+        <h3>Fixed-Token Throughput Lane</h3>
+        <p>Use controlled prompt and decode token counts, such as <code>p512</code>, <code>p1024</code>,
+        <code>p2048</code>, or <code>p4096</code>. This lane answers: how fast is prefill or decode when the model
+        actually receives that many tokens?</p>
+    </div>
+    <div class="method-card">
+        <h3>Operator Profile Lane</h3>
+        <p>Enable CK profile CSV/JSON and rank time by operator. This lane answers: is the wall time in Q4/Q6 prefill,
+        Q8 projection, attention, SwiGLU, quantization, sampling, or runtime overhead?</p>
+    </div>
+    <div class="method-card">
+        <h3>Microkernel Lab</h3>
+        <p>Extract one kernel with the production dimensions and run it alone. This lane answers: can this exact kernel
+        reach the expected instruction rate before we wire it back into the full transformer?</p>
+    </div>
+    <div class="method-card">
+        <h3>Advisor Roofline Lane</h3>
+        <p>Use Intel Advisor to place loops by arithmetic intensity and throughput. This lane answers: should the next
+        patch move the kernel right by increasing reuse, or up by improving SIMD and instruction efficiency?</p>
+    </div>
+    <div class="method-card">
+        <h3>VTune Lane</h3>
+        <p>Use VTune hotspots, uarch exploration, memory access, and threading analysis. This lane answers: are we
+        retiring useful work, stuck on ports, memory-bound, cache-latency-bound, or underusing physical cores?</p>
+    </div>
+</div>
+
+<h2>Context Is Not Tokens</h2>
+
+<div class="alert alert-warning">
+    <strong>Do not treat <code>--context-len 4096</code> as a 4096-token prefill test.</strong>
+    Context length sets KV-cache capacity. It does not turn a 40-token prompt into a 4096-token workload. Long-prefill
+    performance must be measured with a tokenizer-counted prompt that actually contains the requested number of tokens.
+</div>
+
+<p>This distinction matters because prefill is GEMM-heavy and decode is usually GEMV-heavy. A short prompt with a large
+context window mostly tests runtime overhead plus decode. A true <code>p4096</code> prompt tests the batched prefill
+path, weight reuse, quantized GEMM dispatch, thread scheduling, and cache behavior.</p>
+
+<h2>Toolchain</h2>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Tool</th>
+            <th>What It Tells Us</th>
+            <th>Typical CK Decision</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>CK profile CSV</td>
+            <td>Exact operator time inside the generated runtime.</td>
+            <td>Pick the real hot kernel instead of guessing from end-to-end time.</td>
+        </tr>
+        <tr>
+            <td>Intel Advisor</td>
+            <td>Roofline position, arithmetic intensity, GFLOPS/GINTOPS, vectorization hints.</td>
+            <td>Fuse, repack, tile, or improve SIMD depending on whether the loop must move right or up.</td>
+        </tr>
+        <tr>
+            <td>Intel VTune</td>
+            <td>Hotspots, pipeline slots, retiring, front-end bound, back-end bound, memory stalls, port pressure,
+            physical-core utilization, logical-core utilization.</td>
+            <td>Change dot structure, reduce reductions, fix thread underuse, inspect cache latency, or remove
+            scalar overhead.</td>
+        </tr>
+        <tr>
+            <td><code>perf stat</code></td>
+            <td>Cycles, instructions, IPC, cache misses, branch misses, context switches, wall time.</td>
+            <td>Low-overhead regression gate before expensive profiler runs.</td>
+        </tr>
+        <tr>
+            <td>Flamegraph</td>
+            <td>Call-stack shape and whether time is in kernels, tokenization, sampling, or framework overhead.</td>
+            <td>Decide whether to optimize math, dispatch, or runtime glue.</td>
+        </tr>
+        <tr>
+            <td><code>objdump</code>, LLVM-MCA, uops.info, Intel SDE</td>
+            <td>Instruction mix, AVX2/VNNI use, estimated port pressure, latency chains, static throughput.</td>
+            <td>Replace expensive instruction sequences and prove the compiler emitted the intended ISA path.</td>
+        </tr>
+        <tr>
+            <td>Valgrind/Cachegrind</td>
+            <td>Correctness, cache access shape, allocations, and memory mistakes.</td>
+            <td>Use for debug and memory-shape validation, not final speed numbers.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>How To Read The Signals</h2>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Profiler Signal</th>
+            <th>Meaning</th>
+            <th>Likely Fix</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Low arithmetic intensity</td>
+            <td>The kernel does too little math per byte moved.</td>
+            <td>Pack weights, batch more rows, reuse activations, fuse producers/consumers, avoid scratch writes.</td>
+        </tr>
+        <tr>
+            <td>High retiring, low throughput</td>
+            <td>The CPU is doing useful work, but too many instructions are needed per result.</td>
+            <td>Reduce scalar bookkeeping, delay horizontal reductions, use wider dot instructions, precompute scale terms.</td>
+        </tr>
+        <tr>
+            <td>Port pressure</td>
+            <td>The loop is limited by execution resources, often ALU, shuffle, or load ports.</td>
+            <td>Change vector layout, reduce shuffles, unroll for independent accumulators, inspect assembly.</td>
+        </tr>
+        <tr>
+            <td>Memory bound</td>
+            <td>The loop is waiting on L1/L2/L3/DRAM rather than compute.</td>
+            <td>Retile, prefetch, reduce stores, improve packing, keep hot tiles in cache.</td>
+        </tr>
+        <tr>
+            <td>Low physical-core utilization</td>
+            <td>Threads are not doing useful work across the node.</td>
+            <td>Increase job count, use dynamic tiles, inspect affinity, reduce synchronization, avoid long tail work.</td>
+        </tr>
+        <tr>
+            <td>Coherence regression</td>
+            <td>The model circuit may no longer match the reference path.</td>
+            <td>Stop speed work and run parity: logits, layer dumps, RoPE/M-RoPE, KV-cache, quantized projection.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Kernel Iteration Loop</h2>
+
+<ol>
+    <li><strong>Reproduce</strong>: fix model, quant, prompt token count, context, threads, temperature, and runtime cache.</li>
+    <li><strong>Prove quality</strong>: run practical prompts and, when applicable, CK-vs-llama parity.</li>
+    <li><strong>Rank operators</strong>: collect CK profile CSV and identify the top one or two kernels.</li>
+    <li><strong>Profile deeply</strong>: run Advisor roofline and VTune on the exact workload or extracted kernel.</li>
+    <li><strong>Classify the bottleneck</strong>: compute-bound, memory-bound, instruction-heavy, scheduling-heavy, or parity-broken.</li>
+    <li><strong>Patch narrowly</strong>: change one kernel family, dispatcher rule, packing layout, or fusion path.</li>
+    <li><strong>Run microkernel checks</strong>: validate numerical output and isolated throughput before E2E.</li>
+    <li><strong>Run E2E again</strong>: measure practical prompts and fixed-token lanes across representative models.</li>
+    <li><strong>Attach logs</strong>: commit the commands, hardware, hashes, measured token counts, and profiler links.</li>
+</ol>
+
+<h2>Current v8 Lessons</h2>
+
+<p>The July 2026 AVX2 work produced several important lessons that should stay visible in the docs:</p>
+
+<div class="metric-strip">
+    <div class="metric-box">
+        <strong>p4096</strong>
+        Fixed-token long-prefill lanes are the right stress test for batched prefill.
+    </div>
+    <div class="metric-box">
+        <strong>Q4/Q6</strong>
+        Quantized prefill dispatch dominates many v8 text-family models.
+    </div>
+    <div class="metric-box">
+        <strong>Parity first</strong>
+        Qwen3-VL M-RoPE fixes were accuracy fixes, not speed patches.
+    </div>
+    <div class="metric-box">
+        <strong>Coherence gate</strong>
+        Qwen3 and Qwen3.5 short practical prompts remained coherent in fresh canonical runs.
+    </div>
+</div>
+
+<p>On the local AVX2 profiling host, practical short prompts showed coherent outputs and real decode speed, but they
+are not the same benchmark as fixed-token p4096 prefill. A stale p4096 table once suggested large CK wins over
+llama.cpp; a fresh recheck did not reproduce that claim. The defensible conclusion is narrower and more useful:
+the methodology caught the bad measurement trail, kept the coherent E2E signal, and forced the next pass back to
+token-counted prompts, canonical runtime paths, and profiler-backed kernel attribution.</p>
+
+<div class="alert alert-warning">
+    <strong>Benchmark discipline:</strong> do not publish a speedup table unless the exact command, runtime cache path,
+    prompt token count, llama.cpp command, and output artifact are recorded and the row reproduces in a fresh run.
+    Synthetic fixed-token throughput and interactive chat timing are both useful, but they must not be mixed.
+</div>
+
+<h2>Representative Commands</h2>
+
+<p>Use these as starting points. Record the exact model path, model hash, prompt token count, context length, thread
+count, compiler, and git commit in the log directory for the PR.</p>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Practical Coherence Run</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf \
+  --context-len 1024 \
+  --force-convert --force-compile \
+  --generate-visualizer</code></pre>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Fixed-Token CK-vs-llama Matrix</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+CK_V8_DECODER_MODELS=nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m,qwen3-0.6b-q8_0,qwen35-0.8b-q4_k_m \
+CK_V8_DECODER_PROMPT=4096 \
+CK_V8_DECODER_DECODE=128 \
+CK_V8_DECODER_REPEATS=1 \
+make test-v8-decoder-matrix</code></pre>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Operator-Cost Prefill Profile</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+CK_V8_PROFILE_MODELS=nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m,qwen35-0.8b-q4_k_m \
+CK_V8_PROFILE_PROMPT=4096 \
+CK_V8_PROFILE_DECODE=1 \
+CK_V8_PROFILE_CONTEXT=4608 \
+make profile-v8-prefill-ops</code></pre>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Safe Perf Counter Lane</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+CK_V8_PREFILL_PERF_ENGINE=both \
+CK_V8_PREFILL_PERF_PROMPT=4096 \
+CK_V8_PREFILL_PERF_DECODE=1 \
+make profile-v8-prefill-perf-stat</code></pre>
+</div>
+
+<h2>What Gets Committed</h2>
+
+<p>A performance PR should not hide the measurement trail. Add a log directory under <code>logs/</code> when the change
+is meaningful, and reference it from the commit body.</p>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Artifact</th>
+            <th>Required Content</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>README</td>
+            <td>Hardware, compiler, git commit, model paths, hashes when available, prompt token counts, thread count,
+            context length, commands, tables, and caveats.</td>
+        </tr>
+        <tr>
+            <td>Commit message</td>
+            <td>Problem, fix, measured result, parity/coherence gate, and link to the log directory.</td>
+        </tr>
+        <tr>
+            <td>Profiler links</td>
+            <td>Advisor HTML, VTune summaries, CK profile JSON/CSV, flamegraph, or perf-stat output when used.</td>
+        </tr>
+        <tr>
+            <td>Next steps</td>
+            <td>Known remaining bottlenecks, such as Q6 prefill, Gemma routing, Qwen3/Qwen3.5 long-context accounting,
+            Qwen3-VL OCR parity, or decode GEMV improvements.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Architecture Implication</h2>
+
+<p>CK can do this work because generated C keeps the system inspectable. Kernel maps and templates can replace a
+specific sequence with a fused kernel. The threadpool can be profiled directly. Quantized prefill dispatch can be
+changed without rewriting the whole runtime. The BUMP memory path and generated model code make it possible to
+tie one profiler dot back to one function, one tensor layout, and one source patch.</p>
+
+<div class="img-container svg-viewer" data-title="Performance Balance">
+    <img src="assets/performance-balance.svg" alt="Performance balance">
+</div>
+
+<h2>Open Work</h2>
+
+<ul class="check-list">
+    <li><strong>Token-counted practical long prompts</strong>: replace approximate text-length prompts with tokenizer-counted
+    prompts at 1024, 2048, and 4096 tokens.</li>
+    <li><strong>Q4/Q6 prefill</strong>: continue moving packed Q4/Q6 GEMM loops toward roofline across Nanbeige, Qwen2,
+    Qwen3/Qwen3.5, Gemma, and Qwen3-VL decoder shapes.</li>
+    <li><strong>Fusion</strong>: test gate/up GEMM + SwiGLU + Q8_K quantization fusion where it reduces scratch writes and
+    preserves parity.</li>
+    <li><strong>Threading</strong>: keep dynamic scheduling and physical-core utilization measurable before adding complicated
+    P-core/E-core policy.</li>
+    <li><strong>Deep VTune</strong>: use signed VTune drivers or a controlled profiling boot for deeper PMU collection when
+    Secure Boot blocks out-of-tree modules.</li>
+    <li><strong>Parity harnesses</strong>: keep Qwen3-VL long-decode and OCR tests enabled while speed work continues.</li>
+</ul>
+
+<div class="alert alert-info">
+    <strong>Bottom line:</strong> CK performance claims should be reproducible from logs, visible in profiler artifacts,
+    and still produce coherent model output. That is the difference between a real CPU kernel engine and a lucky
+    timing number.
+</div>

--- a/docs/site/_partials/api_content.html
+++ b/docs/site/_partials/api_content.html
@@ -60,7 +60,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_0(const void * weight_q5_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_0 x Q8_0 GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_0 GEMM - batched matrix multiply with Q5_0 weights (32-element blocks)</p>
         </div>
 
 
@@ -70,7 +70,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_1(const void * weight_q5_1, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_1 x Q8_0 GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_1 GEMM - batched matrix multiply with Q5_1 weights (32-element blocks)</p>
         </div>
 
 
@@ -80,7 +80,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_k(const void * weight_q5_k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_K x Q8_K GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_K GEMM - batched matrix multiply with Q5_K weights (256-element super-blocks)</p>
         </div>
 
 
@@ -90,7 +90,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q6_k(const void * weight_q6k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q6_K x Q8_K GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q6_K GEMM - batched matrix multiply with Q6_K weights.</p>
         </div>
 
 
@@ -100,7 +100,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q8_0(const void * weight_q8_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q8_0 x Q8_0 GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q8_0 GEMM - batched matrix multiply with Q8_0 weights (32-element blocks)</p>
         </div>
 
 
@@ -1206,7 +1206,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill (v3 optimized)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill.</p>
         </div>
 
 
@@ -1246,7 +1246,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_rmsnorm_qkv_scratch_size(int hidden)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_rmsnorm_qkv_prefill.</p>
         </div>
 
 
@@ -1462,7 +1462,7 @@ test_parity.py::test_rmsnorm_parity</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void unfused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * x_norm, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for comparison.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for benchmarking comparison.</p>
         </div>
 
     </div>
@@ -2122,7 +2122,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void mega_fused_attention_decode(float * output, const float * input, const float * residual, const float * ln1_gamma, const float * wq, const float * bq, const float * wk, const float * bk, const float * wv, const float * bv, const float * wo, const float * bo, float * kv_cache_k, float * kv_cache_v, const float * rope_cos, const float * rope_sin, int pos, int embed_dim, int aligned_embed_dim, int num_heads, int num_kv_heads, int head_dim, int aligned_head_dim, int cache_capacity, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Mega-fused attention for decode mode (single token)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Full mega-fused attention for decode.</p>
         </div>
 
 
@@ -2350,7 +2350,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_mlp_swiglu_prefill_bias(const float * x, const float * W_gate, const float * W_up, const float * W_down, const float * B_gate, const float * B_up, const float * B_down, float * output, int seq_len, int hidden, int intermediate, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP for prefill with proper tiling.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP (Gate + Up + SwiGLU + Down) for prefill with biases.</p>
         </div>
 
 
@@ -2380,7 +2380,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_mlp_swiglu_scratch_size(int intermediate)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused MLP.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_mlp_swiglu_prefill.</p>
         </div>
 
 
@@ -4437,7 +4437,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_serialize_json_with_plan</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const struct CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -5487,7 +5487,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q5_0_q8_0(const void * weight_q5_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -5497,7 +5497,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q8_0_q8_0(const void * weight_q8_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -7726,7 +7726,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">geglu_backward_fp32</code>
                 <span class="badge badge-blue" style="margin-left: 0.5rem;">Backward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int n_tokens, int dim)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int tokens, int dim)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">GeGLU backward pass (fp32) Testtest_geglu.py::TestGeGLU::test_geglu_backward_fp32</p>
         </div>
 
@@ -9758,7 +9758,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">parse_args</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">bool parse_args(int argc, char ** argv, CLIOptions * opt)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">CLIArgs parse_args(int argc, char ** argv)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -10038,7 +10038,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">print_usage</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * prog)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * argv0)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -10918,7 +10918,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_dim</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, CKDimKind kind, int tokens_override)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKV2AlignInfo * align, CKDimKind kind)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -10928,7 +10928,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_shape_elems</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, const CKDimToken * shape, int tokens_override)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKV2AlignInfo * align, const CKDimToken * shape)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-04 20:36</span>
+        <span class="folder-updated">Updated: 2026-07-08 15:23</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -26,61 +26,31 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
+|-- .cache
+|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
-|       |-- gen1_archive_2026-04-05
-|       `-- spec_archive_2026-04-08
 |-- contracts
 |-- data
 |   |-- eval_contracts
-|   |-- generated
-|   |   |-- toy_svg_semantic_shapes_tokenizer
-|   |   `-- toy_svg_structured_atoms_tokenizer
-|   |-- probe_contracts
 |   |-- spec03
-|   |   |-- contracts
-|   |   |-- holdout
-|   |   |-- manifests
-|   |   |-- midtrain
-|   |   |-- normalized
-|   |   |-- pretrain
-|   |   |-- raw_assets
-|   |   |-- sft
-|   |   `-- tokenizer
 |   `-- spec04
-|       |-- contracts
-|       |-- holdout
-|       |-- manifests
-|       |-- midtrain
-|       |-- normalized
-|       |-- pretrain
-|       |-- raw_assets
-|       |-- sft
-|       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
-|       |-- catalog
-|       |-- core
-|       |-- programs
-|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
 |-- reports
-|   |-- spec12_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec12_gold_mappings
-|   |-- spec13b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec13b_gold_mappings
-|   |-- spec14a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14a_gold_mappings
-|   |-- spec14b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14b_gold_mappings
-|   |-- spec15a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15a_gold_mappings
-|   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
-|   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
-|   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
-|-- runs
-|   |-- logs
-|   `-- overnight_monitor
-|       `-- spec10
+|   |-- spec12_gold_mappings
+|   |-- spec13b_gold_mappings
+|   |-- spec14a_gold_mappings
+|   |-- spec14b_gold_mappings
+|   |-- spec15a_gold_mappings
+|   |-- spec15b_gold_mappings
+|   |-- spec_broader_1_family_packs
+|   `-- spec_broader_1_gold_mappings
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -93,7 +63,7 @@ version/v7
 `-- tools
     `-- src
 
-87 directories
+57 directories
 </pre>
 </div>
 

--- a/docs/site/_partials/header.html
+++ b/docs/site/_partials/header.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1077,7 +1079,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_0(const void * weight_q5_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_0 x Q8_0 GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_0 GEMM - batched matrix multiply with Q5_0 weights (32-element blocks)</p>
         </div>
 
 
@@ -1087,7 +1089,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_1(const void * weight_q5_1, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_1 x Q8_0 GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_1 GEMM - batched matrix multiply with Q5_1 weights (32-element blocks)</p>
         </div>
 
 
@@ -1097,7 +1099,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_k(const void * weight_q5_k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_K x Q8_K GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_K GEMM - batched matrix multiply with Q5_K weights (256-element super-blocks)</p>
         </div>
 
 
@@ -1107,7 +1109,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q6_k(const void * weight_q6k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q6_K x Q8_K GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q6_K GEMM - batched matrix multiply with Q6_K weights.</p>
         </div>
 
 
@@ -1117,7 +1119,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q8_0(const void * weight_q8_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q8_0 x Q8_0 GEMM (batch matrix multiply)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q8_0 GEMM - batched matrix multiply with Q8_0 weights (32-element blocks)</p>
         </div>
 
 
@@ -2223,7 +2225,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill (v3 optimized)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill.</p>
         </div>
 
 
@@ -2263,7 +2265,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_rmsnorm_qkv_scratch_size(int hidden)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_rmsnorm_qkv_prefill.</p>
         </div>
 
 
@@ -2479,7 +2481,7 @@ test_parity.py::test_rmsnorm_parity</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void unfused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * x_norm, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for comparison.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for benchmarking comparison.</p>
         </div>
 
     </div>
@@ -3139,7 +3141,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void mega_fused_attention_decode(float * output, const float * input, const float * residual, const float * ln1_gamma, const float * wq, const float * bq, const float * wk, const float * bk, const float * wv, const float * bv, const float * wo, const float * bo, float * kv_cache_k, float * kv_cache_v, const float * rope_cos, const float * rope_sin, int pos, int embed_dim, int aligned_embed_dim, int num_heads, int num_kv_heads, int head_dim, int aligned_head_dim, int cache_capacity, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Mega-fused attention for decode mode (single token)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Full mega-fused attention for decode.</p>
         </div>
 
 
@@ -3367,7 +3369,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_mlp_swiglu_prefill_bias(const float * x, const float * W_gate, const float * W_up, const float * W_down, const float * B_gate, const float * B_up, const float * B_down, float * output, int seq_len, int hidden, int intermediate, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP for prefill with proper tiling.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP (Gate + Up + SwiGLU + Down) for prefill with biases.</p>
         </div>
 
 
@@ -3397,7 +3399,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_mlp_swiglu_scratch_size(int intermediate)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused MLP.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_mlp_swiglu_prefill.</p>
         </div>
 
 
@@ -5454,7 +5456,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_serialize_json_with_plan</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const struct CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -6504,7 +6506,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q5_0_q8_0(const void * weight_q5_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -6514,7 +6516,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q8_0_q8_0(const void * weight_q8_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -8743,7 +8745,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">geglu_backward_fp32</code>
                 <span class="badge badge-blue" style="margin-left: 0.5rem;">Backward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int n_tokens, int dim)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int tokens, int dim)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">GeGLU backward pass (fp32) Testtest_geglu.py::TestGeGLU::test_geglu_backward_fp32</p>
         </div>
 
@@ -10775,7 +10777,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">parse_args</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">bool parse_args(int argc, char ** argv, CLIOptions * opt)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">CLIArgs parse_args(int argc, char ** argv)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -11055,7 +11057,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">print_usage</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * prog)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * argv0)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -11935,7 +11937,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_dim</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, CKDimKind kind, int tokens_override)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKV2AlignInfo * align, CKDimKind kind)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -11945,7 +11947,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_shape_elems</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, const CKDimToken * shape, int tokens_override)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKV2AlignInfo * align, const CKDimToken * shape)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -12974,7 +12976,7 @@ rmsnorm_backward(d_norm_out, input, gamma, rstd_cache, d_input, d_gamma, tokens,
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture-links.html
+++ b/docs/site/architecture-links.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1053,6 +1055,16 @@
         <a class="runbook-link" href="v7-profiling.html">Open v7 Profiling</a>
     </div>
     <div class="runbook-card">
+        <h3>Kernel Tuning Methodology</h3>
+        <p>CPU-node tuning loop for v8/v7 kernels: practical coherence, fixed-token throughput, CK profile CSV, VTune, Advisor roofline, microkernel labs, and PR logs.</p>
+        <div class="runbook-tags">
+            <span class="runbook-tag">VTune</span>
+            <span class="runbook-tag">Advisor roofline</span>
+            <span class="runbook-tag">CK_PROFILE</span>
+        </div>
+        <a class="runbook-link" href="kernel-tuning-methodology.html">Open Methodology</a>
+    </div>
+    <div class="runbook-card">
         <h3>v7 SVG Dataset Runbook</h3>
         <p>Operator workflow to generate Stage A pretraining and Stage B midtraining SVG corpora from <code>docs/site/assets/*.svg</code>, then hand off to v7 training.</p>
         <div class="runbook-tags">
@@ -1140,6 +1152,8 @@
                 <span class="subtitle">IR3 memory + parallel execution plan</span></li>
             <li><a href="gemm-optimization.html#v7-threadpool-playbook">Threadpool GEMM Playbook</a>
                 <span class="subtitle">Split M/N/K policy for training</span></li>
+            <li><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>
+                <span class="subtitle">VTune, Advisor, roofline, CK profile, parity, and benchmark log discipline</span></li>
             <li><a href="simd-architecture.html">SIMD Architecture</a>
                 <span class="subtitle">AVX-512, VNNI, AMX</span></li>
             <li><a href="flash_attention.html">Flash Attention Analysis</a>
@@ -1156,6 +1170,8 @@
                 <span class="subtitle">RDMA, interpretability</span></li>
             <li><a href="profiling.html">Profiling Guide</a>
                 <span class="subtitle">Valgrind, perf, flamegraphs</span></li>
+            <li><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>
+                <span class="subtitle">CPU-node roofline workflow for v8/v7 kernel performance work</span></li>
             <li><a href="v8-runbook.html">v8 Qwen3-VL Runbook</a>
                 <span class="subtitle">Validated decoder/mmproj workflow for multimodal inference</span></li>
             <li><a href="v8-vision-encoder.html">v8 Vision Encoder Architecture</a>
@@ -1221,11 +1237,11 @@
         </tr>
         <tr>
             <td><strong>Performance optimization</strong></td>
-            <td><a href="gemm-memory-layout.html">GEMM Layout</a>, <a href="gemm-memory-layout.html#v7-train-parallel-plan">v7 Train Layout+Dispatch</a>, <a href="gemm-optimization.html#v7-threadpool-playbook">Threadpool Playbook</a>, <a href="simd-architecture.html">SIMD</a></td>
+            <td><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>, <a href="gemm-memory-layout.html">GEMM Layout</a>, <a href="gemm-memory-layout.html#v7-train-parallel-plan">v7 Train Layout+Dispatch</a>, <a href="gemm-optimization.html#v7-threadpool-playbook">Threadpool Playbook</a>, <a href="simd-architecture.html">SIMD</a></td>
         </tr>
             <tr>
                 <td><strong>Debugging & profiling</strong></td>
-                <td><a href="profiling.html">Profiling</a>, <a href="v7-profiling.html">v7 Profiling Runbook</a>, <a href="testing.html">Testing</a>, <a href="v7-cross-entropy-parity.html">v7 CE Parity Deep Dive</a>, <a href="v7-backprop-ir.html#v7-runtime-stitch-graph">v7 Runtime Stitch Graph</a>, <a href="v7-runbook.html">v7 Runbook</a>, <a href="v7-python-authoring.html">v7 Python Authoring Guide</a></td>
+                <td><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>, <a href="profiling.html">Profiling</a>, <a href="v7-profiling.html">v7 Profiling Runbook</a>, <a href="testing.html">Testing</a>, <a href="v7-cross-entropy-parity.html">v7 CE Parity Deep Dive</a>, <a href="v7-backprop-ir.html#v7-runtime-stitch-graph">v7 Runtime Stitch Graph</a>, <a href="v7-runbook.html">v7 Runbook</a>, <a href="v7-python-authoring.html">v7 Python Authoring Guide</a></td>
             </tr>
             <tr>
                 <td><strong>Operator train + compute workflow</strong></td>
@@ -1461,7 +1477,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -950,6 +952,10 @@
 
 <div class="card card-accent">
     <p style="margin: 0;"><strong>New:</strong> See the <a href="ir-pipeline.html">IR Pipeline v6.6</a> page for end-to-end visuals of templates, IR1/IR2, lowering, memory layout, and dumb codegen.</p>
+</div>
+
+<div class="card card-accent">
+    <p style="margin: 0;"><strong>Performance Methodology:</strong> See <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a> for the VTune, Advisor, roofline, CK profile, parity, and E2E workflow used to push generated kernels toward CPU-node limits.</p>
 </div>
 
 <div class="card">
@@ -1010,6 +1016,7 @@
         <h3 style="margin-top: 0;">Computation Runbook Links</h3>
         <ul>
             <li><a href="ir-pipeline.html">IR Pipeline</a> (IR1/IR2/lowering and memory mapping)</li>
+            <li><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a> (VTune, Advisor, roofline, CK profile, and parity gates)</li>
             <li><a href="v7-profiling.html">v7 Profiling</a> (perf, flamegraph, cache, VTune/Advisor)</li>
             <li><a href="v7-backprop-ir.html">v7 Backprop IR</a> (gradient path and training runtime checks)</li>
         </ul>
@@ -1221,7 +1228,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-04 20:36</span>
+        <span class="folder-updated">Updated: 2026-07-08 15:23</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1245,61 +1252,31 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
+|-- .cache
+|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
-|       |-- gen1_archive_2026-04-05
-|       `-- spec_archive_2026-04-08
 |-- contracts
 |-- data
 |   |-- eval_contracts
-|   |-- generated
-|   |   |-- toy_svg_semantic_shapes_tokenizer
-|   |   `-- toy_svg_structured_atoms_tokenizer
-|   |-- probe_contracts
 |   |-- spec03
-|   |   |-- contracts
-|   |   |-- holdout
-|   |   |-- manifests
-|   |   |-- midtrain
-|   |   |-- normalized
-|   |   |-- pretrain
-|   |   |-- raw_assets
-|   |   |-- sft
-|   |   `-- tokenizer
 |   `-- spec04
-|       |-- contracts
-|       |-- holdout
-|       |-- manifests
-|       |-- midtrain
-|       |-- normalized
-|       |-- pretrain
-|       |-- raw_assets
-|       |-- sft
-|       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
-|       |-- catalog
-|       |-- core
-|       |-- programs
-|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
 |-- reports
-|   |-- spec12_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec12_gold_mappings
-|   |-- spec13b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec13b_gold_mappings
-|   |-- spec14a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14a_gold_mappings
-|   |-- spec14b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14b_gold_mappings
-|   |-- spec15a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15a_gold_mappings
-|   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
-|   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
-|   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
-|-- runs
-|   |-- logs
-|   `-- overnight_monitor
-|       `-- spec10
+|   |-- spec12_gold_mappings
+|   |-- spec13b_gold_mappings
+|   |-- spec14a_gold_mappings
+|   |-- spec14b_gold_mappings
+|   |-- spec15a_gold_mappings
+|   |-- spec15b_gold_mappings
+|   |-- spec_broader_1_family_packs
+|   `-- spec_broader_1_gold_mappings
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -1312,7 +1289,7 @@ version/v7
 `-- tools
     `-- src
 
-87 directories
+57 directories
 </pre>
 </div>
 
@@ -1591,7 +1568,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/build.sh
+++ b/docs/site/build.sh
@@ -102,13 +102,17 @@ if [ -f "$SCRIPT_DIR/scripts/generate_tree.sh" ]; then
 fi
 
 # Step 4: Refresh manifest-driven training history docs
-if [ -f "$REPO_ROOT/version/v7/scripts/build_spec_training_story_v7.py" ]; then
-    echo "  Refreshing spec training manifest..."
-    python3 "$REPO_ROOT/version/v7/scripts/build_spec_training_story_v7.py" || echo "  Warning: spec training manifest refresh failed"
-fi
-if [ -f "$REPO_ROOT/version/v7/scripts/build_spec_training_results_page_v7.py" ]; then
-    echo "  Rendering spec training results page..."
-    python3 "$REPO_ROOT/version/v7/scripts/build_spec_training_results_page_v7.py" || echo "  Warning: spec training results page refresh failed"
+if [ "${CK_SITE_SKIP_SPEC_TRAINING_REFRESH:-0}" = "1" ]; then
+    echo "  Skipping spec training manifest refresh (CK_SITE_SKIP_SPEC_TRAINING_REFRESH=1)"
+else
+    if [ -f "$REPO_ROOT/version/v7/scripts/build_spec_training_story_v7.py" ]; then
+        echo "  Refreshing spec training manifest..."
+        python3 "$REPO_ROOT/version/v7/scripts/build_spec_training_story_v7.py" || echo "  Warning: spec training manifest refresh failed"
+    fi
+    if [ -f "$REPO_ROOT/version/v7/scripts/build_spec_training_results_page_v7.py" ]; then
+        echo "  Rendering spec training results page..."
+        python3 "$REPO_ROOT/version/v7/scripts/build_spec_training_results_page_v7.py" || echo "  Warning: spec training results page refresh failed"
+    fi
 fi
 
 # Process each page in _pages directory

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1543,7 +1545,7 @@ CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/codegen.html
+++ b/docs/site/codegen.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1764,7 +1766,7 @@ static size_t bump(size_t *off, size_t bytes) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2214,7 +2216,7 @@ With weight tying: W = E  (same matrix!)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/contributing.html
+++ b/docs/site/contributing.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1274,7 +1276,7 @@ make test</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions-dynamic.html
+++ b/docs/site/decisions-dynamic.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1460,7 +1462,7 @@ details.adr pre {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions.html
+++ b/docs/site/decisions.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1934,7 +1936,7 @@ weight_mapping:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deltanet-deep-dive.html
+++ b/docs/site/deltanet-deep-dive.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2187,7 +2189,7 @@ void recurrent_conv_state_update_forward(
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deterministic-memory.html
+++ b/docs/site/deterministic-memory.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1615,7 +1617,7 @@ class TrainingObserver:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/developer-guide.html
+++ b/docs/site/developer-guide.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1734,7 +1736,7 @@ make emit CONFIG=x.json OUT=out.c  # Generate runtime</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/flash_attention.html
+++ b/docs/site/flash_attention.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1721,7 +1723,7 @@ pthread_setaffinity_np(pthread_self(),
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout-temp.html
+++ b/docs/site/gemm-memory-layout-temp.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1399,7 +1401,7 @@ for (m_tile = 0; m_tile < M; m_tile += MB) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout.html
+++ b/docs/site/gemm-memory-layout.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1655,7 +1657,7 @@ Token 2: offset 1972    ✗ Kernel expects 1904!</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-optimization.html
+++ b/docs/site/gemm-optimization.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2553,7 +2555,7 @@ gemm_microkernel_packed(A, B, C, M, N, K);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemma4-speculative-pair.html
+++ b/docs/site/gemma4-speculative-pair.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1403,7 +1405,7 @@ int ck_gemma4_pair_generate_speculative(...);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-bump.html
+++ b/docs/site/gguf-bump.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1835,7 +1837,7 @@ make gguf-to-bump GGUF=models/qwen2.5-3b-instruct-q4_k_m.gguf
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-conversion.html
+++ b/docs/site/gguf-conversion.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2183,7 +2185,7 @@ with open(output_path, "w+b") as f:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1572,7 +1574,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-04 20:36</span>
+        <span class="folder-updated">Updated: 2026-07-08 15:23</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1596,61 +1598,31 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
+|-- .cache
+|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
-|       |-- gen1_archive_2026-04-05
-|       `-- spec_archive_2026-04-08
 |-- contracts
 |-- data
 |   |-- eval_contracts
-|   |-- generated
-|   |   |-- toy_svg_semantic_shapes_tokenizer
-|   |   `-- toy_svg_structured_atoms_tokenizer
-|   |-- probe_contracts
 |   |-- spec03
-|   |   |-- contracts
-|   |   |-- holdout
-|   |   |-- manifests
-|   |   |-- midtrain
-|   |   |-- normalized
-|   |   |-- pretrain
-|   |   |-- raw_assets
-|   |   |-- sft
-|   |   `-- tokenizer
 |   `-- spec04
-|       |-- contracts
-|       |-- holdout
-|       |-- manifests
-|       |-- midtrain
-|       |-- normalized
-|       |-- pretrain
-|       |-- raw_assets
-|       |-- sft
-|       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
-|       |-- catalog
-|       |-- core
-|       |-- programs
-|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
 |-- reports
-|   |-- spec12_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec12_gold_mappings
-|   |-- spec13b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec13b_gold_mappings
-|   |-- spec14a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14a_gold_mappings
-|   |-- spec14b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14b_gold_mappings
-|   |-- spec15a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15a_gold_mappings
-|   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
-|   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
-|   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
-|-- runs
-|   |-- logs
-|   `-- overnight_monitor
-|       `-- spec10
+|   |-- spec12_gold_mappings
+|   |-- spec13b_gold_mappings
+|   |-- spec14a_gold_mappings
+|   |-- spec14b_gold_mappings
+|   |-- spec15a_gold_mappings
+|   |-- spec15b_gold_mappings
+|   |-- spec_broader_1_family_packs
+|   `-- spec_broader_1_gold_mappings
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -1663,7 +1635,7 @@ version/v7
 `-- tools
     `-- src
 
-87 directories
+57 directories
 </pre>
 </div>
 
@@ -1942,7 +1914,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-pipeline.html
+++ b/docs/site/ir-pipeline.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2264,7 +2266,7 @@ python version/v6.6/tools/open_ir_visualizer.py Qwen--Qwen3-0.6B-GGUF</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-v2.html
+++ b/docs/site/ir-v2.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1660,7 +1662,7 @@ Page 2 (2-3GB)   → DRAM Bank 2 (Layer 12-17)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/iteration-philosophy.html
+++ b/docs/site/iteration-philosophy.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2578,7 +2580,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernel-tuning-methodology.html
+++ b/docs/site/kernel-tuning-methodology.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deep Training Intuition  | C-Kernel-Engine</title>
-    <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <title>Kernel Tuning Methodology | C-Kernel-Engine</title>
+    <meta name="description" content="C-Kernel-Engine kernel tuning methodology for CPU-node performance work with VTune, Advisor roofline, perf, CK profile CSV, parity gates, and reproducible benchmark logs.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html">
-    <meta property="og:title" content="Deep Training Intuition  | C-Kernel-Engine">
-    <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html">
+    <meta property="og:title" content="Kernel Tuning Methodology | C-Kernel-Engine">
+    <meta property="og:description" content="C-Kernel-Engine kernel tuning methodology for CPU-node performance work with VTune, Advisor roofline, perf, CK profile CSV, parity gates, and reproducible benchmark logs.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -947,1087 +947,406 @@
     <main>
 
 <style>
-.intuition-hero {
-    position: relative;
-    overflow: hidden;
-}
-
-.intuition-hero .badge-row {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-}
-
-.badge-blue {
-    background: var(--blue);
-    color: #fff;
-}
-
-.badge-amber {
-    background: var(--orange);
-    color: var(--dark);
-}
-
-.subtitle {
-    max-width: 860px;
-    margin: 0 auto 1.25rem auto;
-    color: var(--text-secondary);
-}
-
-.stack-board {
-    background: linear-gradient(180deg, rgba(255,180,0,0.08), rgba(7,173,248,0.08));
-    border: 1px solid var(--grey);
-    border-radius: 12px;
-    padding: 1.25rem;
-}
-
-.stack-grid {
+.method-hero {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 0.75rem;
+    grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+    gap: 1rem;
+    align-items: stretch;
+    margin: 1rem 0 1.4rem;
 }
-
-.stack-item {
-    background: rgba(42, 42, 42, 0.9);
+.method-panel {
     border: 1px solid var(--grey);
     border-radius: 8px;
-    padding: 0.9rem;
-    text-align: center;
+    background: linear-gradient(145deg, rgba(255,180,0,0.10), rgba(7,173,248,0.06));
+    padding: 1rem 1.1rem;
 }
-
-.stack-item strong {
-    display: block;
-    margin-bottom: 0.35rem;
-    color: var(--white);
-}
-
-.stack-item .layer-meta {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-}
-
-.board-caption {
-    margin-top: 0.75rem;
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-}
-
-.gap-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1rem;
-}
-
-.gap-card {
-    background: var(--dark-card);
-    border: 1px solid var(--grey);
-    border-radius: 10px;
-    padding: 1rem;
-}
-
-.gap-card h3 {
+.method-panel h3 {
     margin-top: 0;
 }
-
-.gap-list {
-    margin: 0.75rem 0 0 0;
-    padding: 0;
-    list-style: none;
-}
-
-.gap-list li {
-    margin: 0 0 0.55rem 0;
-    padding: 0.5rem 0.65rem;
-    border-radius: 6px;
-    border: 1px solid var(--grey);
-    background: rgba(0,0,0,0.18);
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-}
-
-.size-compare {
-    display: grid;
-    gap: 0.9rem;
-}
-
-.estimate-note {
-    margin-top: 0.6rem;
-    font-size: 0.83rem;
-    color: var(--text-muted);
-}
-
-.size-row {
-    background: var(--dark-card);
-    border: 1px solid var(--grey);
-    border-radius: 8px;
-    padding: 0.8rem;
-}
-
-.size-row .row-top {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.75rem;
-    font-size: 0.9rem;
-    margin-bottom: 0.4rem;
-}
-
-.bar-wrap {
-    width: 100%;
-    background: #202020;
-    border: 1px solid #3a3a3a;
-    border-radius: 999px;
-    height: 12px;
-    overflow: hidden;
-}
-
-.bar {
-    height: 100%;
-    background: linear-gradient(90deg, var(--orange), var(--orange-light));
-}
-
-.bar-small {
-    background: linear-gradient(90deg, var(--blue), #53c7ff);
-}
-
-.bar-resume {
-    background: linear-gradient(90deg, var(--green), #7ad8a0);
-}
-
-.cadence-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 0.85rem;
-}
-
-.cadence-card {
-    border: 1px solid var(--grey);
-    border-left: 3px solid var(--orange);
-    border-radius: 8px;
-    background: var(--dark-card);
-    padding: 0.9rem;
-}
-
-.cadence-card h4 {
-    margin: 0 0 0.4rem 0;
-    color: var(--white);
-}
-
-.cadence-card p {
-    margin: 0;
-    font-size: 0.9rem;
-}
-
-.trigger-strip {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-top: 0.8rem;
-}
-
-.trigger-pill {
-    border: 1px solid var(--grey);
-    background: rgba(255,180,0,0.1);
-    color: var(--orange);
-    border-radius: 999px;
-    padding: 0.35rem 0.7rem;
-    font-size: 0.78rem;
-}
-
-.phase-grid {
+.method-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 1rem;
 }
-
-.phase {
+.method-card {
     border: 1px solid var(--grey);
-    border-radius: 10px;
+    border-left: 4px solid var(--orange);
+    border-radius: 8px;
+    background: rgba(255,255,255,0.02);
     padding: 1rem;
-    background: var(--dark-card);
-    box-shadow: var(--shadow-sm);
 }
-
-.phase h3 {
+.method-card h3 {
     margin-top: 0;
 }
-
-.phase .phase-tag {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.6px;
-    color: var(--orange);
-    margin-bottom: 0.5rem;
-}
-
-.phase ol {
-    margin: 0;
-    padding-left: 1.2rem;
-}
-
-.phase li {
-    margin-bottom: 0.45rem;
-    color: var(--text-secondary);
-}
-
-.triage table td:first-child {
-    font-weight: 600;
-    color: var(--white);
-}
-
-.triage code {
-    font-size: 0.78rem;
-}
-
-.pipeline {
-    margin-top: 1rem;
-    padding: 1rem;
-    border: 1px dashed var(--grey-light);
-    border-radius: 8px;
-    background: rgba(0,0,0,0.16);
-}
-
-.pipeline pre {
-    margin: 0;
-}
-
-.run-grid {
+.metric-strip {
     display: grid;
-    gap: 0.9rem;
-}
-
-.run-step {
-    border: 1px solid var(--grey);
-    border-left: 3px solid var(--blue);
-    border-radius: 8px;
-    background: var(--dark-card);
-    padding: 0.9rem;
-}
-
-.run-step h4 {
-    margin: 0 0 0.45rem 0;
-    color: var(--white);
-}
-
-.run-step p {
-    margin: 0 0 0.6rem 0;
-    font-size: 0.9rem;
-}
-
-.run-step pre {
-    margin: 0;
-}
-
-.playbook-wrap {
-    margin-top: 2rem;
-}
-
-.playbook-phase {
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: 0.75rem;
     margin: 1rem 0;
-    border: 1px solid var(--grey);
-    border-radius: 10px;
-    background: var(--dark-card);
-    overflow: hidden;
 }
-
-.playbook-phase summary {
-    cursor: pointer;
-    padding: 0.95rem 1rem;
-    font-weight: 700;
-    color: var(--white);
-    background: rgba(255, 180, 0, 0.08);
-    border-bottom: 1px solid var(--grey);
-}
-
-.playbook-phase .phase-body {
-    padding: 1rem;
-}
-
-.playbook-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 0.6rem 0 0 0;
-}
-
-.playbook-table th {
-    font-size: 0.78rem;
-}
-
-.playbook-table td {
-    font-size: 0.86rem;
-    vertical-align: top;
-}
-
-.playbook-table td:first-child {
-    font-weight: 600;
-    color: var(--white);
-}
-
-.phase-note {
-    margin-top: 0.65rem;
-    font-size: 0.83rem;
-    color: var(--text-muted);
-}
-
-.protocol-step {
-    border: 1px solid var(--grey);
-    border-left: 3px solid var(--green);
+.metric-box {
+    border: 1px solid rgba(148,163,184,0.35);
     border-radius: 8px;
-    background: rgba(0, 0, 0, 0.14);
-    padding: 0.8rem;
-    margin: 0.6rem 0;
+    padding: 0.85rem;
+    background: rgba(15,23,42,0.35);
 }
-
-.protocol-step h4 {
-    margin: 0 0 0.35rem 0;
-    color: var(--white);
+.metric-box strong {
+    display: block;
+    color: var(--orange);
+    font-size: 1.35rem;
+    margin-bottom: 0.25rem;
 }
-
-.protocol-step p {
-    margin: 0;
-    font-size: 0.9rem;
+.check-list li {
+    margin-bottom: 0.45rem;
 }
-
-@media (max-width: 720px) {
-    .subtitle {
-        font-size: 0.95rem;
+.phase-table td:first-child {
+    white-space: nowrap;
+    font-weight: 600;
+}
+@media (max-width: 860px) {
+    .method-hero {
+        grid-template-columns: 1fr;
     }
 }
 </style>
 
-<div class="hero intuition-hero">
-    <div class="badge-row">
-        <span class="badge badge-amber">Correctness -> Intuition</span>
-        <span class="badge badge-blue">IR + Kernels + Gradients</span>
-        <span class="badge badge-green">Checkpoint-Efficient</span>
+<h1>Kernel Tuning Methodology</h1>
+
+<p>C-Kernel-Engine performance work is not a benchmark stunt. The goal is to make a CPU node behave like a serious
+compute device: correct first, measurable at every layer, then pushed toward the roofline one kernel at a time.</p>
+
+<div class="method-hero">
+    <div class="method-panel">
+        <h3>North Star</h3>
+        <p>CK should make each CPU node run as close as practical to its hardware limits, then compose those nodes into
+        larger CPU-native systems. The engine is written from the ground up in C so the team can inspect, replace,
+        profile, and verify each transformer stage instead of treating inference as a black box.</p>
+        <p>The methodology is simple: prove the model is still coherent and numerically connected, profile the exact hot
+        path, isolate the slow kernel, improve one bottleneck, and rerun the same gates. No speed patch is accepted
+        because it "looks fast" in isolation.</p>
     </div>
-    <h1>Deep Training Intuition Playbook</h1>
-    <p class="subtitle">
-        A practical roadmap for moving from pass/fail parity gates to gradient-level intuition:
-        what to log, what to inspect, what to adjust, and how to learn from recurring failure patterns.
-    </p>
+    <div class="method-panel">
+        <h3>Hard Rule</h3>
+        <p>Performance changes must keep the model path valid.</p>
+        <ul class="check-list">
+            <li>First-token parity must not regress.</li>
+            <li>Multi-token mismatch must not move earlier without explanation.</li>
+            <li>Practical prompts must remain coherent, not just syntactically alive.</li>
+            <li>OCR, vision, and long-context paths must be tested with real artifacts when available.</li>
+            <li>Every meaningful PR should link benchmark logs and profiler artifacts.</li>
+        </ul>
+    </div>
 </div>
 
-<div class="card card-accent" style="margin-top: 1rem;">
-    <h3 style="margin-top: 0;">Companion Guide</h3>
-    <p style="margin: 0;">For full operator details on v7 init, IR1/IR2 lowering, memory layout/canary diagnostics, and CK-vs-oracle parity commands, open <a href="v7-backprop-ir.html"><code>v7-backprop-ir.html</code></a>.</p>
+<div class="img-container svg-viewer" data-title="CKE Node Roofline Math">
+    <img src="assets/cke-node-roofline-math.svg" alt="CKE node roofline math">
 </div>
 
-<h2>Infographic Snapshot</h2>
-<div class="img-container svg-viewer" data-title="Deep Training Intuition Map">
-    <img src="assets/training-intuition-map.svg" alt="Deep training intuition infographic: visibility stack, checkpoint strategy, curriculum, and triage loops">
+<h2>Measurement Lanes</h2>
+
+<p>The work is split into lanes so we do not confuse different questions. A short chat prompt, a 4096-token prefill
+test, an Intel Advisor dot, and a VTune hotspot report are all useful, but they answer different things.</p>
+
+<div class="method-grid">
+    <div class="method-card">
+        <h3>Practical E2E Lane</h3>
+        <p>Run real prompts through <code>cks-v8-run</code> with the correct chat template, tokenizer, context length,
+        and decode budget. This lane answers: does the model still speak coherently, follow the prompt, and produce
+        useful output?</p>
+    </div>
+    <div class="method-card">
+        <h3>Fixed-Token Throughput Lane</h3>
+        <p>Use controlled prompt and decode token counts, such as <code>p512</code>, <code>p1024</code>,
+        <code>p2048</code>, or <code>p4096</code>. This lane answers: how fast is prefill or decode when the model
+        actually receives that many tokens?</p>
+    </div>
+    <div class="method-card">
+        <h3>Operator Profile Lane</h3>
+        <p>Enable CK profile CSV/JSON and rank time by operator. This lane answers: is the wall time in Q4/Q6 prefill,
+        Q8 projection, attention, SwiGLU, quantization, sampling, or runtime overhead?</p>
+    </div>
+    <div class="method-card">
+        <h3>Microkernel Lab</h3>
+        <p>Extract one kernel with the production dimensions and run it alone. This lane answers: can this exact kernel
+        reach the expected instruction rate before we wire it back into the full transformer?</p>
+    </div>
+    <div class="method-card">
+        <h3>Advisor Roofline Lane</h3>
+        <p>Use Intel Advisor to place loops by arithmetic intensity and throughput. This lane answers: should the next
+        patch move the kernel right by increasing reuse, or up by improving SIMD and instruction efficiency?</p>
+    </div>
+    <div class="method-card">
+        <h3>VTune Lane</h3>
+        <p>Use VTune hotspots, uarch exploration, memory access, and threading analysis. This lane answers: are we
+        retiring useful work, stuck on ports, memory-bound, cache-latency-bound, or underusing physical cores?</p>
+    </div>
 </div>
+
+<h2>Context Is Not Tokens</h2>
+
+<div class="alert alert-warning">
+    <strong>Do not treat <code>--context-len 4096</code> as a 4096-token prefill test.</strong>
+    Context length sets KV-cache capacity. It does not turn a 40-token prompt into a 4096-token workload. Long-prefill
+    performance must be measured with a tokenizer-counted prompt that actually contains the requested number of tokens.
+</div>
+
+<p>This distinction matters because prefill is GEMM-heavy and decode is usually GEMV-heavy. A short prompt with a large
+context window mostly tests runtime overhead plus decode. A true <code>p4096</code> prompt tests the batched prefill
+path, weight reuse, quantized GEMM dispatch, thread scheduling, and cache behavior.</p>
+
+<h2>Toolchain</h2>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Tool</th>
+            <th>What It Tells Us</th>
+            <th>Typical CK Decision</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>CK profile CSV</td>
+            <td>Exact operator time inside the generated runtime.</td>
+            <td>Pick the real hot kernel instead of guessing from end-to-end time.</td>
+        </tr>
+        <tr>
+            <td>Intel Advisor</td>
+            <td>Roofline position, arithmetic intensity, GFLOPS/GINTOPS, vectorization hints.</td>
+            <td>Fuse, repack, tile, or improve SIMD depending on whether the loop must move right or up.</td>
+        </tr>
+        <tr>
+            <td>Intel VTune</td>
+            <td>Hotspots, pipeline slots, retiring, front-end bound, back-end bound, memory stalls, port pressure,
+            physical-core utilization, logical-core utilization.</td>
+            <td>Change dot structure, reduce reductions, fix thread underuse, inspect cache latency, or remove
+            scalar overhead.</td>
+        </tr>
+        <tr>
+            <td><code>perf stat</code></td>
+            <td>Cycles, instructions, IPC, cache misses, branch misses, context switches, wall time.</td>
+            <td>Low-overhead regression gate before expensive profiler runs.</td>
+        </tr>
+        <tr>
+            <td>Flamegraph</td>
+            <td>Call-stack shape and whether time is in kernels, tokenization, sampling, or framework overhead.</td>
+            <td>Decide whether to optimize math, dispatch, or runtime glue.</td>
+        </tr>
+        <tr>
+            <td><code>objdump</code>, LLVM-MCA, uops.info, Intel SDE</td>
+            <td>Instruction mix, AVX2/VNNI use, estimated port pressure, latency chains, static throughput.</td>
+            <td>Replace expensive instruction sequences and prove the compiler emitted the intended ISA path.</td>
+        </tr>
+        <tr>
+            <td>Valgrind/Cachegrind</td>
+            <td>Correctness, cache access shape, allocations, and memory mistakes.</td>
+            <td>Use for debug and memory-shape validation, not final speed numbers.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>How To Read The Signals</h2>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Profiler Signal</th>
+            <th>Meaning</th>
+            <th>Likely Fix</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Low arithmetic intensity</td>
+            <td>The kernel does too little math per byte moved.</td>
+            <td>Pack weights, batch more rows, reuse activations, fuse producers/consumers, avoid scratch writes.</td>
+        </tr>
+        <tr>
+            <td>High retiring, low throughput</td>
+            <td>The CPU is doing useful work, but too many instructions are needed per result.</td>
+            <td>Reduce scalar bookkeeping, delay horizontal reductions, use wider dot instructions, precompute scale terms.</td>
+        </tr>
+        <tr>
+            <td>Port pressure</td>
+            <td>The loop is limited by execution resources, often ALU, shuffle, or load ports.</td>
+            <td>Change vector layout, reduce shuffles, unroll for independent accumulators, inspect assembly.</td>
+        </tr>
+        <tr>
+            <td>Memory bound</td>
+            <td>The loop is waiting on L1/L2/L3/DRAM rather than compute.</td>
+            <td>Retile, prefetch, reduce stores, improve packing, keep hot tiles in cache.</td>
+        </tr>
+        <tr>
+            <td>Low physical-core utilization</td>
+            <td>Threads are not doing useful work across the node.</td>
+            <td>Increase job count, use dynamic tiles, inspect affinity, reduce synchronization, avoid long tail work.</td>
+        </tr>
+        <tr>
+            <td>Coherence regression</td>
+            <td>The model circuit may no longer match the reference path.</td>
+            <td>Stop speed work and run parity: logits, layer dumps, RoPE/M-RoPE, KV-cache, quantized projection.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Kernel Iteration Loop</h2>
+
+<ol>
+    <li><strong>Reproduce</strong>: fix model, quant, prompt token count, context, threads, temperature, and runtime cache.</li>
+    <li><strong>Prove quality</strong>: run practical prompts and, when applicable, CK-vs-llama parity.</li>
+    <li><strong>Rank operators</strong>: collect CK profile CSV and identify the top one or two kernels.</li>
+    <li><strong>Profile deeply</strong>: run Advisor roofline and VTune on the exact workload or extracted kernel.</li>
+    <li><strong>Classify the bottleneck</strong>: compute-bound, memory-bound, instruction-heavy, scheduling-heavy, or parity-broken.</li>
+    <li><strong>Patch narrowly</strong>: change one kernel family, dispatcher rule, packing layout, or fusion path.</li>
+    <li><strong>Run microkernel checks</strong>: validate numerical output and isolated throughput before E2E.</li>
+    <li><strong>Run E2E again</strong>: measure practical prompts and fixed-token lanes across representative models.</li>
+    <li><strong>Attach logs</strong>: commit the commands, hardware, hashes, measured token counts, and profiler links.</li>
+</ol>
+
+<h2>Current v8 Lessons</h2>
+
+<p>The July 2026 AVX2 work produced several important lessons that should stay visible in the docs:</p>
+
+<div class="metric-strip">
+    <div class="metric-box">
+        <strong>p4096</strong>
+        Fixed-token long-prefill lanes are the right stress test for batched prefill.
+    </div>
+    <div class="metric-box">
+        <strong>Q4/Q6</strong>
+        Quantized prefill dispatch dominates many v8 text-family models.
+    </div>
+    <div class="metric-box">
+        <strong>Parity first</strong>
+        Qwen3-VL M-RoPE fixes were accuracy fixes, not speed patches.
+    </div>
+    <div class="metric-box">
+        <strong>Coherence gate</strong>
+        Qwen3 and Qwen3.5 short practical prompts remained coherent in fresh canonical runs.
+    </div>
+</div>
+
+<p>On the local AVX2 profiling host, practical short prompts showed coherent outputs and real decode speed, but they
+are not the same benchmark as fixed-token p4096 prefill. A stale p4096 table once suggested large CK wins over
+llama.cpp; a fresh recheck did not reproduce that claim. The defensible conclusion is narrower and more useful:
+the methodology caught the bad measurement trail, kept the coherent E2E signal, and forced the next pass back to
+token-counted prompts, canonical runtime paths, and profiler-backed kernel attribution.</p>
+
+<div class="alert alert-warning">
+    <strong>Benchmark discipline:</strong> do not publish a speedup table unless the exact command, runtime cache path,
+    prompt token count, llama.cpp command, and output artifact are recorded and the row reproduces in a fresh run.
+    Synthetic fixed-token throughput and interactive chat timing are both useful, but they must not be mixed.
+</div>
+
+<h2>Representative Commands</h2>
+
+<p>Use these as starting points. Record the exact model path, model hash, prompt token count, context length, thread
+count, compiler, and git commit in the log directory for the PR.</p>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Practical Coherence Run</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+version/v8/scripts/cks-v8-run run \
+  hf://Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf \
+  --context-len 1024 \
+  --force-convert --force-compile \
+  --generate-visualizer</code></pre>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Fixed-Token CK-vs-llama Matrix</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+CK_V8_DECODER_MODELS=nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m,qwen3-0.6b-q8_0,qwen35-0.8b-q4_k_m \
+CK_V8_DECODER_PROMPT=4096 \
+CK_V8_DECODER_DECODE=128 \
+CK_V8_DECODER_REPEATS=1 \
+make test-v8-decoder-matrix</code></pre>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Operator-Cost Prefill Profile</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+CK_V8_PROFILE_MODELS=nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m,qwen35-0.8b-q4_k_m \
+CK_V8_PROFILE_PROMPT=4096 \
+CK_V8_PROFILE_DECODE=1 \
+CK_V8_PROFILE_CONTEXT=4608 \
+make profile-v8-prefill-ops</code></pre>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Safe Perf Counter Lane</h3>
+    <pre><code>CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+CK_V8_PREFILL_PERF_ENGINE=both \
+CK_V8_PREFILL_PERF_PROMPT=4096 \
+CK_V8_PREFILL_PERF_DECODE=1 \
+make profile-v8-prefill-perf-stat</code></pre>
+</div>
+
+<h2>What Gets Committed</h2>
+
+<p>A performance PR should not hide the measurement trail. Add a log directory under <code>logs/</code> when the change
+is meaningful, and reference it from the commit body.</p>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Artifact</th>
+            <th>Required Content</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>README</td>
+            <td>Hardware, compiler, git commit, model paths, hashes when available, prompt token counts, thread count,
+            context length, commands, tables, and caveats.</td>
+        </tr>
+        <tr>
+            <td>Commit message</td>
+            <td>Problem, fix, measured result, parity/coherence gate, and link to the log directory.</td>
+        </tr>
+        <tr>
+            <td>Profiler links</td>
+            <td>Advisor HTML, VTune summaries, CK profile JSON/CSV, flamegraph, or perf-stat output when used.</td>
+        </tr>
+        <tr>
+            <td>Next steps</td>
+            <td>Known remaining bottlenecks, such as Q6 prefill, Gemma routing, Qwen3/Qwen3.5 long-context accounting,
+            Qwen3-VL OCR parity, or decode GEMV improvements.</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Architecture Implication</h2>
+
+<p>CK can do this work because generated C keeps the system inspectable. Kernel maps and templates can replace a
+specific sequence with a fused kernel. The threadpool can be profiled directly. Quantized prefill dispatch can be
+changed without rewriting the whole runtime. The BUMP memory path and generated model code make it possible to
+tie one profiler dot back to one function, one tensor layout, and one source patch.</p>
+
+<div class="img-container svg-viewer" data-title="Performance Balance">
+    <img src="assets/performance-balance.svg" alt="Performance balance">
+</div>
+
+<h2>Open Work</h2>
+
+<ul class="check-list">
+    <li><strong>Token-counted practical long prompts</strong>: replace approximate text-length prompts with tokenizer-counted
+    prompts at 1024, 2048, and 4096 tokens.</li>
+    <li><strong>Q4/Q6 prefill</strong>: continue moving packed Q4/Q6 GEMM loops toward roofline across Nanbeige, Qwen2,
+    Qwen3/Qwen3.5, Gemma, and Qwen3-VL decoder shapes.</li>
+    <li><strong>Fusion</strong>: test gate/up GEMM + SwiGLU + Q8_K quantization fusion where it reduces scratch writes and
+    preserves parity.</li>
+    <li><strong>Threading</strong>: keep dynamic scheduling and physical-core utilization measurable before adding complicated
+    P-core/E-core policy.</li>
+    <li><strong>Deep VTune</strong>: use signed VTune drivers or a controlled profiling boot for deeper PMU collection when
+    Secure Boot blocks out-of-tree modules.</li>
+    <li><strong>Parity harnesses</strong>: keep Qwen3-VL long-decode and OCR tests enabled while speed work continues.</li>
+</ul>
 
 <div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="10"></circle>
-            <line x1="12" y1="16" x2="12" y2="12"></line>
-            <line x1="12" y1="8" x2="12.01" y2="8"></line>
-        </svg>
-    </div>
-    <div>
-        <strong>Core idea:</strong> keep full model checkpoints rare for resume, but write dense
-        <strong>analysis checkpoints</strong> (statistics + sampled grids) for insight.
-    </div>
-</div>
-
-<h2>Visibility Stack</h2>
-<div class="stack-board">
-    <div class="stack-grid">
-        <div class="stack-item">
-            <strong>Loss Curves</strong>
-            <span class="layer-meta">Surface behavior</span>
-        </div>
-        <div class="stack-item">
-            <strong>Per-Param Grad Norms</strong>
-            <span class="layer-meta">Tensor-level magnitude</span>
-        </div>
-        <div class="stack-item">
-            <strong>IR2 Backward Graph</strong>
-            <span class="layer-meta">Op-by-op gradient path</span>
-        </div>
-        <div class="stack-item">
-            <strong>Generated C + Kernel ID</strong>
-            <span class="layer-meta">Exact compute path</span>
-        </div>
-        <div class="stack-item">
-            <strong>SIMD + Memory Layout</strong>
-            <span class="layer-meta">Hardware-level truth</span>
-        </div>
-    </div>
-    <p class="board-caption">
-        This stack is your advantage: anomalies can be traced from metric -> tensor -> op -> kernel -> runtime.
-    </p>
-</div>
-
-<h2>Correctness vs Intuition</h2>
-<div class="gap-grid">
-    <div class="gap-card">
-        <h3>Already Strong (Correctness)</h3>
-        <ul class="gap-list">
-            <li>Parity and deterministic replay gates</li>
-            <li>Contract checks and kernel coverage</li>
-            <li>Single-run scalar dashboards</li>
-            <li>IR and codegen traceability</li>
-        </ul>
-    </div>
-    <div class="gap-card">
-        <h3>Next Layer (Intuition)</h3>
-        <ul class="gap-list">
-            <li>Activation histograms per layer over time</li>
-            <li>Weight and gradient heatmaps (spatial)</li>
-            <li>Gradient flow waterfall (layer boundary view)</li>
-            <li>Attention entropy + sampled QK pattern evolution</li>
-            <li>Run-to-run diff views, not only single-run views</li>
-        </ul>
-    </div>
-</div>
-
-<h2>Checkpoint Strategy That Fits Real Disk</h2>
-<div class="size-compare">
-    <div class="size-row">
-        <div class="row-top">
-            <strong>Raw full dump (weights + grads + opt + activations)</strong>
-            <span>~5.7 GB per checkpoint</span>
-        </div>
-        <div class="bar-wrap"><div class="bar" style="width: 100%;"></div></div>
-    </div>
-    <div class="size-row">
-        <div class="row-top">
-            <strong>Analysis checkpoint (stats + sampled grids)</strong>
-            <span>~200 KB per checkpoint</span>
-        </div>
-        <div class="bar-wrap"><div class="bar bar-small" style="width: 4%;"></div></div>
-    </div>
-    <div class="size-row">
-        <div class="row-top">
-            <strong>Rare resume checkpoint (weights + optimizer state)</strong>
-            <span>~3 GB each, keep a small rolling window</span>
-        </div>
-        <div class="bar-wrap"><div class="bar bar-resume" style="width: 52%;"></div></div>
-    </div>
-</div>
-<p class="estimate-note">
-    Size values are planning estimates for a Qwen3-0.6B-like setup and vary with precision, sequence length, optimizer state, and which tensors you retain.
-</p>
-
-<div class="card card-blue">
-    <h3 style="margin-top:0;">Logarithmic Cadence + Event Triggers</h3>
-    <div class="cadence-grid">
-        <div class="cadence-card">
-            <h4>Steps 1-100</h4>
-            <p>Analysis checkpoint every 10 steps</p>
-        </div>
-        <div class="cadence-card">
-            <h4>Steps 100-1000</h4>
-            <p>Analysis checkpoint every 50 steps</p>
-        </div>
-        <div class="cadence-card">
-            <h4>Steps 1000-10000</h4>
-            <p>Analysis checkpoint every 200 steps</p>
-        </div>
-        <div class="cadence-card">
-            <h4>Steps 10000+</h4>
-            <p>Analysis checkpoint every 1000 steps</p>
-        </div>
-    </div>
-    <div class="trigger-strip">
-        <span class="trigger-pill">loss spike > 2x moving average</span>
-        <span class="trigger-pill">global grad norm threshold exceeded</span>
-        <span class="trigger-pill">dead-parameter alert (near-zero grad)</span>
-    </div>
-</div>
-
-<h2>Analysis Checkpoint Data Contract</h2>
-<pre><code>{
-  "schema_version": "ck.analysis.v1",
-  "model_scale_hint": "qwen3_0.6b_like",
-  "step": 500,
-  "loss": 2.341,
-  "weights": {
-    "layer.0.wq": {
-      "mean": 0.0012,
-      "std": 0.045,
-      "min": -0.23,
-      "max": 0.19,
-      "percentiles": [0.01, 0.05, 0.25, 0.50, 0.75, 0.95, 0.99],
-      "histogram": { "bins": [...], "counts": [...] },
-      "sampled_grid_32x32": [[...], ...]
-    }
-  },
-  "gradients": { "...": { "norm": 0.045, "histogram": {...} } },
-  "activations": { "...": { "mean": 0.12, "std": 0.45, "sparsity": 0.32 } },
-  "attention": {
-    "layer.0": {
-      "entropy_per_head": [...],
-      "max_attn_per_head": [...],
-      "sampled_qk_grid_32x32_per_head": [...]
-    }
-  }
-}</code></pre>
-<p class="estimate-note">
-    Keep this contract versioned. Dashboards should reject incompatible schema versions early rather than silently misrendering.
-</p>
-
-<h2>12-Experiment Learning Curriculum</h2>
-<div class="phase-grid">
-    <div class="phase">
-        <div class="phase-tag">Phase 1</div>
-        <h3>Learn Healthy Baselines</h3>
-        <ol>
-            <li>Run a stable baseline and memorize normal gradients.</li>
-            <li>Vary init scale (tiny to huge) and inspect layerwise drift.</li>
-        </ol>
-    </div>
-    <div class="phase">
-        <div class="phase-tag">Phase 2</div>
-        <h3>Break Gradient Flow On Purpose</h3>
-        <ol>
-            <li>Sweep LR too high and too low.</li>
-            <li>Zero one projection path and observe blocked upstream grads.</li>
-            <li>Scale weights 5x, then recover with clipping.</li>
-        </ol>
-    </div>
-    <div class="phase">
-        <div class="phase-tag">Phase 3</div>
-        <h3>Understand Optimizer Dynamics</h3>
-        <ol>
-            <li>Compare SGD vs Adam using weight-delta statistics.</li>
-            <li>Add warmup and inspect early-step stability.</li>
-        </ol>
-    </div>
-    <div class="phase">
-        <div class="phase-tag">Phase 4</div>
-        <h3>Read Attention Behavior</h3>
-        <ol>
-            <li>Track head entropy over time.</li>
-            <li>Visualize sampled QK heatmaps and head redundancy.</li>
-        </ol>
-    </div>
-    <div class="phase">
-        <div class="phase-tag">Phase 5</div>
-        <h3>Scale To Real Models</h3>
-        <ol>
-            <li>Build layer gradient waterfalls on Qwen-scale runs.</li>
-            <li>Rank params by relative movement from step 0.</li>
-            <li>Perturb QK-norm and RoPE to identify load-bearing paths.</li>
-        </ol>
-    </div>
-    <div class="phase">
-        <div class="phase-tag">Execution Rule</div>
-        <h3>One Change, Full Observability</h3>
-        <ol>
-            <li>Change one variable per run.</li>
-            <li>Compare against baseline at fixed steps.</li>
-            <li>Record diagnosis as a repeatable failure pattern.</li>
-        </ol>
-    </div>
-</div>
-
-<h2>Gradient Triage Cheat Sheet</h2>
-<div class="card triage">
-    <table>
-        <tr>
-            <th>What You See</th>
-            <th>Likely Cause</th>
-            <th>First Knob To Adjust</th>
-            <th>Where To Inspect</th>
-        </tr>
-        <tr>
-            <td>Layer waterfall pinches mid-depth</td>
-            <td>Vanishing path or norm bottleneck</td>
-            <td>Init scale, residual path, norm params</td>
-            <td><code>activation_stats</code> + per-layer grad norms</td>
-        </tr>
-        <tr>
-            <td>Loss spikes after smooth phase</td>
-            <td>LR too high for local curvature</td>
-            <td>LR decay or longer warmup</td>
-            <td>Weight delta magnitudes vs grad norms</td>
-        </tr>
-        <tr>
-            <td>Frequent clipping</td>
-            <td>Single tensor dominates global norm</td>
-            <td>Find offending tensor; adjust LR/regularization</td>
-            <td>Per-param gradient histogram outliers</td>
-        </tr>
-        <tr>
-            <td>Attention entropy collapses too early</td>
-            <td>Saturated logits / unstable attention scale</td>
-            <td>Check QK-norm path, init, LR</td>
-            <td>Head entropy timeline + sampled QK grids</td>
-        </tr>
-        <tr>
-            <td>Some params barely move across many steps</td>
-            <td>Dead or weakly-coupled path</td>
-            <td>Inspect upstream gradients and mask logic</td>
-            <td>Relative movement ranking + grad flow graph</td>
-        </tr>
-    </table>
-</div>
-
-<h2>Implementation Order (Minimal, High Impact)</h2>
-<div class="grid grid-2">
-    <div class="card card-accent">
-        <h3 style="margin-top:0;">Step 1-3: Stats Instrumentation</h3>
-        <ul>
-            <li>Buffer stats for weights, grads, activations</li>
-            <li>Attention entropy and sparsity per head</li>
-            <li>Weight-delta stats after optimizer step</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top:0;">Step 4-6: Visual Layers</h3>
-        <ul>
-            <li>Weight and gradient heatmaps (sampled grid)</li>
-            <li>Gradient waterfall and run-diff overlays</li>
-            <li>Attention inspector with entropy timeline</li>
-        </ul>
-    </div>
-</div>
-
-<div class="pipeline">
-<pre><code>train loop -> write analysis_checkpoint_*.json
-          -> open_ir_visualizer.py embeds data
-          -> ir_report training tabs render:
-             [gradient flow] [weights + activations] [attention]
-</code></pre>
-</div>
-
-<h2>Run This Now (v7)</h2>
-<div class="run-grid">
-    <div class="run-step">
-        <h4>1) Generate deterministic training reports</h4>
-        <p>Creates core parity/replay artifacts in <code>version/v7/reports/</code>.</p>
-        <pre><code>make v7-train-parity-3
-make v7-replay</code></pre>
-    </div>
-    <div class="run-step">
-        <h4>2) Generate visual report HTML</h4>
-        <p>Build an IR report from your latest artifacts without rerunning probes.</p>
-        <pre><code>python3 version/v7/tools/open_ir_visualizer.py --generate --html-only</code></pre>
-    </div>
-    <div class="run-step">
-        <h4>3) Iterate with one change at a time</h4>
-        <p>Change exactly one knob (LR, init scale, clipping, warmup), rerun, and compare snapshots at fixed steps.</p>
-        <pre><code>artifacts: version/v7/reports/*.json
-report:    version/v7/tools/ir_visualizer.html (or generated ir_report*.html)</code></pre>
-    </div>
-</div>
-
-<div class="playbook-wrap">
-    <h2>Full Diagnostic Matrix (Phases 1-7)</h2>
-    <p class="estimate-note">
-        This section is meant to be operational. Keep it open during training and use it as a live checklist.
-    </p>
-
-    <details class="playbook-phase" open>
-        <summary>Phase 1: Is It Even Working?</summary>
-        <div class="phase-body">
-            <table class="playbook-table">
-                <tr>
-                    <th>Question</th>
-                    <th>What to look at</th>
-                    <th>Good</th>
-                    <th>Bad</th>
-                </tr>
-                <tr>
-                    <td>Is it training at all?</td>
-                    <td>Loss curve, first 10 steps</td>
-                    <td>Loss drops from random baseline (for 151K vocab, ln(vocab_size) is about 11.9)</td>
-                    <td>Loss flat or NaN on step 1</td>
-                </tr>
-                <tr>
-                    <td>Are gradients flowing to every layer?</td>
-                    <td>Gradient waterfall (layer 0 -> layer N)</td>
-                    <td>All layers nonzero, typically within 10x range</td>
-                    <td>Early layers near 1e-12 while late layers are around 1e-1</td>
-                </tr>
-                <tr>
-                    <td>Is any parameter dead?</td>
-                    <td>Gradient Health tab, sort by norm</td>
-                    <td>All trainable params above ~1e-7</td>
-                    <td>Repeated exact 0.0 or near-zero (&lt;1e-10) norms</td>
-                </tr>
-                <tr>
-                    <td>Is implementation correct?</td>
-                    <td>Parity tracker (CK vs PyTorch)</td>
-                    <td><code>loss_diff &lt; 1e-6</code>, <code>param_diff &lt; 1e-5</code></td>
-                    <td>Diverges after a few steps</td>
-                </tr>
-                <tr>
-                    <td>Are weights updating?</td>
-                    <td>Weight delta statistics, <code>||w_new - w_old||_2</code></td>
-                    <td>Nonzero deltas for expected trainable tensors</td>
-                    <td>Near-zero deltas despite nonzero gradients</td>
-                </tr>
-                <tr>
-                    <td>Is it deterministic?</td>
-                    <td>Replay determinism gate</td>
-                    <td>Two identical runs produce identical losses/metrics</td>
-                    <td>Any unexplained drift indicates race/uninitialized state</td>
-                </tr>
-            </table>
-        </div>
-    </details>
-
-    <details class="playbook-phase">
-        <summary>Phase 2: Is The Model Learning?</summary>
-        <div class="phase-body">
-            <table class="playbook-table">
-                <tr>
-                    <th>Question</th>
-                    <th>What to look at</th>
-                    <th>Good</th>
-                    <th>Bad</th>
-                </tr>
-                <tr>
-                    <td>Is loss decreasing over real horizon?</td>
-                    <td>Loss curve over 100+ steps</td>
-                    <td>Clear downward trend (allowing noise)</td>
-                    <td>Immediate plateau or pure oscillation</td>
-                </tr>
-                <tr>
-                    <td>Is it memorizing training data?</td>
-                    <td>Inference on training samples, training perplexity</td>
-                    <td>Perplexity steadily drops toward 1.0 on repeated data</td>
-                    <td>Perplexity remains high on same seen samples</td>
-                </tr>
-                <tr>
-                    <td>How fast is memorization?</td>
-                    <td>Early epoch loss slope</td>
-                    <td>Steep initial drop</td>
-                    <td>Shallow slope points to LR/capacity/data bottleneck</td>
-                </tr>
-                <tr>
-                    <td>Has train set been mostly absorbed?</td>
-                    <td>Training loss near data entropy floor</td>
-                    <td>Plateau near expected entropy floor</td>
-                    <td>Flat but still high means stuck optimization</td>
-                </tr>
-                <tr>
-                    <td>Is it learning tokens or patterns?</td>
-                    <td>Attention heatmaps on seen examples</td>
-                    <td>Positional + semantic structure appears</td>
-                    <td>Uniform attention or always position-0 attention</td>
-                </tr>
-                <tr>
-                    <td>Are all layers contributing?</td>
-                    <td>Per-layer movement, <code>||w_t - w_0||_2 / ||w_0||_2</code></td>
-                    <td>Broad movement across multiple layers</td>
-                    <td>Only small subset moves while others remain frozen</td>
-                </tr>
-            </table>
-        </div>
-    </details>
-
-    <details class="playbook-phase">
-        <summary>Phase 3: What Is It Learning?</summary>
-        <div class="phase-body">
-            <table class="playbook-table">
-                <tr>
-                    <th>Question</th>
-                    <th>What to look at</th>
-                    <th>Good</th>
-                    <th>Bad</th>
-                </tr>
-                <tr>
-                    <td>What are attention heads doing?</td>
-                    <td>Per-head heatmaps across layers</td>
-                    <td>Head specialization (positional, semantic, induction-like)</td>
-                    <td>All heads uniform or all heads nearly identical</td>
-                </tr>
-                <tr>
-                    <td>Which heads are redundant?</td>
-                    <td>Head similarity matrix (cosine similarity)</td>
-                    <td>Diversity within a layer</td>
-                    <td>Many heads with similarity above 0.9</td>
-                </tr>
-                <tr>
-                    <td>Content vs position dependence?</td>
-                    <td>Same tokens at different positions</td>
-                    <td>Attention follows content as well as position</td>
-                    <td>Purely diagonal regardless of content changes</td>
-                </tr>
-                <tr>
-                    <td>Which weights changed most?</td>
-                    <td>Global ranking by relative movement</td>
-                    <td>Core projections and MLP weights move significantly</td>
-                    <td>Only embeddings/norms move while core blocks stay static</td>
-                </tr>
-                <tr>
-                    <td>Are MLP neurons specializing?</td>
-                    <td>MLP hidden activation distributions</td>
-                    <td>Distributions become structured/multimodal</td>
-                    <td>No shape evolution over training</td>
-                </tr>
-                <tr>
-                    <td>Is embedding space organizing?</td>
-                    <td>Embedding heatmap step 0 vs step N</td>
-                    <td>Visible structure/clustering emerges</td>
-                    <td>Matrix remains random-looking with little change</td>
-                </tr>
-            </table>
-        </div>
-    </details>
-
-    <details class="playbook-phase">
-        <summary>Phase 4: Is Something Going Wrong?</summary>
-        <div class="phase-body">
-            <table class="playbook-table">
-                <tr>
-                    <th>Question</th>
-                    <th>What to look at</th>
-                    <th>Good</th>
-                    <th>Bad</th>
-                </tr>
-                <tr>
-                    <td>Why did loss spike?</td>
-                    <td>Checkpoint at spike step: grads, deltas, activations</td>
-                    <td>Transient spike that recovers quickly</td>
-                    <td>No recovery; basin ejection requiring earlier restart</td>
-                </tr>
-                <tr>
-                    <td>Vanishing gradient?</td>
-                    <td>Layer waterfall at fixed step</td>
-                    <td>Roughly stable magnitude across depth (about 2-3x variance)</td>
-                    <td>100x+ collapse from late to early layers</td>
-                </tr>
-                <tr>
-                    <td>Exploding gradient?</td>
-                    <td>Global + per-param norm trends</td>
-                    <td>Stable or slowly decaying norm</td>
-                    <td>Exponential norm growth across steps</td>
-                </tr>
-                <tr>
-                    <td>Is clipping hiding root cause?</td>
-                    <td>Per-param norms when clipping active</td>
-                    <td>Rare clipping on few tensors</td>
-                    <td>Clipping every step from same offenders</td>
-                </tr>
-                <tr>
-                    <td>Are activations healthy?</td>
-                    <td>Per-layer min/max/mean/std</td>
-                    <td>Stable mean/std with bounded ranges</td>
-                    <td>Drift, exploding std, or extreme outliers</td>
-                </tr>
-                <tr>
-                    <td>Is LR schedule right?</td>
-                    <td>Loss, LR, and delta magnitude overlay</td>
-                    <td>Warmup stable, peak controlled, decay helpful</td>
-                    <td>Spike at LR peak or no gain during decay phase</td>
-                </tr>
-            </table>
-        </div>
-    </details>
-
-    <details class="playbook-phase">
-        <summary>Phase 5: Memorization -> Generalization</summary>
-        <div class="phase-body">
-            <table class="playbook-table">
-                <tr>
-                    <th>Question</th>
-                    <th>What to look at</th>
-                    <th>Good</th>
-                    <th>Bad</th>
-                </tr>
-                <tr>
-                    <td>Is it overfitting?</td>
-                    <td>Training loss vs held-out validation loss</td>
-                    <td>Both decrease with a small and stable gap</td>
-                    <td>Train improves while validation stalls/rises</td>
-                </tr>
-                <tr>
-                    <td>When to stop pretraining?</td>
-                    <td>Validation loss plateau window</td>
-                    <td>Minimal improvement for long horizon (for example 100+ steps)</td>
-                    <td>Still meaningful downward trend, or clear overfit trend</td>
-                </tr>
-                <tr>
-                    <td>Is model capacity sufficient?</td>
-                    <td>Final train loss vs entropy estimate</td>
-                    <td>Approaches expected floor</td>
-                    <td>Plateaus far above floor</td>
-                </tr>
-                <tr>
-                    <td>Has it seen enough data?</td>
-                    <td>Tokens processed + slope decay</td>
-                    <td>Diminishing returns clearly visible</td>
-                    <td>Still in steep drop phase</td>
-                </tr>
-                <tr>
-                    <td>Any catastrophic forgetting?</td>
-                    <td>Perplexity on early training probes over time</td>
-                    <td>Remains low at late steps</td>
-                    <td>Rises while training on newer slices</td>
-                </tr>
-            </table>
-        </div>
-    </details>
-
-    <details class="playbook-phase">
-        <summary>Phase 6: Transition Readiness (Pretrain -> SFT -> RLHF/GRPO)</summary>
-        <div class="phase-body">
-            <table class="playbook-table">
-                <tr>
-                    <th>Question</th>
-                    <th>What to look at</th>
-                    <th>Good signal to transition</th>
-                    <th>Not ready</th>
-                </tr>
-                <tr>
-                    <td>When is pretraining done?</td>
-                    <td>Validation slope over last 1K steps</td>
-                    <td>Very low slope and coherent next-token quality on unseen text</td>
-                    <td>Validation still dropping clearly</td>
-                </tr>
-                <tr>
-                    <td>Should SFT start?</td>
-                    <td>Instruction-like generation probes</td>
-                    <td>Fluent language but weak instruction following</td>
-                    <td>Still produces unstable or broken language</td>
-                </tr>
-                <tr>
-                    <td>How to verify SFT works?</td>
-                    <td>Instruction-format loss + held-out instruction eval</td>
-                    <td>Format adherence and response quality improve</td>
-                    <td>Loss drops but behavior still ignores instruction format</td>
-                </tr>
-                <tr>
-                    <td>When move SFT -> preference tuning?</td>
-                    <td>Consistency and quality profile</td>
-                    <td>Follows format reliably, needs preference shaping</td>
-                    <td>Still fails basic instruction compliance</td>
-                </tr>
-                <tr>
-                    <td>How evaluate pretraining quality before SFT?</td>
-                    <td>Half-prompt continuation on seen and held-out samples</td>
-                    <td>Strong continuation on train + reasonable held-out perplexity</td>
-                    <td>Cannot reliably continue seen samples</td>
-                </tr>
-            </table>
-        </div>
-    </details>
-
-    <details class="playbook-phase">
-        <summary>Phase 7: Memorization Test Protocol</summary>
-        <div class="phase-body">
-            <div class="protocol-step">
-                <h4>Step 1: Reserve probes before training</h4>
-                <p>Set aside 10-20 fixed probe samples from training data for longitudinal memorization checks.</p>
-            </div>
-            <div class="protocol-step">
-                <h4>Step 2: Evaluate at resume checkpoints</h4>
-                <p>Feed first half of each probe, generate continuation, and score exact-match, overlap, and perplexity on the true continuation.</p>
-            </div>
-            <div class="protocol-step">
-                <h4>Step 3: Plot memorization curve</h4>
-                <p>Track progression from near-random accuracy toward high completion accuracy as steps grow.</p>
-            </div>
-            <div class="protocol-step">
-                <h4>Step 4: Compare with held-out curve</h4>
-                <p>Training-probe vs held-out accuracy gap is your best generalization indicator for transition decisions.</p>
-            </div>
-
-            <table class="playbook-table">
-                <tr>
-                    <th>Step</th>
-                    <th>Probe accuracy (rough)</th>
-                    <th>Interpretation</th>
-                </tr>
-                <tr>
-                    <td>0</td>
-                    <td>about 0%</td>
-                    <td>Untrained baseline</td>
-                </tr>
-                <tr>
-                    <td>100</td>
-                    <td>5-15%</td>
-                    <td>Learning token statistics</td>
-                </tr>
-                <tr>
-                    <td>500</td>
-                    <td>30-50%</td>
-                    <td>Pattern acquisition phase</td>
-                </tr>
-                <tr>
-                    <td>2000</td>
-                    <td>70-90%</td>
-                    <td>Strong memorization of seen structures</td>
-                </tr>
-                <tr>
-                    <td>5000+</td>
-                    <td>90%+</td>
-                    <td>Train probes mostly memorized</td>
-                </tr>
-            </table>
-        </div>
-    </details>
-
-    <details class="playbook-phase">
-        <summary>The Map: Question -> Tool</summary>
-        <div class="phase-body">
-            <table class="playbook-table">
-                <tr>
-                    <th>Question category</th>
-                    <th>Primary tool</th>
-                    <th>Secondary tool</th>
-                </tr>
-                <tr>
-                    <td>Is it training?</td>
-                    <td>Loss curve + parity tracker</td>
-                    <td>Gradient Health</td>
-                </tr>
-                <tr>
-                    <td>Are gradients correct?</td>
-                    <td>Gradient waterfall</td>
-                    <td>Finite-difference gradient checks</td>
-                </tr>
-                <tr>
-                    <td>What is it learning?</td>
-                    <td>Attention heatmaps</td>
-                    <td>Weight movement ranking</td>
-                </tr>
-                <tr>
-                    <td>Is it memorizing?</td>
-                    <td>Inference on probe set</td>
-                    <td>Loss slope + perplexity trends</td>
-                </tr>
-                <tr>
-                    <td>Is something wrong?</td>
-                    <td>Event checkpoint autopsy</td>
-                    <td>Triage cheat sheet</td>
-                </tr>
-                <tr>
-                    <td>Is pretraining done?</td>
-                    <td>Validation plateau</td>
-                    <td>Held-out quality probes</td>
-                </tr>
-                <tr>
-                    <td>Ready for SFT?</td>
-                    <td>Instruction-following eval</td>
-                    <td>Format compliance tracking</td>
-                </tr>
-            </table>
-            <p class="phase-note">
-                UI framing rule: each dashboard tab should be phrased as a question, not just a metric name.
-            </p>
-        </div>
-    </details>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M20 6L9 17l-5-5"></path>
-        </svg>
-    </div>
-    <div>
-        <strong>Outcome:</strong> this shifts the workflow from "did it pass?" to
-        "why did it move this way?" with fast, affordable, and repeatable evidence.
-    </div>
+    <strong>Bottom line:</strong> CK performance claims should be reproducible from logs, visible in profiler artifacts,
+    and still produce coherent model output. That is the difference between a real CPU kernel engine and a lucky
+    timing number.
 </div>
     </main>
 

--- a/docs/site/kernels.html
+++ b/docs/site/kernels.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1404,7 +1406,7 @@ out     = S_new^T * q_hat</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/mega_fusion.html
+++ b/docs/site/mega_fusion.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1944,7 +1946,7 @@ mega_fused_attention_decode():
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-reality.html
+++ b/docs/site/memory-reality.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1716,7 +1718,7 @@ CPU (2TB server): FITS with 1.8TB headroom
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-safety.html
+++ b/docs/site/memory-safety.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1923,7 +1925,7 @@ echo "=== All memory safety checks passed ==="</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2426,7 +2428,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/page_metadata.json
+++ b/docs/site/page_metadata.json
@@ -61,6 +61,10 @@
       "title": "Architecture Links",
       "description": "Index of architecture, runbook, parity, and design pages for C-Kernel-Engine, including the current v8 multimodal inference documentation."
     },
+    "kernel-tuning-methodology.html": {
+      "title": "Kernel Tuning Methodology",
+      "description": "C-Kernel-Engine kernel tuning methodology for CPU-node performance work with VTune, Advisor roofline, perf, CK profile CSV, parity gates, and reproducible benchmark logs."
+    },
     "quickstart.html": {
       "title": "Getting Started",
       "description": "Quickstart guide for building and running C-Kernel-Engine, including the current v7 runtime path plus the v8 text-inference and Qwen3-VL multimodal bring-up surfaces."

--- a/docs/site/prefill-performance-roadmap.html
+++ b/docs/site/prefill-performance-roadmap.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1358,7 +1360,7 @@ make profile-v8-prefill-perf-stat</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/profiling.html
+++ b/docs/site/profiling.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1635,7 +1637,7 @@ make flamegraph       # Generate SVG flamegraph</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/pytorch-parity.html
+++ b/docs/site/pytorch-parity.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1337,7 +1339,7 @@ make litmus</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/q6-prefill-roofline.html
+++ b/docs/site/q6-prefill-roofline.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1295,7 +1297,7 @@ CK_NUM_THREADS=12 OMP_NUM_THREADS=1 CK_Q6K_Q8K_SIMD=1 \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quant-formats.html
+++ b/docs/site/quant-formats.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1617,7 +1619,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-math-temp.html
+++ b/docs/site/quantization-math-temp.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1381,7 +1383,7 @@ for (int ib = 0; ib < nb; ib++) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-visuals.html
+++ b/docs/site/quantization-visuals.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1513,7 +1515,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization.html
+++ b/docs/site/quantization.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2391,7 +2393,7 @@ void matmul_q4(float* out, const float* x, const tensor* W) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1681,7 +1683,7 @@ firefox build/flamegraph.svg</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/research.html
+++ b/docs/site/research.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1629,7 +1631,7 @@ K = [K_rope (with position), K_nope (from latent)]</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -3390,7 +3392,7 @@ That's it. For any model size.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/scripts/generate_tree.sh
+++ b/docs/site/scripts/generate_tree.sh
@@ -5,11 +5,51 @@
 PROJECT_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 OUTPUT_FILE="$(dirname "$0")/../_partials/folder_structure.html"
 
-# Run a focused tree for core source areas only.
-TREE_OUTPUT=$(cd "$PROJECT_ROOT" && tree -d -L 3 --dirsfirst \
-    src/kernels version/v6.6 version/v7 \
-    -I '__pycache__|*.o|*.pyc|doxygen_output|build|.git|node_modules|*.bin|*.so' \
-    --charset=ascii 2>/dev/null)
+# Run a focused tree for core source areas only. Minimal servers may not have
+# the optional `tree` package installed, so keep a Python fallback.
+if command -v tree >/dev/null 2>&1; then
+    TREE_OUTPUT=$(cd "$PROJECT_ROOT" && tree -d -L 3 --dirsfirst \
+        src/kernels version/v6.6 version/v7 \
+        -I '__pycache__|*.o|*.pyc|doxygen_output|build|.git|node_modules|*.bin|*.so' \
+        --charset=ascii 2>/dev/null)
+else
+    TREE_OUTPUT=$(cd "$PROJECT_ROOT" && python3 - <<'PY'
+from pathlib import Path
+
+roots = [Path("src/kernels"), Path("version/v6.6"), Path("version/v7")]
+ignore = {"__pycache__", "doxygen_output", "build", ".git", "node_modules"}
+max_depth = 3
+dir_count = 0
+
+def children(path):
+    try:
+        items = [p for p in path.iterdir() if p.is_dir() and p.name not in ignore]
+    except OSError:
+        return []
+    return sorted(items, key=lambda p: p.name.lower())
+
+def emit(path, prefix, depth):
+    global dir_count
+    kids = children(path) if depth < max_depth else []
+    for idx, child in enumerate(kids):
+        last = idx == len(kids) - 1
+        connector = "`-- " if last else "|-- "
+        print(f"{prefix}{connector}{child.name}")
+        dir_count += 1
+        emit(child, prefix + ("    " if last else "|   "), depth + 1)
+
+for root in roots:
+    if not root.exists():
+        continue
+    print(root.as_posix())
+    dir_count += 1
+    emit(root, "", 1)
+
+print()
+print(f"{dir_count} directories")
+PY
+)
+fi
 
 # Generate HTML partial
 cat > "$OUTPUT_FILE" << 'HEADER'

--- a/docs/site/sentencepiece.html
+++ b/docs/site/sentencepiece.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1873,7 +1875,7 @@ ck_tokenizer_free(tok);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/simd-architecture.html
+++ b/docs/site/simd-architecture.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2366,7 +2368,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,266 +2,270 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html</loc>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-mla-kimi.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-08</lastmod>
   </url>
 </urlset>

--- a/docs/site/spec-training-method.html
+++ b/docs/site/spec-training-method.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -3775,7 +3777,7 @@ Next run:</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1417,7 +1419,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec17-curriculum-blueprint.html
+++ b/docs/site/spec17-curriculum-blueprint.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1473,7 +1475,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec19-textbook-routing-mixture.html
+++ b/docs/site/spec19-textbook-routing-mixture.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1586,7 +1588,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spectrum.html
+++ b/docs/site/spectrum.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1764,7 +1766,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2729,7 +2731,7 @@ document.addEventListener('DOMContentLoaded', loadResults);
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-viewer.html
+++ b/docs/site/test-viewer.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1387,7 +1389,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1881,7 +1883,7 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/threadpool.html
+++ b/docs/site/threadpool.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2828,7 +2830,7 @@ make test-threadpool-parity-verbose
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/tokenizer.html
+++ b/docs/site/tokenizer.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2315,7 +2317,7 @@ True BPE (merge rules applied in order):
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-curriculum.html
+++ b/docs/site/training-curriculum.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1848,7 +1850,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-lessons-learned.html
+++ b/docs/site/training-lessons-learned.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1841,7 +1843,7 @@ AFTER TRAINING:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-backprop-ir.html
+++ b/docs/site/v7-backprop-ir.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2010,7 +2012,7 @@ version/v7/scripts/cks-v7-run init \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-cross-entropy-parity.html
+++ b/docs/site/v7-cross-entropy-parity.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1397,7 +1399,7 @@ CK_NUM_THREADS=8 python version/v7/scripts/train_parity_epochs_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-grad-accum-windows.html
+++ b/docs/site/v7-grad-accum-windows.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1327,7 +1329,7 @@ at accumulation boundary:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-parity-checklist.html
+++ b/docs/site/v7-parity-checklist.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1526,7 +1528,7 @@ PY</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-profiling.html
+++ b/docs/site/v7-profiling.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1445,7 +1447,7 @@ python3 version/v7/tools/open_ir_visualizer.py --generate --run /tmp/v7_ht_threa
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-python-authoring.html
+++ b/docs/site/v7-python-authoring.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1598,7 +1600,7 @@ python3 version/v7/examples/python_module_api_tiny_lm_v7.py --run-name py-module
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-runbook.html
+++ b/docs/site/v7-runbook.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -5608,7 +5610,7 @@ python3 scripts/ck_chat.py --help</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-svg-dataset-runbook.html
+++ b/docs/site/v7-svg-dataset-runbook.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1656,7 +1658,7 @@ tail -n 20 "$RUN/autopilot/summary.jsonl"</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-training-progression-playbook.html
+++ b/docs/site/v7-training-progression-playbook.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1576,7 +1578,7 @@ jq -r '.status, (.stages // [])' "$RUN/training_parity_regimen_latest.json" 2>/d
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-visualizer-test-runbook.html
+++ b/docs/site/v7-visualizer-test-runbook.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1927,7 +1929,7 @@ document.querySelectorAll('.copy-btn').forEach(btn => {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-mla-kimi.html
+++ b/docs/site/v8-mla-kimi.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1400,7 +1402,7 @@ make build/libckernel_engine.so
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1741,7 +1743,7 @@ make v8-visualizer-vision-artifacts</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1942,7 +1944,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/version-history.html
+++ b/docs/site/version-history.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -2681,7 +2683,7 @@ console.log('Roadmap: ' + versionData.roadmap.map(v => 'v' + v.major).join(' →
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -899,6 +899,7 @@
                         <div class="menu-heading">Optimization</div>
                         <a href="gemm-memory-layout.html">GEMM Memory Layout<small>NN/NT layouts, offsets</small></a>
                         <a href="gemm-optimization.html">GEMM Optimization<small>AVX, MKL, blocking</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>VTune, Advisor, roofline, parity gates</small></a>
                         <a href="cke-throughput-unit.html">CKE Throughput Unit<small>PB/s active-byte target</small></a>
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
@@ -910,6 +911,7 @@
                         <a href="memory-safety.html">Memory Safety<small>Bump allocator, canaries</small></a>
                         <a href="deterministic-memory.html">Deterministic Memory<small>RDMA, interpretability</small></a>
                         <a href="profiling.html">Profiling Guide<small>Valgrind, perf, flamegraphs</small></a>
+                        <a href="kernel-tuning-methodology.html">Kernel Tuning Methodology<small>CPU-node performance runbook</small></a>
                         <a href="v7-profiling.html">v7 Profiling Runbook<small>Train kernels: VTune, Advisor, perf</small></a>
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
@@ -1328,7 +1330,7 @@ permalink: /vision-encoder-parity/
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-04</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
             </div>
         </div>
     </footer>

--- a/logs/2026-07-08-v8-long-context-prefill-sweep/COMMIT_MESSAGE.md
+++ b/logs/2026-07-08-v8-long-context-prefill-sweep/COMMIT_MESSAGE.md
@@ -1,0 +1,88 @@
+# Suggested Commit Message
+
+```text
+perf(v8): record AVX2 long-context prefill sweep
+
+Add a tracked benchmark worklog for the 2026-07-08 v8 AVX2 sweep.
+Align the Qwen benchmark runtime paths with `cks-v8-run` canonical cache
+directories so future sweeps do not accidentally use stale compiled runtimes.
+
+The sweep separates fixed-token long-prefill throughput from practical
+prompt coherence:
+
+Fresh fixed-token p4096/n64 CK-vs-llama retest:
+
+| Model | CK prefill | llama prefill | CK/llama | CK decode | llama decode |
+|---|---:|---:|---:|---:|---:|
+| Nanbeige 4.1 3B Q4 | 57.4 tok/s | 63.0 tok/s | 0.91x | 9.1 | 10.9 |
+| Qwen2 0.5B Q4 | 210.8 tok/s | 223.3 tok/s | 0.94x | 44.3 | 48.2 |
+| Qwen3 0.6B Q8 | 144.3 tok/s | 173.6 tok/s | 0.83x | 26.4 | 34.1 |
+| Qwen3.5 0.8B Q4 | 249.0 tok/s | 262.6 tok/s | 0.95x | 36.1 | 36.0 |
+| Gemma3 270M Q5 | 365.0 tok/s | 761.3 tok/s | 0.48x | 29.1 | 74.7 |
+
+Fresh 4096-context practical prompt smoke with 512-token cap:
+
+| Model | Prompt tok | Prefill | Decode | Quality note |
+|---|---:|---:|---:|---|
+| Nanbeige 4.1 3B Q4 | 53 | 46.85 tok/s | 13.54 tok/s | Coherent thinking, cap ended inside thought |
+| Qwen2 0.5B Q4 | 40 | 282.18 tok/s | 55.32 tok/s | Coherent enough, shallow SQL |
+| Qwen3 0.6B Q8 | 29 | 198.53 tok/s | 39.16 tok/s | Coherent, exits thinking |
+| Qwen3.5 0.8B Q4 | 29 | 40.43 tok/s | 36.84 tok/s | Coherent structure, rough code |
+| Gemma3 270M Q5 | 31 | 29.95 tok/s | 30.92 tok/s | Coherent opening for 270M, repetitive C |
+
+The earlier p4096 table claiming 3.5x+ CK prefill wins did not reproduce and is
+kept only as a superseded cautionary artifact in the log.
+
+Validity notes:
+
+- `--context-len 4096` sets capacity; it is not a 4096-token prompt unless the
+  prompt is tokenizer-counted to that length.
+- Practical 4096-context prompt tokens were still short (29-53 tokens), so those
+  rows validate runtime health and coherence, not long-prefill saturation.
+- Qwen3/Qwen3.5 are not confirmed coherence regressions after fresh terminal
+  runs.
+- Gemma3 is coherent for its size but remains behind llama.cpp in synthetic
+  p4096 and produces weak code.
+
+Benchmark log:
+
+- logs/2026-07-08-v8-long-context-prefill-sweep/README.md
+
+Generated local artifacts, not committed:
+
+- build/reports/v8_p4096_full_retest_20260708.json
+- build/reports/v8_context4096_practical_512_20260708/summary.md
+- build/reports/v8_context4096_practical_512_20260708/summary.json
+```
+
+## Suggested PR Notes
+
+```text
+This PR includes a tracked benchmark log for the AVX2 v8 long-context sweep:
+
+logs/2026-07-08-v8-long-context-prefill-sweep/README.md
+
+Main findings:
+
+- The original fixed-token table was stale/suspect and is now explicitly
+  superseded.
+- Fresh p4096/n64 puts CK close to llama.cpp on Nanbeige, Qwen2, and Qwen3.5
+  prefill, but not ahead.
+- Fresh 4096-context practical prompts run successfully across Nanbeige, Qwen2,
+  Qwen3, Qwen3.5, and Gemma3.
+- Coherence is reasonable for Qwen2/Qwen3 and present for Qwen3.5/Gemma3, but
+  code quality still needs model-specific evaluation.
+
+Do not treat this as a long-context practical benchmark yet: the practical
+prompt was only 29-53 tokens depending on tokenizer/template. The next lane
+needs tokenizer-counted prompts near 1024/2048/4096 tokens.
+
+Next steps after this PR:
+
+1. Generate token-counted practical prompts for 1024/2048/4096 context tests.
+2. Add these prompt lanes to the pre-push/nightly performance script.
+3. Profile p4096 Nanbeige/Qwen2/Qwen3.5 with VTune/Advisor to close the last
+   5-17% prefill gap vs llama.cpp.
+4. Investigate Qwen3 Q8 and Gemma3 gaps separately.
+5. Keep first-token/multi-token parity gates active for any kernel speed patch.
+```

--- a/logs/2026-07-08-v8-long-context-prefill-sweep/README.md
+++ b/logs/2026-07-08-v8-long-context-prefill-sweep/README.md
@@ -1,0 +1,324 @@
+# v8 Long-Context Prefill Sweep - 2026-07-08
+
+## Purpose
+
+Record the AVX2 v8 sweep that separated long-context prefill performance from
+short-prompt practical generation quality.
+
+This log is intentionally tracked because the raw benchmark artifacts live under
+`build/` and are easy to lose. The results below should be referenced from the
+PR/commit message for the AVX2 prefill work.
+
+## Local Artifacts
+
+- Markdown report:
+  `build/reports/v8_practical_context_sweep_20260708-143018/report.md`
+- JSON report:
+  `build/reports/v8_practical_context_sweep_20260708-143018/sweep.json`
+- Local HTTP view during the run:
+  `http://10.0.0.32:8001/build/reports/v8_practical_context_sweep_20260708-143018/report.md`
+
+These generated artifacts are not committed.
+
+## Configuration
+
+- Machine: Intel Core i7-14700T AVX2/AVX-VNNI host
+- CK threads: `20`
+- OpenMP threads: `1`
+- Fixed-token lane:
+  - Contexts: `1024`, `2048`, `4096`
+  - Decode tokens: `64`
+  - CK path: `ck-cli-v8 --prompt-tokens ... --no-chat-template --timing`
+  - llama path: `llama-bench -p <ctx> -n 64 -t 20 -ngl 0`
+- Practical prompt lane:
+  - Context: `4096`
+  - Max new tokens: `128`
+  - CK only; llama-cli practical prompt lane was stopped because the first
+    Gemma3 prompt did not terminate quickly enough for this sweep.
+  - Important limitation: this was a short-prompt smoke. `--context 4096` only
+    sets KV capacity; it does not create a 4096-token prompt.
+
+## Practical Prompts
+
+- `code_c_python_sql`: detailed C, Python, and SQL examples.
+- `linked_list_c`: linked list in C with insert/delete/search/print.
+- `database_hashmap`: relational database vs hash map explanation.
+- `summary_text`: summarize a C-Kernel-Engine throughput paragraph.
+
+## Fixed-Token Performance
+
+### 2026-07-08 correction
+
+The first fixed-token p4096 table from this sweep is **superseded**. It did not
+reproduce after the runtime path corrections and should not be used as a PR
+headline or public claim.
+
+Fresh full recheck command:
+
+```bash
+CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+.venv/bin/python benchmarks/bench_v8_decoder_matrix.py \
+  --models nanbeige4.1-3b-q4_k_m,qwen2-0.5b-q4_k_m,qwen3-0.6b-q8_0,qwen35-0.8b-q4_k_m,gemma3-270m-q5_k_m \
+  --prompt 4096 \
+  --decode 64 \
+  --threads 20 \
+  --repeats 1 \
+  --json-out build/reports/v8_p4096_full_retest_20260708.json
+```
+
+Fresh p4096/n64 result:
+
+| Model | Quant | CK prefill | llama prefill | CK/llama | CK decode | llama decode | CK/llama |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Nanbeige 4.1 3B | Q4_K_M | 57.4 tok/s | 63.0 tok/s | 0.91x | 9.1 tok/s | 10.9 tok/s | 0.84x |
+| Qwen2 0.5B | Q4_K_M | 210.8 tok/s | 223.3 tok/s | 0.94x | 44.3 tok/s | 48.2 tok/s | 0.92x |
+| Qwen3 0.6B | Q8_0 | 144.3 tok/s | 173.6 tok/s | 0.83x | 26.4 tok/s | 34.1 tok/s | 0.77x |
+| Qwen3.5 0.8B | Q4_K_M | 249.0 tok/s | 262.6 tok/s | 0.95x | 36.1 tok/s | 36.0 tok/s | 1.00x |
+| Gemma3 270M | Q5_K_M | 365.0 tok/s | 761.3 tok/s | 0.48x | 29.1 tok/s | 74.7 tok/s | 0.39x |
+
+Gemma3 was also rechecked alone and reached `540.3 tok/s` CK prefill vs
+`1544.1 tok/s` llama prefill, showing run-to-run or thermal/cache variance but
+still not reproducing the stale `31.5 tok/s` CK prefill row.
+
+Superseded p4096/n64 table retained only as a cautionary artifact:
+
+| Model | Quant | CK prefill | llama prefill | CK/llama | CK decode | llama decode | CK/llama |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Nanbeige 4.1 3B | Q4_K_M | 230.3 tok/s | 63.1 tok/s | 3.65x | 12.1 tok/s | 11.1 tok/s | 1.09x |
+| Qwen2 0.5B | Q4_K_M | 836.3 tok/s | 223.8 tok/s | 3.74x | 57.0 tok/s | 47.9 tok/s | 1.19x |
+| Qwen3.5 0.8B | Q4_K_M | 921.4 tok/s | 258.9 tok/s | 3.56x | 39.9 tok/s | 32.4 tok/s | 1.23x |
+| Gemma3 270M | Q5_K_M | 31.5 tok/s | 760.4 tok/s | 0.04x | 31.6 tok/s | 75.2 tok/s | 0.42x |
+| Qwen3 0.6B | Q8_0 | 6075.0 tok/s | 174.0 tok/s | suspect | 45.3 tok/s | 34.0 tok/s | 1.33x |
+
+## Practical CK Timings
+
+Short real prompts do not exercise long batched prefill enough, so these values
+should not be used as the long-prefill headline. `--context 4096` only sets KV
+capacity; it does not make a 40-token prompt into a 4096-token prompt. These
+rows are therefore short-prompt decode/coherence smokes, not proper
+long-context practical tests.
+
+| Model | Prompt token range | Prefill tok/s range | Decode tok/s range |
+|---|---:|---:|---:|
+| Nanbeige 4.1 3B | 40-88 | 28.0-43.6 | 11.4-12.8 |
+| Qwen2 0.5B | 38-85 | 218.4-261.6 | 65.7-67.9 |
+| Qwen3 0.6B | 38-85 | 213.9-270.5 | 53.7-54.6 |
+| Qwen3.5 0.8B | 38-85 | 173.7-226.1 | 45.1-46.3 |
+| Gemma3 270M | 40-86 | 30.0-31.5 | incomplete/30.3 |
+
+Fresh 4096-context practical command shape:
+
+```bash
+CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+.venv/bin/python version/v8/scripts/ck_run_v8.py run <local-gguf> \
+  --context-len 4096 \
+  --prompt "Give me a detailed example of C, Python, and SQL code. Keep the answer concise but useful." \
+  --max-tokens 512 \
+  --temperature 0.0
+```
+
+Fresh 4096-context practical results:
+
+| Model | Prompt tokens | Prefill | Decode cap/runs | Decode | Quality note |
+|---|---:|---:|---:|---:|---|
+| Nanbeige 4.1 3B Q4 | 53 | 46.85 tok/s | 512/512 | 13.54 tok/s | Coherent thinking, but 512 cap ended inside `<think>`; use higher reasoning budget/cap for final answer. |
+| Qwen2 0.5B Q4 | 40 | 282.18 tok/s | 512/347 | 55.32 tok/s | Coherent enough, covers C/Python/SQL but SQL example is shallow. |
+| Qwen3 0.6B Q8 | 29 | 198.53 tok/s | 512/350 | 39.16 tok/s | Coherent, exits thinking, gives concise examples. |
+| Qwen3.5 0.8B Q4 | 29 | 40.43 tok/s | 512/512 | 36.84 tok/s | Coherent structure, but code quality is rough; calls C example C++. |
+| Gemma3 270M Q5 | 31 | 29.95 tok/s | 512/135 | 30.92 tok/s | Coherent opening for size, but weak/repetitive C code. |
+
+Artifacts:
+
+- `build/reports/v8_p4096_full_retest_20260708.json`
+- `build/reports/v8_context4096_practical_512_20260708/summary.md`
+- `build/reports/v8_context4096_practical_512_20260708/summary.json`
+
+Follow-up interactive Gemma3 run from the operator terminal was coherent for the
+model size and did not match the stale low-prefill claim:
+
+```text
+Hello:
+prompt eval: 58.29 ms / 13 tokens, 223.04 tok/s
+decode: 319.76 ms / 10 runs, 31.27 tok/s
+
+capital of France:
+prompt eval: 62.58 ms / 17 tokens, 271.67 tok/s
+decode: 256.17 ms / 8 runs, 31.23 tok/s
+
+Shakespeare:
+prompt eval: 60.45 ms / 16 tokens, 264.68 tok/s
+decode: 1653.69 ms / 51 runs, 30.84 tok/s
+```
+
+## Output Quality Findings
+
+- Nanbeige 4.1 3B: coherent thinking-mode output on the practical prompts.
+- Qwen2 0.5B: coherent enough for the tested prompts.
+- Qwen3 0.6B: initial practical sweep tail looked suspect after a plausible
+  start, but a follow-up one-shot/interactive run produced coherent thinking
+  and answer text. Treat Qwen3 as validation-pending, not a confirmed numerical
+  regression.
+- Qwen3.5 0.8B: coherent in the 4096-context 512-token run, but code quality is
+  rough. It is a performance/correctness-quality follow-up, not a hard
+  coherence failure.
+- Gemma3 270M: follow-up interactive checks are coherent for model size, with
+  short-prompt prefill around 220-285 tok/s and decode around 31-33 tok/s.
+  Synthetic p4096 still lags llama.cpp, so Gemma remains a performance issue,
+  not a coherence failure.
+
+## Follow-Up Qwen3 / Qwen3.5 Checks
+
+The runbook-style command without `--prompt` successfully converted, compiled,
+and generated the visualizer, then exited with code `2` in this non-interactive
+agent session because stdin is not a TTY:
+
+```text
+Error: interactive chat requires a TTY on stdin.
+Run from a terminal or pass --prompt for one-shot generation.
+```
+
+Generated files:
+
+- `/home/antshiv/.cache/ck-engine-v8/models/Qwen--Qwen3-0.6B-GGUF/libmodel.so`
+- `/home/antshiv/.cache/ck-engine-v8/models/Qwen--Qwen3-0.6B-GGUF/weights.bump`
+- `/home/antshiv/.cache/ck-engine-v8/models/Qwen--Qwen3-0.6B-GGUF/ir_report.html`
+
+Direct one-shot timing from the compiled runtime:
+
+```text
+prompt: Give me a detailed example of C, Python, and SQL code. Explain what each example does.
+prefill 28 tok: 131.5 ms, 213.0 tok/s
+decode 127 tok: 2450.6 ms, 51.8 tok/s, 19.3 ms/tok
+```
+
+User interactive terminal run with a longer cap was also coherent:
+
+```text
+prompt eval: 126.41 ms / 23 tokens, 181.95 tok/s
+decode: 11560.50 ms / 512 runs, 44.29 tok/s
+reasoning: started=1 ended=1 tokens=390
+stop: max_tokens reached
+```
+
+Conclusion: Qwen3 Q8 speed should still be checked for token accounting and
+logit parity, but current evidence does not show a critical coherence
+regression.
+
+The user also ran Qwen3 interactively with a `Hello` prompt:
+
+```text
+prompt eval: 74.23 ms / 10 tokens, 134.72 tok/s
+decode: 1716.11 ms / 90 runs, 52.44 tok/s
+reasoning: started=1 ended=1 tokens=77
+stop: eos token 151645
+```
+
+Qwen3.5 was retested through `cks-v8-run` after a fresh compile under the
+canonical cache directory:
+
+```text
+/home/antshiv/.cache/ck-engine-v8/models/unsloth--Qwen3.5-0.8B-GGUF/libmodel.so
+```
+
+Observed Qwen3.5 timing:
+
+```text
+Hello prompt:
+prompt eval: 222.59 ms / 10 tokens, 44.93 tok/s
+decode: 332.69 ms / 15 runs, 45.09 tok/s
+
+code prompt:
+prompt eval: 517.15 ms / 24 tokens, 46.41 tok/s
+decode: 11412.71 ms / 512 runs, 44.86 tok/s
+reasoning: started=1 ended=1 tokens=3
+stop: max_tokens reached
+```
+
+Qwen3.5 output was coherent enough for a practical smoke. The earlier
+Qwen3/Qwen3.5 garbage tails are now attributed to an invalid benchmark setup:
+stale compiled runtime paths and too-short practical prompts, not a confirmed
+model/kernel regression.
+
+Harness correction:
+
+- `benchmarks/bench_v8_decoder_matrix.py` now points Qwen3.5 to
+  `unsloth--Qwen3.5-0.8B-GGUF`, matching `cks-v8-run`.
+- `benchmarks/compare_ck_llama_v8.py` now points Qwen3 to
+  `Qwen--Qwen3-0.6B-GGUF`, matching `cks-v8-run`.
+
+## Corrected Long-Prompt Attempt
+
+A follow-up Qwen3 test attempted to use actual long text prompts with 512-token
+decode caps. The 512-token and 1024-token prompt rows are valid; the 4096
+context row is invalid because the generated prompt collapsed to only 6 tokens
+as reported by CK timing.
+
+```text
+ctx=1024: prompt=512 tokens, prefill=247.5 tok/s, decode=511 tokens at 35.0 tok/s
+ctx=2048: prompt=1024 tokens, prefill=207.8 tok/s, decode=511 tokens at 54.4 tok/s
+ctx=4096: invalid, CK reported prompt=6 tokens
+```
+
+Artifact:
+
+- `build/reports/qwen3_corrected_practical_long_context_20260708.json`
+
+This confirms the next practical sweep must generate prompts by tokenizer count,
+not approximate word count.
+
+## What Changed / What The Sweep Proves
+
+This sweep did not prove that every v8 model is fixed. It proved a narrower,
+useful point:
+
+1. The stale p4096 table cannot be used as evidence that CK beats llama.cpp.
+   Fresh full recheck puts CK near llama.cpp for Nanbeige, Qwen2, and Qwen3.5
+   prefill, but still behind; Gemma3 and Qwen3 Q8 are farther behind.
+2. The practical interactive signal is still good: Qwen3, Qwen3.5, and Gemma3
+   produce coherent output in fresh `cks-v8-run` terminal runs, and short-prompt
+   speed is real.
+3. Short practical prompts are dominated by overhead and decode. They do not
+   show the same prefill speedup because they only contain about 40-90 prompt
+   tokens.
+4. Qwen3/Qwen3.5 coherence is not a confirmed regression after fresh
+   `cks-v8-run` checks, but their benchmark numbers must be regenerated with
+   canonical runtime paths and token-counted prompts.
+5. Gemma3 is a separate performance/routing problem, not evidence that the Q4
+   long-prefill path failed.
+
+## Likely Issue Split
+
+- Q4 long prefill: improved enough to justify continued roofline work, but the
+  old "CK beats llama.cpp by 3.6x" table is invalid until regenerated and
+  reproduced.
+- Qwen3/Qwen3.5: validation-pending for performance accounting, but no longer
+  considered confirmed coherence regressions after fresh `cks-v8-run` checks.
+- Benchmark harness: stale runtime cache paths can produce false coherence
+  failures. Always align benchmark `run` directories with the directories that
+  `cks-v8-run --force-convert --force-compile` writes.
+- Gemma3: coherent in interactive use, but still slower than llama.cpp in the
+  fresh synthetic p4096 recheck.
+- Qwen3 Q8 p4096 speed: suspect until output quality and token accounting are
+  verified.
+
+## Next Steps
+
+1. Rerun CK-vs-llama fixed-token and practical-prompt sweeps after the runtime
+   path corrections.
+2. Replace the flawed practical lane with actual token-counted long prompts:
+   - context 1024: about 512 prompt tokens, 512 decode cap
+   - context 2048: about 1024-1536 prompt tokens, 512 decode cap
+   - context 4096: about 3072-3584 prompt tokens, 512 decode cap
+3. Verify Qwen3 p4096 token accounting, because the fixed-token throughput
+   number is unusually high relative to the rest of the model family.
+4. If output diverges, run first-token and multi-token logit parity with the
+   same prompt and generated prefix.
+5. Attribute the first Qwen3/Qwen3.5 divergence by layer/op before changing
+   speed kernels further.
+6. Inspect Gemma3 v8 lowering and kernel-map routing. Confirm whether Gemma3 is
+   using the intended batched/sliding prefill path.
+7. After correctness is stable, rerun Advisor/VTune on:
+   - Nanbeige p4096 prefill
+   - Qwen2 p4096 prefill
+   - Qwen3.5 p4096 only after coherence/parity is fixed
+   - Gemma3 after routing is fixed


### PR DESCRIPTION
## Summary
- Adds the kernel tuning methodology page and navigation link.
- Records the fresh v8 AVX2 4096-context benchmark log under logs/2026-07-08-v8-long-context-prefill-sweep/.
- Fixes benchmark harness paths and force-rebuild behavior so retests use the intended model cache directories.

## Key Evidence
See logs/2026-07-08-v8-long-context-prefill-sweep/README.md.

Fresh fixed-token p4096/n64 retest:

| Model | CK prefill | llama prefill | CK/llama | CK decode | llama decode |
| --- | ---: | ---: | ---: | ---: | ---: |
| Nanbeige 4.1 3B Q4 | 57.4 tok/s | 63.0 tok/s | 0.91x | 9.1 | 10.9 |
| Qwen2 0.5B Q4 | 210.8 tok/s | 223.3 tok/s | 0.94x | 44.3 | 48.2 |
| Qwen3 0.6B Q8 | 144.3 tok/s | 173.6 tok/s | 0.83x | 26.4 | 34.1 |
| Qwen3.5 0.8B Q4 | 249.0 tok/s | 262.6 tok/s | 0.95x | 36.1 | 36.0 |
| Gemma3 270M Q5 | 365.0 tok/s | 761.3 tok/s | 0.48x | 29.1 | 74.7 |

## Tests
- .venv/bin/python -m py_compile benchmarks/bench_v8_decoder_matrix.py benchmarks/compare_ck_llama_v8.py benchmarks/profile_v8_prefill_ops.py
- CK_SITE_SKIP_SPEC_TRAINING_REFRESH=1 bash docs/site/build.sh
- Full p4096 fixed-token CK-vs-llama retest
- 4096-context practical 512-token smoke
- Pre-push: build, kernel parity, v8 E2E smoke, v8 inference contracts, v7 training contract, training-kernel parity