### PR TITLE
test(v8): align Qwen3-VL attention diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,8 +511,9 @@ endif
 # Opt-in llama.cpp-backed engine for strict stitched parity diagnostics.
 # This keeps ordinary CK builds independent from a local llama.cpp checkout.
 ifdef CK_LLAMA_PARITY_ENGINE
+LLAMA_CPP_PARITY_ROOT ?= $(V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT)
 SRCS += src/kernels/attention_oracle_ggml.c
-CFLAGS += -DCK_ENABLE_LLAMA_CPP_PARITY=1 -Illama.cpp/ggml/include -Illama.cpp/ggml/src
+CFLAGS += -DCK_ENABLE_LLAMA_CPP_PARITY=1 -I$(LLAMA_CPP_PARITY_ROOT)/ggml/include -I$(LLAMA_CPP_PARITY_ROOT)/ggml/src
 $(info Building strict llama.cpp-backed parity engine)
 endif
 
@@ -2330,11 +2331,11 @@ llamacpp-parity-stitched:
 	  $(if $(V8_STITCHED_GRANULAR_LAYERS),--granular-layers "$(V8_STITCHED_GRANULAR_LAYERS)",)
 
 test-qwen3vl-strict-attn-oracle-build:
-	@if [ ! -f llama.cpp/ggml/include/ggml.h ]; then \
-	  echo "ERROR: llama.cpp GGML headers are required for the strict attention oracle."; \
+	@if [ ! -f "$(V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT)/ggml/include/ggml.h" ]; then \
+	  echo "ERROR: llama.cpp GGML headers are required for the strict attention oracle at $(V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT)."; \
 	  exit 2; \
 	fi
-	@$(MAKE) --no-print-directory CK_LLAMA_PARITY_ENGINE=1 build/libckernel_engine.so
+	@$(MAKE) --no-print-directory CK_LLAMA_PARITY_ENGINE=1 LLAMA_CPP_PARITY_ROOT="$(V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT)" build/libckernel_engine.so
 	@nm -D build/libckernel_engine.so | grep -q ' ck_attention_full_ggml_graph_oracle_multihead$$' || { \
 	  echo "ERROR: strict attention oracle symbol is missing from build/libckernel_engine.so"; \
 	  exit 1; \

--- a/logs/2026-07-10-qwen3vl-attention-score-parity/README.md
+++ b/logs/2026-07-10-qwen3vl-attention-score-parity/README.md
@@ -68,6 +68,13 @@ inputs to FP16.
 
 ## Next step
 
-Implement and benchmark a bounded reference that matches llama's FP16 Q/K
-conversion and value reduction order exactly. Accept it only if it reduces the
-model-level `kqv_out` error and does not move the first token divergence earlier.
+llama.cpp's CPU flash path adds one more required semantic for this case. For a
+single query with at least 512 KV rows, it partitions KV into one chunk per
+worker. Each worker computes an FP16 Q/K/V online-softmax partial, then the
+partials are combined in chunk order with an FP32 accumulator. CK currently
+uses a single FP32-style reduction for this mixed-prefix replay.
+
+Implement and benchmark a bounded split-KV reference with that exact contract.
+Then vectorize the proven reference and share the split-KV dispatcher with
+persistent decode. Accept it only if it reduces model-level `kqv_out` error,
+keeps one-token parity, and does not move the 64-token divergence earlier.

--- a/logs/2026-07-10-qwen3vl-attention-score-parity/README.md
+++ b/logs/2026-07-10-qwen3vl-attention-score-parity/README.md
@@ -1,0 +1,73 @@
+# Qwen3-VL AVX2 attention score parity
+
+## Scope
+
+Canonical Qwen3-VL OCR replay at generated step 31:
+
+- image: `ocr/1 81.jpg`
+- image SHA256: `eb3becd507063f184d417a6baccfdb22d86277308f21a679aac4e029ed8f25ff`
+- visual prefix: `1008 x 16384`
+- grid: `36 x 28`
+- context: `4096`
+- threads: `20`
+- prompt: `Extract visible form fields as compact JSON.`
+
+CK persistent decode and CK full replay both choose token `788` (`":`), while
+llama.cpp chooses token `1269` (`_name`). The full-replay failure rules out a
+KV-cache-only bug.
+
+## Boundary attribution
+
+The post-RoPE comparator previously mixed two llama callback occurrences and
+treated CK's token-major RoPE dump as raw head-major scratch storage. After
+normalizing both sides:
+
+| Boundary | Max abs | RMSE | Cosine |
+| --- | ---: | ---: | ---: |
+| post-RoPE Q | `3.8147e-6` | `3.8907e-7` | effectively `1.0` |
+| post-RoPE K, final row | `4.5776e-5` | `2.3371e-6` | effectively `1.0` |
+
+This rules out a material M-RoPE circuit/layout error at the failing row.
+
+Focused layer-0, query-1057 captures then compared the active 1058-token
+attention window. llama.cpp's unfused graph pads the score dimension to 1280;
+only its first 1058 entries are active.
+
+| Boundary | Worst max abs | Worst RMSE | Interpretation |
+| --- | ---: | ---: | --- |
+| raw Q dot K score | `4.5780e-2` | `1.3684e-2` per head | first measurable semantic delta |
+| softmax probability | `3.8594e-4` | `1.5196e-5` per head | mask and normalization remain tight |
+| value-weighted context | `6.4460e-5` | `1.2867e-5` per head | consistent with the model-level attention drift |
+
+Score recomputation identifies the contract difference:
+
+- llama score vs FP32 Q/K recomputation: RMSE `8.6550e-3`
+- llama score vs FP16-rounded Q/K recomputation: RMSE `3.5507e-6`
+- CK score vs CK FP32 Q/K recomputation: RMSE `3.7754e-6`
+
+llama's score path therefore follows an FP16-rounded Q/K contract, while CK's
+strict mixed-prefill path currently computes the score from FP32 Q/K. This is
+not a causal-mask, softmax-shape, output-projection, or M-RoPE wiring failure.
+
+## Rejected change
+
+The existing `attention_flash_query_causal_exact_f16kv` implementation is not
+a valid replacement for this path. Its online FP16 output accumulation made
+the selected context comparison worse. A production routing change must match
+llama's complete score, softmax, and value-reduction contract, not merely round
+inputs to FP16.
+
+## Tooling changes
+
+- Label the second llama `Qcur`/`Kcur` callback occurrence as post-RoPE.
+- Extract CK post-RoPE rows from their actual `[token, head, dim]` dump layout.
+- Disable llama flash attention only when `kq`, `kq_soft_max`, or `kqv`
+  diagnostics are explicitly requested.
+- Emit bounded CK score, probability, and context vectors for a selected
+  layer/query/head without changing the computed output.
+
+## Next step
+
+Implement and benchmark a bounded reference that matches llama's FP16 Q/K
+conversion and value reduction order exactly. Accept it only if it reduces the
+model-level `kqv_out` error and does not move the first token divergence earlier.

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -24,7 +24,7 @@
 #include "ckernel_engine.h"
 #include "ck_threadpool.h"
 #if CK_ENABLE_LLAMA_CPP_PARITY
-#include "../../llama.cpp/ggml/include/ggml.h"
+#include <ggml.h>
 #endif
 #include <dlfcn.h>
 #ifndef RTLD_DEFAULT
@@ -1699,6 +1699,57 @@ static void attention_flash_query_causal_exact(const float *q_vec,
     }
 }
 
+static void ck_attention_vec_dump_exact_query(const float *q_vec,
+                                              const float *k_head,
+                                              const float *out_vec,
+                                              int kv_tokens,
+                                              int head_dim,
+                                              int aligned_head_dim,
+                                              float scale,
+                                              int layer_id,
+                                              int head_id,
+                                              int query_id)
+{
+    if (!ck_attention_vec_dump_should_emit(layer_id, head_id, query_id)) {
+        return;
+    }
+
+    float *raw_scores = (float *) alloca((size_t) kv_tokens * sizeof(float));
+    float *probs = (float *) alloca((size_t) kv_tokens * sizeof(float));
+    float max_score = -INFINITY;
+    for (int j = 0; j < kv_tokens; ++j) {
+        const float *k_vec = k_head + (size_t) j * (size_t) aligned_head_dim;
+        float dot = 0.0f;
+        for (int d = 0; d < head_dim; ++d) {
+            dot += q_vec[d] * k_vec[d];
+        }
+        raw_scores[j] = dot;
+        const float scaled = dot * scale;
+        probs[j] = scaled;
+        if (scaled > max_score) {
+            max_score = scaled;
+        }
+    }
+
+    float sum = 0.0f;
+    for (int j = 0; j < kv_tokens; ++j) {
+        probs[j] = expf(probs[j] - max_score);
+        sum += probs[j];
+    }
+    if (sum > 0.0f) {
+        const float inv_sum = 1.0f / sum;
+        for (int j = 0; j < kv_tokens; ++j) {
+            probs[j] *= inv_sum;
+        }
+    } else {
+        memset(probs, 0, (size_t) kv_tokens * sizeof(float));
+    }
+
+    ck_attention_vec_dump_selected_query(raw_scores, probs, out_vec, NULL,
+                                         kv_tokens, head_dim,
+                                         layer_id, head_id, query_id);
+}
+
 // Llama-parity attention reference: K/V are rounded through F16 before use.
 static void attention_flash_query_causal_exact_f16kv(const float *q_vec,
                                                      const float *k_head,
@@ -3284,6 +3335,9 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
 
     if (ck_strict_parity_enabled()) {
         const float strict_scale = ck_attention_strict_scale_f32(head_dim);
+        const int debug_layer_id = ck_attention_vec_dump_enabled()
+            ? ck_attention_vec_dump_next_layer_id()
+            : -1;
 #if CK_ENABLE_LLAMA_CPP_PARITY
         if (!causal &&
             ck_attention_full_ggml_graph_oracle_multihead(q,
@@ -3329,6 +3383,11 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
                     const float *k_vec = k_head + (size_t) j * (size_t) aligned_head_dim;
                     score_row[j] = ck_ggml_vec_dot_f32_contig(q_vec, k_vec, head_dim);
                 }
+                float *raw_dump = NULL;
+                if (ck_attention_vec_dump_should_emit(debug_layer_id, h, i)) {
+                    raw_dump = (float *) alloca((size_t) kv_tokens * sizeof(float));
+                    memcpy(raw_dump, score_row, (size_t) kv_tokens * sizeof(float));
+                }
                 memcpy(logit_row, score_row, (size_t) kv_tokens * sizeof(float));
                 ck_vec_scale_f32_inplace(logit_row, kv_tokens, strict_scale);
                 const float max_score = ck_vec_max_f32_contig(logit_row, kv_tokens);
@@ -3347,6 +3406,11 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
                 }
                 for (int d = head_dim; d < aligned_head_dim; ++d) {
                     out_vec[d] = 0.0f;
+                }
+                if (raw_dump) {
+                    ck_attention_vec_dump_selected_query(raw_dump, score_row, out_vec, v_cols,
+                                                         kv_tokens, head_dim,
+                                                         debug_layer_id, h, i);
                 }
             }
         }
@@ -3649,6 +3713,9 @@ void attention_forward_mixed_visual_chunk_head_major_gqa_flash_strided_gemma4(co
     const float scale = 1.0f;
 
     if (ck_strict_parity_enabled()) {
+        const int debug_layer_id = ck_attention_vec_dump_enabled()
+            ? ck_attention_vec_dump_next_layer_id()
+            : -1;
         for (int h = 0; h < num_heads; ++h) {
             int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
             const float *k_head = k + (size_t)kv_head * kv_head_stride;
@@ -3663,6 +3730,11 @@ void attention_forward_mixed_visual_chunk_head_major_gqa_flash_strided_gemma4(co
                                                    kv_tokens,
                                                    head_dim, aligned_head_dim,
                                                    scale, out_vec);
+                ck_attention_vec_dump_exact_query(q_vec, k_head, out_vec,
+                                                  kv_tokens,
+                                                  head_dim, aligned_head_dim,
+                                                  scale,
+                                                  debug_layer_id, h, i);
             }
         }
         return;

--- a/src/kernels/attention_oracle_ggml.c
+++ b/src/kernels/attention_oracle_ggml.c
@@ -10,9 +10,9 @@
 #define CK_ENABLE_LLAMA_CPP_PARITY 1
 #include "attention_oracle_ggml.h"
 #include "ckernel_engine.h"
-#include "../../llama.cpp/ggml/include/ggml.h"
-#include "../../llama.cpp/ggml/include/ggml-backend.h"
-#include "../../llama.cpp/ggml/include/ggml-alloc.h"
+#include <ggml.h>
+#include <ggml-backend.h>
+#include <ggml-alloc.h>
 #include <dlfcn.h>
 #ifndef RTLD_DEFAULT
 #define RTLD_DEFAULT ((void *)0)

--- a/tests/test_v8_decoder_first_token_parity.py
+++ b/tests/test_v8_decoder_first_token_parity.py
@@ -73,6 +73,37 @@ class V8DecoderFirstTokenParityTests(unittest.TestCase):
             self.assertEqual(dumps[0].token_id, 1)
             np.testing.assert_allclose(dumps[0].data, raw.reshape(2, 2))
 
+    def test_load_llama_dump_dir_labels_post_rope_occurrence(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="v8_decoder_llama_rope_dump_") as tmpdir:
+            tmp = Path(tmpdir)
+            rows = []
+            for occurrence in (0, 1):
+                name = f"Qcur-0-token-000001-occ-{occurrence:03d}"
+                raw = np.full(8, float(occurrence), dtype=np.float32)
+                (tmp / f"{name}.bin").write_bytes(raw.tobytes())
+                rows.append(
+                    {
+                        "name": name,
+                        "base_name": "Qcur-0",
+                        "token_id": 1,
+                        "occurrence": occurrence,
+                        "dtype": 0,
+                        "rank": 2,
+                        "shape": [4, 2, 1, 1],
+                        "elem_count": 8,
+                        "nbytes": 32,
+                    }
+                )
+            (tmp / "index.json").write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+
+            dumps = decoder_parity_v8._load_llama_dump_dir(tmp)
+
+            self.assertEqual([dump.op_name for dump in dumps], ["q_proj", "qcur_rope"])
+
+
     def test_compare_dump_sets_reports_failures(self) -> None:
         ck_dumps = [
             decoder_parity_v8.parity_test_v7.ParityDump(
@@ -208,6 +239,41 @@ class V8DecoderFirstTokenParityTests(unittest.TestCase):
         self.assertEqual([d.token_id for d in rows], [0, 1])
         np.testing.assert_allclose(rows[0].data, ck_tensor[:, 1, :])
         np.testing.assert_allclose(rows[1].data, ck_tensor[:, 2, :])
+
+    def test_expand_ck_prefill_decode_dumps_extracts_token_major_rope_rows(self) -> None:
+        # The dedicated CK post-RoPE dumper writes [tokens, heads, dim], unlike
+        # the raw qcur_normed scratch tensor above.
+        ck_tensor = np.arange(3 * 2 * 4, dtype=np.float32).reshape(3, 2, 4)
+        ck_dumps = [
+            decoder_parity_v8.parity_test_v7.ParityDump(
+                0,
+                "qcur_rope",
+                ck_tensor.reshape(-1),
+                0,
+                "fp32",
+            )
+        ]
+        llama_dumps = [
+            decoder_parity_v8.parity_test_v7.ParityDump(
+                0,
+                "qcur_rope",
+                np.zeros((4, 2), dtype=np.float32),
+                0,
+                "fp32",
+            )
+        ]
+
+        expanded = decoder_parity_v8._expand_ck_prefill_decode_dumps(
+            ck_dumps,
+            llama_dumps,
+            prompt_start_token=0,
+            prompt_token_count=2,
+        )
+
+        rows = [d for d in expanded if d.layer_id == 0 and d.op_name == "qcur_rope"]
+        self.assertEqual([d.token_id for d in rows], [0, 1])
+        np.testing.assert_allclose(rows[0].data, ck_tensor[1])
+        np.testing.assert_allclose(rows[1].data, ck_tensor[2])
 
     def test_build_llama_row_specs_prefers_ranked_norm_shape_on_tie(self) -> None:
         specs = decoder_parity_v8._build_llama_row_specs(

--- a/version/v8/scripts/decoder_first_token_parity_v8.py
+++ b/version/v8/scripts/decoder_first_token_parity_v8.py
@@ -377,6 +377,11 @@ def _load_llama_dump_dir(dump_dir: Path) -> list[Any]:
                 -1,
                 str(row.get("base_name", row.get("name", ""))),
             )
+            occurrence = int(row.get("occurrence", 0) or 0)
+            if occurrence == 1 and norm_op == "q_proj":
+                norm_op = "qcur_rope"
+            elif occurrence == 1 and norm_op == "k_proj":
+                norm_op = "kcur_rope"
             dumps.append(
                 parity_test_v7.ParityDump(
                     norm_layer,
@@ -495,7 +500,8 @@ def _build_llama_row_specs(llama_dumps: list[Any]) -> dict[tuple[int, str], tupl
         prev = specs.get(key)
         choose = prev is None or row_elems < prev[0]
         if not choose and prev is not None and row_elems == prev[0]:
-            if op_name in {"qcur_normed", "kcur_normed"} and len(row_shape) > len(prev[1]):
+            shaped_qk_ops = {"qcur_normed", "kcur_normed", "qcur_rope", "kcur_rope"}
+            if op_name in shaped_qk_ops and len(row_shape) > len(prev[1]):
                 choose = True
         if choose:
             specs[key] = (row_elems, row_shape)
@@ -630,6 +636,7 @@ def _expand_ck_prefill_decode_dumps(
             and row_shape[1] > 0
             and flat.size % (int(row_shape[0]) * int(row_shape[1])) == 0
         )
+        token_major_rope = head_major and op_name in {"qcur_rope", "kcur_rope"}
         if head_major:
             dim = int(row_shape[0])
             heads = int(row_shape[1])
@@ -638,14 +645,22 @@ def _expand_ck_prefill_decode_dumps(
             if batch_rows < prompt_token_count:
                 expanded.append(dump)
                 continue
-            tensor = flat.reshape(heads, batch_rows, dim)
+            if token_major_rope:
+                # CK's dedicated post-RoPE dump helper has already converted
+                # [head, token, dim] scratch storage to [token, head, dim].
+                tensor = flat.reshape(batch_rows, heads, dim)
+            else:
+                tensor = flat.reshape(heads, batch_rows, dim)
         for prompt_idx in range(prompt_token_count):
             if head_major:
                 token_idx = (batch_rows - prompt_token_count) + prompt_idx
-                # Preserve CK's native head-major flat order here.
-                # compare_dumps() flattens both sides, and llama.cpp's dump
-                # index shape metadata does not imply NumPy/C-order transpose.
-                row = tensor[:, token_idx, :].copy()
+                if token_major_rope:
+                    row = tensor[token_idx, :, :].copy()
+                else:
+                    # Preserve CK's native head-major flat order here.
+                    # compare_dumps() flattens both sides, and llama.cpp's dump
+                    # index shape metadata does not imply NumPy/C-order transpose.
+                    row = tensor[:, token_idx, :].copy()
             else:
                 start = (prompt_start + prompt_idx) * row_elems
                 end = start + row_elems

--- a/version/v8/scripts/llama_token_replay_v8.cpp
+++ b/version/v8/scripts/llama_token_replay_v8.cpp
@@ -788,6 +788,20 @@ int main(int argc, char ** argv) {
     cparams.n_threads = n_threads;
     cparams.n_threads_batch = n_threads;
     cparams.embeddings = !args.embeddings_out_path.empty();
+    const bool dump_attention_internals = std::any_of(
+        args.dump_names.begin(),
+        args.dump_names.end(),
+        [](const std::string & name) {
+            return name.rfind("kq-", 0) == 0 ||
+                   name.rfind("kq_soft_max-", 0) == 0 ||
+                   name.rfind("kqv-", 0) == 0;
+        });
+    if (dump_attention_internals) {
+        // Flash attention intentionally hides scores and probabilities as one
+        // fused node. Use llama.cpp's unfused reference graph only for a
+        // diagnostic capture that explicitly requests those boundaries.
+        cparams.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
+    }
     DumpState dump_state;
     if (!args.dump_dir.empty()) {
         dump_state.dump_dir = args.dump_dir;

--- a/version/v8/scripts/parity_test_v8.py
+++ b/version/v8/scripts/parity_test_v8.py
@@ -216,6 +216,8 @@ def _normalize_layer_and_op(layer_id: int, op_name: str) -> Tuple[int, str]:
         "vcur": "v_proj",
         "qcur_normed": "qcur_normed",
         "kcur_normed": "kcur_normed",
+        "qcur_rope": "qcur_rope",
+        "kcur_rope": "kcur_rope",
         "sa_out": "attn_output",
         "ffn_gate": "gate_proj",
         "ffn_up": "up_proj",


### PR DESCRIPTION
## Why

The canonical Qwen3-VL AVX2 replay still diverges at generated step 31. Existing granular output conflated llama's pre/post-RoPE callback occurrences and interpreted CK's post-RoPE dump with the wrong token/head layout, obscuring the first real attention delta.

## What

- Label llama's second Qcur/Kcur occurrence as post-RoPE.
- Extract CK post-RoPE tensors from their actual token-major dump layout.
- Add bounded CK raw-score, softmax, and context capture for a selected layer/query/head without changing production output.
- Force llama's unfused graph only when kq/kq_soft_max/kqv diagnostics are requested.
- Make the strict GGML oracle honor V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT.
- Record the exact step-31 attribution in logs/2026-07-10-qwen3vl-attention-score-parity/README.md.

## Finding

Post-RoPE Q/K are tight. llama raw scores match FP16-rounded Q/K (RMSE 3.55e-6), while CK strict prefill scores use FP32 Q/K. The existing online f16kv helper is not a valid replacement because it worsens the selected context comparison.

## Validation

- 26 decoder parity unit tests passed.
- make test-flash-attention passed, including llama.cpp and 51,200-token cases.
- strict oracle build passed with an explicit external llama.cpp root.
- staged v7-regression-fast and v8-regression-fast passed.
- full pre-push suite passed: build, kernel parity, Gemma3 E2E, v8 contracts, v7 training smoke, v7/v8 fast regression, and training-kernel parity.