### PR TITLE
perf(v8): speed up Gemma3 Q5_1 prefill

### DIFF
--- a/benchmarks/bench_v8_decoder_matrix.py
+++ b/benchmarks/bench_v8_decoder_matrix.py
@@ -128,7 +128,7 @@ def _run_llama(gguf: Path, *, prompt: int, decode: int, threads: int, repeats: i
     return row
 
 
-def _run_cke(run_dir: Path, *, prompt: int, decode: int, threads: int, timeout: int) -> dict[str, Any]:
+def _run_cke(run_dir: Path, *, prompt: int, decode: int, threads: int, context: int, timeout: int) -> dict[str, Any]:
     lib = run_dir / "libmodel.so"
     weights = run_dir / "weights.bump"
     env = os.environ.copy()
@@ -144,6 +144,10 @@ def _run_cke(run_dir: Path, *, prompt: int, decode: int, threads: int, timeout: 
         prompt_tokens,
         "--max-tokens",
         str(decode),
+        "--context",
+        str(context),
+        "--no-chat-template",
+        "--no-stream",
         "--ignore-eos",
         "--quiet-output",
         "--timing",
@@ -186,6 +190,7 @@ def main() -> int:
     parser.add_argument("--models", default=",".join(MODELS), help="Comma-separated model ids, or 'all'")
     parser.add_argument("--prompt", type=int, default=512)
     parser.add_argument("--decode", type=int, default=128)
+    parser.add_argument("--context", type=int, default=0, help="CK context for fixed-token runs; 0 means prompt + decode + 8")
     parser.add_argument("--threads", type=int, default=12)
     parser.add_argument("--repeats", type=int, default=1)
     parser.add_argument("--timeout", type=int, default=900)
@@ -208,7 +213,8 @@ def main() -> int:
             continue
         print(f"== {spec['label']} {spec['quant']} ==", flush=True)
         row["llama"] = _run_llama(gguf, prompt=args.prompt, decode=args.decode, threads=args.threads, repeats=args.repeats, timeout=args.timeout)
-        row["cke"] = _run_cke(run_dir, prompt=args.prompt, decode=args.decode, threads=args.threads, timeout=args.timeout)
+        ck_context = args.context if args.context > 0 else args.prompt + args.decode + 8
+        row["cke"] = _run_cke(run_dir, prompt=args.prompt, decode=args.decode, threads=args.threads, context=ck_context, timeout=args.timeout)
         results.append(row)
 
     args.json_out.parent.mkdir(parents=True, exist_ok=True)

--- a/logs/2026-07-08-gemma3-q51-prefill/COMMIT_MESSAGE.md
+++ b/logs/2026-07-08-gemma3-q51-prefill/COMMIT_MESSAGE.md
@@ -1,0 +1,50 @@
+# Suggested Commit Message
+
+```text
+perf(v8): speed up Gemma3 Q5_1 prefill
+
+Why: Gemma3 270M Q5_K_M prefill was dominated by the Q5_1 x Q8_1 contract path,
+especially MLP gate/up and q/k projections, and the fixed-token benchmark
+harness could clip CK p4096 runs below the requested prompt length.
+Test: make -B build/libckernel_engine.so; objdump confirmed vpdpbusd in the
+rebuilt shared library; py_compile benchmark scripts; make test-kernels; focused
+Q5_1 x Q8_1 scalar-contract parity; corrected Gemma3 p4096/n64 CK-vs-llama
+benchmark; Gemma3 practical coherence smoke.
+
+Changes:
+
+- Add an AVX2/VNNI Q5_1 x Q8_1 dot path using vpdpbusd when __AVXVNNI__ is
+  available.
+- Replace scalar Q5_1 high-bit reconstruction with a nibble lookup table.
+- Reuse each quantized activation row across eight output columns in
+  gemm_nt_q5_1_q8_1.
+- Fix the fixed-token benchmark harness to pass explicit context, disable chat
+  templates, and disable streaming for deterministic token accounting.
+
+Gemma3 p4096 profile delta:
+
+| Metric | Before | After |
+|---|---:|---:|
+| CK profiled prefill | 569.5 tok/s | 874.4 tok/s |
+| Prompt wall time | 7192.4 ms | 4684.2 ms |
+| mlp_gate_up Q5_1 | 3130.0 ms | 1346.2 ms |
+| q_proj Q5_1 | 834.6 ms | 340.5 ms |
+| k_proj Q5_1 | 217.3 ms | 92.9 ms |
+
+Corrected fixed-token p4096/n64 CK-vs-llama:
+
+| Model | llama prefill | CK prefill | CK/llama | llama decode | CK decode |
+|---|---:|---:|---:|---:|---:|
+| Gemma3 270M Q5_K_M | 1549.2 tok/s | 859.3 tok/s | 0.55x | 118.3 tok/s | 30.5 tok/s |
+
+Benchmark log:
+
+- logs/2026-07-08-gemma3-q51-prefill/README.md
+
+Next:
+
+- Gemma3 decode remains the largest relative gap.
+- Remaining prefill hotspots are sliding attention, GEGLU/fusion, Q8_0 contract
+  projection routing, and MLP down.
+- Add committed Q5_1 focused parity coverage.
+```

--- a/logs/2026-07-08-gemma3-q51-prefill/README.md
+++ b/logs/2026-07-08-gemma3-q51-prefill/README.md
@@ -1,0 +1,159 @@
+# Gemma3 Q5_1 Prefill Tuning - 2026-07-08
+
+## Purpose
+
+Record the Gemma3-specific v8 AVX2 tuning pass. This log is tracked so the
+benchmark trail is tied to the code change instead of only living in `build/`
+artifacts.
+
+Gemma3 270M Q5_K_M was lagging llama.cpp badly in the fixed-token p4096 lane.
+The v8 profile showed the real prefill bottleneck was not generic Q5_K alone:
+Gemma3 uses the Q5_1 x Q8_1 contract path heavily for q/k projections and
+especially MLP gate/up.
+
+## Change Summary
+
+- Added an AVX2/VNNI Q5_1 x Q8_1 dot path using `vpdpbusd` when the compiler
+  target exposes `__AVXVNNI__`.
+- Replaced scalar high-bit reconstruction with a 4-bit lookup table that expands
+  Q5_1 high bits into byte lanes.
+- Reused each quantized activation row across eight output columns in
+  `gemm_nt_q5_1_q8_1`.
+- Fixed the fixed-token benchmark harness so CK p4096 runs use the requested
+  token count:
+  - explicit `--context`
+  - `--no-chat-template`
+  - `--no-stream`
+  - default context = `prompt + decode + 8`
+
+## Machine And Configuration
+
+- Host: Intel Core i7-14700T AVX2/AVX-VNNI
+- CK threads: `20`
+- OpenMP threads: `1`
+- Model: `unsloth--gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf`
+- Fixed-token lane: `p4096/n64`, CK context `4168`
+- Local generated artifacts:
+  - `build/reports/gemma3_q5_prefill_profile_p4096_20260708.json`
+  - `build/reports/gemma3_q5_prefill_profile_p4096_after_q51_lut_20260708.json`
+  - `build/reports/gemma3_q5_p4096n64_final_20260708.json`
+
+## Prefill Profile Delta
+
+Profile command family:
+
+```bash
+CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+.venv/bin/python benchmarks/profile_v8_prefill_ops.py \
+  --models gemma3-270m-q5_k_m \
+  --prompt 4096 \
+  --decode 1 \
+  --threads 20
+```
+
+| Metric | Before | After |
+|---|---:|---:|
+| CK profiled prefill tok/s | 569.5 | 874.4 |
+| Prompt wall time | 7192.4 ms | 4684.2 ms |
+| Profiled op coverage | 97.5% | 96.9% |
+| `mlp_gate_up` Q5_1 | 3130.0 ms | 1346.2 ms |
+| `q_proj` Q5_1 | 834.6 ms | 340.5 ms |
+| `k_proj` Q5_1 | 217.3 ms | 92.9 ms |
+| Q5_1 `v_proj` layers | 108.2 ms | 45.2 ms |
+
+After the Q5_1 fix, the next prefill hotspots are no longer just Q5_1:
+
+| Op/kernel | Time | Share |
+|---|---:|---:|
+| `gemm_nt_q5_1_q8_1` / `mlp_gate_up` | 1346.2 ms | 29.7% |
+| `attention_forward_causal_head_major_gqa_flash_strided_sliding` | 911.6 ms | 20.1% |
+| `geglu_forward_exact` | 710.2 ms | 15.6% |
+| `gemm_nt_q8_0_q8_0_contract` / `v_proj` | 422.1 ms | 9.3% |
+| `gemm_nt_q5_1_q8_1` / `q_proj` | 340.5 ms | 7.5% |
+| `gemm_nt_q5_k` / `mlp_down` | 192.5 ms | 4.2% |
+| `gemm_nt_q6_k_q8_k` / `mlp_down` | 105.0 ms | 2.3% |
+
+## Corrected CK-vs-llama Fixed-Token Result
+
+The earlier Gemma3 p4096 rows were misleading because the CK harness could clip
+the requested fixed-token prompt. The corrected harness reports all 4096 prompt
+tokens:
+
+```bash
+CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+.venv/bin/python benchmarks/bench_v8_decoder_matrix.py \
+  --models gemma3-270m-q5_k_m \
+  --prompt 4096 \
+  --decode 64 \
+  --context 4168 \
+  --threads 20 \
+  --repeats 1 \
+  --timeout 1200 \
+  --json-out build/reports/gemma3_q5_p4096n64_final_20260708.json
+```
+
+| Model | Quant | llama prefill | CK prefill | CK/llama | llama decode | CK decode | CK/llama |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Gemma3 270M | Q5_K_M | 1549.2 tok/s | 859.3 tok/s | 0.55x | 118.3 tok/s | 30.5 tok/s | 0.26x |
+
+Interpretation:
+
+- The Q5_1 prefill kernel itself improved materially.
+- Gemma3 prefill is still behind llama.cpp end-to-end.
+- Decode is still the largest relative Gemma3 gap.
+- The next Gemma3 work should target sliding attention, GEGLU/fusion, Q8_0
+  projection routing, and decode GEMV paths.
+
+## Correctness And Smoke Checks
+
+Build and kernel parity:
+
+```bash
+make -B build/libckernel_engine.so
+objdump -d -Mintel build/libckernel_engine.so | rg "vpdpbusd"
+.venv/bin/python -m py_compile \
+  benchmarks/bench_v8_decoder_matrix.py \
+  benchmarks/compare_ck_llama_v8.py
+make test-kernels
+```
+
+Results:
+
+- `vpdpbusd` is present in `build/libckernel_engine.so`.
+- `py_compile` passed.
+- `make test-kernels` passed: `58/58`.
+- Focused Q5_1 x Q8_1 randomized scalar-contract parity passed:
+
+```text
+shape M=1 N=7 K=32: max=1.19209e-07 mean=4.0446e-08
+shape M=3 N=17 K=64: max=1.90735e-06 mean=2.41925e-07
+shape M=5 N=33 K=160: max=1.90735e-06 mean=3.63001e-07
+shape M=9 N=64 K=640: max=2.28882e-05 mean=2.07134e-06
+Q5_1 x Q8_1 focused parity OK
+```
+
+Practical Gemma3 smoke:
+
+```text
+Prompt: What is the capital of France? Give one sentence.
+Response: Paris
+Please provide the city name.
+
+prompt eval: 61.24 ms / 21 tokens, 342.89 tok/s
+decode: 264.89 ms / 8 runs, 30.20 tok/s
+stop: eos token 106
+```
+
+This is coherent enough for a 270M model and does not indicate a kernel-level
+coherence regression.
+
+## Next Steps
+
+1. Fix Gemma3 decode: profile `gemv_q5_1_q8_1`, final logits, and Q5_K/Q6_K
+   decode paths.
+2. Improve remaining Gemma3 prefill hotspots: sliding attention, GEGLU, Q8_0
+   contract projections, and MLP down.
+3. Add a direct Q5_1 parity test to the committed kernel test suite instead of
+   keeping it only as an ad hoc ctypes check.
+4. Move to Gemma4 only after Gemma3 decode and prefill are both closer to
+   llama.cpp.

--- a/src/kernels/gemm_kernels_q5_1_q8_1.c
+++ b/src/kernels/gemm_kernels_q5_1_q8_1.c
@@ -9,6 +9,10 @@
 
 #include "ckernel_quant.h"
 
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
+
 #define CK_Q51_STACK_Q8_BLOCKS 256
 
 /* Q8_1 is used only by this contract kernel path. Keep a local definition so
@@ -23,6 +27,37 @@ typedef struct {
     ck_half s;
     int8_t qs[QK8_1];
 } block_q8_1;
+
+#if defined(__AVX2__)
+static const uint32_t ck_q51_high_nibble_lut[16] = {
+    0x00000000U, 0x00000010U, 0x00001000U, 0x00001010U,
+    0x00100000U, 0x00100010U, 0x00101000U, 0x00101010U,
+    0x10000000U, 0x10000010U, 0x10001000U, 0x10001010U,
+    0x10100000U, 0x10100010U, 0x10101000U, 0x10101010U,
+};
+
+static inline uint32_t ck_q51_high_nibble_word(uint32_t bits4) {
+    return ck_q51_high_nibble_lut[bits4 & 0x0fU];
+}
+
+static inline __m128i ck_q51_high_bits_16_avx2(uint32_t bits16) {
+    const uint32_t w0 = ck_q51_high_nibble_word(bits16);
+    const uint32_t w1 = ck_q51_high_nibble_word(bits16 >> 4);
+    const uint32_t w2 = ck_q51_high_nibble_word(bits16 >> 8);
+    const uint32_t w3 = ck_q51_high_nibble_word(bits16 >> 12);
+    return _mm_set_epi32((int)w3, (int)w2, (int)w1, (int)w0);
+}
+
+static inline int ck_q51_hsum256_epi32(__m256i v) {
+    const __m128i lo = _mm256_castsi256_si128(v);
+    const __m128i hi = _mm256_extracti128_si256(v, 1);
+    __m128i sum = _mm_add_epi32(lo, hi);
+    sum = _mm_hadd_epi32(sum, sum);
+    sum = _mm_hadd_epi32(sum, sum);
+    return _mm_cvtsi128_si32(sum);
+}
+
+#endif
 
 /* Quantize one FP32 row to Q8_1 blocks (ggml-compatible scalar path). */
 static void quantize_row_q8_1_scalar(const float *x, block_q8_1 *y, int k) {
@@ -49,8 +84,48 @@ static void quantize_row_q8_1_scalar(const float *x, block_q8_1 *y, int k) {
     }
 }
 
+#if defined(__AVX2__)
+static inline __m256i dot_q5_1_q8_1_block_sumi_avx2(const block_q5_1 *w,
+                                                     const block_q8_1 *x) {
+    uint32_t qh;
+    memcpy(&qh, w->qh, sizeof(qh));
+
+    const __m128i qpacked = _mm_loadu_si128((const __m128i *)(const void *)w->qs);
+    const __m128i low_mask = _mm_set1_epi8(0x0f);
+    const __m128i qlo = _mm_or_si128(_mm_and_si128(qpacked, low_mask),
+                                     ck_q51_high_bits_16_avx2(qh));
+    const __m128i qhi = _mm_or_si128(_mm_and_si128(_mm_srli_epi16(qpacked, 4), low_mask),
+                                     ck_q51_high_bits_16_avx2(qh >> 16));
+    const __m256i q5 = _mm256_inserti128_si256(_mm256_castsi128_si256(qlo), qhi, 1);
+    const __m256i q8 = _mm256_loadu_si256((const __m256i *)(const void *)x->qs);
+#if defined(__AVXVNNI__)
+    return _mm256_dpbusd_epi32(_mm256_setzero_si256(), q5, q8);
+#else
+    const __m256i prod16 = _mm256_maddubs_epi16(q5, q8);
+    return _mm256_madd_epi16(prod16, _mm256_set1_epi16(1));
+#endif
+}
+
+/* One 32-element block dot: Q5_1(weights) x Q8_1(activations), AVX2.
+ * The high-bit placement intentionally mirrors dot_q5_1_q8_1_block().
+ */
+static float dot_q5_1_q8_1_block_avx2(const block_q5_1 *w, const block_q8_1 *x) {
+    const __m256i sumi = dot_q5_1_q8_1_block_sumi_avx2(w, x);
+
+    const float wd = CK_FP16_TO_FP32(w->d);
+    const float wm = CK_FP16_TO_FP32(w->m);
+    const float xd = CK_FP16_TO_FP32(x->d);
+    const float xs = CK_FP16_TO_FP32(x->s);
+    return (wd * xd) * (float)ck_q51_hsum256_epi32(sumi) + wm * xs;
+}
+
+#endif
+
 /* One 32-element block dot: Q5_1(weights) x Q8_1(activations). */
 static float dot_q5_1_q8_1_block(const block_q5_1 *w, const block_q8_1 *x) {
+#if defined(__AVX2__)
+    return dot_q5_1_q8_1_block_avx2(w, x);
+#else
     uint32_t qh;
     memcpy(&qh, w->qh, sizeof(qh));
 
@@ -70,6 +145,7 @@ static float dot_q5_1_q8_1_block(const block_q5_1 *w, const block_q8_1 *x) {
     const float xd = CK_FP16_TO_FP32(x->d);
     const float xs = CK_FP16_TO_FP32(x->s);
     return (wd * xd) * (float)(sumi0 + sumi1) + wm * xs;
+#endif
 }
 
 void gemv_q5_1_q8_1_ref(float *y,
@@ -159,9 +235,61 @@ void gemm_nt_q5_1_q8_1(const float *A,
         return;
     }
 
+    const block_q5_1 *W = (const block_q5_1 *)B;
+
     for (int m = 0; m < M; ++m) {
         block_q8_1 a_q8[CK_Q51_STACK_Q8_BLOCKS];
         quantize_row_q8_1_scalar(&A[m * K], a_q8, K);
-        gemm_nt_q5_1_q8_1_ref(a_q8, B, bias, &C[m * N], 1, N, K);
+        float *c_row = &C[(size_t)m * (size_t)N];
+
+        int n = 0;
+        for (; n + 7 < N; n += 8) {
+            const block_q5_1 *w0 = &W[(size_t)(n + 0) * (size_t)blocks_per_row];
+            const block_q5_1 *w1 = &W[(size_t)(n + 1) * (size_t)blocks_per_row];
+            const block_q5_1 *w2 = &W[(size_t)(n + 2) * (size_t)blocks_per_row];
+            const block_q5_1 *w3 = &W[(size_t)(n + 3) * (size_t)blocks_per_row];
+            const block_q5_1 *w4 = &W[(size_t)(n + 4) * (size_t)blocks_per_row];
+            const block_q5_1 *w5 = &W[(size_t)(n + 5) * (size_t)blocks_per_row];
+            const block_q5_1 *w6 = &W[(size_t)(n + 6) * (size_t)blocks_per_row];
+            const block_q5_1 *w7 = &W[(size_t)(n + 7) * (size_t)blocks_per_row];
+            float s0 = 0.0f;
+            float s1 = 0.0f;
+            float s2 = 0.0f;
+            float s3 = 0.0f;
+            float s4 = 0.0f;
+            float s5 = 0.0f;
+            float s6 = 0.0f;
+            float s7 = 0.0f;
+
+            for (int b = 0; b < blocks_per_row; ++b) {
+                const block_q8_1 *x = &a_q8[b];
+                s0 += dot_q5_1_q8_1_block(&w0[b], x);
+                s1 += dot_q5_1_q8_1_block(&w1[b], x);
+                s2 += dot_q5_1_q8_1_block(&w2[b], x);
+                s3 += dot_q5_1_q8_1_block(&w3[b], x);
+                s4 += dot_q5_1_q8_1_block(&w4[b], x);
+                s5 += dot_q5_1_q8_1_block(&w5[b], x);
+                s6 += dot_q5_1_q8_1_block(&w6[b], x);
+                s7 += dot_q5_1_q8_1_block(&w7[b], x);
+            }
+
+            c_row[n + 0] = s0 + (bias ? bias[n + 0] : 0.0f);
+            c_row[n + 1] = s1 + (bias ? bias[n + 1] : 0.0f);
+            c_row[n + 2] = s2 + (bias ? bias[n + 2] : 0.0f);
+            c_row[n + 3] = s3 + (bias ? bias[n + 3] : 0.0f);
+            c_row[n + 4] = s4 + (bias ? bias[n + 4] : 0.0f);
+            c_row[n + 5] = s5 + (bias ? bias[n + 5] : 0.0f);
+            c_row[n + 6] = s6 + (bias ? bias[n + 6] : 0.0f);
+            c_row[n + 7] = s7 + (bias ? bias[n + 7] : 0.0f);
+        }
+
+        for (; n < N; ++n) {
+            const block_q5_1 *w_row = &W[(size_t)n * (size_t)blocks_per_row];
+            float sum = 0.0f;
+            for (int b = 0; b < blocks_per_row; ++b) {
+                sum += dot_q5_1_q8_1_block(&w_row[b], &a_q8[b]);
+            }
+            c_row[n] = sum + (bias ? bias[n] : 0.0f);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- speed up the Gemma3 Q5_1 x Q8_1 prefill path with AVX2/AVX-VNNI `vpdpbusd`, nibble-LUT high-bit expansion, and 8-column activation-row reuse
- fix the fixed-token v8 benchmark harness so CK p4096 runs use explicit context, no chat template, and no streaming
- add a tracked Gemma3 benchmark log at `logs/2026-07-08-gemma3-q51-prefill/README.md`

## Results

Gemma3 p4096 profile delta:

| Metric | Before | After |
|---|---:|---:|
| CK profiled prefill | 569.5 tok/s | 874.4 tok/s |
| Prompt wall time | 7192.4 ms | 4684.2 ms |
| mlp_gate_up Q5_1 | 3130.0 ms | 1346.2 ms |
| q_proj Q5_1 | 834.6 ms | 340.5 ms |
| k_proj Q5_1 | 217.3 ms | 92.9 ms |

Corrected fixed-token p4096/n64 CK-vs-llama:

| Model | llama prefill | CK prefill | CK/llama | llama decode | CK decode |
|---|---:|---:|---:|---:|---:|
| Gemma3 270M Q5_K_M | 1549.2 tok/s | 859.3 tok/s | 0.55x | 118.3 tok/s | 30.5 tok/s |

## Validation

- `make -B build/libckernel_engine.so`
- `objdump -d -Mintel build/libckernel_engine.so | rg vpdpbusd`
- `.venv/bin/python -m py_compile benchmarks/bench_v8_decoder_matrix.py benchmarks/compare_ck_llama_v8.py`
- `make test-kernels` -> 58/58 passed
- focused Q5_1 x Q8_1 scalar-contract parity passed
- corrected Gemma3 p4096/n64 CK-vs-llama benchmark
- Gemma3 practical coherence smoke
- pre-commit hook passed: v7-regression-fast, v8-regression-fast
- pre-push hook passed: build, kernel parity, Gemma3 v8 E2E smoke, v8 contracts, v7 training smoke, v7/v8 fast regression, v7 training-kernel parity

## Notes

This fixes a real Gemma3 prefill hotspot, but Gemma3 is still behind llama.cpp end-to-end. Next targets are Gemma3 decode, sliding attention, GEGLU/fusion, Q8_0 contract projections, and MLP down.