### PR TITLE
fix(v8/qwen3vl): keep stitched logs best-effort under quota pressure

### DIFF
--- a/version/v8/scripts/stitched_parity_v8.py
+++ b/version/v8/scripts/stitched_parity_v8.py
@@ -134,20 +134,24 @@ def _run_logged(
     elapsed = time.time() - started
     stdout_text = stdout_capture.text()
     stderr_text = stderr_capture.text()
-    with log_path.open("a", encoding="utf-8") as f:
-        f.write("$ " + " ".join(cmd) + "\n")
-        f.write(f"exit={returncode} elapsed_sec={elapsed:.3f}\n")
-        if stdout_text:
-            f.write("\n[stdout]\n")
-            f.write(stdout_text)
-            if not stdout_text.endswith("\n"):
-                f.write("\n")
-        if stderr_text:
-            f.write("\n[stderr]\n")
-            f.write(stderr_text)
-            if not stderr_text.endswith("\n"):
-                f.write("\n")
-        f.write("\n")
+    try:
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write("$ " + " ".join(cmd) + "\n")
+            f.write(f"exit={returncode} elapsed_sec={elapsed:.3f}\n")
+            if stdout_text:
+                f.write("\n[stdout]\n")
+                f.write(stdout_text)
+                if not stdout_text.endswith("\n"):
+                    f.write("\n")
+            if stderr_text:
+                f.write("\n[stderr]\n")
+                f.write(stderr_text)
+                if not stderr_text.endswith("\n"):
+                    f.write("\n")
+            f.write("\n")
+    except OSError as exc:
+        stderr_text += f"\n[stitched-parity] failed to append command log {log_path}: {exc}\n"
+        print(stderr_text.rstrip(), file=sys.stderr)
     return subprocess.CompletedProcess(cmd, returncode, stdout=stdout_text, stderr=stderr_text)
 
 


### PR DESCRIPTION
## Summary
- make stitched parity command logging best-effort when quota pressure prevents appending commands.log
- preserve subprocess stdout/stderr and final report flow instead of crashing after a phase has already produced useful diagnostics

## Validation
- .venv/bin/python -m py_compile version/v8/scripts/stitched_parity_v8.py
- git diff --check -- version/v8/scripts/stitched_parity_v8.py
- pre-push passed: build, v8 E2E smoke, v8 inference contracts, v7 training smoke, v8 fast regression, v7 training-kernel parity

## Note
- direct pre-commit hit the known staged snapshot issue: `No valid patches in input`; the final push validation passed on the clean branch.