### PR TITLE
feat(v8/qwen3vl): add stitched parity divergence harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1754,6 +1754,7 @@ showtests:
 	@echo "  make llamacpp-parity      Quick parity vs llama.cpp/ggml"
 	@echo "  make llamacpp-parity-full Full parity test (all kernels)"
 	@echo "  make llamacpp-parity-full-all-isa-variants Full parity + AVX/AVX2/AVX-512 sweep"
+	@echo "  make llamacpp-parity-stitched  v8 Qwen3-VL bridge + multitoken + granular divergence harness"
 	@echo "  Note: Requires llama.cpp submodule (git submodule update --init)"
 	@echo ""
 	@echo "End-to-End Tests:"
@@ -2175,6 +2176,28 @@ smollm-train-parity: $(LIB)
 #
 # RECOMMENDED: Run 'make llamacpp-parity-rebuild' first time or when patches change
 
+V8_STITCHED_TEMPLATE ?= qwen3vl
+V8_STITCHED_MODE ?= fast
+V8_STITCHED_WORKDIR ?= build/stitched_parity/$(V8_STITCHED_TEMPLATE)
+V8_STITCHED_THREADS ?= 20
+V8_STITCHED_CTX ?= 4096
+V8_STITCHED_TOP_K ?= 16
+V8_STITCHED_MAX_NEW_TOKENS ?= 64
+V8_STITCHED_PHASE_TIMEOUT_SEC ?= 0
+V8_STITCHED_SKIP_ENCODER_NUMERIC ?= 0
+V8_STITCHED_NO_GRANULAR ?= 0
+V8_STITCHED_GRANULAR_CK_STOP ?= 1
+V8_STITCHED_GRANULAR_LAYERS ?=
+CK_RUN_STITCHED_PARITY ?= 0
+V8_QWEN3VL_LOCAL_MODEL ?= models/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf
+V8_QWEN3VL_LOCAL_MMPROJ ?= models/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf
+V8_QWEN3VL_STITCHED_DECODER ?= $(V8_QWEN3VL_LOCAL_MODEL)
+V8_QWEN3VL_STITCHED_MMPROJ ?= $(V8_QWEN3VL_LOCAL_MMPROJ)
+V8_QWEN3VL_STITCHED_IMAGE ?= ocr/1 81.jpg
+V8_QWEN3VL_STITCHED_PROMPT ?= Extract visible form fields as compact JSON.
+V8_QWEN3VL_STITCHED_IMAGE_MIN_TOKENS ?=
+V8_QWEN3VL_STITCHED_IMAGE_MAX_TOKENS ?= 1024
+
 # First time / fix everything: clean rebuild with all patches
 llamacpp-parity-rebuild:
 	@echo "Force rebuilding llama.cpp with latest patches..."
@@ -2233,6 +2256,38 @@ llamacpp-e2e:
 	@echo ""
 	@echo "Running v8 Qwen3-VL mmproj contract/codegen parity..."
 	@$(MAKE) --no-print-directory parity-v8-qwen3vl-mmproj
+	@if [ "$(CK_RUN_STITCHED_PARITY)" = "1" ]; then \
+	  echo ""; \
+	  echo "Running v8 stitched parity harness..."; \
+	  $(MAKE) --no-print-directory llamacpp-parity-stitched; \
+	else \
+	  echo ""; \
+	  echo "Skipping v8 stitched parity harness (set CK_RUN_STITCHED_PARITY=1 to enable)."; \
+	fi
+
+llamacpp-parity-stitched:
+	@echo "Running v8 stitched parity harness ($(V8_STITCHED_TEMPLATE), $(V8_STITCHED_MODE))..."
+	@$(PYTHON) version/v8/scripts/stitched_parity_v8.py \
+	  --template "$(V8_STITCHED_TEMPLATE)" \
+	  --mode "$(V8_STITCHED_MODE)" \
+	  --decoder-gguf "$(V8_QWEN3VL_STITCHED_DECODER)" \
+	  --mmproj-gguf "$(V8_QWEN3VL_STITCHED_MMPROJ)" \
+	  --image-path "$(V8_QWEN3VL_STITCHED_IMAGE)" \
+	  --prompt "$(V8_QWEN3VL_STITCHED_PROMPT)" \
+	  --workdir "$(V8_STITCHED_WORKDIR)" \
+	  --ctx-len "$(V8_STITCHED_CTX)" \
+	  --threads "$(V8_STITCHED_THREADS)" \
+	  --top-k "$(V8_STITCHED_TOP_K)" \
+	  --max-new-tokens "$(V8_STITCHED_MAX_NEW_TOKENS)" \
+	  --phase-timeout-sec "$(V8_STITCHED_PHASE_TIMEOUT_SEC)" \
+	  $(if $(V8_QWEN3VL_STITCHED_IMAGE_MIN_TOKENS),--image-min-tokens "$(V8_QWEN3VL_STITCHED_IMAGE_MIN_TOKENS)",) \
+	  $(if $(V8_QWEN3VL_STITCHED_IMAGE_MAX_TOKENS),--image-max-tokens "$(V8_QWEN3VL_STITCHED_IMAGE_MAX_TOKENS)",) \
+	  $(if $(filter 1,$(V8_STITCHED_SKIP_ENCODER_NUMERIC)),--skip-encoder-numeric,) \
+	  $(if $(filter 1,$(V8_STITCHED_NO_GRANULAR)),--no-granular,) \
+	  $(if $(filter 0,$(V8_STITCHED_GRANULAR_CK_STOP)),--no-granular-ck-stop,--granular-ck-stop) \
+	  $(if $(V8_STITCHED_GRANULAR_LAYERS),--granular-layers "$(V8_STITCHED_GRANULAR_LAYERS)",)
+
+llamacpp-parity-full-stitched: llamacpp-parity-full llamacpp-parity-stitched
 
 # Nightly parity profile: keep correctness coverage, but use quick ISA parity
 # benches so nightly does not block on long benchmark loops.
@@ -3238,6 +3293,7 @@ help:
 	@echo "  make layer-parity         PyTorch parity (fp32/bf16)"
 	@echo "  make llamacpp-parity      llama.cpp parity (Q4_K)"
 	@echo "  make llamacpp-parity-full llama.cpp kernel parity suite"
+	@echo "  make llamacpp-parity-stitched v8 Qwen3-VL stitched parity harness"
 	@echo "  make llamacpp-e2e         llama.cpp end-to-end compatibility suite"
 	@echo "  make smollm-train-parity  Full training parity"
 	@echo ""
@@ -4027,7 +4083,7 @@ report-md:
 	@echo ""
 	@$(PYTHON) scripts/optimization_status.py --markdown
 
-.PHONY: all clean test test-bf16 test-libs test-quant test-flash-attention test_flash_attention unittest unittest-show show_test help litmus litmus-test test-quick test-full test-stress profile-memory profile-heap profile-cpu profile-flash-attn profile-cache flamegraph ck-cli ck-cli-v4 ck-cli-v5 ck-chat ck-server ck-chat-py ck-server-py generate-model gguf-inspect gguf-list gguf-to-bump gguf-to-bump-v4 hf-to-bump-v4 ir-v4 ir-v4-q4k opt-status opt-pending opt-inference opt-training opt-kernels opt-targets opt-md kernel-coverage kernel-coverage-md test-coverage test-coverage-md meta-check meta-sync meta-init report report-md show_config show-config v5 demo-v5 demo-v5-debug llamacpp-parity llamacpp-parity-full llamacpp-parity-full-all-isa-variants showtests version version-history e2e e2e-quick e2e-qwen e2e-smollm e2e-v66 e2e-v66-full v6.6-test-help v6.6-test-quick v6.6-sanity v6.6-test-parity v6.6-test-memory v6.6-test-divergence v6.6-test-nan v6.6-test-all v6.6-test v6.6-download v6.6-kernel-map-regenerate v6.6-kernel-map-gate v6.6-validate-contracts v6.6-validate-matrix v6.6-validate-matrix-nightly v6.6-validate-matrix-smoke v6.6-validate-parity-matrix v6.6-validate-parity-matrix-required v6.6-validate-longdecode v6.6-gate v6.6-build v6.6 v6.6-full v6.6-ir-visualizer v6.6-memory-signoff v6.6-perf-gate v6.6-perf-gate-evaluate v7-help v7-sync-inference v7-infer-run v7-infer-gate v7-validate-contracts v7-parity-1tok v7-train-ir-smoke v7-train-ir-backward v7-train-parity-3 v7-train-parity-5 v7-gate-train v7-gate v7 profile-v6-prepare-runtime profile-v6-decode profile-v6-prefill profile-v6-flamegraph profile-v6-perf-stat profile-v6-vtune profile-v6-cachegrind profile-v6-full profile-v7-prepare-runtime profile-v7-decode profile-v7-prefill profile-v7-flamegraph profile-v7-perf-stat profile-v7-vtune profile-v7-advisor profile-v7-cachegrind profile-v7-full
+.PHONY: all clean test test-bf16 test-libs test-quant test-flash-attention test_flash_attention unittest unittest-show show_test help litmus litmus-test test-quick test-full test-stress profile-memory profile-heap profile-cpu profile-flash-attn profile-cache flamegraph ck-cli ck-cli-v4 ck-cli-v5 ck-chat ck-server ck-chat-py ck-server-py generate-model gguf-inspect gguf-list gguf-to-bump gguf-to-bump-v4 hf-to-bump-v4 ir-v4 ir-v4-q4k opt-status opt-pending opt-inference opt-training opt-kernels opt-targets opt-md kernel-coverage kernel-coverage-md test-coverage test-coverage-md meta-check meta-sync meta-init report report-md show_config show-config v5 demo-v5 demo-v5-debug llamacpp-parity llamacpp-parity-full llamacpp-parity-full-all-isa-variants llamacpp-parity-stitched llamacpp-parity-full-stitched showtests version version-history e2e e2e-quick e2e-qwen e2e-smollm e2e-v66 e2e-v66-full v6.6-test-help v6.6-test-quick v6.6-sanity v6.6-test-parity v6.6-test-memory v6.6-test-divergence v6.6-test-nan v6.6-test-all v6.6-test v6.6-download v6.6-kernel-map-regenerate v6.6-kernel-map-gate v6.6-validate-contracts v6.6-validate-matrix v6.6-validate-matrix-nightly v6.6-validate-matrix-smoke v6.6-validate-parity-matrix v6.6-validate-parity-matrix-required v6.6-validate-longdecode v6.6-gate v6.6-build v6.6 v6.6-full v6.6-ir-visualizer v6.6-memory-signoff v6.6-perf-gate v6.6-perf-gate-evaluate v7-help v7-sync-inference v7-infer-run v7-infer-gate v7-validate-contracts v7-parity-1tok v7-train-ir-smoke v7-train-ir-backward v7-train-parity-3 v7-train-parity-5 v7-gate-train v7-gate v7 profile-v6-prepare-runtime profile-v6-decode profile-v6-prefill profile-v6-flamegraph profile-v6-perf-stat profile-v6-vtune profile-v6-cachegrind profile-v6-full profile-v7-prepare-runtime profile-v7-decode profile-v7-prefill profile-v7-flamegraph profile-v7-perf-stat profile-v7-vtune profile-v7-advisor profile-v7-cachegrind profile-v7-full
 .PHONY: v7-perf-gate v7-perf-gate-evaluate
 .PHONY: v7-inference-smoke
 .PHONY: v7-grad-fd v7-replay

--- a/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
+++ b/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
@@ -61,17 +61,57 @@ def _compile_generated_dump_model(output_dir: Path, c_path: Path) -> Path:
 
 def _generate_dump_model_source(output_dir: Path) -> Path:
     c_path = output_dir / "qwen3_vl_mmproj_v8_parity_dump.c"
+    granular_report = output_dir / "granular_codegen.json"
     rc = codegen_v8.main(
         [
             "--ir", str(output_dir / "call.json"),
             "--layout", str(output_dir / "layout.json"),
             "--output", str(c_path),
-            "--parity-dump",
+            "--granular-test",
+            "--granular-report", str(granular_report),
         ]
     )
     if rc != 0:
-        raise RuntimeError(f"codegen_v8 parity-dump failed with rc={rc}")
+        raise RuntimeError(f"codegen_v8 granular-test failed with rc={rc}")
     return c_path
+
+
+def _resolve_ck_stop_op(output_dir: Path, ck_stop_op: int | None, ck_stop_layer: int | None) -> int | None:
+    if ck_stop_op is not None:
+        return int(ck_stop_op)
+    if ck_stop_layer is None:
+        return None
+
+    granular_report = output_dir / "granular_codegen.json"
+    if not granular_report.exists():
+        raise RuntimeError(f"cannot resolve --ck-stop-layer without granular report: {granular_report}")
+    data = json.loads(granular_report.read_text(encoding="utf-8"))
+    cutpoints = data.get("cutpoints")
+    if not isinstance(cutpoints, list):
+        raise RuntimeError(f"invalid granular report {granular_report}: missing cutpoints")
+
+    matches: list[int] = []
+    available_layers: set[int] = set()
+    for row in cutpoints:
+        if not isinstance(row, dict):
+            continue
+        try:
+            layer = int(row.get("layer", -999999))
+        except (TypeError, ValueError):
+            continue
+        available_layers.add(layer)
+        if layer != int(ck_stop_layer):
+            continue
+        try:
+            matches.append(int(row["index"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RuntimeError(f"invalid cutpoint row in {granular_report}: {row!r}") from exc
+    if not matches:
+        raise RuntimeError(
+            f"granular report {granular_report} has no cutpoints for layer {ck_stop_layer}; "
+            f"available layers: {sorted(available_layers)}"
+        )
+    return max(matches)
 
 
 def _with_env_var(name: str, value: str | None):
@@ -113,6 +153,7 @@ def _run_generated_encoder_with_dump(
     dump_dir: Path,
     strict_parity: bool,
     strict_dump_layer: int | None,
+    ck_stop_op: int | None,
 ) -> None:
     dump_dir.mkdir(parents=True, exist_ok=True)
     dump_path = dump_dir / "dump.bin"
@@ -129,6 +170,7 @@ def _run_generated_encoder_with_dump(
         "CK_STRICT_ATTN_DUMP_LAYER",
         None if strict_dump_layer is None else str(strict_dump_layer),
     )
+    old_stop_op = _with_env_var("CK_STOP_OP", None if ck_stop_op is None else str(int(ck_stop_op)))
     try:
         npv8._run_generated_encoder(
             model_so=model_so,
@@ -139,6 +181,7 @@ def _run_generated_encoder_with_dump(
             strict_parity=strict_parity,
         )
     finally:
+        _restore_env_var("CK_STOP_OP", old_stop_op)
         _restore_env_var("CK_STRICT_ATTN_DUMP_LAYER", old_dump_layer)
         _restore_env_var("CK_PARITY_DIR", old_dump)
 
@@ -205,6 +248,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--output-dir", type=Path, default=Path("/tmp/qwen3vl_mmproj_v8_activation_parity"))
     ap.add_argument("--image-mode", choices=("gradient", "gray", "checker"), default="gradient")
     ap.add_argument("--image-path", type=Path, default=None, help="Optional real image path; overrides --image-mode")
+    ap.add_argument("--image-min-tokens", type=int, default=None, help="Override minimum merged visual tokens for dynamic-resolution Qwen3-VL images")
+    ap.add_argument("--image-max-tokens", type=int, default=None, help="Override maximum merged visual tokens for dynamic-resolution Qwen3-VL images")
     ap.add_argument("--threads", type=int, default=1)
     ap.add_argument("--ck-threads", type=int, default=None)
     ap.add_argument("--strict-parity", action="store_true", help="Enable parity-only strict mode in CK during the generated encoder run")
@@ -220,6 +265,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     ap.add_argument("--llama-dump-layer", type=int, default=None, help="Optional exact llama layer id filter; globals remain included")
     ap.add_argument("--ck-strict-dump-layer", type=int, default=None, help="Optional exact CK strict-attention dump layer filter")
+    ck_stop = ap.add_mutually_exclusive_group()
+    ck_stop.add_argument("--ck-stop-op", type=int, default=None, help="Return from generated CK encoder immediately after this generated op index")
+    ck_stop.add_argument("--ck-stop-layer", type=int, default=None, help="Return from generated CK encoder after the last generated op in this encoder layer")
     args = ap.parse_args(argv)
 
     ck_threads = int(args.ck_threads or args.threads)
@@ -228,14 +276,23 @@ def main(argv: list[str] | None = None) -> int:
     output_dir = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    report = npv8._ensure_runtime_artifacts(args.gguf, output_dir)
+    report = npv8._ensure_runtime_artifacts(
+        args.gguf,
+        output_dir,
+        image_path=args.image_path.resolve() if args.image_path is not None else None,
+        image_min_tokens=args.image_min_tokens,
+        image_max_tokens=args.image_max_tokens,
+    )
     c_path = _generate_dump_model_source(output_dir)
+    ck_stop_op = _resolve_ck_stop_op(output_dir, args.ck_stop_op, args.ck_stop_layer)
     model_so = _compile_generated_dump_model(output_dir, c_path)
     shim_so = npv8._compile_mtmd_shim(output_dir)
 
     config = report["config"]
-    height = int(config["image_size"])
-    width = int(config["image_size"])
+    height = int(config.get("image_height", config.get("image_size")))
+    width = int(config.get("image_width", config.get("image_size")))
+    if height <= 0 or width <= 0:
+        raise RuntimeError(f"invalid encoder image shape in generated config: height={height} width={width}")
     if args.image_path is not None:
         image_report = npv8._load_image_file(args.image_path.resolve(), height, width)
         interleaved = image_report["interleaved"]
@@ -262,6 +319,7 @@ def main(argv: list[str] | None = None) -> int:
         dump_dir=ck_dump_dir,
         strict_parity=bool(args.strict_parity),
         strict_dump_layer=args.ck_strict_dump_layer,
+        ck_stop_op=ck_stop_op,
     )
     _run_llama_encoder_with_dump(
         shim_so=shim_so,
@@ -302,6 +360,8 @@ def main(argv: list[str] | None = None) -> int:
         "image_path": image_report.get("image_path"),
         "source_image_size": image_report.get("source_image_size"),
         "preprocess": image_report.get("preprocess"),
+        "image_min_tokens": args.image_min_tokens,
+        "image_max_tokens": args.image_max_tokens,
         "threads": {
             "llama_cpp": args.threads,
             "ck_runtime": ck_threads,
@@ -313,6 +373,10 @@ def main(argv: list[str] | None = None) -> int:
         "rtol": args.rtol,
         "ck_dump": str(ck_dump),
         "llama_dump": str(ref_dump),
+        "granular_codegen": str(output_dir / "granular_codegen.json"),
+        "ck_stop_layer": args.ck_stop_layer,
+        "ck_stop_op_requested": args.ck_stop_op,
+        "ck_stop_op_resolved": ck_stop_op,
         "summary": summary,
         "first_issue": first_issue,
         "results": results,

--- a/version/v8/scripts/codegen_v8.py
+++ b/version/v8/scripts/codegen_v8.py
@@ -40,6 +40,41 @@ def _patch_codegen_config(obj: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
+def _granular_cutpoint_report(ir_obj: Dict[str, Any], layout_obj: Dict[str, Any]) -> Dict[str, Any]:
+    """Describe generated stop points without making model-specific assumptions.
+
+    codegen_core_v8 emits `if (stop_seq == <op index>) return;` after most
+    operations. The parity harness uses this metadata to turn a layer-level
+    request into the concrete CK_STOP_OP index used by generated C.
+    """
+    ops = ir_obj.get("operations", [])
+    if not isinstance(ops, list):
+        ops = []
+    cutpoints = []
+    for index, op in enumerate(ops):
+        if not isinstance(op, dict):
+            continue
+        try:
+            layer = int(op.get("layer", -1) if op.get("layer", -1) is not None else -1)
+        except (TypeError, ValueError):
+            layer = -1
+        cutpoints.append(
+            {
+                "index": int(index),
+                "layer": layer,
+                "op": str(op.get("op") or op.get("name") or op.get("type") or ""),
+                "function": str(op.get("function") or op.get("kernel") or op.get("kernel_fn") or ""),
+                "section": str(op.get("section") or ""),
+            }
+        )
+    return {
+        "schema": "ck.v8.granular_codegen.v1",
+        "mode": str(ir_obj.get("mode") or layout_obj.get("mode") or ""),
+        "model": str((ir_obj.get("config") or {}).get("model") or (layout_obj.get("config") or {}).get("model") or ""),
+        "cutpoints": cutpoints,
+    }
+
+
 def _inject_vision_only_fallbacks(code: str, layout_obj: Dict[str, Any]) -> str:
     act_buffers = (layout_obj.get("memory", {}) or {}).get("activations", {}).get("buffers", []) or []
     present = {str(buf.get("name", "")) for buf in act_buffers}
@@ -942,8 +977,11 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--debug", action="store_true", help="Emit debug dumps")
     ap.add_argument("--profile", action="store_true", help="Emit profiling wrappers")
     ap.add_argument("--parity-dump", action="store_true", help="Emit parity dump helpers")
+    ap.add_argument("--granular-test", action="store_true", help="Emit parity dumps and a generated-op cutpoint map for stitched parity debugging")
+    ap.add_argument("--granular-report", type=Path, default=None, help="Optional JSON output for --granular-test cutpoints")
     ap.add_argument("--strict-contracts", action="store_true", help="Fail on strict contract/codegen errors")
     args = ap.parse_args(argv)
+    emit_parity_dumps = bool(args.parity_dump or args.granular_test)
 
     with open(args.ir, "r", encoding="utf-8") as f:
         ir_obj = _patch_codegen_config(json.load(f))
@@ -979,7 +1017,7 @@ def main(argv: list[str] | None = None) -> int:
             prefill_code = codegen_prefill_v8.generate_prefill(
                 prefill_path,
                 profile=args.profile,
-                dump=args.parity_dump,
+                dump=emit_parity_dumps,
             )
         code = codegen_core_v8.generate(
             ir_path,
@@ -987,7 +1025,7 @@ def main(argv: list[str] | None = None) -> int:
             debug=args.debug,
             init_call=init_call_obj,
             profile=args.profile,
-            dump=args.parity_dump,
+            dump=emit_parity_dumps,
             strict_contracts=args.strict_contracts,
         )
         if prefill_code:
@@ -1006,9 +1044,9 @@ def main(argv: list[str] | None = None) -> int:
                 code,
                 ir_obj,
                 profile=args.profile,
-                dump=args.parity_dump,
+                dump=emit_parity_dumps,
             )
-        if args.parity_dump:
+        if emit_parity_dumps:
             code = _inject_decode_attention_parity_dumps(code, layout_obj)
         code = _inject_vision_only_fallbacks(code, layout_obj)
         code = _patch_standalone_prefill_runtime(code, layout_obj)
@@ -1017,6 +1055,12 @@ def main(argv: list[str] | None = None) -> int:
         code = _inject_activation_lookup_api(code, layout_obj)
 
     args.output.write_text(code, encoding="utf-8")
+    if args.granular_report is not None:
+        args.granular_report.parent.mkdir(parents=True, exist_ok=True)
+        args.granular_report.write_text(
+            json.dumps(_granular_cutpoint_report(ir_obj, layout_obj), indent=2),
+            encoding="utf-8",
+        )
     print(f"Generated: {args.output}")
     return 0
 

--- a/version/v8/scripts/stitched_parity_v8.py
+++ b/version/v8/scripts/stitched_parity_v8.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    return obj if isinstance(obj, dict) else {}
+
+
+def _write_json(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2), encoding="utf-8")
+
+
+def _run_logged(
+    cmd: list[str],
+    *,
+    log_path: Path,
+    env: dict[str, str],
+    timeout_sec: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    started = time.time()
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(REPO_ROOT),
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=None if int(timeout_sec) <= 0 else int(timeout_sec),
+        )
+    except subprocess.TimeoutExpired as exc:
+        proc = subprocess.CompletedProcess(
+            cmd,
+            124,
+            stdout=exc.stdout if isinstance(exc.stdout, str) else "",
+            stderr=(exc.stderr if isinstance(exc.stderr, str) else "") + f"\nTIMEOUT after {int(timeout_sec)}s\n",
+        )
+    elapsed = time.time() - started
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write("$ " + " ".join(cmd) + "\n")
+        f.write(f"exit={proc.returncode} elapsed_sec={elapsed:.3f}\n")
+        if proc.stdout:
+            f.write("\n[stdout]\n")
+            f.write(proc.stdout)
+            if not proc.stdout.endswith("\n"):
+                f.write("\n")
+        if proc.stderr:
+            f.write("\n[stderr]\n")
+            f.write(proc.stderr)
+            if not proc.stderr.endswith("\n"):
+                f.write("\n")
+        f.write("\n")
+    return proc
+
+
+def _layers_for_mode(mode: str, explicit: str | None) -> list[int]:
+    if explicit:
+        return [int(x.strip()) for x in explicit.split(",") if x.strip()]
+    if mode == "fast":
+        return [0, 1]
+    if mode == "nightly":
+        return [0, 1, 4, 8, 16, 31]
+    return list(range(32))
+
+
+def _bridge_command(args: argparse.Namespace, bridge_dir: Path, prefix_f32: Path) -> list[str]:
+    cmd = [
+        sys.executable,
+        str(SCRIPT_DIR / "run_multimodal_bridge_v8.py"),
+        "--decoder-gguf",
+        str(args.decoder_gguf),
+        "--encoder-gguf",
+        str(args.mmproj_gguf),
+        "--workdir",
+        str(bridge_dir),
+        "--prompt",
+        str(args.prompt),
+        "--chat-template",
+        str(args.chat_template),
+        "--image-path",
+        str(args.image_path),
+        "--decoder-context-len",
+        str(int(args.ctx_len)),
+        "--dump-prefix-f32",
+        str(prefix_f32),
+        "--report-top-k",
+        str(int(args.top_k)),
+        "--max-tokens",
+        "0",
+        "--temperature",
+        "0",
+        "--no-stream-output",
+        "--strict-parity",
+    ]
+    if args.image_min_tokens is not None:
+        cmd.extend(["--image-min-tokens", str(int(args.image_min_tokens))])
+    if args.image_max_tokens is not None:
+        cmd.extend(["--image-max-tokens", str(int(args.image_max_tokens))])
+    return cmd
+
+
+def _multitoken_command(args: argparse.Namespace, bridge_report: Path, prefix_f32: Path, out_json: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(SCRIPT_DIR / "compare_multimodal_multitoken_logits_v8.py"),
+        "--bridge-report",
+        str(bridge_report),
+        "--prefix-f32",
+        str(prefix_f32),
+        "--workdir",
+        str(args.workdir / "multitoken"),
+        "--ctx-len",
+        str(int(args.ctx_len)),
+        "--threads",
+        str(int(args.threads)),
+        "--top-k",
+        str(int(args.top_k)),
+        "--max-new-tokens",
+        str(int(args.max_new_tokens)),
+        "--append-on-divergence",
+        "stop",
+        "--json-out",
+        str(out_json),
+        "--summary",
+    ]
+
+
+def _encoder_numeric_command(args: argparse.Namespace, out_dir: Path, out_json: Path) -> list[str]:
+    cmd = [
+        sys.executable,
+        str(SCRIPT_DIR / "numeric_parity_qwen3vl_mmproj_v8.py"),
+        "--gguf",
+        str(args.mmproj_gguf),
+        "--output-dir",
+        str(out_dir),
+        "--image-path",
+        str(args.image_path),
+        "--threads",
+        str(int(args.threads)),
+        "--ck-threads",
+        str(int(args.threads)),
+        "--strict-parity",
+        "--report",
+        str(out_json),
+    ]
+    if args.image_min_tokens is not None:
+        cmd.extend(["--image-min-tokens", str(int(args.image_min_tokens))])
+    if args.image_max_tokens is not None:
+        cmd.extend(["--image-max-tokens", str(int(args.image_max_tokens))])
+    return cmd
+
+
+def _granular_command(args: argparse.Namespace, layer: int, out_dir: Path, out_json: Path) -> list[str]:
+    cmd = [
+        sys.executable,
+        str(SCRIPT_DIR / "activation_parity_qwen3vl_mmproj_v8.py"),
+        "--gguf",
+        str(args.mmproj_gguf),
+        "--output-dir",
+        str(out_dir),
+        "--image-path",
+        str(args.image_path),
+        "--threads",
+        str(int(args.threads)),
+        "--ck-threads",
+        str(int(args.threads)),
+        "--strict-parity",
+        "--llama-dump-layer",
+        str(int(layer)),
+        "--ck-strict-dump-layer",
+        str(int(layer)),
+        "--llama-dump-names",
+        str(args.granular_dump_names),
+        "--report",
+        str(out_json),
+        "--quiet",
+    ]
+    if args.granular_ck_stop:
+        cmd.extend(["--ck-stop-layer", str(int(layer))])
+    if args.image_min_tokens is not None:
+        cmd.extend(["--image-min-tokens", str(int(args.image_min_tokens))])
+    if args.image_max_tokens is not None:
+        cmd.extend(["--image-max-tokens", str(int(args.image_max_tokens))])
+    return cmd
+
+
+def _encoder_numeric_pass(report: dict[str, Any], args: argparse.Namespace) -> bool:
+    metrics = report.get("metrics")
+    if not isinstance(metrics, dict):
+        return False
+    try:
+        cosine = float(metrics.get("cosine", 0.0))
+        rmse = float(metrics.get("rmse", float("inf")))
+        max_abs = float(metrics.get("max_abs", float("inf")))
+    except (TypeError, ValueError):
+        return False
+    return (
+        cosine >= float(args.encoder_cosine_min)
+        and rmse <= float(args.encoder_rmse_max)
+        and max_abs <= float(args.encoder_max_abs_max)
+    )
+
+
+def _first_granular_issue(reports: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for row in reports:
+        report = row.get("report")
+        if not isinstance(report, dict):
+            continue
+        issue = report.get("first_issue")
+        if isinstance(issue, dict):
+            out = dict(issue)
+            out.setdefault("layer", row.get("layer"))
+            out["report_path"] = row.get("report_path")
+            return out
+    return None
+
+
+def _write_markdown(report: dict[str, Any], path: Path) -> None:
+    lines = [
+        "# v8 Stitched Parity Report",
+        "",
+        f"- template: `{report.get('template')}`",
+        f"- status: `{report.get('status')}`",
+        f"- workdir: `{report.get('workdir')}`",
+        "",
+    ]
+    mismatch = report.get("first_divergence")
+    encoder_metrics = report.get("encoder_numeric_metrics")
+    if isinstance(encoder_metrics, dict):
+        lines.extend(
+            [
+                "## Encoder Numeric Parity",
+                "",
+                f"- pass: `{report.get('encoder_numeric_pass')}`",
+                f"- cosine: `{encoder_metrics.get('cosine')}`",
+                f"- rmse: `{encoder_metrics.get('rmse')}`",
+                f"- max abs: `{encoder_metrics.get('max_abs')}`",
+                f"- report: `{report.get('encoder_numeric_report')}`",
+                "",
+            ]
+        )
+    if isinstance(mismatch, dict):
+        lines.extend(
+            [
+                "## First Multitoken Divergence",
+                "",
+                f"- step: `{mismatch.get('step')}`",
+                f"- CK token: `{mismatch.get('ck_next')}` `{mismatch.get('ck_next_text')}`",
+                f"- llama token: `{mismatch.get('llama_next')}` `{mismatch.get('llama_next_text')}`",
+                f"- cosine: `{mismatch.get('cosine')}`",
+                f"- rmse: `{mismatch.get('rmse')}`",
+                f"- top-k overlap: `{mismatch.get('topk_overlap_count')}`",
+                "",
+            ]
+        )
+    issue = report.get("first_granular_issue")
+    if isinstance(issue, dict):
+        lines.extend(
+            [
+                "## First Granular Issue",
+                "",
+                f"- layer: `{issue.get('layer')}`",
+                f"- op: `{issue.get('op')}`",
+                f"- status: `{issue.get('status')}`",
+                f"- max abs diff: `{issue.get('max_abs_diff')}`",
+                f"- rmse: `{issue.get('rmse')}`",
+                f"- report: `{issue.get('report_path')}`",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Artifacts",
+            "",
+            f"- bridge report: `{report.get('bridge_report')}`",
+            f"- prefix f32: `{report.get('prefix_f32')}`",
+            f"- multitoken report: `{report.get('multitoken_report')}`",
+            f"- command log: `{report.get('command_log')}`",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Clean v8 stitched parity runner with automatic granular attribution")
+    ap.add_argument("--template", choices=["qwen3vl"], default="qwen3vl")
+    ap.add_argument("--mode", choices=["fast", "nightly", "deep"], default="fast")
+    ap.add_argument("--decoder-gguf", type=Path, required=True)
+    ap.add_argument("--mmproj-gguf", type=Path, required=True)
+    ap.add_argument("--image-path", type=Path, required=True)
+    ap.add_argument("--prompt", type=str, default="Extract visible form fields as compact JSON.")
+    ap.add_argument("--chat-template", type=str, default="qwen3vl")
+    ap.add_argument("--workdir", type=Path, default=REPO_ROOT / "build" / "stitched_parity" / "qwen3vl")
+    ap.add_argument("--ctx-len", type=int, default=4096)
+    ap.add_argument("--threads", type=int, default=20)
+    ap.add_argument("--top-k", type=int, default=16)
+    ap.add_argument("--max-new-tokens", type=int, default=64)
+    ap.add_argument("--image-min-tokens", type=int, default=None)
+    ap.add_argument("--image-max-tokens", type=int, default=1024)
+    ap.add_argument("--skip-encoder-numeric", action="store_true", help="Skip final vision prefix numeric parity against llama.cpp")
+    ap.add_argument("--encoder-cosine-min", type=float, default=0.9999)
+    ap.add_argument("--encoder-rmse-max", type=float, default=1.0e-3)
+    ap.add_argument("--encoder-max-abs-max", type=float, default=1.0e-1)
+    ap.add_argument("--phase-timeout-sec", type=int, default=0, help="Optional timeout per subprocess phase; 0 disables")
+    ap.add_argument("--granular-layers", type=str, default=None, help="Comma-separated activation layers to inspect after coarse mismatch")
+    ap.add_argument(
+        "--granular-ck-stop",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="For granular attribution, stop the generated CK encoder after the inspected layer while llama.cpp still runs the full graph",
+    )
+    ap.add_argument(
+        "--granular-dump-names",
+        type=str,
+        default="patch_bias,inp_pos_emb,ln1,Qcur,Kcur,Vcur,Qcur_rope,Kcur_rope,kqv_out,attn_out,ffn_inp,ffn_inp_normed,ffn_up_b,ffn_out,layer_out",
+    )
+    ap.add_argument("--no-granular", action="store_true", help="Only run clean bridge + multitoken parity")
+    ap.add_argument("--clean", action=argparse.BooleanOptionalAction, default=True, help="Delete --workdir before running")
+    args = ap.parse_args(argv)
+
+    args.decoder_gguf = args.decoder_gguf.resolve()
+    args.mmproj_gguf = args.mmproj_gguf.resolve()
+    args.image_path = args.image_path.resolve()
+    args.workdir = args.workdir.resolve()
+
+    missing = [str(p) for p in (args.decoder_gguf, args.mmproj_gguf, args.image_path) if not p.exists()]
+    if missing:
+        print("missing required artifact(s): " + ", ".join(missing), file=sys.stderr)
+        return 2
+
+    if args.clean and args.workdir.exists():
+        shutil.rmtree(args.workdir)
+    args.workdir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(int(args.threads))
+    env["OMP_NUM_THREADS"] = str(int(args.threads))
+
+    command_log = args.workdir / "commands.log"
+    bridge_dir = args.workdir / "bridge"
+    prefix_f32 = args.workdir / "prefix.f32"
+    bridge_report = bridge_dir / "bridge_report.json"
+    multitoken_report = args.workdir / "multitoken.json"
+    encoder_numeric_report = args.workdir / "encoder_numeric.json"
+    final_json = args.workdir / "stitched_report.json"
+    final_md = args.workdir / "stitched_report.md"
+
+    report: dict[str, Any] = {
+        "schema": "ck.v8.stitched_parity.v1",
+        "template": args.template,
+        "mode": args.mode,
+        "status": "running",
+        "workdir": str(args.workdir),
+        "decoder_gguf": str(args.decoder_gguf),
+        "mmproj_gguf": str(args.mmproj_gguf),
+        "image_path": str(args.image_path),
+        "prompt": args.prompt,
+        "ctx_len": int(args.ctx_len),
+        "threads": int(args.threads),
+        "image_min_tokens": args.image_min_tokens,
+        "image_max_tokens": args.image_max_tokens,
+        "command_log": str(command_log),
+        "bridge_report": str(bridge_report),
+        "prefix_f32": str(prefix_f32),
+        "encoder_numeric_report": str(encoder_numeric_report),
+        "multitoken_report": str(multitoken_report),
+        "granular_ck_stop": bool(args.granular_ck_stop),
+    }
+
+    bridge_proc = _run_logged(_bridge_command(args, bridge_dir, prefix_f32), log_path=command_log, env=env, timeout_sec=args.phase_timeout_sec)
+    if bridge_proc.returncode != 0 or not bridge_report.exists() or not prefix_f32.exists():
+        report.update({"status": "setup_fail", "bridge_exit_code": bridge_proc.returncode})
+        _write_json(final_json, report)
+        _write_markdown(report, final_md)
+        print(f"status=setup_fail report={final_json}", file=sys.stderr)
+        return 2
+
+    encoder_ok = True
+    if not args.skip_encoder_numeric:
+        encoder_dir = args.workdir / "encoder_numeric"
+        encoder_proc = _run_logged(_encoder_numeric_command(args, encoder_dir, encoder_numeric_report), log_path=command_log, env=env, timeout_sec=args.phase_timeout_sec)
+        encoder_numeric = _load_json(encoder_numeric_report)
+        encoder_ok = encoder_proc.returncode == 0 and _encoder_numeric_pass(encoder_numeric, args)
+        report["encoder_numeric_exit_code"] = int(encoder_proc.returncode)
+        report["encoder_numeric_metrics"] = encoder_numeric.get("metrics")
+        report["encoder_numeric_pass"] = bool(encoder_ok)
+        if not encoder_ok:
+            report["status"] = "fail"
+            report["failure_stage"] = "encoder_numeric"
+            if not args.no_granular:
+                granular_reports: list[dict[str, Any]] = []
+                for layer in _layers_for_mode(args.mode, args.granular_layers):
+                    layer_dir = args.workdir / "granular" / f"layer_{layer}"
+                    layer_json = layer_dir / "activation_report.json"
+                    proc = _run_logged(_granular_command(args, layer, layer_dir, layer_json), log_path=command_log, env=env, timeout_sec=args.phase_timeout_sec)
+                    granular_reports.append(
+                        {
+                            "layer": int(layer),
+                            "exit_code": int(proc.returncode),
+                            "report_path": str(layer_json),
+                            "report": _load_json(layer_json),
+                        }
+                    )
+                    if isinstance(granular_reports[-1]["report"].get("first_issue"), dict):
+                        break
+                report["granular_reports"] = [
+                    {k: v for k, v in row.items() if k != "report"} for row in granular_reports
+                ]
+                report["first_granular_issue"] = _first_granular_issue(granular_reports)
+            _write_json(final_json, report)
+            _write_markdown(report, final_md)
+            issue = report.get("first_granular_issue") or {}
+            metrics = report.get("encoder_numeric_metrics") or {}
+            print(
+                "status=fail stage=encoder_numeric "
+                f"cosine={metrics.get('cosine')} rmse={metrics.get('rmse')} max_abs={metrics.get('max_abs')} "
+                f"granular_layer={issue.get('layer')} granular_op={issue.get('op')} "
+                f"report={final_json}"
+            )
+            return 3
+
+    multi_proc = _run_logged(_multitoken_command(args, bridge_report, prefix_f32, multitoken_report), log_path=command_log, env=env, timeout_sec=args.phase_timeout_sec)
+    multitoken = _load_json(multitoken_report)
+    report["multitoken_exit_code"] = int(multi_proc.returncode)
+    report["multitoken_status"] = multitoken.get("status")
+    report["first_divergence"] = multitoken.get("first_divergence")
+
+    if multitoken.get("pass") is True:
+        report["status"] = "pass"
+        _write_json(final_json, report)
+        _write_markdown(report, final_md)
+        print(f"status=pass report={final_json}")
+        return 0
+
+    report["status"] = "fail"
+    if not args.no_granular:
+        granular_reports: list[dict[str, Any]] = []
+        for layer in _layers_for_mode(args.mode, args.granular_layers):
+            layer_dir = args.workdir / "granular" / f"layer_{layer}"
+            layer_json = layer_dir / "activation_report.json"
+            proc = _run_logged(_granular_command(args, layer, layer_dir, layer_json), log_path=command_log, env=env, timeout_sec=args.phase_timeout_sec)
+            granular_reports.append(
+                {
+                    "layer": int(layer),
+                    "exit_code": int(proc.returncode),
+                    "report_path": str(layer_json),
+                    "report": _load_json(layer_json),
+                }
+            )
+            if isinstance(granular_reports[-1]["report"].get("first_issue"), dict):
+                break
+        report["granular_reports"] = [
+            {k: v for k, v in row.items() if k != "report"} for row in granular_reports
+        ]
+        report["first_granular_issue"] = _first_granular_issue(granular_reports)
+
+    _write_json(final_json, report)
+    _write_markdown(report, final_md)
+    first = report.get("first_divergence") or {}
+    issue = report.get("first_granular_issue") or {}
+    print(
+        "status=fail "
+        f"step={first.get('step')} "
+        f"ck={first.get('ck_next')} llama={first.get('llama_next')} "
+        f"granular_layer={issue.get('layer')} granular_op={issue.get('op')} "
+        f"report={final_json}"
+    )
+    return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Qwen3-VL parity debugging needs a repeatable end-to-end command that does more than kernel unit tests. Kernel parity can pass while a stitched model path still diverges because of bridge layout, image-token geometry, generated op order, tensor boundary semantics, or persistent multimodal decode state.

This PR adds a v8 stitched parity harness that can run the same canonical Qwen3-VL image/prompt through CK and llama.cpp, then automatically drop into granular encoder activation attribution when the coarse check fails.

## What

- Adds `version/v8/scripts/stitched_parity_v8.py`.
  - Builds a fresh multimodal bridge/prefix.
  - Optionally runs encoder numeric parity against llama.cpp.
  - Runs persistent multitoken CK-vs-llama parity.
  - On failure, runs focused layer activation parity and writes JSON/Markdown reports plus a command log.
- Adds codegen cutpoint metadata:
  - `codegen_v8.py --granular-test --granular-report <json>`
  - maps generated op index, layer, op, function, and section.
- Extends `activation_parity_qwen3vl_mmproj_v8.py`:
  - supports Qwen3-VL image min/max token overrides.
  - supports `--ck-stop-op` and `--ck-stop-layer` via generated cutpoint metadata.
  - records the resolved CK stop point in the activation parity report.
- Adds Make targets:
  - `make llamacpp-parity-stitched`
  - `make llamacpp-parity-full-stitched`
  - optional `CK_RUN_STITCHED_PARITY=1 make llamacpp-e2e`

## Example

```bash
make llamacpp-parity-stitched \
  V8_QWEN3VL_STITCHED_DECODER=models/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
  V8_QWEN3VL_STITCHED_MMPROJ=models/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
  V8_QWEN3VL_STITCHED_IMAGE='ocr/1 81.jpg' \
  V8_STITCHED_CTX=4096 \
  V8_STITCHED_MAX_NEW_TOKENS=64 \
  V8_QWEN3VL_STITCHED_IMAGE_MAX_TOKENS=1024
```

Reports are written under `build/stitched_parity/qwen3vl/` by default.

## Validation

- `python -m py_compile`:
  - `version/v8/scripts/stitched_parity_v8.py`
  - `version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py`
  - `version/v8/scripts/codegen_v8.py`
  - `version/v8/scripts/compare_multimodal_multitoken_logits_v8.py`
  - `version/v8/scripts/numeric_parity_qwen3vl_mmproj_v8.py`
- `version/v8/scripts/stitched_parity_v8.py --help`
- `version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py --help`
- `version/v8/scripts/codegen_v8.py --help` shows granular flags.
- `make -n llamacpp-parity-stitched ...` verifies command construction and OCR image path quoting.
- Codegen smoke on cached Qwen3-VL encoder graph:
  - generated parity C successfully.
  - wrote `ck.v8.granular_codegen.v1` report with 515 cutpoints.
- Pre-push hook passed after initializing/building local llama.cpp parity artifacts:
  - submodule pins reachable
  - visualizer health passed
  - CK build passed
  - kernel parity passed
  - v8 E2E text smoke passed
  - v8 inference contracts passed
  - v7 training contract smoke passed
  - v7 fast regression passed
  - v8 fast regression passed
  - v7 training-kernel parity passed

## Notes

The harness is backend/ISA neutral by design: AVX2, AVX-512/BF16, NEON, or future backends can use the same runner as long as the generated runtime and reference backend expose matching tensor dump names.
