### PR TITLE
fix(v8/parity): report true first decoder divergence

### DIFF
--- a/tests/test_v8_decoder_first_token_parity.py
+++ b/tests/test_v8_decoder_first_token_parity.py
@@ -35,6 +35,12 @@ decoder_parity_v8 = _load_module("decoder_first_token_parity_v8_tests", V8_DECOD
 
 
 class V8DecoderFirstTokenParityTests(unittest.TestCase):
+    def test_ck_dump_filter_names_expands_llama_aliases(self) -> None:
+        self.assertEqual(
+            decoder_parity_v8._ck_dump_filter_names("Qcur-0,Kcur_normed-2,ffn_inp-0,l_out-3"),
+            "Qcur-0,q_proj-0,Kcur_normed-2,kcur_normed-2,ffn_inp-0,l_out-3,layer_out-3",
+        )
+
     def test_load_llama_dump_dir_parses_jsonl_index(self) -> None:
         with tempfile.TemporaryDirectory(prefix="v8_decoder_llama_dump_") as tmpdir:
             tmp = Path(tmpdir)
@@ -98,6 +104,23 @@ class V8DecoderFirstTokenParityTests(unittest.TestCase):
         self.assertEqual(report["summary"]["fail"], 1)
         self.assertEqual(report["first_issue"]["op"], "Qcur")
         self.assertEqual(report["first_issue"]["status"], "FAIL")
+
+    def test_compare_dump_sets_preserves_graph_order_for_first_issue(self) -> None:
+        def dump(op_name: str, value: float):
+            return decoder_parity_v8.parity_test_v7.ParityDump(
+                0, op_name, np.array([value], dtype=np.float32), 0, "fp32"
+            )
+
+        report = decoder_parity_v8._compare_dump_sets(
+            [dump("ffn_inp", 2.0), dump("down_proj", 4.0)],
+            [dump("ffn_inp", 1.0), dump("down_proj", 3.0)],
+            atol=1.0e-4,
+            rtol=1.0e-3,
+            pass_filter="decode",
+        )
+
+        self.assertEqual([row["op"] for row in report["results"]], ["ffn_inp", "down_proj"])
+        self.assertEqual(report["first_issue"]["op"], "ffn_inp")
 
     def test_expand_ck_prefill_decode_dumps_splits_prompt_rows(self) -> None:
         ck_dumps = [

--- a/version/v8/scripts/decoder_first_token_parity_v8.py
+++ b/version/v8/scripts/decoder_first_token_parity_v8.py
@@ -417,6 +417,23 @@ def _canonical_dump_op_name(op_name: str) -> str:
     return str(op_name)
 
 
+def _ck_dump_filter_names(dump_names: str) -> str:
+    """Expand llama.cpp callback names to the equivalent CK dump names."""
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for raw_name in str(dump_names).split(","):
+        raw_name = raw_name.strip()
+        if not raw_name:
+            continue
+        layer_id, canonical_name = parity_test_v7._normalize_layer_and_op(-1, raw_name)
+        canonical_filter = f"{canonical_name}-{layer_id}" if layer_id >= 0 else canonical_name
+        for candidate in (raw_name, canonical_filter):
+            if candidate not in seen:
+                seen.add(candidate)
+                expanded.append(candidate)
+    return ",".join(expanded)
+
+
 def _augment_legacy_kqv_aliases(dumps: list[Any]) -> list[Any]:
     """
     Preserve modern native ``kqv_out`` dumps, but backfill a compatibility
@@ -720,7 +737,16 @@ def _compare_dump_sets(
         llama_by_key.setdefault(key, []).append(dump)
 
     results: list[dict[str, Any]] = []
-    all_keys = sorted(set(ck_by_key.keys()) | set(llama_by_key.keys()))
+    # Dump files are emitted in graph execution order. Preserve that order so
+    # first_issue identifies the first failing circuit boundary, not the first
+    # failing operation alphabetically.
+    all_keys: list[tuple[int, str]] = []
+    seen_keys: set[tuple[int, str]] = set()
+    for dump in [*ck_filtered, *llama_filtered]:
+        key = (int(dump.layer_id), _canonical_dump_op_name(str(dump.op_name)))
+        if key not in seen_keys:
+            seen_keys.add(key)
+            all_keys.append(key)
     for layer_id, op_name in all_keys:
         ck_candidates = ck_by_key.get((layer_id, op_name), [])
         llama_candidates = llama_by_key.get((layer_id, op_name), [])
@@ -926,16 +952,17 @@ def _capture_dump_compare(
         dump_dir=llama_dump_dir,
         dump_names=dump_names,
     )
+    ck_dump_names = _ck_dump_filter_names(dump_names)
     old_ck_op_filter = os.environ.get("CK_PARITY_OP_FILTER")
-    if dump_names:
-        os.environ["CK_PARITY_OP_FILTER"] = str(dump_names)
+    if ck_dump_names:
+        os.environ["CK_PARITY_OP_FILTER"] = ck_dump_names
     try:
         try:
             import ctypes as _ctypes
             _libc = _ctypes.CDLL(None)
             _libc.setenv.argtypes = [_ctypes.c_char_p, _ctypes.c_char_p, _ctypes.c_int]
-            if dump_names:
-                _libc.setenv(b"CK_PARITY_OP_FILTER", str(dump_names).encode(), 1)
+            if ck_dump_names:
+                _libc.setenv(b"CK_PARITY_OP_FILTER", ck_dump_names.encode(), 1)
         except Exception:
             pass
         ck = _capture_ck_dump(
@@ -1011,6 +1038,7 @@ def _capture_dump_compare(
     return ck, {
         "status": status,
         "dump_names": [item.strip() for item in str(dump_names).split(",") if item.strip()],
+        "ck_dump_names": [item.strip() for item in ck_dump_names.split(",") if item.strip()],
         "pass_filter": str(dump_pass),
         "atol": float(dump_atol),
         "rtol": float(dump_rtol),


### PR DESCRIPTION
## Why

The bounded decoder divergence harness passed llama.cpp callback names directly to CK and sorted comparison keys alphabetically. This hid emitted Q/K/V tensors as missing and could report a later operation as the first failure.

## What

- Expand llama.cpp callback names such as `Qcur-0` and `l_out-3` into CK dump filter names.
- Preserve graph emission order when selecting `first_issue`.
- Add focused unit coverage for alias expansion and graph-order attribution.

## Qwen3-VL result

Canonical OCR image, exact llama.cpp 1008 x 16384 visual prefix, generated step 31:

| Boundary | Result | Max abs diff |
|---|---:|---:|
| `attn_norm` | pass | 0 |
| `q_proj` | pass | 8.94e-8 |
| `k_proj` | pass | 7.45e-8 |
| `v_proj` | pass | 1.49e-8 |
| `qcur_normed` | pass | 4.77e-6 |
| `kcur_normed` | pass | 4.58e-5 |
| `kqv_out` | pass | 9.46e-5 |
| `ffn_inp` | first material failure | 8.19e-4 |

An exact-input microcheck showed CK AVX2 Q4 x Q8_K output projection matches llama.cpp at max diff 2.38e-7. The model-level increase at `ffn_inp` is small attention drift crossing activation-quantization thresholds, not a Q4 projection/layout error.

## Validation

- 24 decoder parity unit tests passed.
- Python compile checks passed.
- Pre-push passed all six gates, including kernel parity, v8 E2E, v7/v8 fast regression, and training-kernel parity.

The pre-commit linked-worktree snapshot path was bypassed after manual tests because `core.hooksPath` resolved against the primary checkout and supplied an empty staged patch. Pre-push subsequently passed in full.