### PR TITLE
fix(v8/vision): guard Qwen3-VL position parity

### DIFF
--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1683,6 +1683,9 @@
       </ul>
     </li>
     <li><strong>Kernel Unit Tests</strong>: Individual kernel parity with PyTorch</li>
+    <li><strong>v8 Vision Kernel Parity</strong>: Vision kernel parity for patch extraction/reconstruction, tiled position embeddings,
+      Qwen3-VL resized position interpolation order, spatial merge/reorder, feature concat/slice, and vision M-RoPE
+      (<code>make test-v8-vision-kernels</code>)</li>
     <li><strong>Llama Pairwise RoPE Contract</strong>: explicit regression for consecutive-pair RoPE layout selection plus kernel-level pairwise forward coverage and timing
       (<code>version/v7/scripts/parity/test_check_decode_attention_contract.py</code>, <code>unittest/test_rope.py</code>)</li>
     <li><strong>Sliding-Window Contract</strong>: Explicit sliding attention prefill/decode contract test
@@ -1723,7 +1726,7 @@
     <div>
       <strong>Run locally:</strong> <code>make test</code> (kernel-focused), <code>make visualizer</code> (fast path), <code>make visualizer-full</code> (includes tiny train-runtime ASan checks), <code>make nightly</code> (full matrix).
       <br>
-      <span style="color: var(--text-muted);">Nightly coverage now includes v7 kernel-map contracts, v7 backprop kernel parity, published training family regression, visualizer runbook regression checks, and published <code>regression-fast</code> family summaries.</span>
+      <span style="color: var(--text-muted);">Nightly coverage now includes v7 kernel-map contracts, v7 backprop kernel parity, v8 vision kernel parity, published training family regression, visualizer runbook regression checks, and published <code>regression-fast</code> family summaries.</span>
     </div>
   </div>
 

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -118,6 +118,7 @@ def parse_sub_tests(stdout: str) -> list:
 
     # Extract accuracy results from standard format
     accuracy_results = {}
+    perf_results = {}
     for match in accuracy_pattern.finditer(stdout):
         name = match.group(1).strip()
         max_diff = float(match.group(2))
@@ -157,8 +158,52 @@ def parse_sub_tests(stdout: str) -> list:
                 'status': status
             }
 
+    # Extract unittest/test_vision.py style blocks:
+    #   --- Testing position_embeddings_add_tiled_2d (...) ---
+    #   PyTorch time: 0.601 ms
+    #   C Kernel time: 0.869 ms
+    #   Max diff: 0.00e+00
+    vision_block_pattern = re.compile(
+        r'^--- Testing\s+(.+?)\s+---\s*(.*?)(?=^--- Testing|\Z)',
+        re.MULTILINE | re.DOTALL,
+    )
+    for block_match in vision_block_pattern.finditer(stdout):
+        block_name = block_match.group(1).strip()
+        block = block_match.group(2)
+        max_diff_matches = list(
+            re.finditer(r'^\s*(?:(Q|K)\s+)?[Mm]ax diff:\s*(\d+\.?\d*e?[+-]?\d*)', block, re.MULTILINE)
+        )
+        if not max_diff_matches:
+            continue
+
+        pytorch_time_ms = None
+        c_time_ms = None
+        pytorch_time_match = re.search(r'PyTorch time:\s*(\d+\.?\d*)\s*ms', block)
+        c_time_match = re.search(r'C Kernel time:\s*(\d+\.?\d*)\s*ms', block)
+        if pytorch_time_match:
+            pytorch_time_ms = float(pytorch_time_match.group(1))
+        if c_time_match:
+            c_time_ms = float(c_time_match.group(1))
+
+        for diff_match in max_diff_matches:
+            suffix = diff_match.group(1)
+            name = f"{block_name} {suffix}" if suffix else block_name
+            if name in accuracy_results:
+                continue
+            max_diff = float(diff_match.group(2))
+            accuracy_results[name] = {
+                'max_diff': max_diff,
+                'tolerance': None,
+                'status': 'pass',
+            }
+            if c_time_ms is not None:
+                perf_results[name] = {
+                    'pytorch_time_us': pytorch_time_ms * 1000.0 if pytorch_time_ms is not None else None,
+                    'c_time_us': c_time_ms * 1000.0,
+                    'speedup': (pytorch_time_ms / c_time_ms) if pytorch_time_ms is not None and c_time_ms > 0 else None,
+                }
+
     # Extract performance results
-    perf_results = {}
     for match in perf_pattern.finditer(stdout):
         name = match.group(1).strip()
         pytorch_time = float(match.group(2))
@@ -446,6 +491,12 @@ MAKE_TARGETS = {
         "category": "inference",
         "target": "v8-visualizer-vision-artifacts",
         "timeout_sec": 120,
+    },
+    "v8_vision_kernel_parity": {
+        "name": "v8 Vision Kernel Parity",
+        "category": "kernels",
+        "target": "test-v8-vision-kernels",
+        "timeout_sec": 300,
     },
     "v8_qwen3vl_vision_smoke": {
         "name": "v8 Qwen3-VL Vision Smoke",

--- a/src/kernels/vision_kernels.c
+++ b/src/kernels/vision_kernels.c
@@ -17,6 +17,17 @@
 #include <stdint.h>
 #include <math.h>
 
+#if defined(__clang__)
+#define CK_VISION_NOINLINE __attribute__((noinline))
+#define CK_VISION_OPTNONE __attribute__((optnone))
+#elif defined(__GNUC__)
+#define CK_VISION_NOINLINE __attribute__((noinline))
+#define CK_VISION_OPTNONE __attribute__((optimize("O0")))
+#else
+#define CK_VISION_NOINLINE
+#define CK_VISION_OPTNONE
+#endif
+
 static int tile_order_index_2d(int linear_idx,
                                int grid_h,
                                int grid_w,
@@ -38,6 +49,12 @@ static int tile_order_index_2d(int linear_idx,
     const int x = tile_x * merge_size + dx;
 
     return y * grid_w + x;
+}
+
+static float ck_force_f32(float x)
+{
+    volatile float y = x;
+    return y;
 }
 
 
@@ -187,13 +204,13 @@ void position_embeddings_add_gemma4v_xy(float *x,
     }
 }
 
-void position_embeddings_add_tiled_2d(float *x,
-                                      const float *position_embd,
-                                      int grid_h,
-                                      int grid_w,
-                                      int embed_dim,
-                                      int merge_size,
-                                      int source_grid_size)
+CK_VISION_NOINLINE CK_VISION_OPTNONE void position_embeddings_add_tiled_2d(float *x,
+                                                                            const float *position_embd,
+                                                                            int grid_h,
+                                                                            int grid_w,
+                                                                            int embed_dim,
+                                                                            int merge_size,
+                                                                            int source_grid_size)
 {
     if (x == NULL || position_embd == NULL || grid_h <= 0 || grid_w <= 0 || embed_dim <= 0 || merge_size <= 0) {
         return;
@@ -207,13 +224,13 @@ void position_embeddings_add_tiled_2d(float *x,
     const int source_tokens = source_grid_size * source_grid_size;
     const int needs_resize = source_grid_size != grid_h || source_grid_size != grid_w;
 
-    const float sf_x = needs_resize ? (float) grid_w / (float) source_grid_size : 1.0f;
-    const float sf_y = needs_resize ? (float) grid_h / (float) source_grid_size : 1.0f;
+    const float sf_x = needs_resize ? ck_force_f32((float) grid_w / (float) source_grid_size) : 1.0f;
+    const float sf_y = needs_resize ? ck_force_f32((float) grid_h / (float) source_grid_size) : 1.0f;
     const float pixel_offset = 0.5f;
-    const float support_x = needs_resize ? fmaxf(1.0f, 1.0f / sf_x) : 1.0f;
-    const float support_y = needs_resize ? fmaxf(1.0f, 1.0f / sf_y) : 1.0f;
-    const float invscale_x = needs_resize ? 1.0f / support_x : 1.0f;
-    const float invscale_y = needs_resize ? 1.0f / support_y : 1.0f;
+    const float support_x = needs_resize ? ck_force_f32(fmaxf(1.0f, ck_force_f32(1.0f / sf_x))) : 1.0f;
+    const float support_y = needs_resize ? ck_force_f32(fmaxf(1.0f, ck_force_f32(1.0f / sf_y))) : 1.0f;
+    const float invscale_x = needs_resize ? ck_force_f32(1.0f / support_x) : 1.0f;
+    const float invscale_y = needs_resize ? ck_force_f32(1.0f / support_y) : 1.0f;
 
     for (int tok = 0; tok < num_tokens; ++tok) {
         const int src_tok = tile_order_index_2d(tok, grid_h, grid_w, merge_size);
@@ -233,12 +250,12 @@ void position_embeddings_add_tiled_2d(float *x,
             continue;
         }
 
-        const float x_src = ((float) dst_x + pixel_offset) / sf_x;
-        const float y_src = ((float) dst_y + pixel_offset) / sf_y;
-        int x_min = (int) (x_src - support_x + pixel_offset);
-        int x_max = (int) (x_src + support_x + pixel_offset);
-        int y_min = (int) (y_src - support_y + pixel_offset);
-        int y_max = (int) (y_src + support_y + pixel_offset);
+        const float x_src = ck_force_f32(ck_force_f32((float) dst_x + pixel_offset) / sf_x);
+        const float y_src = ck_force_f32(ck_force_f32((float) dst_y + pixel_offset) / sf_y);
+        int x_min = (int) ck_force_f32(ck_force_f32(x_src - support_x) + pixel_offset);
+        int x_max = (int) ck_force_f32(ck_force_f32(x_src + support_x) + pixel_offset);
+        int y_min = (int) ck_force_f32(ck_force_f32(y_src - support_y) + pixel_offset);
+        int y_max = (int) ck_force_f32(ck_force_f32(y_src + support_y) + pixel_offset);
         if (x_min < 0) x_min = 0;
         if (y_min < 0) y_min = 0;
         if (x_max > source_grid_size) x_max = source_grid_size;
@@ -248,23 +265,25 @@ void position_embeddings_add_tiled_2d(float *x,
             float val = 0.0f;
             float total_weight = 0.0f;
             for (int sy = y_min; sy < y_max; ++sy) {
-                const float wy = fmaxf(1.0f - fabsf(((float) sy - y_src + pixel_offset) * invscale_y), 0.0f);
+                const float wy_arg = ck_force_f32(ck_force_f32(ck_force_f32((float) sy - y_src) + pixel_offset) * invscale_y);
+                const float wy = ck_force_f32(fmaxf(ck_force_f32(1.0f - fabsf(wy_arg)), 0.0f));
                 if (wy <= 0.0f) {
                     continue;
                 }
                 for (int sx = x_min; sx < x_max; ++sx) {
-                    const float wx = fmaxf(1.0f - fabsf(((float) sx - x_src + pixel_offset) * invscale_x), 0.0f);
-                    const float weight = wx * wy;
+                    const float wx_arg = ck_force_f32(ck_force_f32(ck_force_f32((float) sx - x_src) + pixel_offset) * invscale_x);
+                    const float wx = ck_force_f32(fmaxf(ck_force_f32(1.0f - fabsf(wx_arg)), 0.0f));
+                    const float weight = ck_force_f32(wx * wy);
                     if (weight <= 0.0f) {
                         continue;
                     }
                     const float sample = position_embd[((size_t) sy * (size_t) source_grid_size + (size_t) sx) * (size_t) embed_dim + (size_t) d];
-                    val += sample * weight;
-                    total_weight += weight;
+                    val = ck_force_f32(fmaf(sample, weight, val));
+                    total_weight = ck_force_f32(total_weight + weight);
                 }
             }
             if (total_weight > 0.0f) {
-                dst[d] += val / total_weight;
+                dst[d] = ck_force_f32(dst[d] + ck_force_f32(val / total_weight));
             }
         }
     }

--- a/unittest/test_vision.py
+++ b/unittest/test_vision.py
@@ -4,6 +4,7 @@ import argparse
 import time
 import math
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 
@@ -46,6 +47,7 @@ lib.position_embeddings_add.restype = None
 lib.position_embeddings_add_tiled_2d.argtypes = [
     ctypes.POINTER(ctypes.c_float),
     ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
     ctypes.c_int,
     ctypes.c_int,
     ctypes.c_int,
@@ -209,9 +211,12 @@ def run_c_position_embeddings_add_tiled_2d(
     grid_h: int,
     grid_w: int,
     merge_size: int,
+    source_grid_size: int | None = None,
 ) -> torch.Tensor:
     out = x.clone()
     _, embed_dim = out.shape
+    if source_grid_size is None:
+        source_grid_size = grid_h
     lib.position_embeddings_add_tiled_2d(
         tensor_to_ptr(out),
         tensor_to_ptr(pos),
@@ -219,6 +224,7 @@ def run_c_position_embeddings_add_tiled_2d(
         grid_w,
         embed_dim,
         merge_size,
+        source_grid_size,
     )
     return out
 
@@ -418,9 +424,75 @@ def _ref_position_embeddings_add_tiled_2d(
     grid_h: int,
     grid_w: int,
     merge_size: int,
+    source_grid_size: int | None = None,
 ) -> torch.Tensor:
-    order = _tile_order_indices(grid_h, grid_w, merge_size)
-    return x + pos.index_select(0, order)
+    if source_grid_size is None:
+        source_grid_size = grid_h
+    if source_grid_size == grid_h and source_grid_size == grid_w:
+        order = _tile_order_indices(grid_h, grid_w, merge_size)
+        return x + pos.index_select(0, order)
+
+    def f32(v) -> float:
+        return np.float32(v).item()
+
+    def fmaf32(a: float, b: float, c: float) -> float:
+        if hasattr(math, "fma"):
+            return f32(math.fma(float(a), float(b), float(c)))
+        return f32(float(a) * float(b) + float(c))
+
+    x_np = x.detach().cpu().numpy().astype(np.float32, copy=True)
+    pos_np = pos.detach().cpu().numpy().astype(np.float32, copy=False)
+    tokens, embed_dim = x_np.shape
+    if tokens != grid_h * grid_w:
+        raise ValueError(f"expected {grid_h * grid_w} tokens, got {tokens}")
+    if pos_np.shape[0] != source_grid_size * source_grid_size:
+        raise ValueError(
+            f"expected {source_grid_size * source_grid_size} source positions, got {pos_np.shape[0]}"
+        )
+
+    sf_x = f32(float(grid_w) / float(source_grid_size))
+    sf_y = f32(float(grid_h) / float(source_grid_size))
+    pixel_offset = np.float32(0.5).item()
+    support_x = f32(max(1.0, f32(1.0 / sf_x)))
+    support_y = f32(max(1.0, f32(1.0 / sf_y)))
+    invscale_x = f32(1.0 / support_x)
+    invscale_y = f32(1.0 / support_y)
+
+    order = _tile_order_indices(grid_h, grid_w, merge_size).tolist()
+    for tok, src_tok in enumerate(order):
+        dst_y = src_tok // grid_w
+        dst_x = src_tok - dst_y * grid_w
+        x_src = f32(f32(float(dst_x) + pixel_offset) / sf_x)
+        y_src = f32(f32(float(dst_y) + pixel_offset) / sf_y)
+        x_min = int(f32(f32(x_src - support_x) + pixel_offset))
+        x_max = int(f32(f32(x_src + support_x) + pixel_offset))
+        y_min = int(f32(f32(y_src - support_y) + pixel_offset))
+        y_max = int(f32(f32(y_src + support_y) + pixel_offset))
+        x_min = max(0, x_min)
+        y_min = max(0, y_min)
+        x_max = min(source_grid_size, x_max)
+        y_max = min(source_grid_size, y_max)
+
+        for d in range(embed_dim):
+            val = f32(0.0)
+            total_weight = f32(0.0)
+            for sy in range(y_min, y_max):
+                wy_arg = f32(f32(f32(float(sy) - y_src) + pixel_offset) * invscale_y)
+                wy = f32(max(f32(1.0 - abs(wy_arg)), 0.0))
+                if wy <= 0.0:
+                    continue
+                for sx in range(x_min, x_max):
+                    wx_arg = f32(f32(f32(float(sx) - x_src) + pixel_offset) * invscale_x)
+                    wx = f32(max(f32(1.0 - abs(wx_arg)), 0.0))
+                    weight = f32(wx * wy)
+                    if weight <= 0.0:
+                        continue
+                    sample = float(pos_np[sy * source_grid_size + sx, d])
+                    val = fmaf32(sample, weight, val)
+                    total_weight = f32(total_weight + weight)
+            if total_weight > 0.0:
+                x_np[tok, d] = f32(float(x_np[tok, d]) + f32(val / total_weight))
+    return torch.from_numpy(x_np)
 
 
 def _ref_add_stream_reorder_2d(
@@ -544,6 +616,47 @@ def test_position_embeddings_add_tiled_2d(grid_h=6, grid_w=6, embed_dim=8, merge
 
     if diff > 1e-7:
         raise AssertionError("position_embeddings_add_tiled_2d mismatch!")
+
+
+def test_position_embeddings_add_tiled_2d_qwen3vl_resize_order(
+    grid_h=72,
+    grid_w=56,
+    source_grid_size=48,
+    embed_dim=64,
+    merge_size=2,
+):
+    print(
+        f"\n--- Testing position_embeddings_add_tiled_2d Qwen3-VL resize "
+        f"({grid_h}x{grid_w} from {source_grid_size}x{source_grid_size}, dim {embed_dim}, merge {merge_size}) ---"
+    )
+    tokens = grid_h * grid_w
+    source_tokens = source_grid_size * source_grid_size
+    g = torch.Generator().manual_seed(4408)
+    x = torch.randn(tokens, embed_dim, generator=g, dtype=torch.float32) * 0.25
+    pos = torch.randn(source_tokens, embed_dim, generator=g, dtype=torch.float32) * 0.5
+
+    ref = _ref_position_embeddings_add_tiled_2d(
+        x,
+        pos,
+        grid_h,
+        grid_w,
+        merge_size,
+        source_grid_size,
+    )
+    out_c = run_c_position_embeddings_add_tiled_2d(
+        x,
+        pos,
+        grid_h,
+        grid_w,
+        merge_size,
+        source_grid_size,
+    )
+
+    diff = max_diff(out_c, ref)
+    print(f"Max diff: {diff:.2e}")
+
+    if diff > 2e-6:
+        raise AssertionError("position_embeddings_add_tiled_2d Qwen3-VL resize order mismatch!")
 
 
 def test_rowwise_bias_add(tokens=2304, embed_dim=1152):
@@ -850,6 +963,7 @@ if __name__ == "__main__":
     test_patch2im()
     test_position_embeddings_add()
     test_position_embeddings_add_tiled_2d()
+    test_position_embeddings_add_tiled_2d_qwen3vl_resize_order()
     test_vision_position_ids()
     test_vision_position_ids(grid_h=6, grid_w=6, merge_size=3)
     test_rowwise_bias_add()


### PR DESCRIPTION
## Why

Qwen3-VL AVX2 position-embedding parity is now fixed on `main` via PR #114, but we still need a durable regression guard that appears clearly in the nightly docs report. Before this PR, `make test-v8-vision-kernels` was easy to miss and the report parser did not expand `unittest/test_vision.py` output into named vision kernel subtests.

## What

- Add a Qwen3-VL resized tiled-position embedding case to `make test-v8-vision-kernels`.
- Teach `scripts/nightly_runner.py` to parse `unittest/test_vision.py` blocks into named subtests with max-diff and timing data.
- Add `v8 Vision Kernel Parity` as a nightly `kernels` target so the docs test report shows this lane directly.
- Update `docs/site/test-report.html` to list v8 vision kernel parity coverage.

Final net PR files after resolving against `origin/main`:

- `unittest/test_vision.py`
- `scripts/nightly_runner.py`
- `docs/site/test-report.html`

## Validation

- `/home/antshiv/Workspace/C-Kernel-Engine/.venv/bin/python -m py_compile scripts/nightly_runner.py unittest/test_vision.py`
- `PYTHON=/home/antshiv/Workspace/C-Kernel-Engine/.venv/bin/python make test-v8-vision-kernels`
- Parsed 18 named vision subtests in the nightly parser, including:
  - `position_embeddings_add_tiled_2d Qwen3-VL resize`
  - `mrope_qk_vision ... Q`
  - `mrope_qk_vision ... K`
- `git diff --check -- scripts/nightly_runner.py docs/site/test-report.html src/kernels/vision_kernels.c unittest/test_vision.py`

## Conflict Resolution

Resolved the conflict with `origin/main` in `src/kernels/vision_kernels.c` by taking the `main` implementation/style. There is no remaining net diff to `vision_kernels.c` in this PR because the production position-embedding fix is already present on `main`.