### PR TITLE
fix(v8/vision): align Qwen3-VL encoder parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,6 +508,14 @@ AVX_FLAGS :=
 SSSE3_FLAGS :=
 endif
 
+# Opt-in llama.cpp-backed engine for strict stitched parity diagnostics.
+# This keeps ordinary CK builds independent from a local llama.cpp checkout.
+ifdef CK_LLAMA_PARITY_ENGINE
+SRCS += src/kernels/attention_oracle_ggml.c
+CFLAGS += -DCK_ENABLE_LLAMA_CPP_PARITY=1 -Illama.cpp/ggml/include -Illama.cpp/ggml/src
+$(info Building strict llama.cpp-backed parity engine)
+endif
+
 QUANT_COMMON_SRCS := src/kernels/dequant_kernels.c \
 	src/kernels/gemm_kernels_q4_0.c \
 	src/kernels/gemm_kernels_q4_1.c \
@@ -2298,7 +2306,7 @@ llamacpp-e2e:
 
 llamacpp-parity-stitched:
 	@echo "Running v8 stitched parity harness ($(V8_STITCHED_TEMPLATE), $(V8_STITCHED_MODE))..."
-	@$(PYTHON) version/v8/scripts/stitched_parity_v8.py \
+	@CK_LLAMA_PARITY_ENGINE=1 $(PYTHON) version/v8/scripts/stitched_parity_v8.py \
 	  --template "$(V8_STITCHED_TEMPLATE)" \
 	  --mode "$(V8_STITCHED_MODE)" \
 	  --decoder-gguf "$(V8_QWEN3VL_STITCHED_DECODER)" \
@@ -2317,6 +2325,20 @@ llamacpp-parity-stitched:
 	  $(if $(filter 1,$(V8_STITCHED_NO_GRANULAR)),--no-granular,) \
 	  $(if $(filter 0,$(V8_STITCHED_GRANULAR_CK_STOP)),--no-granular-ck-stop,--granular-ck-stop) \
 	  $(if $(V8_STITCHED_GRANULAR_LAYERS),--granular-layers "$(V8_STITCHED_GRANULAR_LAYERS)",)
+
+test-qwen3vl-strict-attn-oracle-build:
+	@if [ ! -f llama.cpp/ggml/include/ggml.h ]; then \
+	  echo "ERROR: llama.cpp GGML headers are required for the strict attention oracle."; \
+	  exit 2; \
+	fi
+	@$(MAKE) --no-print-directory CK_LLAMA_PARITY_ENGINE=1 build/libckernel_engine.so
+	@nm -D build/libckernel_engine.so | grep -q ' ck_attention_full_ggml_graph_oracle_multihead$$' || { \
+	  echo "ERROR: strict attention oracle symbol is missing from build/libckernel_engine.so"; \
+	  exit 1; \
+	}
+	@echo "Strict Qwen3-VL attention oracle build: PASS"
+
+.PHONY: test-qwen3vl-strict-attn-oracle-build
 
 llamacpp-parity-full-stitched: llamacpp-parity-full llamacpp-parity-stitched
 
@@ -3325,6 +3347,7 @@ help:
 	@echo "  make llamacpp-parity      llama.cpp parity (Q4_K)"
 	@echo "  make llamacpp-parity-full llama.cpp kernel parity suite"
 	@echo "  make llamacpp-parity-stitched v8 Qwen3-VL stitched parity harness"
+	@echo "  make test-qwen3vl-strict-attn-oracle-build verify stitched parity oracle build"
 	@echo "  make llamacpp-e2e         llama.cpp end-to-end compatibility suite"
 	@echo "  make smollm-train-parity  Full training parity"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -747,7 +747,10 @@ all: $(BUILD_DIR) $(LIB)
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-$(BUILD_STAMP): | $(BUILD_DIR)
+.PHONY: FORCE_BUILD_FLAGS
+FORCE_BUILD_FLAGS:
+
+$(BUILD_STAMP): FORCE_BUILD_FLAGS | $(BUILD_DIR)
 	@printf 'CC=%s\nCFLAGS=%s\nLDFLAGS=%s\n' "$(CC)" "$(CFLAGS)" "$(LDFLAGS)" > $@.tmp
 	@if [ ! -f $@ ] || ! cmp -s $@.tmp $@; then mv $@.tmp $@; else rm $@.tmp; fi
 

--- a/logs/2026-07-10-qwen3vl-avx2-encoder-circuit/COMMIT_MESSAGE.md
+++ b/logs/2026-07-10-qwen3vl-avx2-encoder-circuit/COMMIT_MESSAGE.md
@@ -1,0 +1,21 @@
+fix(v8/vision): align qwen3-vl mrope circuit
+
+Why: Qwen3-VL AVX2 diverged from llama.cpp early because the production vision
+kernel interpreted GGML's M-RoPE n_dims as total width instead of the half-width
+pair offset. Strict Q8 diagnostics could also consume a stale attention cache
+when unrelated tensor shapes had the same element count.
+
+What: implement the 72-wide Qwen3-VL vision rotary contract, guard strict cached
+Q8 input substitution behind an explicit diagnostic switch, route Q8 projector
+and DeepStack operations through architecture metadata, and bound stitched CK
+dumps with the same op filter used for llama.cpp. Revalidate the Make build-flags
+stamp on every invocation so strict-oracle, OpenMP, and ISA variants cannot reuse
+an incompatible engine library.
+
+Validation: vision kernels and Qwen3-VL template tests pass. The strict 27-layer
+encoder matches all 16,515,072 final-prefix floats exactly against llama.cpp.
+Layer-0 post-RoPE Q and K are within 4.768e-7 in production attribution.
+Canonical OCR persistent parity moves from step 4 to step 20 and now matches the
+Xeon signature. An exact llama visual prefix moves the remaining decoder mismatch
+to step 31. Full replay at step 20 confirms the residual mismatch is not
+KV-cache-only. No tolerance was relaxed.

--- a/logs/2026-07-10-qwen3vl-avx2-encoder-circuit/README.md
+++ b/logs/2026-07-10-qwen3vl-avx2-encoder-circuit/README.md
@@ -1,0 +1,117 @@
+# Qwen3-VL AVX2 encoder circuit attribution
+
+## Scope
+
+Canonical GGUF parity run using:
+
+- image: `ocr/1 81.jpg`, converted to the canonical PPM
+- source JPEG SHA-256: `eb3becd507063f184d417a6baccfdb22d86277308f21a679aac4e029ed8f25ff`
+- image token cap: 1024
+- visual grid: `36 x 28`
+- visual prefix: `1008 x 16384`
+- prompt: `Extract visible form fields as compact JSON.`
+- context: 4096
+- threads: 20
+
+## Fixed circuit defects
+
+### Vision M-RoPE width
+
+The production vision kernel treated `n_dims=36` as the total rotary width. In
+GGML's Qwen3-VL vision contract it is the half-width offset: a 72-wide head is
+rotated as `(i, i + 36)`, with 18 height pairs and 18 width pairs. The kernel
+also used the wrong frequency denominator as a consequence.
+
+The corrected production kernel now matches the Qwen3-VL vision reference for
+the complete 72-wide head within one FP32 ULP:
+
+| Tensor | Maximum absolute difference |
+|---|---:|
+| layer 0 Q after M-RoPE | `4.768e-7` |
+| layer 0 K after M-RoPE | `4.768e-7` |
+
+The focused vision unit test uses the real Qwen3-VL dimensions so this semantic
+error cannot regress behind a smaller synthetic shape.
+
+### Q8 projection routing
+
+Qwen3-VL Q8 projector and DeepStack projections now use the existing Q8
+activation-contract adapter through architecture metadata. The selection is
+data-driven (`q8_0_contract_ops`) rather than embedded in generated C.
+
+Strict attention diagnostics can cache the GGML attention result for the next
+Q8 projection. A token-count/product collision made that cache unsafe when it
+was consumed solely by element count, so cached substitution now requires the
+explicit diagnostic variable `CK_STRICT_GEMM_USE_CACHED_A=1`. Production does
+not use this substitution.
+
+### Diagnostic build selection
+
+The Make build-flags stamp existed but was not reevaluated after its first
+creation. Changing `CK_LLAMA_PARITY_ENGINE`, OpenMP, or ISA flags could
+therefore leave an incompatible `libckernel_engine.so` marked up to date. The
+stamp is now checked on every Make invocation and only changes timestamp when
+the effective compiler/linker flags differ. The strict-oracle symbol gate now
+tests the library variant it requested rather than whichever variant happened
+to be built last.
+
+## Fresh circuit attribution
+
+After the build-stamp correction, a fresh strict-oracle run passes every
+comparable layer-0 boundary exactly:
+
+| Boundary | Maximum absolute difference |
+|---|---:|
+| Q after M-RoPE | `0` |
+| K after M-RoPE | `0` |
+| raw attention context (`kqv_out`) | `0` |
+| Q8 attention output projection | `0` |
+| residual after attention | `0` |
+| MLP output | `0` |
+| layer output | `0` |
+
+The full 27-layer strict encoder also matches llama.cpp exactly:
+
+| Metric | Value |
+|---|---:|
+| compared FP32 values | `16,515,072` |
+| cosine | `1.0` |
+| RMSE | `0` |
+| mean absolute difference | `0` |
+| maximum absolute difference | `0` |
+
+This proves the generated circuit, weight views, tensor order, DeepStack
+branches, projector, and final `1008 x 16384` bridge layout. Production AVX2
+still accumulates numerical drift: the current full prefix is approximately
+cosine `0.99950`, RMSE `0.00514`, and maximum absolute difference `0.467`.
+That is an optimized-kernel parity problem, not a remaining stitching problem.
+
+## End-to-end result
+
+The production encoder and persistent decoder were tested against llama.cpp
+for 64 greedy tokens, stopping at the first top-1 mismatch.
+
+| Prefix source | First mismatch | CK | llama.cpp | Logit cosine | Top-16 overlap |
+|---|---:|---|---|---:|---:|
+| CK production encoder | 20 | `5` | `submit` | `0.999366` | `16/16` |
+| exact llama.cpp encoder prefix | 31 | `":` | `_name` | `0.999365` | `15/16` |
+
+Before the M-RoPE correction, this AVX2 lane failed at step 4. The corrected
+encoder now reproduces the Xeon first-mismatch signature at step 20.
+
+Full replay at step 20 still chooses CK token `5`, so this is not an
+incremental KV-cache-only failure. Persistent-vs-full-replay layer-0 tensors
+remain close, while full CK replay still differs from llama.cpp logits.
+
+## Remaining work
+
+This change does not claim 64-token exact parity. The next targets are:
+
+1. Reduce production AVX2 attention/Q8 projection accumulation drift while
+   preserving the now-proven circuit contract.
+2. Attribute the later decoder-only mismatch exposed at step 31 with an exact
+   llama.cpp visual prefix.
+3. Run the OCR image sweep only after the canonical image passes the required
+   long-token criterion.
+
+No tolerance was relaxed.

--- a/logs/2026-07-10-qwen3vl-strict-attention-oracle/README.md
+++ b/logs/2026-07-10-qwen3vl-strict-attention-oracle/README.md
@@ -1,0 +1,60 @@
+# Qwen3-VL strict attention oracle guard
+
+## Why this change exists
+
+The v8 stitched Qwen3-VL harness enabled `--strict-parity`, but the bridge and
+numeric-parity subprocesses rebuilt the ordinary CK engine. The llama/GGML
+attention oracle was therefore absent and strict attention silently fell back
+to the CK implementation. That made the first reported `attn_output` and MLP-up
+divergences unsuitable for locating the remaining model stitching bug.
+
+This change makes the llama-backed engine an explicit, opt-in diagnostic build
+and propagates that build mode through the complete stitched parity subprocess
+tree. Normal production builds remain independent of a llama.cpp checkout.
+
+## Changes
+
+- `CK_LLAMA_PARITY_ENGINE=1` adds the llama/GGML attention oracle to
+  `build/libckernel_engine.so`.
+- Strict non-causal attention uses the multi-head GGML graph oracle when that
+  diagnostic engine is loaded.
+- The oracle executes through its owned GGML context, avoiding the backend
+  scheduler assertion caused by tensors without backend buffers.
+- `make test-qwen3vl-strict-attn-oracle-build` verifies that the diagnostic
+  library exports the multi-head oracle symbol.
+- `make llamacpp-parity-stitched` propagates the diagnostic build mode to every
+  child process and internal `make` invocation.
+
+## Validation
+
+```sh
+make test-qwen3vl-strict-attn-oracle-build
+git diff --check
+```
+
+Canonical Qwen3-VL OCR diagnostic configuration:
+
+- image: `ocr/1 81.jpg`, canonical PPM equivalent
+- image token cap: 1024
+- visual output shape: `1008 x 16384`
+- prompt: `Extract visible form fields as compact JSON.`
+- context: 4096
+- threads: 20
+
+With the diagnostic oracle enabled, comparable tensors at encoder layers 0, 1,
+5, and 26 passed with maximum absolute difference 0.0. The final prefix is
+improved but not parity-clean:
+
+| Metric | Value |
+|---|---:|
+| cosine | 0.9999405675 |
+| RMSE | 0.0017708609 |
+| mean absolute difference | 0.0012538217 |
+| maximum absolute difference | 0.0231761634 |
+
+## Remaining divergence
+
+The next attribution target is after the final encoder block: final post-LN,
+spatial merge, DeepStack branches, projector FC1/GELU/FC2, and branch/prefix
+concatenation. The attention oracle is diagnostic infrastructure, not a claim
+that production AVX2 attention or the full Qwen3-VL prefix is parity-complete.

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -377,6 +377,7 @@ static inline void ck_vec_scale_f32_inplace(float *x, int n, float scale);
 static inline float ck_vec_max_f32_contig(const float *x, int n);
 
 #if CK_ENABLE_LLAMA_CPP_PARITY
+struct ggml_compute_params;
 typedef void (*ck_ggml_vec_dot_f32_fn)(int, float *, size_t, const float *, size_t, const float *, size_t, int);
 typedef double (*ck_ggml_vec_soft_max_f32_fn)(int, float *, const float *, float);
 typedef void (*ck_ggml_compute_forward_mul_mat_fn)(const struct ggml_compute_params *, struct ggml_tensor *);
@@ -3283,6 +3284,22 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
 
     if (ck_strict_parity_enabled()) {
         const float strict_scale = ck_attention_strict_scale_f32(head_dim);
+#if CK_ENABLE_LLAMA_CPP_PARITY
+        if (!causal &&
+            ck_attention_full_ggml_graph_oracle_multihead(q,
+                                                          k,
+                                                          v,
+                                                          output,
+                                                          num_heads,
+                                                          num_kv_heads,
+                                                          num_tokens,
+                                                          head_dim,
+                                                          aligned_head_dim,
+                                                          kv_stride_tokens,
+                                                          strict_scale)) {
+            return;
+        }
+#endif
         float *score_row = (float *) alloca((size_t) T * sizeof(float));
         float *logit_row = (float *) alloca((size_t) T * sizeof(float));
         float *v_cols = (float *) alloca((size_t) head_dim * (size_t) T * sizeof(float));

--- a/src/kernels/attention_oracle_ggml.c
+++ b/src/kernels/attention_oracle_ggml.c
@@ -727,29 +727,14 @@ int ck_attention_full_ggml_graph_oracle_multihead(const float *q,
     ck_ggml_new_graph_fn ggml_new_graph_fn = ck_resolve_ggml_new_graph();
     ck_ggml_build_forward_expand_fn ggml_build_forward_expand_fn = ck_resolve_ggml_build_forward_expand();
     ck_ggml_set_input_fn ggml_set_input_fn = ck_resolve_ggml_set_input();
-    ck_ggml_backend_init_by_type_fn ggml_backend_init_by_type_fn = ck_resolve_ggml_backend_init_by_type();
-    ck_ggml_backend_free_fn ggml_backend_free_fn = ck_resolve_ggml_backend_free();
-    ck_ggml_backend_cpu_set_n_threads_fn ggml_backend_cpu_set_n_threads_fn = ck_resolve_ggml_backend_cpu_set_n_threads();
-    ck_ggml_backend_get_default_buffer_type_fn ggml_backend_get_default_buffer_type_fn = ck_resolve_ggml_backend_get_default_buffer_type();
-    ck_ggml_backend_sched_new_fn ggml_backend_sched_new_fn = ck_resolve_ggml_backend_sched_new();
-    ck_ggml_backend_sched_free_fn ggml_backend_sched_free_fn = ck_resolve_ggml_backend_sched_free();
-    ck_ggml_backend_sched_reset_fn ggml_backend_sched_reset_fn = ck_resolve_ggml_backend_sched_reset();
-    ck_ggml_backend_sched_alloc_graph_fn ggml_backend_sched_alloc_graph_fn = ck_resolve_ggml_backend_sched_alloc_graph();
-    ck_ggml_backend_tensor_set_fn ggml_backend_tensor_set_fn = ck_resolve_ggml_backend_tensor_set();
-    ck_ggml_backend_tensor_get_fn ggml_backend_tensor_get_fn = ck_resolve_ggml_backend_tensor_get();
-    ck_ggml_backend_sched_graph_compute_fn ggml_backend_sched_graph_compute_fn = ck_resolve_ggml_backend_sched_graph_compute();
+    ck_ggml_graph_compute_with_ctx_fn ggml_graph_compute_with_ctx_fn = ck_resolve_ggml_graph_compute_with_ctx();
 
     if (!ggml_cpu_init_fn || !ggml_init_fn || !ggml_free_fn ||
         !ggml_new_tensor_1d_fn || !ggml_new_tensor_2d_fn ||
         !ggml_view_3d_fn || !ggml_permute_fn || !ggml_cont_fn || !ggml_cont_2d_fn ||
         !ggml_mul_mat_fn || !ggml_soft_max_ext_fn || !ggml_new_graph_fn ||
-        !ggml_build_forward_expand_fn || !ggml_backend_init_by_type_fn ||
-        !ggml_set_input_fn ||
-        !ggml_backend_free_fn || !ggml_backend_cpu_set_n_threads_fn ||
-        !ggml_backend_get_default_buffer_type_fn || !ggml_backend_sched_new_fn ||
-        !ggml_backend_sched_free_fn || !ggml_backend_sched_reset_fn ||
-        !ggml_backend_sched_alloc_graph_fn || !ggml_backend_tensor_set_fn ||
-        !ggml_backend_tensor_get_fn || !ggml_backend_sched_graph_compute_fn) {
+        !ggml_build_forward_expand_fn || !ggml_graph_compute_with_ctx_fn ||
+        !ggml_set_input_fn) {
         return 0;
     }
 
@@ -768,7 +753,7 @@ int ck_attention_full_ggml_graph_oracle_multihead(const float *q,
     struct ggml_init_params params = {
         .mem_size = mem_size,
         .mem_buffer = NULL,
-        .no_alloc = true,
+        .no_alloc = false,
     };
     struct ggml_context *ctx = ggml_init_fn(params);
     if (!ctx) {
@@ -882,36 +867,8 @@ int ck_attention_full_ggml_graph_oracle_multihead(const float *q,
         ggml_build_forward_expand_fn(gf, kq_scores_dump);
     }
     ggml_build_forward_expand_fn(gf, cur);
-    ggml_backend_t backend = ggml_backend_init_by_type_fn(GGML_BACKEND_DEVICE_TYPE_CPU, NULL);
-    if (!backend) {
+    if (ggml_graph_compute_with_ctx_fn(ctx, gf, 1) != GGML_STATUS_SUCCESS) {
         free(qkv_pack);
-        ggml_free_fn(ctx);
-        return 0;
-    }
-    ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type_fn(backend);
-    ggml_backend_t backends[1] = { backend };
-    ggml_backend_buffer_type_t bufts[1] = { buft };
-    ggml_backend_sched_t sched = ggml_backend_sched_new_fn(backends, bufts, 1, 8192, false, true);
-    if (!sched) {
-        free(qkv_pack);
-        ggml_backend_free_fn(backend);
-        ggml_free_fn(ctx);
-        return 0;
-    }
-    ggml_backend_cpu_set_n_threads_fn(backend, 1);
-    ggml_backend_sched_reset_fn(sched);
-    if (!ggml_backend_sched_alloc_graph_fn(sched, gf)) {
-        free(qkv_pack);
-        ggml_backend_sched_free_fn(sched);
-        ggml_backend_free_fn(backend);
-        ggml_free_fn(ctx);
-        return 0;
-    }
-    ggml_backend_tensor_set_fn(qkv_base, qkv_pack, 0, qkv_pack_elems * sizeof(float));
-    free(qkv_pack);
-    if (ggml_backend_sched_graph_compute_fn(sched, gf) != GGML_STATUS_SUCCESS) {
-        ggml_backend_sched_free_fn(sched);
-        ggml_backend_free_fn(backend);
         ggml_free_fn(ctx);
         return 0;
     }
@@ -934,12 +891,11 @@ int ck_attention_full_ggml_graph_oracle_multihead(const float *q,
         const size_t cur_elems = (size_t) cur->ne[0] * (size_t) cur->ne[1] * (size_t) cur->ne[2] * (size_t) cur->ne[3];
         float *cur_host = (float *) malloc(cur_elems * sizeof(float));
         if (!cur_host) {
-            ggml_backend_sched_free_fn(sched);
-            ggml_backend_free_fn(backend);
+            free(qkv_pack);
             ggml_free_fn(ctx);
             return 0;
         }
-        ggml_backend_tensor_get_fn(cur, cur_host, 0, cur_elems * sizeof(float));
+        memcpy(cur_host, cur->data, cur_elems * sizeof(float));
         const float *src = cur_host;
         ck_strict_store_next_gemm_a(src, (size_t) num_tokens * (size_t) num_heads * (size_t) head_dim);
         const size_t token_width = (size_t) num_heads * (size_t) head_dim;
@@ -957,8 +913,7 @@ int ck_attention_full_ggml_graph_oracle_multihead(const float *q,
     }
 
     ok = 1;
-    ggml_backend_sched_free_fn(sched);
-    ggml_backend_free_fn(backend);
+    free(qkv_pack);
     ggml_free_fn(ctx);
     return ok;
 }

--- a/src/kernels/gemm_kernels_q8_0_q8_0_contract.c
+++ b/src/kernels/gemm_kernels_q8_0_q8_0_contract.c
@@ -43,6 +43,12 @@ static int ck_q80_contract_dump_enabled(void)
     return v && v[0] && strcmp(v, "0") != 0;
 }
 
+static int ck_q80_contract_cached_input_enabled(void)
+{
+    const char *v = getenv("CK_STRICT_GEMM_USE_CACHED_A");
+    return v && v[0] && strcmp(v, "0") != 0;
+}
+
 static void ck_q80_contract_dump_tensor(const char *name,
                                         int layer_id,
                                         const float *data,
@@ -422,7 +428,7 @@ void gemm_nt_q8_0_q8_0_contract(const float *A,
     const int dump_enabled = strict && ck_q80_contract_dump_enabled();
     int strict_cached_layer = -1;
     int strict_dump_layer = -1;
-    if (ck_strict_parity_enabled()) {
+    if (ck_strict_parity_enabled() && ck_q80_contract_cached_input_enabled()) {
         const float *cached = ck_strict_consume_next_gemm_a((size_t) M * (size_t) K);
         if (cached) {
             A_use = cached;

--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -1240,27 +1240,24 @@ static void vision_mrope_apply_head(
         return;
     }
 
-    int rope_dims = n_dims;
-    if (rope_dims > head_dim) {
-        rope_dims = head_dim;
+    int rope_pairs = n_dims;
+    if (rope_pairs > head_dim / 2) {
+        rope_pairs = head_dim / 2;
     }
-    rope_dims &= ~1;
-    if (rope_dims <= 0) {
+    if (rope_pairs <= 0 || 2 * rope_pairs > aligned_head_dim) {
         return;
     }
 
-    const int rope_pairs = rope_dims / 2;
-    const int axis_pairs = rope_pairs / 2;
-    if (axis_pairs <= 0) {
+    const int axis_y_pairs = sections[0];
+    const int axis_x_pairs = sections[1];
+    if (axis_y_pairs <= 0 || axis_x_pairs <= 0 || axis_y_pairs + axis_x_pairs > rope_pairs) {
         return;
     }
 
     const int num_pos = num_tokens;
-    const int axis_rotary_dim = axis_pairs * 2;
-    const float theta_scale = powf(freq_base, -2.0f / (float) axis_rotary_dim);
-    float corr_dims[2] = {0.0f, (float) (axis_rotary_dim - 1)};
-    vision_mrope_yarn_corr_dims(axis_rotary_dim, n_ctx_orig, freq_base, beta_fast, beta_slow, corr_dims);
-    (void) sections;
+    const float theta_scale = powf(freq_base, -2.0f / (float) rope_pairs);
+    float corr_dims[2] = {0.0f, (float) (rope_pairs - 1)};
+    vision_mrope_yarn_corr_dims(rope_pairs, n_ctx_orig, freq_base, beta_fast, beta_slow, corr_dims);
 
     for (int tok = 0; tok < num_tokens; ++tok) {
         float theta_y = (float) positions[tok];
@@ -1268,8 +1265,10 @@ static void vision_mrope_apply_head(
         float *row = x + (size_t) tok * (size_t) aligned_head_dim;
 
         for (int pair = 0; pair < rope_pairs; ++pair) {
-            const int is_x_axis = pair >= axis_pairs;
-            const int axis_pair = is_x_axis ? pair - axis_pairs : pair;
+            const int is_x_axis = pair >= axis_y_pairs && pair < axis_y_pairs + axis_x_pairs;
+            if (pair == axis_y_pairs) {
+                theta_x = (float) positions[tok + num_pos];
+            }
             const float theta = is_x_axis ? theta_x : theta_y;
 
             float cos_theta = 0.0f;
@@ -1278,7 +1277,7 @@ static void vision_mrope_apply_head(
                 theta,
                 freq_scale,
                 corr_dims,
-                axis_pair * 2,
+                pair * 2,
                 ext_factor,
                 attn_factor,
                 &cos_theta,
@@ -1286,15 +1285,12 @@ static void vision_mrope_apply_head(
             );
 
             const float x0 = row[pair];
-            const float x1 = row[pair + rope_pairs];
+            const float x1 = row[pair + n_dims];
             row[pair] = x0 * cos_theta - x1 * sin_theta;
-            row[pair + rope_pairs] = x0 * sin_theta + x1 * cos_theta;
+            row[pair + n_dims] = x0 * sin_theta + x1 * cos_theta;
 
-            if (is_x_axis) {
-                theta_x *= theta_scale;
-            } else {
-                theta_y *= theta_scale;
-            }
+            theta_y *= theta_scale;
+            theta_x *= theta_scale;
         }
     }
 }

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -285,6 +285,11 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
         self.assertTrue(gemma_cfg["prefer_fp32_logits"])
 
         vision_cfg = build_ir_v8._inject_runtime_config_defaults({}, "qwen3_vl_vision")
+        self.assertTrue(vision_cfg["prefer_q8_0_contract"])
+        self.assertEqual(
+            vision_cfg["q8_0_contract_ops"],
+            ["projector_fc2", "branch_fc1", "branch_fc2"],
+        )
         self.assertEqual(
             vision_cfg["activation_preference_by_op"],
             {
@@ -294,7 +299,6 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
                 "branch_fc2": "fp32",
             },
         )
-        self.assertNotIn("prefer_q8_0_contract", vision_cfg)
 
     def test_qwen3vl_branch_plan_reads_template_declared_layers(self) -> None:
         manifest = _make_qwen3vl_manifest()
@@ -433,10 +437,8 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             split_qkv = next(op for op in call_ops if op.get("op") == "split_qkv_packed")
             self.assertEqual(split_qkv.get("function"), "split_qkv_packed_head_major_forward")
             qkv_packed_proj = next(op for op in call_ops if op.get("op") == "qkv_packed_proj")
-            self.assertEqual(qkv_packed_proj.get("function"), "gemm_nt_q8_0_q8_0")
-            quantize_input_0 = next(op for op in call_ops if op.get("op") == "quantize_input_0")
-            quantize_input_rows = next(arg for arg in quantize_input_0.get("args", []) if arg.get("name") == "rows")
-            self.assertEqual(quantize_input_rows.get("expr"), str(manifest["config"]["context_length"]))
+            self.assertEqual(qkv_packed_proj.get("function"), "gemm_nt_q8_0_q8_0_contract")
+            self.assertNotIn("quantize_input_0", [op.get("op") for op in call_ops])
             attn = next(op for op in call_ops if op.get("op") == "attn")
             self.assertEqual(attn.get("function"), "attention_forward_full_head_major_gqa_flash_strided")
             attn_idx = next(i for i, op in enumerate(call_ops) if op.get("op") == "attn")
@@ -445,15 +447,15 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             self.assertLess(attn_idx, transpose_idx)
             self.assertLess(transpose_idx, out_proj_idx)
             out_proj = next(op for op in call_ops if op.get("op") == "out_proj")
-            self.assertEqual(out_proj.get("function"), "gemm_nt_q8_0_q8_0")
-            self.assertIn("quantize_out_proj_input", [op.get("op") for op in call_ops])
+            self.assertEqual(out_proj.get("function"), "gemm_nt_q8_0_q8_0_contract")
+            self.assertNotIn("quantize_out_proj_input", [op.get("op") for op in call_ops])
             self.assertNotIn("kv_cache_batch_copy", [op.get("op") for op in call_ops])
             projector_fc1 = next(op for op in call_ops if op.get("op") == "projector_fc1")
-            self.assertEqual(projector_fc1.get("function"), "gemm_nt_q8_0_q8_0")
+            self.assertEqual(projector_fc1.get("function"), "gemm_nt_q8_0_q8_0_contract")
             projector_fc1_bias = next(arg for arg in projector_fc1.get("args", []) if arg.get("name") == "bias")
             self.assertEqual(projector_fc1_bias.get("weight_ref"), "mm.0.bias")
             projector_fc2 = next(op for op in call_ops if op.get("op") == "projector_fc2")
-            self.assertEqual(projector_fc2.get("function"), "gemm_nt_q8_0")
+            self.assertEqual(projector_fc2.get("function"), "gemm_nt_q8_0_q8_0_contract")
             projector_fc2_input = next(arg for arg in projector_fc2.get("args", []) if arg.get("name") == "A")
             self.assertEqual(projector_fc2_input.get("buffer_ref"), "mlp_scratch")
             projector_fc2_bias = next(arg for arg in projector_fc2.get("args", []) if arg.get("name") == "bias")
@@ -462,11 +464,11 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             branch_concat_main = next(arg for arg in branch_concat.get("args", []) if arg.get("name") == "main_input")
             self.assertEqual(branch_concat_main.get("buffer_ref"), "vision_output")
             branch_fc1 = next(op for op in call_ops if op.get("op") == "branch_fc1")
-            self.assertEqual(branch_fc1.get("function"), "gemm_nt_q8_0")
+            self.assertEqual(branch_fc1.get("function"), "gemm_nt_q8_0_q8_0_contract")
             branch_fc1_bias = next(arg for arg in branch_fc1.get("args", []) if arg.get("name") == "bias")
             self.assertEqual(branch_fc1_bias.get("weight_ref"), "v.deepstack.0.fc1.bias")
             branch_fc2 = next(op for op in call_ops if op.get("op") == "branch_fc2")
-            self.assertEqual(branch_fc2.get("function"), "gemm_nt_q8_0")
+            self.assertEqual(branch_fc2.get("function"), "gemm_nt_q8_0_q8_0_contract")
             branch_fc2_bias = next(arg for arg in branch_fc2.get("args", []) if arg.get("name") == "bias")
             self.assertEqual(branch_fc2_bias.get("weight_ref"), "v.deepstack.0.fc2.bias")
             patch_proj = next(op for op in call_ops if op.get("op") == "patch_proj")
@@ -478,7 +480,7 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             branch_norm = next(op for op in call_ops if op.get("op") == "branch_layernorm")
             self.assertEqual(branch_norm.get("function"), "layernorm_naive_serial_matched_precision")
             mlp_up = next(op for op in call_ops if op.get("op") == "mlp_up")
-            self.assertEqual(mlp_up.get("function"), "gemm_nt_q8_0_q8_0")
+            self.assertEqual(mlp_up.get("function"), "gemm_nt_q8_0_q8_0_contract")
             mlp_up_n = next(arg for arg in mlp_up.get("args", []) if arg.get("name") == "N")
             self.assertEqual(mlp_up_n.get("expr"), str(manifest["config"]["intermediate_size"]))
             gelu = next(op for op in call_ops if op.get("op") == "gelu")
@@ -495,15 +497,7 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             spatial_merge = next(op for op in call_ops if op.get("op") == "spatial_merge")
             spatial_merge_out = next(arg for arg in spatial_merge.get("args", []) if arg.get("name") == "output")
             self.assertEqual(spatial_merge_out.get("buffer_ref"), "embedded_input")
-            quantize_final_output = next(op for op in call_ops if op.get("op") == "quantize_final_output")
-            quant_x = next(arg for arg in quantize_final_output.get("args", []) if arg.get("name") == "x")
-            quant_y = next(arg for arg in quantize_final_output.get("args", []) if arg.get("name") == "y")
-            quant_k = next(arg for arg in quantize_final_output.get("args", []) if arg.get("name") == "k")
-            quant_rows = next(arg for arg in quantize_final_output.get("args", []) if arg.get("name") == "rows")
-            self.assertEqual(quant_x.get("buffer_ref"), "embedded_input")
-            self.assertEqual(quant_y.get("buffer_ref"), "layer_input")
-            self.assertEqual(quant_k.get("expr"), str(manifest["config"]["projector_in_dim"]))
-            self.assertEqual(quant_rows.get("expr"), str(manifest["config"]["vision_merged_tokens"]))
+            self.assertNotIn("quantize_final_output", [op.get("op") for op in call_ops])
             mlp_down = next(op for op in call_ops if op.get("op") == "mlp_down")
             self.assertEqual(mlp_down.get("function"), "gemm_nt_f16")
 
@@ -525,8 +519,7 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             self.assertIn("gemm_naive_parallel", text)
             self.assertIn("position_embeddings_add_tiled_2d", text)
             self.assertIn("spatial_merge_contiguous_tiled", text)
-            self.assertIn("for (int _t = 0; _t < _rows; ++_t)", text)
-            self.assertIn("quantize_row_q8_0(_x_base + (size_t)_t * (size_t)_k, (void*)(_y_base + (size_t)_t * _row_bytes), _k);", text)
+            self.assertIn("gemm_nt_q8_0_q8_0_contract", text)
             self.assertIn("add_stream_reorder_2d", text)
             self.assertIn("vision_bridge_output", text)
             self.assertIn("ck_strict_mtmd_clip_encode_planar_f32", text)

--- a/unittest/test_vision.py
+++ b/unittest/test_vision.py
@@ -945,12 +945,11 @@ def _ref_qwen3vl_vision_mrope_qk(
     def apply(x: torch.Tensor) -> torch.Tensor:
         out = x.clone()
         head_dim = out.shape[-1]
-        rope_dims = min(int(n_dims), int(head_dim)) & ~1
-        rope_pairs = rope_dims // 2
+        rope_pairs = min(int(n_dims), int(head_dim) // 2)
         axis_pairs = rope_pairs // 2
-        if axis_pairs <= 0:
+        if axis_pairs <= 0 or 2 * rope_pairs > head_dim:
             return out
-        theta_scale = freq_base ** (-2.0 / float(axis_pairs * 2))
+        theta_scale = freq_base ** (-2.0 / float(rope_pairs))
         num_tokens = out.shape[1]
         for h in range(out.shape[0]):
             for tok in range(num_tokens):
@@ -958,15 +957,14 @@ def _ref_qwen3vl_vision_mrope_qk(
                 theta_x = float(positions[1, tok].item())
                 for pair in range(rope_pairs):
                     is_x_axis = pair >= axis_pairs
-                    axis_pair = pair - axis_pairs if is_x_axis else pair
                     base_theta = theta_x if is_x_axis else theta_y
-                    theta = base_theta * (theta_scale ** axis_pair) * freq_scale
+                    theta = base_theta * (theta_scale ** (pair % axis_pairs)) * freq_scale
                     c = math.cos(theta)
                     s = math.sin(theta)
                     x0 = float(out[h, tok, pair].item())
-                    x1 = float(out[h, tok, pair + rope_pairs].item())
+                    x1 = float(out[h, tok, pair + n_dims].item())
                     out[h, tok, pair] = x0 * c - x1 * s
-                    out[h, tok, pair + rope_pairs] = x0 * s + x1 * c
+                    out[h, tok, pair + n_dims] = x0 * s + x1 * c
         return out
 
     return apply(q), apply(k)
@@ -990,7 +988,7 @@ def test_mrope_qk_vision(num_heads=2, num_kv_heads=2, num_tokens=4, head_dim=8):
     k = torch.randn(num_kv_heads, num_tokens, head_dim, dtype=torch.float32)
     positions = _ref_vision_position_ids(2, 2, 2)
     sections = [max(1, head_dim // 4)] * 4
-    n_dims = head_dim
+    n_dims = head_dim // 2
 
     ref_q, ref_k = _ref_qwen3vl_vision_mrope_qk(q, k, positions, n_dims)
     out_q, out_k = run_c_mrope_qk(q, k, positions, n_dims, sections)

--- a/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
+++ b/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
@@ -154,6 +154,7 @@ def _run_generated_encoder_with_dump(
     strict_parity: bool,
     strict_dump_layer: int | None,
     ck_stop_op: int | None,
+    dump_names: str | None,
 ) -> None:
     dump_dir.mkdir(parents=True, exist_ok=True)
     dump_path = dump_dir / "dump.bin"
@@ -171,6 +172,7 @@ def _run_generated_encoder_with_dump(
         None if strict_dump_layer is None else str(strict_dump_layer),
     )
     old_stop_op = _with_env_var("CK_STOP_OP", None if ck_stop_op is None else str(int(ck_stop_op)))
+    old_filter = _with_env_var("CK_PARITY_OP_FILTER", dump_names)
     try:
         npv8._run_generated_encoder(
             model_so=model_so,
@@ -181,6 +183,7 @@ def _run_generated_encoder_with_dump(
             strict_parity=strict_parity,
         )
     finally:
+        _restore_env_var("CK_PARITY_OP_FILTER", old_filter)
         _restore_env_var("CK_STOP_OP", old_stop_op)
         _restore_env_var("CK_STRICT_ATTN_DUMP_LAYER", old_dump_layer)
         _restore_env_var("CK_PARITY_DIR", old_dump)
@@ -265,6 +268,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     ap.add_argument("--llama-dump-layer", type=int, default=None, help="Optional exact llama layer id filter; globals remain included")
     ap.add_argument("--ck-strict-dump-layer", type=int, default=None, help="Optional exact CK strict-attention dump layer filter")
+    ap.add_argument(
+        "--ck-dump-names",
+        type=str,
+        default=None,
+        help="Optional comma-separated CK dump filter; defaults to --llama-dump-names",
+    )
     ck_stop = ap.add_mutually_exclusive_group()
     ck_stop.add_argument("--ck-stop-op", type=int, default=None, help="Return from generated CK encoder immediately after this generated op index")
     ck_stop.add_argument("--ck-stop-layer", type=int, default=None, help="Return from generated CK encoder after the last generated op in this encoder layer")
@@ -320,6 +329,7 @@ def main(argv: list[str] | None = None) -> int:
         strict_parity=bool(args.strict_parity),
         strict_dump_layer=args.ck_strict_dump_layer,
         ck_stop_op=ck_stop_op,
+        dump_names=args.ck_dump_names or args.llama_dump_names,
     )
     _run_llama_encoder_with_dump(
         shim_so=shim_so,
@@ -368,6 +378,7 @@ def main(argv: list[str] | None = None) -> int:
         },
         "strict_parity": bool(args.strict_parity),
         "llama_dump_names": args.llama_dump_names,
+        "ck_dump_names": args.ck_dump_names or args.llama_dump_names,
         "llama_dump_layer": args.llama_dump_layer,
         "atol": args.atol,
         "rtol": args.rtol,

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -244,6 +244,10 @@ def _inject_runtime_config_defaults(config: Dict[str, Any], arch: str) -> Dict[s
         )
     elif arch_lc == "qwen3_vl_vision":
         config.setdefault("prefer_q8_0_contract", True)
+        config.setdefault(
+            "q8_0_contract_ops",
+            ["projector_fc2", "branch_fc1", "branch_fc2"],
+        )
         _merge_activation_defaults({
             "mlp_down": "fp32",
             "out_proj": "q8_0",
@@ -4498,6 +4502,12 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
     # Weight dtype still comes from the manifest; this only selects the activation
     # contract path when a model family explicitly requests it.
     prefer_q8_contract = bool(config.get("prefer_q8_0_contract", False))
+    q8_contract_ops_raw = config.get("q8_0_contract_ops", [])
+    q8_contract_ops = {
+        str(op).strip()
+        for op in q8_contract_ops_raw
+        if str(op).strip()
+    } if isinstance(q8_contract_ops_raw, (list, tuple, set)) else set()
     # Gemma parity guardrail: keep logits projection on FP32-activation kernels.
     # This remains a runtime config knob rather than template metadata.
     prefer_fp32_logits = bool(config.get("prefer_fp32_logits", False))
@@ -4694,7 +4704,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         allow_q8_contract: bool,
     ) -> Optional[str]:
         """Optionally remap standard Q8_0 kernels to explicit contract adapters."""
-        if not kernel_id or not prefer_q8_contract or not allow_q8_contract:
+        if not kernel_id or not allow_q8_contract:
             return kernel_id
         if weight_dtype != "q8_0":
             return kernel_id
@@ -5080,9 +5090,11 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                 # must stay on an fp32-activation kernel.
                 kernel_prefer_q8_activation = False
             allow_q8_contract = bool(
-                prefer_q8_contract
-                and weight_dtype == "q8_0"
-                and kernel_prefer_q8_activation
+                weight_dtype == "q8_0"
+                and (
+                    op in q8_contract_ops
+                    or (prefer_q8_contract and kernel_prefer_q8_activation)
+                )
             )
             if allow_q8_contract:
                 # Preserve the reference contract flow: select the FP32-activation

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -361,6 +361,10 @@ def _inject_runtime_config_defaults(config: dict, arch: str) -> dict:
         )
     elif arch_lc == "qwen3_vl_vision":
         config.setdefault("prefer_q8_0_contract", True)
+        config.setdefault(
+            "q8_0_contract_ops",
+            ["projector_fc2", "branch_fc1", "branch_fc2"],
+        )
         _merge_activation_defaults({
             "mlp_down": "fp32",
             "out_proj": "q8_0",

--- a/version/v8/scripts/stitched_parity_v8.py
+++ b/version/v8/scripts/stitched_parity_v8.py
@@ -273,6 +273,8 @@ def _granular_command(args: argparse.Namespace, layer: int, out_dir: Path, out_j
         str(int(layer)),
         "--llama-dump-names",
         str(args.granular_dump_names),
+        "--ck-dump-names",
+        str(args.granular_dump_names),
         "--report",
         str(out_json),
         "--quiet",


### PR DESCRIPTION
## Why

Qwen3-VL AVX2 vision parity diverged early because production M-RoPE interpreted GGML `n_dims=36` as total rotary width instead of the half-width pair offset. Strict diagnostics could also silently reuse an ordinary engine because the Make build-flags stamp was not reevaluated.

## What

- Fix Qwen3-VL 72-wide vision M-RoPE pairing and frequency order.
- Route Q8 projector and DeepStack operations through explicit architecture metadata.
- Require an explicit switch before strict Q8 cached-input substitution.
- Reevaluate the Make build-flags stamp so OpenMP/ISA/oracle variants rebuild correctly.
- Bound CK granular dumps with the same names used for llama.cpp.
- Add real Qwen3-VL dimensions to vision-kernel and codegen regression tests.
- Record commands, metrics, and remaining work in `logs/2026-07-10-qwen3vl-avx2-encoder-circuit/`.

## Results

- Fresh strict 27-layer encoder: **16,515,072/16,515,072 FP32 values exact**, cosine 1.0, RMSE 0, max diff 0.
- Production layer-0 post-RoPE Q/K: max diff 4.768e-7.
- Canonical OCR persistent mismatch moves from AVX2 step 4 to step 20, matching the Xeon signature.
- Supplying the exact llama.cpp visual prefix moves the remaining decoder mismatch to step 31.
- Full replay at step 20 still chooses CK token `5`, so the residual is not KV-cache-only.
- No tolerance was relaxed.

## Validation

- `make test-v8-vision-kernels`
- `make test-qwen3vl-strict-attn-oracle-build`
- `make llamacpp-parity-full`
- `python -m unittest tests.test_v8_qwen3vl_template tests.test_v8_numeric_parity_qwen3vl_mmproj`
- `v8-regression-fast` passed in the staged hook.

The staged v7 hook still reports pre-existing Qwen3.5 smoke and Nanbeige coherence failures; this PR does not relax or modify those gates.