### PR TITLE
fix(v8/qwen3vl): align mrope width and guard fused prefill

### DIFF
--- a/logs/2026-07-09-qwen3vl-avx2-mrope-prefill-parity/COMMIT_MESSAGE.md
+++ b/logs/2026-07-09-qwen3vl-avx2-mrope-prefill-parity/COMMIT_MESSAGE.md
@@ -1,0 +1,81 @@
+fix(v8/qwen3vl): align mrope width and gate fused prefill path
+
+Why: Qwen3-VL AVX2 OCR decode diverged from llama.cpp on the canonical image after a correct-looking visual bridge. The failure was caused by an M-RoPE width mismatch first, then by Qwen3-VL taking a fused Q4 gate-up/SwiGLU prefill path whose live persistent decode parity was worse than the unfused path.
+
+Validation: py_compile for modified v8 scripts, `make -B build/libckernel_engine.so`, canonical Qwen3-VL OCR persistent parity `status=pass steps=64`, and pre-commit `v8-regression-fast`.
+
+Qwen3-VL M-RoPE was using `sum(mrope_sections)` as the rotary width.
+That gives 64 for the 24/20/20/0 section layout, but llama.cpp passes
+`n_rot == head_dim == 128`. The sections select the M-RoPE axis pattern;
+they are not the rotary width.
+
+This changes GGUF conversion and IR fallback defaults so Qwen3-VL emits
+and consumes the full rotary width.
+
+The AVX2 parity run then moved from a hard early failure to a late
+numeric drift:
+
+| Case | First mismatch | CK token | llama token | cosine | top-k overlap |
+| --- | ---: | --- | --- | ---: | ---: |
+| before M-RoPE fix | 4 | `262` (`'   '`) | `220` (`' '`) | `0.797069` | `8/16` |
+| after M-RoPE fix | 45 | `5500` (`'_number'`) | `82427` (`'_instructions'`) | `0.998952` | `15/16` |
+
+Layer-0 persistent-vs-full-replay attribution after the M-RoPE fix:
+
+| Boundary | Max abs | RMSE | Cosine |
+| --- | ---: | ---: | ---: |
+| `attn_out` | `5.60e-05` | `3.88e-06` | `0.99999988` |
+| `out_proj` | `2.61e-04` | `7.25e-05` | `0.99999905` |
+| `after_attn` | `2.61e-04` | `7.25e-05` | `0.99999946` |
+| `ffn_norm` | `6.83e-04` | `1.51e-04` | `0.99999785` |
+| `layer_out` | `1.18e-02` | `1.12e-03` | `0.99997771` |
+
+That places the remaining split inside layer-0 MLP. A diagnostic run with
+`CK_DISABLE_Q4K_GATEUP_SWIGLU_X16=1` made the actual persistent OCR decode
+match llama through 64 tokens. Therefore Qwen3-VL now defaults the fused
+Q4 gate-up/SwiGLU x16 prefill path off until the fused kernel is fixed.
+Other models retain the previous default, and the path can still be
+explicitly enabled with `CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1`.
+
+Validation:
+
+```
+.venv/bin/python -m py_compile \
+  version/v8/scripts/codegen_prefill_v8.py \
+  version/v8/scripts/codegen_core_v8.py \
+  version/v8/scripts/build_ir_v8.py \
+  version/v8/scripts/convert_gguf_to_bump_v8.py \
+  version/v8/scripts/compare_multimodal_multitoken_logits_v8.py \
+  version/v8/scripts/decoder_first_token_parity_v8.py
+```
+
+Canonical Qwen3-VL OCR parity:
+
+```
+CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+.venv/bin/python version/v8/scripts/compare_multimodal_multitoken_logits_v8.py \
+  --bridge-report build/qwen3vl_avx2_mrope128_bridge_20260709/bridge/bridge_report.json \
+  --prefix-f32 build/qwen3vl_avx2_mrope128_bridge_20260709/prefix.f32 \
+  --prefix-grid-x 36 \
+  --prefix-grid-y 28 \
+  --prefix-text-pos 41 \
+  --workdir build/qwen3vl_avx2_mrope128_default_safe_20260709 \
+  --ctx-len 4096 \
+  --threads 20 \
+  --top-k 16 \
+  --max-new-tokens 64 \
+  --append-on-divergence stop \
+  --json-out build/qwen3vl_avx2_mrope128_default_safe_20260709/persistent64.json \
+  --summary
+```
+
+Result:
+
+```
+status=pass steps=64
+first_mismatch=None
+```
+
+Research log:
+
+`logs/2026-07-09-qwen3vl-avx2-mrope-prefill-parity/README.md`

--- a/logs/2026-07-09-qwen3vl-avx2-mrope-prefill-parity/README.md
+++ b/logs/2026-07-09-qwen3vl-avx2-mrope-prefill-parity/README.md
@@ -1,0 +1,145 @@
+# Qwen3-VL AVX2 M-RoPE and Prefill Parity Handoff
+
+Date: 2026-07-09
+
+## Scope
+
+This log records the AVX2 Qwen3-VL OCR parity work on the canonical SDPR OCR image.
+
+The goal was correctness, not speed. VTune/Advisor work should stay paused for this path until the parity split is closed.
+
+## Canonical Inputs
+
+- Image: `ocr/1 81.jpg`
+- JPEG sha256: `eb3becd507063f184d417a6baccfdb22d86277308f21a679aac4e029ed8f25ff`
+- Canonical PPM sha256: `81ab4a6dabf3fc41ef86b620602a28dbbba59aea89414301b604df355afda182`
+- Decoder GGUF: `Qwen3VL-8B-Instruct-Q4_K_M.gguf`
+- Decoder GGUF sha256: `67d1659bfe71b89d50b45a4ad1a9e5b997e5bb16ce5da66a6a6167abd569e9e2`
+- mmproj GGUF: `mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf`
+- mmproj sha256: `c6ba85508d82f42590e6eb77d5340369ab6fecf107a7561d809523d8aa5f3bfd`
+- Prompt: `Extract visible form fields as compact JSON.`
+- Context: `4096`
+- Threads: `20`
+- Visual prefix: `1008 x 16384`
+- Grid: `36 x 28`
+- `prefix_text_pos`: `41`
+
+## Fix 1: M-RoPE Width
+
+Root cause:
+
+CK derived `mrope_n_dims` from `sum(mrope_sections) == 64`. For Qwen3-VL llama.cpp passes `n_rot == head_dim == 128`. The section values select the time/height/width axis pattern; they are not the rotary width.
+
+Changed:
+
+- `version/v8/scripts/convert_gguf_to_bump_v8.py`
+  - Emits full `mrope_n_dims` from rotary/head width.
+- `version/v8/scripts/build_ir_v8.py`
+  - Uses head width as stale-config fallback, not `sum(mrope_sections)`.
+
+Result:
+
+- Before: fresh AVX2 bridge failed at generated step 4.
+  - CK token `262` (`'   '`)
+  - llama token `220` (`' '`)
+  - cosine `0.797069`
+  - top-k overlap `8/16`
+- After: persistent decode matched much further and first mismatch moved to step 45.
+  - CK token `5500` (`'_number'`)
+  - llama token `82427` (`'_instructions'`)
+  - cosine `0.998952`
+  - top-k overlap `15/16`
+
+## Fix 2: Qwen3-VL Prefill Safety Gate
+
+After the M-RoPE fix, full replay at step 45 matched llama, but persistent decode still flipped top-1. Layer-0 hidden-state attribution showed:
+
+| Boundary | Max abs | RMSE | Cosine |
+| --- | ---: | ---: | ---: |
+| `attn_out` | `5.60e-05` | `3.88e-06` | `0.99999988` |
+| `out_proj` | `2.61e-04` | `7.25e-05` | `0.99999905` |
+| `after_attn` | `2.61e-04` | `7.25e-05` | `0.99999946` |
+| `ffn_norm` | `6.83e-04` | `1.51e-04` | `0.99999785` |
+| `layer_out` | `1.18e-02` | `1.12e-03` | `0.99997771` |
+
+This placed the material persistent/full-replay split inside layer-0 MLP.
+
+Diagnostic result:
+
+- With `CK_DISABLE_Q4K_GATEUP_SWIGLU_X16=1`, persistent decode matched llama through 64 tokens.
+- Generated text begins with coherent OCR JSON:
+  - `{"form_title": "Monthly Report", ...}`
+- With the fused path enabled, the same run failed at step 45.
+
+Production hardening:
+
+- Qwen3-VL now defaults `ck_enable_q4k_gateup_swiglu_x16 = 0`.
+- Other models keep the previous default.
+- `CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1` can still explicitly enable the path for performance experiments.
+- `CK_DISABLE_Q4K_GATEUP_SWIGLU_X16=1` remains a hard off switch.
+
+## Validation Commands
+
+Syntax:
+
+```bash
+/home/antshiv/Workspace/C-Kernel-Engine/.venv/bin/python -m py_compile \
+  version/v8/scripts/codegen_prefill_v8.py \
+  version/v8/scripts/codegen_core_v8.py \
+  version/v8/scripts/build_ir_v8.py \
+  version/v8/scripts/convert_gguf_to_bump_v8.py \
+  version/v8/scripts/compare_multimodal_multitoken_logits_v8.py \
+  version/v8/scripts/decoder_first_token_parity_v8.py
+```
+
+Default-safe Qwen3-VL AVX2 persistent parity:
+
+```bash
+CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
+/home/antshiv/Workspace/C-Kernel-Engine/.venv/bin/python \
+  version/v8/scripts/compare_multimodal_multitoken_logits_v8.py \
+  --bridge-report /home/antshiv/Workspace/C-Kernel-Engine/build/qwen3vl_avx2_mrope128_bridge_20260709/bridge/bridge_report.json \
+  --prefix-f32 /home/antshiv/Workspace/C-Kernel-Engine/build/qwen3vl_avx2_mrope128_bridge_20260709/prefix.f32 \
+  --prefix-grid-x 36 \
+  --prefix-grid-y 28 \
+  --prefix-text-pos 41 \
+  --workdir /home/antshiv/Workspace/C-Kernel-Engine/build/qwen3vl_avx2_mrope128_default_safe_20260709 \
+  --ctx-len 4096 \
+  --threads 20 \
+  --top-k 16 \
+  --max-new-tokens 64 \
+  --append-on-divergence stop \
+  --json-out /home/antshiv/Workspace/C-Kernel-Engine/build/qwen3vl_avx2_mrope128_default_safe_20260709/persistent64.json \
+  --summary
+```
+
+Result:
+
+```text
+status=pass steps=64
+first_mismatch=None
+```
+
+Generated C check:
+
+```bash
+rg -n "ck_enable_q4k_gateup_swiglu_x16 =" \
+  /home/antshiv/Workspace/C-Kernel-Engine/build/qwen3vl_avx2_mrope128_default_safe_20260709/decoder/decoder_v8.c \
+  /home/antshiv/Workspace/C-Kernel-Engine/build/qwen3vl_avx2_mrope128_default_safe_20260709/decoder/decoder_v8_prefill.c
+```
+
+Result:
+
+```text
+ck_enable_q4k_gateup_swiglu_x16 = 0
+```
+
+## Remaining Work
+
+The fused Q4 gate-up/SwiGLU x16 prefill kernel still needs a real numerical parity fix. Keep it opt-in for Qwen3-VL until:
+
+1. Persistent decode and full replay both match llama on the canonical OCR image.
+2. The same result holds for at least the 5-image OCR smoke set.
+3. Full OCR output quality does not regress.
+4. The performance win is remeasured after correctness is restored.
+

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -243,6 +243,7 @@ def _inject_runtime_config_defaults(config: Dict[str, Any], arch: str) -> Dict[s
             }
         )
     elif arch_lc == "qwen3_vl_vision":
+        config.setdefault("prefer_q8_0_contract", True)
         _merge_activation_defaults({
             "mlp_down": "fp32",
             "out_proj": "q8_0",
@@ -9486,7 +9487,11 @@ def generate_ir_lower_2(
             if not isinstance(sections, list) or len(sections) != 4:
                 default_section = max(1, int(params.get("head_dim", 0) or 0) // 4)
                 sections = [default_section, default_section, default_section, default_section]
-            default_n_dims = max(1, int(sum(int(v) for v in sections) or int(params.get("head_dim", 0) or 0) // 2))
+            # M-RoPE sections choose the axis pattern; they are not the rotary
+            # width. For Qwen3-VL/Qwen3.5, llama.cpp passes n_rot as the full
+            # head width. Use the op/config head dim as the fallback so stale
+            # configs cannot silently rotate only sum(sections) dimensions.
+            default_n_dims = max(1, int(params.get("head_dim", config.get("head_dim", 0)) or 0))
             params.setdefault("n_dims", int(config.get("mrope_n_dims", default_n_dims)))
             params.setdefault("section_0", int(sections[0]))
             params.setdefault("section_1", int(sections[1]))

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -935,6 +935,7 @@ def emit_op(
         x_expr = arg_expr_by_name.get("x") or arg_expr_by_name.get("x_q8")
         y_expr = arg_expr_by_name.get("y")
         k_expr = arg_expr_by_name.get("k")
+        rows_expr = arg_expr_by_name.get("rows")
         if x_expr and y_expr and k_expr:
             active_name = f"ck_debug_outproj_fp32_active_{seq_idx if seq_idx is not None else idx}"
             lines.append(
@@ -946,6 +947,12 @@ def emit_op(
                 f'    ck_debug_export_hidden(model, {layer}, "attn_out", '
                 f'(const float*)({x_expr}), (int)({k_expr}));'
             )
+            if rows_expr:
+                lines.append(
+                    f'    if ((int)({rows_expr}) > 1) ck_debug_export_hidden(model, {layer}, "attn_out_last", '
+                    f'(const float*)(((const float*)({x_expr})) + (((size_t)({rows_expr}) - 1u) * (size_t)({k_expr}))), '
+                    f'(int)({k_expr}));'
+                )
             lines.append(f"    if (!{active_name}) {{")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
@@ -1583,6 +1590,17 @@ def emit_op(
             elif op_instance_idx == 1:
                 lines.append(f'    ck_debug_export_hidden(model, {layer}, "layer_out", (const float*){out_expr}, EMBED_DIM);')
                 _emit_hidden_export_last_row(out_expr, "layer_out", "EMBED_DIM")
+    elif op_name == "rmsnorm":
+        out_expr = _hidden_arg("output", "out", "x", "y")
+        if op_instance_idx == 0:
+            _emit_hidden_export(out_expr, "block_rmsnorm", "EMBED_DIM")
+            _emit_hidden_export_last_row(out_expr, "block_rmsnorm", "EMBED_DIM")
+        elif op_instance_idx == 1:
+            _emit_hidden_export(out_expr, "ffn_norm", "EMBED_DIM")
+            _emit_hidden_export_last_row(out_expr, "ffn_norm", "EMBED_DIM")
+        else:
+            _emit_hidden_export(out_expr, "rmsnorm", "EMBED_DIM")
+            _emit_hidden_export_last_row(out_expr, "rmsnorm", "EMBED_DIM")
     elif op_name == "post_attention_norm":
         out_expr = _hidden_raw(_hidden_arg("output", "out", "x", "y"))
         if out_expr:
@@ -2612,6 +2630,14 @@ static void ck_trace_pos(const char *stage, int32_t token, int count, int before
 static void ck_debug_export_hidden(CKModel *model, int layer, const char *name, const float *data, int count) {{
     const char *dir = getenv("CK_DEBUG_EXPORT_HIDDEN");
     if (!dir || !dir[0] || !model || !name || !data || count <= 0) return;
+    const char *layer_filter = getenv("CK_DEBUG_EXPORT_HIDDEN_LAYER");
+    if (layer_filter && layer_filter[0]) {{
+        char *end = NULL;
+        long wanted = strtol(layer_filter, &end, 10);
+        if (end != layer_filter && layer != (int)wanted) return;
+    }}
+    const char *name_filter = getenv("CK_DEBUG_EXPORT_HIDDEN_NAME");
+    if (name_filter && name_filter[0] && strcmp(name_filter, name) != 0) return;
     char path[1024];
     int n = snprintf(path, sizeof(path), "%s/tok_%04d_layer_%03d_%s.f32",
                      dir, model->pos, layer, name);

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -379,6 +379,12 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         omp_pragma = get_parallel_pragma(op)
         if omp_pragma:
             omp_pragma = f"\n        {omp_pragma}"
+        dump_block = ""
+        if dump:
+            dump_block = f"""
+    #ifdef CK_PARITY_DUMP
+    ck_dump_tensor((float*)(model->bump + A_ATTN_SCRATCH), {layer}, "kqv_out", (num_tokens) * ({num_heads}) * ({head_dim}));
+    #endif"""
         return f"""    /* Op {seq_idx}: transpose_attn_out_to_token_major layer={layer} */
     /* Transpose from [H, T, D] (head-major attention output) to [T, H*D] (token-major for out_proj) */
     {{
@@ -397,7 +403,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         }}
         /* Copy back */
         memcpy(buf, _temp_buf, (size_t)num_tokens * H * D * sizeof(float));
-    }}"""
+    }}{dump_block}"""
 
     embed_dim = config.get("embed_dim", 896)
 
@@ -498,6 +504,13 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         k_expr = arg_expr_by_name.get("k") or str(config.get("embed_dim", "EMBED_DIM"))
         if x_expr and y_expr and k_expr:
             row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)" if batch_quant_kind == "quantize_row_q8_k" else "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+            if op_type == "quantize_out_proj_input":
+                lines.append(f"    ck_debug_outproj_fp32_input = (const float*)({x_expr});")
+                lines.append(
+                    f'    if (num_tokens > 1) ck_debug_export_hidden(model, {layer}, "attn_out_last", '
+                    f'(const float*)(((const float*)({x_expr})) + (((size_t)num_tokens - 1u) * (size_t)({k_expr}))), '
+                    f'(int)({k_expr}));'
+                )
             lines.append("    {")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
@@ -560,7 +573,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
                 raw_expr = c_expr.replace("(float*)", "").replace("(void*)", "").strip()
                 size_expr = f"({m_expr}) * ({n_expr})"
                 lines.append("    #ifdef CK_PARITY_DUMP")
-                lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "attn_output", {size_expr});')
+                lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "attn_out", {size_expr});')
                 lines.append("    #endif")
             return "\n".join(lines)
 
@@ -755,6 +768,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     elif (
         op_type in {"attn", "attn_sliding"}
         and func in {
+            "attention_forward_causal_head_major_gqa_flash_strided",
             "attention_forward_causal_head_major_gqa_flash_strided_gemma4",
             "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
         }
@@ -853,6 +867,15 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         _emit_head_major_last(_hidden_arg("k"), "rope_k", _hidden_arg("num_kv_heads") or "NUM_KV_HEADS", _hidden_arg("aligned_head_dim", "head_dim") or "HEAD_DIM")
     elif op_type == "out_proj":
         _emit_hidden_last(_hidden_arg("output", "out", "c", "y"), "out_proj", "EMBED_DIM")
+    elif op_type in ("rmsnorm", "layernorm"):
+        if str(section or "") == "footer" or int(layer) < 0:
+            _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "final_hidden", "EMBED_DIM")
+        elif op_instance_idx == 0:
+            _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "block_rmsnorm", "EMBED_DIM")
+        elif op_instance_idx == 1:
+            _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "ffn_norm", "EMBED_DIM")
+        else:
+            _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "rmsnorm", "EMBED_DIM")
     elif op_type == "block_rmsnorm":
         _emit_hidden_last(_hidden_arg("output", "out", "x", "y"), "block_rmsnorm", "EMBED_DIM")
     elif op_type == "post_attention_norm":
@@ -959,6 +982,23 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             lines.append(f'    ck_dump_tensor((float*){raw_expr}, {layer}, "{name}", {size_expr});')
             lines.append("    #endif")
 
+        def _emit_head_major_dump(
+            expr: Optional[str],
+            name: str,
+            heads_expr: Optional[str],
+            tokens_expr: Optional[str],
+            head_dim_expr: Optional[str],
+        ) -> None:
+            if not expr or not heads_expr or not tokens_expr or not head_dim_expr:
+                return
+            raw_expr = expr.replace("(float*)", "").replace("(void*)", "").strip()
+            lines.append("    #ifdef CK_PARITY_DUMP")
+            lines.append(
+                f'    ck_dump_tensor_head_major_token_major((float*){raw_expr}, {layer}, "{name}", '
+                f"{heads_expr}, {tokens_expr}, {head_dim_expr});"
+            )
+            lines.append("    #endif")
+
         tokens = "num_tokens"
         embed_dim_expr = _get_arg("aligned_embed_dim", "d_model", "embed_dim") or str(embed_dim)
         m_dim = _get_arg("m")
@@ -974,6 +1014,11 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             k_size = _mul_expr(tokens, num_kv_heads, head_dim)
             _emit_dump(q_expr, "qcur_normed", q_size)
             _emit_dump(k_expr, "kcur_normed", k_size)
+        elif op_type == "rope_qk":
+            q_expr = _get_arg("q")
+            k_expr = _get_arg("k")
+            _emit_head_major_dump(q_expr, "Qcur_rope", num_heads, tokens, head_dim)
+            _emit_head_major_dump(k_expr, "Kcur_rope", num_kv_heads, tokens, head_dim)
         elif op_type in ("rmsnorm", "layernorm"):
             dump_label = None
             if str(section or "") == "footer":
@@ -1016,6 +1061,7 @@ def emit_prefill_function(ops: List[Dict], config: Dict, profile: bool = False, 
     scale_embeddings_sqrt_dim = bool(config.get("scale_embeddings_sqrt_dim", False))
     outproj_policy = str(config.get("out_proj_input_policy") or "").strip().lower()
     debug_outproj_default = 1 if outproj_policy in {"fp32", "fp32_input", "force_fp32"} else 0
+    q4_gateup_swiglu_x16_default = 0 if _is_qwen3vl_multimodal_config(config) else 1
     embed_scale_emitted = False
     prologue = """
 /* ============================================================================
@@ -1053,11 +1099,19 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
+    const char *ck_enable_q4k_gateup_swiglu_x16_env = getenv("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
     const char *ck_disable_q4k_gateup_swiglu_x16_env = getenv("CK_DISABLE_Q4K_GATEUP_SWIGLU_X16");
-    int ck_enable_q4k_gateup_swiglu_x16 =
-        !(ck_disable_q4k_gateup_swiglu_x16_env &&
-          ck_disable_q4k_gateup_swiglu_x16_env[0] &&
-          strcmp(ck_disable_q4k_gateup_swiglu_x16_env, "0") != 0);
+    int ck_enable_q4k_gateup_swiglu_x16 = CK_Q4_GATEUP_SWIGLU_X16_DEFAULT;
+    if (ck_enable_q4k_gateup_swiglu_x16_env &&
+        ck_enable_q4k_gateup_swiglu_x16_env[0] &&
+        strcmp(ck_enable_q4k_gateup_swiglu_x16_env, "0") != 0) {
+        ck_enable_q4k_gateup_swiglu_x16 = 1;
+    }
+    if (ck_disable_q4k_gateup_swiglu_x16_env &&
+        ck_disable_q4k_gateup_swiglu_x16_env[0] &&
+        strcmp(ck_disable_q4k_gateup_swiglu_x16_env, "0") != 0) {
+        ck_enable_q4k_gateup_swiglu_x16 = 0;
+    }
     int ck_enable_swiglu_q8k_fusion = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_SWIGLU_Q8K_FUSION");
 
     /* Copy input tokens to activation buffer (follow same pattern as decode) */
@@ -1067,6 +1121,7 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
         "int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;",
         f"int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : {debug_outproj_default};",
     )
+    prologue = prologue.replace("CK_Q4_GATEUP_SWIGLU_X16_DEFAULT", str(q4_gateup_swiglu_x16_default))
     lines.append(prologue)
 
     if profile:
@@ -1076,6 +1131,7 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     _annotate_kv_transpose_roles(ops)
     residual_add_count_total = 0
     residual_add_counts_by_layer: Dict[int, int] = {}
+    rmsnorm_counts_by_layer: Dict[int, int] = {}
 
     swiglu_q8k_fusion_guard: Optional[str] = None
     swiglu_q8k_fusion_call: Optional[str] = None
@@ -1633,6 +1689,7 @@ def emit_prefill_from_embedded_function(
     debug_outproj_default = 1 if outproj_policy in {"fp32", "fp32_input", "force_fp32"} else 0
     embed_scale_emitted = False
     is_qwen3vl = _is_qwen3vl_multimodal_config(config)
+    q4_gateup_swiglu_x16_default = 0 if is_qwen3vl else 1
     num_deepstack_layers = int(config.get("num_deepstack_layers", 0) or 0) if is_qwen3vl else 0
     helper_block = _emit_qwen3vl_prefill_bridge_helpers(config) if is_qwen3vl else ""
     if helper_block:
@@ -1677,11 +1734,19 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     int debug_prefill_mlp_gate_up_row_gemv_layer = debug_prefill_mlp_gate_up_row_gemv_layer_env ? atoi(debug_prefill_mlp_gate_up_row_gemv_layer_env) : -1;
     const char *debug_prefill_mamba_in_proj_row_gemv_env = getenv("CK_V8_DEBUG_PREFILL_MAMBA_IN_PROJ_ROW_GEMV");
     int debug_prefill_mamba_in_proj_row_gemv = debug_prefill_mamba_in_proj_row_gemv_env ? (atoi(debug_prefill_mamba_in_proj_row_gemv_env) != 0) : 0;
+    const char *ck_enable_q4k_gateup_swiglu_x16_env = getenv("CK_ENABLE_Q4K_GATEUP_SWIGLU_X16");
     const char *ck_disable_q4k_gateup_swiglu_x16_env = getenv("CK_DISABLE_Q4K_GATEUP_SWIGLU_X16");
-    int ck_enable_q4k_gateup_swiglu_x16 =
-        !(ck_disable_q4k_gateup_swiglu_x16_env &&
-          ck_disable_q4k_gateup_swiglu_x16_env[0] &&
-          strcmp(ck_disable_q4k_gateup_swiglu_x16_env, "0") != 0);
+    int ck_enable_q4k_gateup_swiglu_x16 = CK_Q4_GATEUP_SWIGLU_X16_DEFAULT;
+    if (ck_enable_q4k_gateup_swiglu_x16_env &&
+        ck_enable_q4k_gateup_swiglu_x16_env[0] &&
+        strcmp(ck_enable_q4k_gateup_swiglu_x16_env, "0") != 0) {
+        ck_enable_q4k_gateup_swiglu_x16 = 1;
+    }
+    if (ck_disable_q4k_gateup_swiglu_x16_env &&
+        ck_disable_q4k_gateup_swiglu_x16_env[0] &&
+        strcmp(ck_disable_q4k_gateup_swiglu_x16_env, "0") != 0) {
+        ck_enable_q4k_gateup_swiglu_x16 = 0;
+    }
     int ck_enable_swiglu_q8k_fusion = ck_env_truthy_or_qwen3vl_ocr_profile("CK_ENABLE_SWIGLU_Q8K_FUSION");
     const float *ck_debug_mlp_gate_up_fp32_input = NULL;
 """
@@ -1689,6 +1754,7 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
         "int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : 0;",
         f"int debug_outproj_fp32 = debug_outproj_env ? (atoi(debug_outproj_env) != 0) : {debug_outproj_default};",
     )
+    prologue = prologue.replace("CK_Q4_GATEUP_SWIGLU_X16_DEFAULT", str(q4_gateup_swiglu_x16_default))
     lines.append(prologue)
     if is_qwen3vl:
         lines.append(
@@ -1708,6 +1774,7 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     _annotate_kv_transpose_roles(ops)
     residual_add_count_total = 0
     residual_add_counts_by_layer: Dict[int, int] = {}
+    rmsnorm_counts_by_layer: Dict[int, int] = {}
 
     skip_swiglu_guard: Optional[str] = None
     swiglu_q8k_fusion_guard: Optional[str] = None
@@ -1725,6 +1792,12 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
             op = dict(op)
             op["op_instance_idx"] = inst
             residual_add_counts_by_layer[layer_for_instance] = inst + 1
+        if op_type in {"rmsnorm", "layernorm"} and "op_instance_idx" not in op and "instance" not in op:
+            layer_for_instance = int(op.get("layer", -1))
+            inst = rmsnorm_counts_by_layer.get(layer_for_instance, 0)
+            op = dict(op)
+            op["op_instance_idx"] = inst
+            rmsnorm_counts_by_layer[layer_for_instance] = inst + 1
         if op_type == "dense_embedding_lookup":
             lines.append(f"    if (stop_seq == {seq_idx}) return;")
             if (

--- a/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
+++ b/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
@@ -14,6 +14,7 @@ import argparse
 import ctypes
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -53,6 +54,102 @@ def _decode_topk(logits: np.ndarray, tokenizer: GGUFTokenizer, top_k: int) -> li
     return rows
 
 
+
+
+
+def _set_process_env(name: str, value: str | None) -> None:
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = str(value)
+    try:
+        libc = ctypes.CDLL(None)
+        if value is None:
+            libc.unsetenv.argtypes = [ctypes.c_char_p]
+            libc.unsetenv(name.encode())
+        else:
+            libc.setenv.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
+            libc.setenv(name.encode(), str(value).encode(), 1)
+    except Exception:
+        pass
+
+
+def _restore_process_env(saved: dict[str, str | None]) -> None:
+    for key, value in saved.items():
+        _set_process_env(key, value)
+
+
+def _single_hidden_file(root: Path) -> Path:
+    files = sorted(root.glob("*.f32"))
+    if len(files) != 1:
+        raise RuntimeError(f"expected exactly one hidden dump in {root}, found {len(files)}")
+    return files[0]
+
+
+def _hidden_files_by_layer(root: Path) -> dict[int, Path]:
+    out: dict[int, Path] = {}
+    for path in sorted(root.glob("*.f32")):
+        m = re.search(r"_layer_(\d+)_", path.name)
+        if not m:
+            continue
+        layer = int(m.group(1))
+        if layer in out:
+            raise RuntimeError(f"duplicate hidden dump for layer {layer} in {root}")
+        out[layer] = path
+    if not out:
+        raise RuntimeError(f"expected hidden dumps in {root}, found 0")
+    return out
+
+
+def _hidden_compare_many(persistent_dir: Path, full_dir: Path) -> list[dict[str, Any]]:
+    persistent = _hidden_files_by_layer(persistent_dir)
+    full = _hidden_files_by_layer(full_dir)
+    rows: list[dict[str, Any]] = []
+    for layer in sorted(set(persistent) | set(full)):
+        if layer not in persistent or layer not in full:
+            rows.append({
+                "layer": int(layer),
+                "status": "missing",
+                "persistent_path": None if layer not in persistent else str(persistent[layer]),
+                "full_replay_path": None if layer not in full else str(full[layer]),
+            })
+            continue
+        rows.append({"layer": int(layer), **_hidden_compare(persistent[layer], full[layer])})
+    return rows
+
+
+def _hidden_compare(a_path: Path, b_path: Path) -> dict[str, Any]:
+    a = np.fromfile(a_path, dtype=np.float32)
+    b = np.fromfile(b_path, dtype=np.float32)
+    if a.shape != b.shape:
+        return {
+            "status": "shape_mismatch",
+            "persistent_path": str(a_path),
+            "full_replay_path": str(b_path),
+            "persistent_shape": list(a.shape),
+            "full_replay_shape": list(b.shape),
+        }
+    diff = np.abs(a - b)
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b))
+    cosine = float(np.dot(a, b) / denom) if denom > 0.0 else 1.0
+    return {
+        "status": "ok",
+        "persistent_path": str(a_path),
+        "full_replay_path": str(b_path),
+        "shape": list(a.shape),
+        "max_abs_diff": float(diff.max()) if diff.size else 0.0,
+        "mean_abs_diff": float(diff.mean()) if diff.size else 0.0,
+        "rmse": float(np.sqrt(np.mean((a - b) ** 2))) if diff.size else 0.0,
+        "cosine": cosine,
+    }
+
+
+def _hidden_full_replay_name(name: str) -> str:
+    # Full replay runs through prefill, which exports last-row tensors with
+    # the *_last suffix for token-major intermediates.
+    if name.endswith("_last"):
+        return name
+    return f"{name}_last"
 
 def _run_llama_greedy_sequence(inputs: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
     helper = first_token.compare_first_token_logits_v7.ensure_llama_helper()
@@ -124,7 +221,13 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
     gguf_path = Path(gguf_value).resolve()
     workdir = args.workdir.resolve()
     workdir.mkdir(parents=True, exist_ok=True)
-    decoder_dir = workdir / "decoder"
+    if bool(getattr(args, "reuse_bridge_decoder_runtime", False)):
+        decoder_workdir = str(((bridge_report.get("decoder_runtime") or {}).get("workdir") or "")).strip()
+        if not decoder_workdir:
+            raise ValueError("bridge report does not include decoder_runtime.workdir")
+        decoder_dir = Path(decoder_workdir).resolve()
+    else:
+        decoder_dir = workdir / "decoder"
 
     requested_ctx_len = int(args.ctx_len or bridge_report.get("decoder_context_len") or 256)
     runtime = first_token.bridge_runner_v8._prepare_decoder_runtime(
@@ -184,6 +287,19 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
             )
         )
     )
+    bridge_contract = bridge_report.get("bridge_contract") or {}
+    encoder_report = bridge_report.get("encoder_report") or {}
+    prefix_decode_policy = (
+        str(
+            bridge_report.get("prefix_decode_policy")
+            or bridge_contract.get("decode_policy")
+            or encoder_report.get("prefix_decode_policy")
+            or "causal_mixed_prefix"
+        )
+        .strip()
+        .lower()
+        or "causal_mixed_prefix"
+    )
     llama_prefix_path = first_token._materialize_llama_prefix(
         prefix_embeddings,
         int(prefix_tokens),
@@ -207,9 +323,36 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
         "llama_prefix_path": llama_prefix_path,
         "prefix_grid": prefix_grid,
         "prefix_text_pos": int(prefix_text_pos),
+        "prefix_decode_policy": prefix_decode_policy,
         "ctx_len": int(resolved_ctx_len),
         "requested_ctx_len": int(requested_ctx_len),
     }
+
+
+def _apply_prefix_decode_policy_env(inputs: dict[str, Any]) -> dict[str, str | None]:
+    old = {
+        "CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK": os.environ.get("CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK"),
+        "CK_BRIDGE_VISUAL_START": os.environ.get("CK_BRIDGE_VISUAL_START"),
+        "CK_BRIDGE_VISUAL_TOKENS": os.environ.get("CK_BRIDGE_VISUAL_TOKENS"),
+    }
+    policy = str(inputs.get("prefix_decode_policy") or "").strip().lower()
+    if policy == "non_causal_visual_chunk":
+        os.environ["CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK"] = "1"
+        os.environ["CK_BRIDGE_VISUAL_START"] = str(len(inputs.get("tokens_before") or []))
+        os.environ["CK_BRIDGE_VISUAL_TOKENS"] = str(int(inputs.get("prefix_tokens") or 0))
+    else:
+        os.environ.pop("CK_BRIDGE_NONCAUSAL_VISUAL_CHUNK", None)
+        os.environ.pop("CK_BRIDGE_VISUAL_START", None)
+        os.environ.pop("CK_BRIDGE_VISUAL_TOKENS", None)
+    return old
+
+
+def _restore_prefix_decode_policy_env(old: dict[str, str | None]) -> None:
+    for key, value in old.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
 
 
 def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
@@ -225,26 +368,30 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
     row = dict(steps[step_index])
     generated_prefix = [int(t) for t in list(row.get("generated_prefix") or [])]
     replay_tokens_after = [int(t) for t in inputs["tokens_after"]] + generated_prefix
-    ck, dump_report = first_token._capture_dump_compare(
-        inputs["gguf_path"],
-        inputs["runtime"],
-        inputs["prefix_embeddings"],
-        int(inputs["prefix_tokens"]),
-        replay_tokens_after,
-        tokens_before=inputs["tokens_before"],
-        prefix_row_dim=int(inputs["prefix_row_dim"]),
-        ctx_len=int(inputs["ctx_len"]),
-        top_k=int(args.top_k),
-        threads=int(args.threads),
-        dump_root=dump_dir.resolve(),
-        dump_names=str(args.dump_names),
-        dump_pass=str(args.dump_pass),
-        dump_atol=float(args.dump_atol),
-        dump_rtol=float(args.dump_rtol),
-        prefix_grid=inputs["prefix_grid"],
-        prefix_text_pos=int(inputs["prefix_text_pos"]),
-        ck_strict_parity=bool(args.ck_strict_parity),
-    )
+    old_env = _apply_prefix_decode_policy_env(inputs)
+    try:
+        ck, dump_report = first_token._capture_dump_compare(
+            inputs["gguf_path"],
+            inputs["runtime"],
+            inputs["prefix_embeddings"],
+            int(inputs["prefix_tokens"]),
+            replay_tokens_after,
+            tokens_before=inputs["tokens_before"],
+            prefix_row_dim=int(inputs["prefix_row_dim"]),
+            ctx_len=int(inputs["ctx_len"]),
+            top_k=int(args.top_k),
+            threads=int(args.threads),
+            dump_root=dump_dir.resolve(),
+            dump_names=str(args.dump_names),
+            dump_pass=str(args.dump_pass),
+            dump_atol=float(args.dump_atol),
+            dump_rtol=float(args.dump_rtol),
+            prefix_grid=inputs["prefix_grid"],
+            prefix_text_pos=int(inputs["prefix_text_pos"]),
+            ck_strict_parity=bool(args.ck_strict_parity),
+        )
+    finally:
+        _restore_prefix_decode_policy_env(old_env)
     return {
         "step": int(step_index),
         "step_row": row,
@@ -254,6 +401,203 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
         "ck_top1": int((ck.get("comparison") or {}).get("top1_ck", ck.get("ck_top1", -1))),
         "dump": dump_report,
     }
+
+
+
+
+def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    step_index = int(args.hidden_state_step)
+    steps = list(report.get("steps") or [])
+    if step_index < 0 or step_index >= len(steps):
+        raise ValueError(f"--hidden-state-step {step_index} is outside captured steps [0, {max(0, len(steps) - 1)}]")
+    row = dict(steps[step_index])
+    generated_prefix = [int(t) for t in list(row.get("generated_prefix") or [])]
+    if not generated_prefix:
+        raise ValueError("hidden persistent decode capture needs a generated prefix; step 0 has no decode call to capture")
+
+    inputs = _prepare_inputs(args)
+    layer = int(args.hidden_state_layer)
+    names = [item.strip() for item in str(args.hidden_state_names).split(",") if item.strip()]
+    if not names:
+        raise ValueError("--hidden-state-names did not contain any names")
+    root = (args.hidden_state_dir or (args.workdir / f"hidden_state_step_{step_index:04d}")).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+
+    env_keys = ["CK_DEBUG_EXPORT_HIDDEN", "CK_DEBUG_EXPORT_HIDDEN_NAME", "CK_DEBUG_EXPORT_HIDDEN_LAYER"]
+    saved_env = {key: os.environ.get(key) for key in env_keys}
+    results: list[dict[str, Any]] = []
+    for name in names:
+        persistent_dir = root / f"persistent_{name}"
+        full_dir = root / f"full_replay_{name}"
+        if persistent_dir.exists():
+            import shutil
+            shutil.rmtree(persistent_dir)
+        if full_dir.exists():
+            import shutil
+            shutil.rmtree(full_dir)
+        persistent_dir.mkdir(parents=True, exist_ok=True)
+        full_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            _restore_process_env({key: None for key in env_keys})
+            lib, logits_buf, _vocab_size = _init_ck_state(inputs, bool(args.ck_strict_parity))
+            try:
+                last_i = len(generated_prefix) - 1
+                for i, token in enumerate(generated_prefix):
+                    if i == last_i:
+                        _set_process_env("CK_DEBUG_EXPORT_HIDDEN", str(persistent_dir))
+                        _set_process_env("CK_DEBUG_EXPORT_HIDDEN_NAME", name)
+                        if layer >= 0:
+                            _set_process_env("CK_DEBUG_EXPORT_HIDDEN_LAYER", str(layer))
+                    rc = lib.ck_model_decode(ctypes.c_int32(int(token)), logits_buf)
+                    if rc != 0:
+                        raise RuntimeError(f"ck_model_decode failed rc={rc} while capturing persistent hidden state")
+                    if i == last_i:
+                        _restore_process_env({key: None for key in env_keys})
+            finally:
+                if hasattr(lib, "ck_model_free"):
+                    try:
+                        lib.ck_model_free()
+                    except Exception:
+                        pass
+
+            replay_inputs = dict(inputs)
+            replay_inputs["tokens_after"] = [int(t) for t in inputs["tokens_after"]] + generated_prefix
+            _set_process_env("CK_DEBUG_EXPORT_HIDDEN", str(full_dir))
+            _set_process_env("CK_DEBUG_EXPORT_HIDDEN_NAME", _hidden_full_replay_name(name))
+            if layer >= 0:
+                _set_process_env("CK_DEBUG_EXPORT_HIDDEN_LAYER", str(layer))
+            lib2, _logits2, _vocab2 = _init_ck_state(replay_inputs, bool(args.ck_strict_parity))
+            if hasattr(lib2, "ck_model_free"):
+                try:
+                    lib2.ck_model_free()
+                except Exception:
+                    pass
+            _restore_process_env({key: None for key in env_keys})
+
+            if layer < 0:
+                per_layer = _hidden_compare_many(persistent_dir, full_dir)
+                max_diff = max(float(r.get("max_abs_diff", 0.0)) for r in per_layer if r.get("status") == "ok") if per_layer else 0.0
+                first_layer_issue = next((r for r in per_layer if r.get("status") != "ok" or float(r.get("max_abs_diff", 0.0)) > float(args.hidden_state_atol)), None)
+                results.append({
+                    "name": name,
+                    "full_replay_name": _hidden_full_replay_name(name),
+                    "status": "ok" if first_layer_issue is None else "fail",
+                    "max_abs_diff": float(max_diff),
+                    "first_layer_issue": first_layer_issue,
+                    "layers": per_layer,
+                })
+            else:
+                persistent_file = _single_hidden_file(persistent_dir)
+                full_file = _single_hidden_file(full_dir)
+                results.append({
+                    "name": name,
+                    "full_replay_name": _hidden_full_replay_name(name),
+                    **_hidden_compare(persistent_file, full_file),
+                })
+        except Exception as exc:
+            results.append({
+                "name": name,
+                "full_replay_name": _hidden_full_replay_name(name),
+                "status": "error",
+                "error": str(exc),
+                "persistent_dir": str(persistent_dir),
+                "full_replay_dir": str(full_dir),
+            })
+        finally:
+            _restore_process_env(saved_env)
+
+    first_issue = next((r for r in results if r.get("status") != "ok" or float(r.get("max_abs_diff", 0.0)) > float(args.hidden_state_atol)), None)
+    return {
+        "step": int(step_index),
+        "layer": int(layer),
+        "generated_prefix_count": int(len(generated_prefix)),
+        "persistent_ck_next": int(row.get("ck_next", -1)),
+        "persistent_ck_next_text": str(row.get("ck_next_text", "")),
+        "llama_next": int(row.get("llama_next", -1)),
+        "llama_next_text": str(row.get("llama_next_text", "")),
+        "root": str(root),
+        "atol": float(args.hidden_state_atol),
+        "first_issue": first_issue,
+        "results": results,
+    }
+
+def _capture_full_replay_step(report: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    step_index = int(args.full_replay_step)
+    steps = list(report.get("steps") or [])
+    if step_index < 0 or step_index >= len(steps):
+        raise ValueError(f"--full-replay-step {step_index} is outside captured steps [0, {max(0, len(steps) - 1)}]")
+
+    inputs = _prepare_inputs(args)
+    tokenizer: GGUFTokenizer = inputs["tokenizer"]
+    row = dict(steps[step_index])
+    generated_prefix = [int(t) for t in list(row.get("generated_prefix") or [])]
+
+    replay_inputs = dict(inputs)
+    replay_inputs["tokens_after"] = [int(t) for t in inputs["tokens_after"]] + generated_prefix
+
+    llama_args = argparse.Namespace(**vars(args))
+    llama_args.max_new_tokens = max(int(args.max_new_tokens), step_index + 1)
+    llama_seq = _run_llama_greedy_sequence(inputs, llama_args)
+    llama_logits = llama_seq["logits"][step_index]
+
+    lib, logits_buf, vocab_size = _init_ck_state(replay_inputs, bool(args.ck_strict_parity))
+    try:
+        replay_logits = _ck_logits_from_buffer(logits_buf, vocab_size)
+    finally:
+        if hasattr(lib, "ck_model_free"):
+            try:
+                lib.ck_model_free()
+            except Exception:
+                pass
+
+    cmp = first_token.compare_first_token_logits_v7.compare_logits(replay_logits, llama_logits, int(args.top_k))
+    replay_top1 = int(cmp["top1_ck"])
+    llama_generated = list((llama_seq.get("meta") or {}).get("greedy_generated", []))
+    llama_top1 = int(llama_generated[step_index]) if step_index < len(llama_generated) else int(cmp["top1_llama"])
+    return {
+        "step": int(step_index),
+        "generated_prefix": generated_prefix,
+        "replay_tokens_after_count": int(len(replay_inputs["tokens_after"])),
+        "persistent_ck_next": int(row.get("ck_next", -1)),
+        "persistent_ck_next_text": str(row.get("ck_next_text", "")),
+        "llama_next": int(llama_top1),
+        "llama_next_text": tokenizer.decode([int(llama_top1)], skip_special=False),
+        "full_replay_ck_next": int(replay_top1),
+        "full_replay_ck_next_text": tokenizer.decode([int(replay_top1)], skip_special=False),
+        "full_replay_matches_persistent_ck": bool(replay_top1 == int(row.get("ck_next", -1))),
+        "full_replay_matches_llama": bool(replay_top1 == int(llama_top1)),
+        "comparison_vs_llama": {
+            "cosine": float(cmp["cosine"]),
+            "rmse": float(cmp["rmse"]),
+            "mean_abs_diff": float(cmp["mean_abs_diff"]),
+            "max_abs_diff": float(cmp["max_abs_diff"]),
+            "topk_overlap_count": int(cmp["topk_overlap_count"]),
+            "topk_overlap_ratio": float(cmp["topk_overlap_ratio"]),
+            "ck_top1_margin": float(cmp.get("ck_top1_margin", 0.0)),
+            "llama_top1_margin": float(cmp.get("llama_top1_margin", 0.0)),
+        },
+        "full_replay_ck_topk": _decode_topk(replay_logits, tokenizer, int(args.top_k)),
+        "llama_topk": _decode_topk(llama_logits, tokenizer, int(args.top_k)),
+    }
+
+
+def _set_ck_strict_parity(lib: Any, strict_parity: bool) -> None:
+    value = 1 if strict_parity else 0
+    if hasattr(lib, "ck_set_strict_parity"):
+        lib.ck_set_strict_parity.argtypes = [ctypes.c_int]
+        lib.ck_set_strict_parity.restype = None
+        lib.ck_set_strict_parity(value)
+        return
+
+    engine_so = REPO_ROOT / "build" / "libckernel_engine.so"
+    if not engine_so.exists():
+        return
+    engine = ctypes.CDLL(str(engine_so))
+    if hasattr(engine, "ck_set_strict_parity"):
+        engine.ck_set_strict_parity.argtypes = [ctypes.c_int]
+        engine.ck_set_strict_parity.restype = None
+        engine.ck_set_strict_parity(value)
 
 
 def _init_ck_state(inputs: dict[str, Any], strict_parity: bool) -> tuple[Any, Any, int]:
@@ -266,8 +610,7 @@ def _init_ck_state(inputs: dict[str, Any], strict_parity: bool) -> tuple[Any, An
     )
     if rc != 0:
         raise RuntimeError(f"decoder init failed with rc={rc}")
-    if hasattr(lib, "ck_set_strict_parity"):
-        lib.ck_set_strict_parity(1 if strict_parity else 0)
+    _set_ck_strict_parity(lib, strict_parity)
 
     vocab_size = int(lib.ck_model_get_vocab_size())
     if vocab_size <= 0:
@@ -289,38 +632,42 @@ def _init_ck_state(inputs: dict[str, Any], strict_parity: bool) -> tuple[Any, An
     before_arr = (ctypes.c_int32 * len(tokens_before))(*tokens_before) if tokens_before else None
     after_arr = (ctypes.c_int32 * len(tokens_after))(*tokens_after) if tokens_after else None
     grid = inputs["prefix_grid"]
-    if tokens_before and hasattr(lib, "ck_model_forward_segments_grid_ex"):
-        grid_x, grid_y = grid if grid is not None else (0, 0)
-        rc = lib.ck_model_forward_segments_grid_ex(
-            before_arr,
-            len(tokens_before),
-            prefix_ptr,
-            prefix_tokens,
-            prefix_row_dim,
-            int(grid_x),
-            int(grid_y),
-            int(inputs["prefix_text_pos"]),
-            after_arr,
-            len(tokens_after),
-            logits,
-        )
-    elif hasattr(lib, "ck_model_forward_mixed_grid_ex") and grid is not None:
-        grid_x, grid_y = grid
-        rc = lib.ck_model_forward_mixed_grid_ex(
-            prefix_ptr,
-            prefix_tokens,
-            prefix_row_dim,
-            int(grid_x),
-            int(grid_y),
-            int(inputs["prefix_text_pos"]),
-            after_arr,
-            len(tokens_after),
-            logits,
-        )
-    elif hasattr(lib, "ck_model_forward_mixed_ex"):
-        rc = lib.ck_model_forward_mixed_ex(prefix_ptr, prefix_tokens, prefix_row_dim, after_arr, len(tokens_after), logits)
-    else:
-        rc = lib.ck_model_forward_mixed(prefix_ptr, prefix_tokens, after_arr, len(tokens_after), logits)
+    old_env = _apply_prefix_decode_policy_env(inputs)
+    try:
+        if tokens_before and hasattr(lib, "ck_model_forward_segments_grid_ex"):
+            grid_x, grid_y = grid if grid is not None else (0, 0)
+            rc = lib.ck_model_forward_segments_grid_ex(
+                before_arr,
+                len(tokens_before),
+                prefix_ptr,
+                prefix_tokens,
+                prefix_row_dim,
+                int(grid_x),
+                int(grid_y),
+                int(inputs["prefix_text_pos"]),
+                after_arr,
+                len(tokens_after),
+                logits,
+            )
+        elif hasattr(lib, "ck_model_forward_mixed_grid_ex") and grid is not None:
+            grid_x, grid_y = grid
+            rc = lib.ck_model_forward_mixed_grid_ex(
+                prefix_ptr,
+                prefix_tokens,
+                prefix_row_dim,
+                int(grid_x),
+                int(grid_y),
+                int(inputs["prefix_text_pos"]),
+                after_arr,
+                len(tokens_after),
+                logits,
+            )
+        elif hasattr(lib, "ck_model_forward_mixed_ex"):
+            rc = lib.ck_model_forward_mixed_ex(prefix_ptr, prefix_tokens, prefix_row_dim, after_arr, len(tokens_after), logits)
+        else:
+            rc = lib.ck_model_forward_mixed(prefix_ptr, prefix_tokens, after_arr, len(tokens_after), logits)
+    finally:
+        _restore_prefix_decode_policy_env(old_env)
     if rc != 0:
         raise RuntimeError(f"decoder forward_mixed failed rc={rc}")
     return lib, logits, vocab_size
@@ -432,6 +779,7 @@ def main() -> int:
     ap.add_argument("--prefix-grid-y", type=int, default=None)
     ap.add_argument("--prefix-text-pos", type=int, default=None)
     ap.add_argument("--workdir", required=True, type=Path)
+    ap.add_argument("--reuse-bridge-decoder-runtime", action="store_true", help="Reuse decoder_runtime.workdir from bridge_report instead of creating a new decoder copy under --workdir")
     ap.add_argument("--ctx-len", type=int, default=None)
     ap.add_argument("--max-new-tokens", type=int, default=16)
     ap.add_argument("--top-k", type=int, default=16)
@@ -443,6 +791,7 @@ def main() -> int:
     ap.add_argument("--ck-strict-parity", action=argparse.BooleanOptionalAction, default=True)
     ap.add_argument("--json-out", type=Path, default=None)
     ap.add_argument("--dump-step", type=int, default=None, help="Capture CK-vs-llama tensor dumps at this generated step")
+    ap.add_argument("--full-replay-step", type=int, default=None, help="Compare a generated step by full mixed-prefix replay instead of incremental CK decode, without tensor dumps")
     ap.add_argument("--dump-dir", type=Path, default=None, help="Directory for --dump-step tensor dumps")
     ap.add_argument(
         "--dump-names",
@@ -453,6 +802,11 @@ def main() -> int:
     ap.add_argument("--dump-pass", choices=("all", "prefill", "decode"), default="decode")
     ap.add_argument("--dump-atol", type=float, default=1.0e-4)
     ap.add_argument("--dump-rtol", type=float, default=1.0e-3)
+    ap.add_argument("--hidden-state-step", type=int, default=None, help="Compare CK persistent decode hidden tensors against CK full replay at this generated step")
+    ap.add_argument("--hidden-state-layer", type=int, default=0)
+    ap.add_argument("--hidden-state-names", type=str, default="attn_out,out_proj,after_attn,layer_out")
+    ap.add_argument("--hidden-state-dir", type=Path, default=None)
+    ap.add_argument("--hidden-state-atol", type=float, default=1.0e-5)
     ap.add_argument("--summary", action="store_true")
     args = ap.parse_args()
 
@@ -462,6 +816,10 @@ def main() -> int:
     report = run_multimodal_multitoken_parity(args)
     if args.dump_step is not None:
         report["step_dump"] = _capture_step_dump(report, args)
+    if args.full_replay_step is not None:
+        report["full_replay_step"] = _capture_full_replay_step(report, args)
+    if args.hidden_state_step is not None:
+        report["hidden_state_step"] = _capture_hidden_state_step(report, args)
     if args.json_out is not None:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(json.dumps(report, indent=2), encoding="utf-8")
@@ -496,6 +854,21 @@ def main() -> int:
                 )
             else:
                 print(f"dump={dump.get('status', 'ok')} step={report['step_dump']['step']} summary={summary}")
+        if report.get("full_replay_step"):
+            replay = report["full_replay_step"]
+            cmp = replay.get("comparison_vs_llama") or {}
+            print(
+                "full_replay "
+                f"step={replay['step']} "
+                f"persistent_ck={replay['persistent_ck_next']}({replay['persistent_ck_next_text']!r}) "
+                f"full_replay_ck={replay['full_replay_ck_next']}({replay['full_replay_ck_next_text']!r}) "
+                f"llama={replay['llama_next']}({replay['llama_next_text']!r}) "
+                f"matches_persistent={replay['full_replay_matches_persistent_ck']} "
+                f"matches_llama={replay['full_replay_matches_llama']} "
+                f"cosine={float(cmp.get('cosine', 0.0)):.6f} "
+                f"rmse={float(cmp.get('rmse', 0.0)):.6f} "
+                f"topk_overlap={int(cmp.get('topk_overlap_count', 0))}/{args.top_k}"
+            )
     else:
         print(json.dumps(report, indent=2))
     return 0 if report.get("pass") else 3

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -360,7 +360,13 @@ def _inject_runtime_config_defaults(config: dict, arch: str) -> dict:
             }
         )
     elif arch_lc == "qwen3_vl_vision":
-        _merge_activation_defaults({"mlp_down": "fp32", "out_proj": "fp32"})
+        config.setdefault("prefer_q8_0_contract", True)
+        _merge_activation_defaults({
+            "mlp_down": "fp32",
+            "out_proj": "q8_0",
+            "branch_fc1": "fp32",
+            "branch_fc2": "fp32",
+        })
     elif arch_lc == "gemma3":
         config.setdefault("prefer_q8_0_contract", True)
         config.setdefault("prefer_fp32_logits", True)
@@ -3959,6 +3965,12 @@ def main() -> None:
             print(f"Warning: rotary_dim {rotary_dim} is odd, decrementing to make even")
             rotary_dim -= 1
 
+        # GGUF M-RoPE dimension sections define the time/height/width/extra axis
+        # selection pattern. They do not define the rotary width. llama.cpp passes
+        # n_rot == head_dim for Qwen3-VL/Qwen3.5 M-RoPE, so keep the full resolved
+        # rotary width here instead of sum(mrope_sections).
+        mrope_n_dims = int(rotary_dim or head_dim)
+
         # Infer correct dimensions from the first actual attention tensors if metadata
         # is missing or inconsistent. Hybrid models such as Nemotron can start with
         # Mamba layers, so blk.0 is not necessarily an attention block.
@@ -4277,7 +4289,7 @@ def main() -> None:
                 qwen35_config["rope_layout"] = rope_layout
             if mrope_sections:
                 qwen35_config["mrope_sections"] = [int(v) for v in mrope_sections]
-                qwen35_config["mrope_n_dims"] = int(sum(int(v) for v in mrope_sections))
+                qwen35_config["mrope_n_dims"] = int(mrope_n_dims)
             if full_attention_interval is not None:
                 qwen35_config["full_attention_interval"] = int(full_attention_interval)
             if attn_q_gate_proj_dim is not None:
@@ -5643,7 +5655,7 @@ def main() -> None:
                         config["num_deepstack_layers"] = num_deepstack_layers
                     if mrope_sections:
                         config["mrope_sections"] = [int(v) for v in mrope_sections]
-                        config["mrope_n_dims"] = int(sum(int(v) for v in mrope_sections))
+                        config["mrope_n_dims"] = int(mrope_n_dims)
                 if arch == "gemma4":
                     config.update({
                         "layer_kinds": attention_plan["layer_kinds"],
@@ -5883,7 +5895,7 @@ def main() -> None:
                 cfg["num_deepstack_layers"] = num_deepstack_layers
             if mrope_sections:
                 cfg["mrope_sections"] = [int(v) for v in mrope_sections]
-                cfg["mrope_n_dims"] = int(sum(int(v) for v in mrope_sections))
+                cfg["mrope_n_dims"] = int(mrope_n_dims)
         if sliding_window and sliding_window > 0:
             cfg["sliding_window"] = int(sliding_window)
         if rope_layout:

--- a/version/v8/scripts/decoder_first_token_parity_v8.py
+++ b/version/v8/scripts/decoder_first_token_parity_v8.py
@@ -811,9 +811,25 @@ def _capture_ck_dump(
     dump_dir.mkdir(parents=True, exist_ok=True)
 
     old_dump = os.environ.get("CK_PARITY_DIR")
+    old_cwd = Path.cwd()
+    fallback_dir = dump_dir / "ck_parity_dumps"
+    fallback_dir.mkdir(parents=True, exist_ok=True)
     os.environ["CK_PARITY_DIR"] = str(dump_dir)
     try:
-        return bridge_runner_v8._run_decoder(
+        # Some parity runs load generated C through ctypes before Python's
+        # os.environ update is visible to libc getenv(). Force the C process
+        # environment too, so ck_dump_init(NULL) always sees the dump dir.
+        try:
+            import ctypes as _ctypes
+            _libc = _ctypes.CDLL(None)
+            _libc.setenv.argtypes = [_ctypes.c_char_p, _ctypes.c_char_p, _ctypes.c_int]
+            _libc.setenv(b"CK_PARITY_DIR", str(dump_dir).encode(), 1)
+        except Exception:
+            pass
+        # If the generated C still falls back to ck_parity_dumps/dump.bin,
+        # run from dump_dir and harvest that fallback file after execution.
+        os.chdir(dump_dir)
+        result = bridge_runner_v8._run_decoder(
             runtime,
             prefix_embeddings,
             prefix_tokens,
@@ -824,11 +840,31 @@ def _capture_ck_dump(
             prefix_text_pos=prefix_text_pos,
             strict_parity=ck_strict_parity,
         )
+        target = dump_dir / "dump.bin"
+        fallback = fallback_dir / "dump.bin"
+        if not target.exists() and fallback.exists():
+            shutil.move(str(fallback), str(target))
+        return result
     finally:
+        os.chdir(old_cwd)
         if old_dump is None:
             os.environ.pop("CK_PARITY_DIR", None)
+            try:
+                import ctypes as _ctypes
+                _libc = _ctypes.CDLL(None)
+                _libc.unsetenv.argtypes = [_ctypes.c_char_p]
+                _libc.unsetenv(b"CK_PARITY_DIR")
+            except Exception:
+                pass
         else:
             os.environ["CK_PARITY_DIR"] = old_dump
+            try:
+                import ctypes as _ctypes
+                _libc = _ctypes.CDLL(None)
+                _libc.setenv.argtypes = [_ctypes.c_char_p, _ctypes.c_char_p, _ctypes.c_int]
+                _libc.setenv(b"CK_PARITY_DIR", old_dump.encode(), 1)
+            except Exception:
+                pass
 
 
 def _capture_dump_compare(
@@ -890,18 +926,49 @@ def _capture_dump_compare(
         dump_dir=llama_dump_dir,
         dump_names=dump_names,
     )
-    ck = _capture_ck_dump(
-        runtime,
-        prefix_embeddings,
-        prefix_tokens,
-        token_ids,
-        ck_dump_dir,
-        int(prefix_row_dim),
-        tokens_before=tokens_before,
-        prefix_grid=prefix_grid,
-        prefix_text_pos=prefix_text_pos,
-        ck_strict_parity=ck_strict_parity,
-    )
+    old_ck_op_filter = os.environ.get("CK_PARITY_OP_FILTER")
+    if dump_names:
+        os.environ["CK_PARITY_OP_FILTER"] = str(dump_names)
+    try:
+        try:
+            import ctypes as _ctypes
+            _libc = _ctypes.CDLL(None)
+            _libc.setenv.argtypes = [_ctypes.c_char_p, _ctypes.c_char_p, _ctypes.c_int]
+            if dump_names:
+                _libc.setenv(b"CK_PARITY_OP_FILTER", str(dump_names).encode(), 1)
+        except Exception:
+            pass
+        ck = _capture_ck_dump(
+            runtime,
+            prefix_embeddings,
+            prefix_tokens,
+            token_ids,
+            ck_dump_dir,
+            int(prefix_row_dim),
+            tokens_before=tokens_before,
+            prefix_grid=prefix_grid,
+            prefix_text_pos=prefix_text_pos,
+            ck_strict_parity=ck_strict_parity,
+        )
+    finally:
+        if old_ck_op_filter is None:
+            os.environ.pop("CK_PARITY_OP_FILTER", None)
+            try:
+                import ctypes as _ctypes
+                _libc = _ctypes.CDLL(None)
+                _libc.unsetenv.argtypes = [_ctypes.c_char_p]
+                _libc.unsetenv(b"CK_PARITY_OP_FILTER")
+            except Exception:
+                pass
+        else:
+            os.environ["CK_PARITY_OP_FILTER"] = old_ck_op_filter
+            try:
+                import ctypes as _ctypes
+                _libc = _ctypes.CDLL(None)
+                _libc.setenv.argtypes = [_ctypes.c_char_p, _ctypes.c_char_p, _ctypes.c_int]
+                _libc.setenv(b"CK_PARITY_OP_FILTER", old_ck_op_filter.encode(), 1)
+            except Exception:
+                pass
 
     ck_dump_path = ck_dump_dir / "dump.bin"
     ck_dumps = parity_test_v7.read_dump_file(ck_dump_path)

--- a/version/v8/scripts/parity_test_v8.py
+++ b/version/v8/scripts/parity_test_v8.py
@@ -216,7 +216,6 @@ def _normalize_layer_and_op(layer_id: int, op_name: str) -> Tuple[int, str]:
         "vcur": "v_proj",
         "qcur_normed": "qcur_normed",
         "kcur_normed": "kcur_normed",
-        "attn_out": "attn_output",
         "sa_out": "attn_output",
         "ffn_gate": "gate_proj",
         "ffn_up": "up_proj",

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -151,6 +151,7 @@ def _clean_activation_preference_baseline(config: dict[str, Any]) -> dict[str, A
     updated = dict(config)
     model = str(updated.get("model", updated.get("arch", "")) or "").strip().lower()
     if model == "qwen3_vl_vision":
+        updated.setdefault("prefer_q8_0_contract", True)
         updated["activation_preference_by_op"] = {
             "mlp_down": "fp32",
             "out_proj": "q8_0",

--- a/version/v8/src/ck_parity_dump.h
+++ b/version/v8/src/ck_parity_dump.h
@@ -50,6 +50,48 @@ _Static_assert(sizeof(CKDumpFileHeader) == 128, "CKDumpFileHeader must be 128 by
 static FILE *g_ck_dump_file = NULL;
 static int g_ck_dump_token = 0;
 
+static inline int ck_dump_filter_token_matches(const char *filter, const char *candidate) {
+    if (!filter || !filter[0] || !candidate || !candidate[0]) return 0;
+    const char *p = filter;
+    const size_t clen = strlen(candidate);
+    while (*p) {
+        while (*p == ',' || *p == ';' || *p == ' ' || *p == '\t' || *p == '\n') p++;
+        const char *start = p;
+        while (*p && *p != ',' && *p != ';' && *p != ' ' && *p != '\t' && *p != '\n') p++;
+        const size_t len = (size_t)(p - start);
+        if (len == clen && strncmp(start, candidate, clen) == 0) return 1;
+    }
+    return 0;
+}
+
+static inline int ck_dump_layer_allowed(int layer_id) {
+    const char *filter = getenv("CK_PARITY_LAYER_FILTER");
+    if (!filter || !filter[0]) return 1;
+    if (ck_dump_filter_token_matches(filter, "all") || ck_dump_filter_token_matches(filter, "*")) return 1;
+
+    char layer_buf[32];
+    snprintf(layer_buf, sizeof(layer_buf), "%d", layer_id);
+    return ck_dump_filter_token_matches(filter, layer_buf);
+}
+
+static inline int ck_dump_op_allowed(int layer_id, const char *op_name) {
+    const char *filter = getenv("CK_PARITY_OP_FILTER");
+    if (!filter || !filter[0]) return 1;
+    if (ck_dump_filter_token_matches(filter, "all") || ck_dump_filter_token_matches(filter, "*")) return 1;
+    if (ck_dump_filter_token_matches(filter, op_name)) return 1;
+
+    char layered_name[96];
+    snprintf(layered_name, sizeof(layered_name), "%s-%d", op_name, layer_id);
+    if (ck_dump_filter_token_matches(filter, layered_name)) return 1;
+    snprintf(layered_name, sizeof(layered_name), "%s:%d", op_name, layer_id);
+    if (ck_dump_filter_token_matches(filter, layered_name)) return 1;
+    return 0;
+}
+
+static inline int ck_dump_should_emit(int layer_id, const char *op_name) {
+    return ck_dump_layer_allowed(layer_id) && ck_dump_op_allowed(layer_id, op_name);
+}
+
 /**
  * Initialize dumping. Call before any inference.
  * @param dump_dir Directory to write dump.bin (default: uses CK_PARITY_DIR env, or "ck_parity_dumps")
@@ -96,6 +138,7 @@ static inline void ck_dump_tensor(
     int elem_count
 ) {
     if (!g_ck_dump_file || !data) return;
+    if (!ck_dump_should_emit(layer_id, op_name)) return;
 
     CKDumpFileHeader header = {0};
     memcpy(header.magic, CKDUMP_MAGIC, 8);
@@ -125,6 +168,7 @@ static inline void ck_dump_tensor_2d(
     int dim1
 ) {
     if (!g_ck_dump_file || !data) return;
+    if (!ck_dump_should_emit(layer_id, op_name)) return;
 
     CKDumpFileHeader header = {0};
     memcpy(header.magic, CKDUMP_MAGIC, 8);
@@ -165,6 +209,7 @@ static inline void ck_dump_tensor_head_major_token_major(
     int head_dim
 ) {
     if (!g_ck_dump_file || !data || num_heads <= 0 || num_tokens <= 0 || head_dim <= 0) return;
+    if (!ck_dump_should_emit(layer_id, op_name)) return;
 
     const size_t elem_count = (size_t) num_heads * (size_t) num_tokens * (size_t) head_dim;
     float *tmp = (float *) malloc(elem_count * sizeof(float));

--- a/version/v8/tools/mtmd_clip_shim.cpp
+++ b/version/v8/tools/mtmd_clip_shim.cpp
@@ -366,18 +366,7 @@ size_t ck_mtmd_clip_embd_nbytes_by_img(void *handle_ptr, int img_w, int img_h) {
     if (!ctx || img_w <= 0 || img_h <= 0) {
         return 0;
     }
-    clip_image_f32 *image = clip_image_f32_init();
-    if (!image) {
-        return 0;
-    }
-    image->set_size({img_w, img_h}, false, false);
-    const int n_tokens = clip_n_output_tokens(ctx, image);
-    const int n_embd = clip_n_mmproj_embd(ctx);
-    clip_image_f32_free(image);
-    if (n_tokens <= 0 || n_embd <= 0) {
-        return 0;
-    }
-    return (size_t)n_tokens * (size_t)n_embd * sizeof(float);
+    return clip_embd_nbytes_by_img(ctx, img_w, img_h);
 }
 
 int ck_mtmd_clip_encode_float_image(void *handle_ptr, int n_threads, float *img, int h, int w, float *vec) {
@@ -385,26 +374,7 @@ int ck_mtmd_clip_encode_float_image(void *handle_ptr, int n_threads, float *img,
     if (!ctx || !img || !vec || h <= 0 || w <= 0) {
         return 0;
     }
-    clip_image_f32 *image = clip_image_f32_init();
-    if (!image) {
-        return 0;
-    }
-    image->set_size({w, h}, false, false);
-    image->cpy_buf(std::vector<float>(img, img + (size_t)h * (size_t)w * 3));
-    const int n_tokens = clip_n_output_tokens(ctx, image);
-    const int n_embd = clip_n_mmproj_embd(ctx);
-    if (n_tokens <= 0 || n_embd <= 0) {
-        clip_image_f32_free(image);
-        return 0;
-    }
-    std::vector<float> out((size_t)n_tokens * (size_t)n_embd);
-    const bool ok = clip_image_encode(ctx, n_threads, image, out);
-    clip_image_f32_free(image);
-    if (!ok || out.empty()) {
-        return 0;
-    }
-    std::memcpy(vec, out.data(), out.size() * sizeof(float));
-    return 1;
+    return clip_encode_float_image(ctx, n_threads, img, h, w, vec) ? 1 : 0;
 }
 
 }


### PR DESCRIPTION
fix(v8/qwen3vl): align mrope width and gate fused prefill path

Why: Qwen3-VL AVX2 OCR decode diverged from llama.cpp on the canonical image after a correct-looking visual bridge. The failure was caused by an M-RoPE width mismatch first, then by Qwen3-VL taking a fused Q4 gate-up/SwiGLU prefill path whose live persistent decode parity was worse than the unfused path.

Validation: py_compile for modified v8 scripts, `make -B build/libckernel_engine.so`, canonical Qwen3-VL OCR persistent parity `status=pass steps=64`, and pre-commit `v8-regression-fast`.

Qwen3-VL M-RoPE was using `sum(mrope_sections)` as the rotary width.
That gives 64 for the 24/20/20/0 section layout, but llama.cpp passes
`n_rot == head_dim == 128`. The sections select the M-RoPE axis pattern;
they are not the rotary width.

This changes GGUF conversion and IR fallback defaults so Qwen3-VL emits
and consumes the full rotary width.

The AVX2 parity run then moved from a hard early failure to a late
numeric drift:

| Case | First mismatch | CK token | llama token | cosine | top-k overlap |
| --- | ---: | --- | --- | ---: | ---: |
| before M-RoPE fix | 4 | `262` (`'   '`) | `220` (`' '`) | `0.797069` | `8/16` |
| after M-RoPE fix | 45 | `5500` (`'_number'`) | `82427` (`'_instructions'`) | `0.998952` | `15/16` |

Layer-0 persistent-vs-full-replay attribution after the M-RoPE fix:

| Boundary | Max abs | RMSE | Cosine |
| --- | ---: | ---: | ---: |
| `attn_out` | `5.60e-05` | `3.88e-06` | `0.99999988` |
| `out_proj` | `2.61e-04` | `7.25e-05` | `0.99999905` |
| `after_attn` | `2.61e-04` | `7.25e-05` | `0.99999946` |
| `ffn_norm` | `6.83e-04` | `1.51e-04` | `0.99999785` |
| `layer_out` | `1.18e-02` | `1.12e-03` | `0.99997771` |

That places the remaining split inside layer-0 MLP. A diagnostic run with
`CK_DISABLE_Q4K_GATEUP_SWIGLU_X16=1` made the actual persistent OCR decode
match llama through 64 tokens. Therefore Qwen3-VL now defaults the fused
Q4 gate-up/SwiGLU x16 prefill path off until the fused kernel is fixed.
Other models retain the previous default, and the path can still be
explicitly enabled with `CK_ENABLE_Q4K_GATEUP_SWIGLU_X16=1`.

Validation:

```
.venv/bin/python -m py_compile \
  version/v8/scripts/codegen_prefill_v8.py \
  version/v8/scripts/codegen_core_v8.py \
  version/v8/scripts/build_ir_v8.py \
  version/v8/scripts/convert_gguf_to_bump_v8.py \
  version/v8/scripts/compare_multimodal_multitoken_logits_v8.py \
  version/v8/scripts/decoder_first_token_parity_v8.py
```

Canonical Qwen3-VL OCR parity:

```
CK_NUM_THREADS=20 OMP_NUM_THREADS=1 \
.venv/bin/python version/v8/scripts/compare_multimodal_multitoken_logits_v8.py \
  --bridge-report build/qwen3vl_avx2_mrope128_bridge_20260709/bridge/bridge_report.json \
  --prefix-f32 build/qwen3vl_avx2_mrope128_bridge_20260709/prefix.f32 \
  --prefix-grid-x 36 \
  --prefix-grid-y 28 \
  --prefix-text-pos 41 \
  --workdir build/qwen3vl_avx2_mrope128_default_safe_20260709 \
  --ctx-len 4096 \
  --threads 20 \
  --top-k 16 \
  --max-new-tokens 64 \
  --append-on-divergence stop \
  --json-out build/qwen3vl_avx2_mrope128_default_safe_20260709/persistent64.json \
  --summary
```

Result:

```
status=pass steps=64
first_mismatch=None
```

Research log:

`logs/2026-07-09-qwen3vl-avx2-mrope-prefill-parity/README.md`
