### PR TITLE
test(attention): guard llama F16 split-KV contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1752,6 +1752,7 @@ showtests:
 	@echo "  make test-bf16        Run BF16 kernel tests"
 	@echo "  make test-quant       Run quantization kernel tests"
 	@echo "  make test-flash-attention  Run flash attention tests (50K+ contexts)"
+	@echo "  make test-attention-f16-split-kv  Run llama-backed FP16 split-KV contract"
 	@echo "  make nightly          Run full test suite (doesn't stop on failure)"
 	@echo ""
 	@echo "Per-Kernel Libraries:"
@@ -1994,6 +1995,13 @@ test-flash-attention: $(LIB)
 		$(PYTHON) $(PYTHONFLAGS) unittest/test_flash_attention.py
 
 test_flash_attention: test-flash-attention
+
+test-attention-f16-split-kv: $(LIB)
+	@echo "Running FP16 split-KV decode attention contract tests..."
+	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH \
+		$(PYTHON) $(PYTHONFLAGS) unittest/test_attention_f16_split_kv.py
+
+.PHONY: test-attention-f16-split-kv
 
 # GEMM benchmark comparing CKernel (Native + MKL if available) vs PyTorch
 bench_gemm:
@@ -2283,6 +2291,9 @@ llamacpp-parity-full:
 	@echo ""
 	@echo "Running v8 vision kernel oracle tests..."
 	@$(MAKE) --no-print-directory test-v8-vision-kernels
+	@echo ""
+	@echo "Running FP16 split-KV decode attention contract tests..."
+	@$(MAKE) --no-print-directory test-attention-f16-split-kv
 	@echo ""
 	@echo "Running head-major Q5 out-proj parity benchmark..."
 	@$(MAKE) --no-print-directory test-head-major-q5-outproj

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1686,6 +1686,10 @@
     <li><strong>v8 Vision Kernel Parity</strong>: Vision kernel parity for patch extraction/reconstruction, tiled position embeddings,
       Qwen3-VL resized position interpolation order, spatial merge/reorder, feature concat/slice, and vision M-RoPE
       (<code>make test-v8-vision-kernels</code>)</li>
+    <li><strong>FP16 Split-KV Decode Contract</strong>: Named numerical guards for the llama.cpp-compatible decode reduction contract,
+      including FP16 Q/K rounding, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding, the KV 511/512 semantic boundary,
+      and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
+      (<code>make test-attention-f16-split-kv</code>)</li>
     <li><strong>Llama Pairwise RoPE Contract</strong>: explicit regression for consecutive-pair RoPE layout selection plus kernel-level pairwise forward coverage and timing
       (<code>version/v7/scripts/parity/test_check_decode_attention_contract.py</code>, <code>unittest/test_rope.py</code>)</li>
     <li><strong>Sliding-Window Contract</strong>: Explicit sliding attention prefill/decode contract test

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -1495,6 +1495,21 @@ void attention_forward_decode_head_major_gqa_flash_f16cache(const float *q_token
                                                             int head_dim,
                                                             int aligned_head_dim);
 
+// Deterministic llama.cpp-style FP16 split-KV oracle. The explicit chunk count
+// makes diagnostics independent of the host's available core count. Production
+// routing must be accepted separately by stitched model parity.
+void attention_forward_decode_head_major_gqa_flash_f16cache_split(const float *q_token,
+                                                                  const uint16_t *k_cache,
+                                                                  const uint16_t *v_cache,
+                                                                  float *out_token,
+                                                                  int num_heads,
+                                                                  int num_kv_heads,
+                                                                  int kv_tokens,
+                                                                  int cache_capacity,
+                                                                  int head_dim,
+                                                                  int aligned_head_dim,
+                                                                  int split_chunks);
+
 // Decode attention for a single token using a KV cache (REGULAR - NOT flash).
 //   q_token: [num_heads, aligned_head_dim]
 //   k_cache/v_cache: [num_kv_heads, cache_capacity, aligned_head_dim]

--- a/logs/2026-07-10-qwen3vl-split-kv-contract/README.md
+++ b/logs/2026-07-10-qwen3vl-split-kv-contract/README.md
@@ -1,0 +1,75 @@
+# Qwen3-VL FP16 Split-KV Decode Contract
+
+## Root Cause
+
+The focused Qwen3-VL decode attention comparison ruled out mask, M-RoPE,
+shape, output projection, and generic softmax wiring at that boundary.
+llama.cpp changes its CPU decode reduction contract when the KV sequence
+reaches 512 tokens:
+
+- Q and K are rounded through FP16.
+- KV work is split across worker chunks.
+- Each chunk produces an FP16 online-softmax/value partial.
+- Chunk partials are reduced in FP32, in chunk order.
+
+CK previously used a single FP32-style reduction. Both implementations are
+reasonable attention algorithms, but they are not numerically equivalent.
+The difference can change top-1 selection after a long mixed visual/text
+prefix.
+
+## Oracle Kernel
+
+`attention_forward_decode_head_major_gqa_flash_f16cache_split()` entry point
+takes an explicit chunk count so parity tests do not depend on host core count.
+It is an oracle/diagnostic entry point, not the production default. Production
+routing remains unchanged until stitched model parity accepts the change.
+
+## Regression Matrix
+
+Run:
+
+```bash
+make test-attention-f16-split-kv
+```
+
+| Case | Purpose |
+|---|---|
+| KV 511, one chunk | Guard the pre-threshold contract |
+| KV 512, four chunks | Guard the exact split threshold |
+| KV 1058, H=32, Hkv=8, D=128, 20 chunks | Match the diagnosed Qwen3-VL decode shape |
+| KV 513, padded D=80/A=128, GQA | Guard layout, padding, and head mapping |
+| llama.cpp at KV 511, 512, and 1058 | Compare directly with `ggml_flash_attn_ext` using F16 K/V |
+| FP32 rejection oracle | Prove the test fails if split FP16 is replaced by single FP32 |
+
+The independent Python oracle currently agrees with CK within `1.61e-5`; the
+enforced tolerance is `2e-5`. Direct llama.cpp agreement is within `8.32e-6`
+under the same `2e-5` limit.
+The adversarial FP32 rejection case separates the two contracts by `8.81e-4`.
+
+## Rejected Production Routing
+
+Routing every generated decode layer through the split-KV oracle did not move
+the canonical OCR divergence beyond step 31 and worsened its logit metrics:
+
+| Candidate | First mismatch | Cosine | RMSE | Top-k overlap |
+|---|---:|---:|---:|---:|
+| scalar-dot split | 31 | 0.999045 | 0.258115 | 16/16 |
+| llama AVX2 reduction tree | 31 | 0.998776 | 0.282321 | 15/16 |
+
+The split kernel is numerically correct in isolation. The rejected routing
+shows that the first unresolved model state is earlier in the mixed-prefill
+path; changing persistent decode at the same time only adds another delta.
+
+## Test Integration
+
+- `make llamacpp-parity-full` runs this contract.
+- `scripts/nightly_runner.py` exposes it as the named kernel lane
+  `FP16 Split-KV Decode Contract`.
+- `docs/site/test-report.html` documents the lane so nightly JSON/report output
+  can be monitored as individual expandable subtests.
+
+## Remaining Validation
+
+This contract test prevents the reduction semantics from regressing. The full
+Qwen3-VL 64-token stitched parity run remains the authority for proving that
+the production model path reaches the expected llama.cpp tokens end to end.

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -390,6 +390,12 @@ MAKE_TARGETS = {
         "target": "test-flash-attention",
         "timeout_sec": 1800,
     },
+    "attention_f16_split_kv": {
+        "name": "FP16 Split-KV Decode Contract",
+        "category": "kernels",
+        "target": "test-attention-f16-split-kv",
+        "timeout_sec": 180,
+    },
     "threadpool_parity": {
         "name": "Thread Pool GEMV Parity (serial vs dispatch)",
         "category": "parity",

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -4320,6 +4320,239 @@ void attention_forward_decode_head_major_gqa_flash_f16kv(const float *q_token,
     }
 }
 
+typedef struct {
+    const float *q_token;
+    const uint16_t *k_cache;
+    const uint16_t *v_cache;
+    float *partials;
+    int num_heads;
+    int num_kv_heads;
+    int kv_tokens;
+    int cache_capacity;
+    int head_dim;
+    int aligned_head_dim;
+    int split_chunks;
+} ck_attention_f16_split_args_t;
+
+static inline float ck_attention_dot_f16_llama(const uint16_t *x,
+                                                const uint16_t *y,
+                                                int n)
+{
+    int i = 0;
+#if defined(__AVX2__) && defined(__F16C__)
+    // Match ggml_vec_dot_f16's AVX reduction contract: four independent
+    // accumulators per 32 values, followed by its fixed pairwise tree.
+    __m256 sum0 = _mm256_setzero_ps();
+    __m256 sum1 = _mm256_setzero_ps();
+    __m256 sum2 = _mm256_setzero_ps();
+    __m256 sum3 = _mm256_setzero_ps();
+    const int n32 = n & ~31;
+    for (; i < n32; i += 32) {
+        const __m256 x0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i)));
+        const __m256 y0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i)));
+        const __m256 x1 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i + 8)));
+        const __m256 y1 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i + 8)));
+        const __m256 x2 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i + 16)));
+        const __m256 y2 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i + 16)));
+        const __m256 x3 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i + 24)));
+        const __m256 y3 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i + 24)));
+#if defined(__FMA__)
+        sum0 = _mm256_fmadd_ps(x0, y0, sum0);
+        sum1 = _mm256_fmadd_ps(x1, y1, sum1);
+        sum2 = _mm256_fmadd_ps(x2, y2, sum2);
+        sum3 = _mm256_fmadd_ps(x3, y3, sum3);
+#else
+        sum0 = _mm256_add_ps(sum0, _mm256_mul_ps(x0, y0));
+        sum1 = _mm256_add_ps(sum1, _mm256_mul_ps(x1, y1));
+        sum2 = _mm256_add_ps(sum2, _mm256_mul_ps(x2, y2));
+        sum3 = _mm256_add_ps(sum3, _mm256_mul_ps(x3, y3));
+#endif
+    }
+    sum0 = _mm256_add_ps(sum0, sum2);
+    sum1 = _mm256_add_ps(sum1, sum3);
+    sum0 = _mm256_add_ps(sum0, sum1);
+    const __m128 pair = _mm_add_ps(
+        _mm256_castps256_ps128(sum0),
+        _mm256_extractf128_ps(sum0, 1));
+    const __m128 half = _mm_hadd_ps(pair, pair);
+    float result = _mm_cvtss_f32(_mm_hadd_ps(half, half));
+#else
+    float result = 0.0f;
+#endif
+    for (; i < n; ++i) {
+        result += CK_FP16_TO_FP32(x[i]) * CK_FP16_TO_FP32(y[i]);
+    }
+    return result;
+}
+
+static void ck_attention_f16_split_work(int ith, int nth, void *opaque)
+{
+    ck_attention_f16_split_args_t *args = (ck_attention_f16_split_args_t *) opaque;
+    const int partial_stride = args->aligned_head_dim + 2;
+    const int total_jobs = args->num_heads * args->split_chunks;
+    const int chunk_size = (args->kv_tokens + args->split_chunks - 1) / args->split_chunks;
+    const size_t head_stride = (size_t) args->cache_capacity * (size_t) args->aligned_head_dim;
+    const float scale = 1.0f / sqrtf((float) args->head_dim);
+    uint16_t *q_half = (uint16_t *) alloca((size_t) args->aligned_head_dim * sizeof(uint16_t));
+    uint16_t *acc_half = (uint16_t *) alloca((size_t) args->aligned_head_dim * sizeof(uint16_t));
+
+    for (int job = ith; job < total_jobs; job += nth) {
+        const int h = job / args->split_chunks;
+        const int chunk = job % args->split_chunks;
+        const int kv_head = (int) ((long long) h * (long long) args->num_kv_heads /
+                                   (long long) args->num_heads);
+        const int begin = chunk * chunk_size;
+        const int end = begin + chunk_size < args->kv_tokens
+            ? begin + chunk_size
+            : args->kv_tokens;
+        const float *q_head = args->q_token + (size_t) h * (size_t) args->aligned_head_dim;
+        const uint16_t *k_head = args->k_cache + (size_t) kv_head * head_stride;
+        const uint16_t *v_head = args->v_cache + (size_t) kv_head * head_stride;
+        float *partial = args->partials + (size_t) job * (size_t) partial_stride;
+
+        for (int d = 0; d < args->aligned_head_dim; ++d) {
+            q_half[d] = CK_FP32_TO_FP16(q_head[d]);
+            acc_half[d] = CK_FP32_TO_FP16(0.0f);
+        }
+
+        float sum = 0.0f;
+        float max_score = -INFINITY;
+        for (int j = begin; j < end; ++j) {
+            const uint16_t *k_vec = k_head + (size_t) j * (size_t) args->aligned_head_dim;
+            const uint16_t *v_vec = v_head + (size_t) j * (size_t) args->aligned_head_dim;
+            const float dot = ck_attention_dot_f16_llama(q_half, k_vec, args->head_dim);
+            const float score = dot * scale;
+            const float old_max = max_score;
+            float max_scale = 1.0f;
+            float value_scale = 1.0f;
+
+            if (score > max_score) {
+                max_score = score;
+                max_scale = isfinite(old_max) ? expf(old_max - max_score) : 0.0f;
+                for (int d = 0; d < args->head_dim; ++d) {
+                    const float scaled = CK_FP16_TO_FP32(acc_half[d]) * max_scale;
+                    acc_half[d] = CK_FP32_TO_FP16(scaled);
+                }
+            } else {
+                value_scale = expf(score - max_score);
+            }
+
+            for (int d = 0; d < args->head_dim; ++d) {
+                const float updated = CK_FP16_TO_FP32(acc_half[d]) +
+                                      value_scale * CK_FP16_TO_FP32(v_vec[d]);
+                acc_half[d] = CK_FP32_TO_FP16(updated);
+            }
+            sum = sum * max_scale + value_scale;
+        }
+
+        partial[0] = max_score;
+        partial[1] = sum;
+        for (int d = 0; d < args->head_dim; ++d) {
+            partial[2 + d] = CK_FP16_TO_FP32(acc_half[d]);
+        }
+        for (int d = args->head_dim; d < args->aligned_head_dim; ++d) {
+            partial[2 + d] = 0.0f;
+        }
+    }
+}
+
+void attention_forward_decode_head_major_gqa_flash_f16cache_split(const float *q_token,
+                                                                  const uint16_t *k_cache,
+                                                                  const uint16_t *v_cache,
+                                                                  float *out_token,
+                                                                  int num_heads,
+                                                                  int num_kv_heads,
+                                                                  int kv_tokens,
+                                                                  int cache_capacity,
+                                                                  int head_dim,
+                                                                  int aligned_head_dim,
+                                                                  int split_chunks)
+{
+    if (!q_token || !k_cache || !v_cache || !out_token ||
+        num_heads <= 0 || num_kv_heads <= 0 || kv_tokens <= 0 ||
+        cache_capacity <= 0 || kv_tokens > cache_capacity ||
+        head_dim <= 0 || aligned_head_dim < head_dim) {
+        return;
+    }
+
+    if (split_chunks < 1) {
+        split_chunks = 1;
+    }
+    if (split_chunks > kv_tokens) {
+        split_chunks = kv_tokens;
+    }
+
+    const int partial_stride = aligned_head_dim + 2;
+    const size_t max_partial_bytes = 1024u * 1024u;
+    while (split_chunks > 1 &&
+           (size_t) num_heads * (size_t) split_chunks * (size_t) partial_stride * sizeof(float) >
+               max_partial_bytes) {
+        split_chunks = (split_chunks + 1) / 2;
+    }
+
+    const size_t resolved_count = (size_t) num_heads * (size_t) split_chunks * (size_t) partial_stride;
+    float *partials = (float *) alloca(resolved_count * sizeof(float));
+    ck_attention_f16_split_args_t args = {
+        .q_token = q_token,
+        .k_cache = k_cache,
+        .v_cache = v_cache,
+        .partials = partials,
+        .num_heads = num_heads,
+        .num_kv_heads = num_kv_heads,
+        .kv_tokens = kv_tokens,
+        .cache_capacity = cache_capacity,
+        .head_dim = head_dim,
+        .aligned_head_dim = aligned_head_dim,
+        .split_chunks = split_chunks,
+    };
+
+    ck_threadpool_t *pool = ck_threadpool_global();
+    int active_threads = pool ? ck_threadpool_n_threads(pool) : 1;
+    const int total_jobs = num_heads * split_chunks;
+    if (active_threads > total_jobs) {
+        active_threads = total_jobs;
+    }
+    if (pool && active_threads > 1) {
+        ck_threadpool_dispatch_n(pool, active_threads, ck_attention_f16_split_work, &args);
+    } else {
+        ck_attention_f16_split_work(0, 1, &args);
+    }
+
+    for (int h = 0; h < num_heads; ++h) {
+        float *out_head = out_token + (size_t) h * (size_t) aligned_head_dim;
+        float final_max = -INFINITY;
+        float final_sum = 0.0f;
+        for (int d = 0; d < aligned_head_dim; ++d) {
+            out_head[d] = 0.0f;
+        }
+
+        for (int chunk = 0; chunk < split_chunks; ++chunk) {
+            const float *partial = partials +
+                ((size_t) h * (size_t) split_chunks + (size_t) chunk) * (size_t) partial_stride;
+            const float chunk_max = partial[0];
+            const float chunk_sum = partial[1];
+            if (chunk_sum == 0.0f) {
+                continue;
+            }
+            const float new_max = fmaxf(final_max, chunk_max);
+            const float old_scale = isfinite(final_max) ? expf(final_max - new_max) : 0.0f;
+            const float chunk_scale = expf(chunk_max - new_max);
+            for (int d = 0; d < head_dim; ++d) {
+                out_head[d] = out_head[d] * old_scale + partial[2 + d] * chunk_scale;
+            }
+            final_sum = final_sum * old_scale + chunk_sum * chunk_scale;
+            final_max = new_max;
+        }
+
+        if (final_sum > 0.0f) {
+            const float inv_sum = 1.0f / final_sum;
+            for (int d = 0; d < head_dim; ++d) {
+                out_head[d] *= inv_sum;
+            }
+        }
+    }
+}
+
 void attention_forward_decode_head_major_gqa_flash_f16cache(const float *q_token,
                                                             const uint16_t *k_cache,
                                                             const uint16_t *v_cache,

--- a/unittest/test_attention_f16_split_kv.py
+++ b/unittest/test_attention_f16_split_kv.py
@@ -1,0 +1,402 @@
+"""Regression tests for llama.cpp-compatible FP16 split-KV decode attention.
+
+The Qwen3-VL mixed-prefix decode path crosses a semantic boundary at KV=512:
+llama.cpp rounds Q/K through FP16, computes FP16 online-softmax partials per
+worker chunk, then combines those partials in FP32 chunk order.  A conventional
+single FP32 reduction is mathematically reasonable, but is not the same model
+contract and can change long-decode top-1 tokens.
+"""
+
+import ctypes
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+
+import numpy as np
+
+from lib_loader import load_lib
+
+
+lib = load_lib("libckernel_engine.so")
+
+_FLOAT_P = ctypes.POINTER(ctypes.c_float)
+_U16_P = ctypes.POINTER(ctypes.c_uint16)
+_SPLIT_ARGS = [
+    _FLOAT_P, _U16_P, _U16_P, _FLOAT_P,
+    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+    ctypes.c_int, ctypes.c_int, ctypes.c_int,
+]
+lib.attention_forward_decode_head_major_gqa_flash_f16cache_split.argtypes = _SPLIT_ARGS
+lib.attention_forward_decode_head_major_gqa_flash_f16cache_split.restype = None
+lib.ck_get_num_threads.argtypes = []
+lib.ck_get_num_threads.restype = ctypes.c_int
+
+
+_LLAMA_HELPER_SOURCE = r"""
+#include "ggml.h"
+#include "ggml-cpu.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+static bool read_exact(const char * path, void * dst, size_t bytes) {
+    FILE * f = fopen(path, "rb");
+    if (!f) return false;
+    const size_t got = fread(dst, 1, bytes, f);
+    fclose(f);
+    return got == bytes;
+}
+
+static bool write_exact(const char * path, const void * src, size_t bytes) {
+    FILE * f = fopen(path, "wb");
+    if (!f) return false;
+    const size_t put = fwrite(src, 1, bytes, f);
+    fclose(f);
+    return put == bytes;
+}
+
+static size_t tensor_offset(const ggml_tensor * t, int i0, int i1, int i2, int i3) {
+    return (size_t) i0 * t->nb[0] + (size_t) i1 * t->nb[1] +
+           (size_t) i2 * t->nb[2] + (size_t) i3 * t->nb[3];
+}
+
+int main(int argc, char ** argv) {
+    if (argc != 10) {
+        fprintf(stderr, "usage: %s q.f32 k.f16 v.f16 out.f32 H Hkv KV D threads\n", argv[0]);
+        return 2;
+    }
+    const int H = atoi(argv[5]);
+    const int Hkv = atoi(argv[6]);
+    const int KV = atoi(argv[7]);
+    const int D = atoi(argv[8]);
+    const int threads = atoi(argv[9]);
+    if (H <= 0 || Hkv <= 0 || KV <= 0 || D <= 0 || threads <= 0 || H % Hkv != 0) return 2;
+
+    const size_t q_count = (size_t) H * (size_t) D;
+    const size_t kv_count = (size_t) Hkv * (size_t) KV * (size_t) D;
+    const size_t memory = 64u * 1024u * 1024u +
+                          q_count * sizeof(float) + 2u * kv_count * sizeof(ggml_fp16_t);
+    ggml_init_params init = { memory, nullptr, false };
+    ggml_context * ctx = ggml_init(init);
+    if (!ctx) return 3;
+    ggml_cpu_init();
+
+    ggml_tensor * q = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, D, 1, H, 1);
+    ggml_tensor * k = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, D, KV, Hkv, 1);
+    ggml_tensor * v = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, D, KV, Hkv, 1);
+    if (!read_exact(argv[1], q->data, q_count * sizeof(float)) ||
+        !read_exact(argv[2], k->data, kv_count * sizeof(ggml_fp16_t)) ||
+        !read_exact(argv[3], v->data, kv_count * sizeof(ggml_fp16_t))) {
+        ggml_free(ctx);
+        return 4;
+    }
+
+    ggml_tensor * out = ggml_flash_attn_ext(
+        ctx, q, k, v, nullptr, 1.0f / sqrtf((float) D), 0.0f, 0.0f);
+    ggml_flash_attn_ext_set_prec(out, GGML_PREC_F32);
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, out);
+    ggml_threadpool_params tp_params = ggml_threadpool_params_default(threads);
+    tp_params.paused = false;
+    ggml_threadpool * threadpool = ggml_threadpool_new(&tp_params);
+    ggml_cplan plan = ggml_graph_plan(graph, threads, threadpool);
+    plan.work_data = plan.work_size ? (uint8_t *) malloc(plan.work_size) : nullptr;
+    if (plan.work_size && !plan.work_data) return 5;
+    const ggml_status status = ggml_graph_compute(graph, &plan);
+    if (status != GGML_STATUS_SUCCESS) return 6;
+
+    float * host = (float *) malloc(q_count * sizeof(float));
+    if (!host) return 7;
+    for (int h = 0; h < H; ++h) {
+        for (int d = 0; d < D; ++d) {
+            memcpy(host + (size_t) h * (size_t) D + (size_t) d,
+                   (const char *) out->data + tensor_offset(out, d, h, 0, 0), sizeof(float));
+        }
+    }
+    const bool ok = write_exact(argv[4], host, q_count * sizeof(float));
+    free(host);
+    free(plan.work_data);
+    ggml_threadpool_free(threadpool);
+    ggml_free(ctx);
+    return ok ? 0 : 8;
+}
+"""
+
+
+def _llama_root():
+    value = os.environ.get("V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT", "").strip()
+    return Path(value).resolve() if value else (Path(__file__).resolve().parents[1] / "llama.cpp")
+
+
+def _ensure_llama_helper():
+    root = _llama_root()
+    bin_dir = root / "build" / "bin"
+    required = [bin_dir / "libggml.so", bin_dir / "libggml-cpu.so", bin_dir / "libggml-base.so"]
+    if not (root / "ggml" / "include" / "ggml.h").is_file() or not all(p.is_file() for p in required):
+        raise RuntimeError(f"llama.cpp GGML headers/libraries not found under {root}")
+    helper_dir = Path(tempfile.gettempdir()) / "ck_attention_f16_split_kv"
+    helper_dir.mkdir(parents=True, exist_ok=True)
+    source = helper_dir / "llama_f16_split_kv.cpp"
+    binary = helper_dir / "llama_f16_split_kv"
+    if not source.is_file() or source.read_text() != _LLAMA_HELPER_SOURCE:
+        source.write_text(_LLAMA_HELPER_SOURCE)
+    if not binary.is_file() or binary.stat().st_mtime < source.stat().st_mtime:
+        command = [
+            "g++", "-O2", "-std=c++11",
+            "-I", str(root / "ggml" / "include"),
+            "-o", str(binary), str(source),
+            "-L", str(bin_dir), "-lggml", "-lggml-cpu", "-lggml-base",
+            "-lm", "-lpthread", f"-Wl,-rpath,{bin_dir}",
+        ]
+        completed = subprocess.run(command, capture_output=True, text=True)
+        if completed.returncode != 0:
+            raise RuntimeError(f"llama.cpp split-KV helper compile failed:\n{completed.stderr}")
+    return binary, bin_dir
+
+
+def _llama_split_output(q, k_bits, v_bits, head_dim, threads):
+    helper, bin_dir = _ensure_llama_helper()
+    heads, _ = q.shape
+    kv_heads, kv_tokens, _ = k_bits.shape
+    q_compact = np.ascontiguousarray(q[:, :head_dim], dtype=np.float32)
+    k_compact = np.ascontiguousarray(k_bits[:, :, :head_dim], dtype=np.uint16)
+    v_compact = np.ascontiguousarray(v_bits[:, :, :head_dim], dtype=np.uint16)
+    with tempfile.TemporaryDirectory(prefix="ck_f16_split_kv_") as tmp:
+        tmp = Path(tmp)
+        q_path, k_path, v_path, out_path = [tmp / name for name in ("q.f32", "k.f16", "v.f16", "out.f32")]
+        q_compact.tofile(q_path)
+        k_compact.tofile(k_path)
+        v_compact.tofile(v_path)
+        command = [
+            str(helper), str(q_path), str(k_path), str(v_path), str(out_path),
+            str(heads), str(kv_heads), str(kv_tokens), str(head_dim), str(threads),
+        ]
+        env = os.environ.copy()
+        env["LD_LIBRARY_PATH"] = f"{bin_dir}:{env.get('LD_LIBRARY_PATH', '')}"
+        completed = subprocess.run(command, capture_output=True, text=True, env=env)
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"llama.cpp split-KV helper failed ({completed.returncode}):\n{completed.stderr}"
+            )
+        return np.fromfile(out_path, dtype=np.float32).reshape(heads, head_dim)
+
+
+def _f32_ptr(a):
+    return a.ctypes.data_as(_FLOAT_P)
+
+
+def _u16_ptr(a):
+    return a.ctypes.data_as(_U16_P)
+
+
+def _half_bits(a):
+    return np.ascontiguousarray(a.astype(np.float16)).view(np.uint16)
+
+
+def _split_oracle(q, k_bits, v_bits, head_dim, chunks):
+    """Independent scalar-contract oracle with explicit FP16 accumulators."""
+    num_heads, aligned = q.shape
+    num_kv_heads, kv_tokens, _ = k_bits.shape
+    chunks = max(1, min(chunks, kv_tokens))
+    chunk_size = (kv_tokens + chunks - 1) // chunks
+    scale = np.float32(1.0 / math.sqrt(head_dim))
+    q_half = q.astype(np.float16)
+    k_half = k_bits.view(np.float16)
+    v_half = v_bits.view(np.float16)
+    partial_max = np.full((num_heads, chunks), -np.inf, dtype=np.float32)
+    partial_sum = np.zeros((num_heads, chunks), dtype=np.float32)
+    partial_acc = np.zeros((num_heads, chunks, aligned), dtype=np.float32)
+
+    for h in range(num_heads):
+        kv_head = h * num_kv_heads // num_heads
+        q32 = q_half[h, :head_dim].astype(np.float32)
+        for chunk in range(chunks):
+            begin = chunk * chunk_size
+            end = min(begin + chunk_size, kv_tokens)
+            maximum = np.float32(-np.inf)
+            total = np.float32(0.0)
+            acc = np.zeros(head_dim, dtype=np.float16)
+            for token in range(begin, end):
+                # np.sum(dtype=float32) preserves the intended FP32 reduction
+                # contract while keeping the real Qwen3-VL shape test practical.
+                dot = np.sum(
+                    q32 * k_half[kv_head, token, :head_dim].astype(np.float32),
+                    dtype=np.float32,
+                )
+                score = np.float32(dot * scale)
+                old_max = maximum
+                max_scale = np.float32(1.0)
+                value_scale = np.float32(1.0)
+                if score > maximum:
+                    maximum = score
+                    max_scale = (
+                        np.float32(math.exp(float(old_max - maximum)))
+                        if np.isfinite(old_max)
+                        else np.float32(0.0)
+                    )
+                    acc = (acc.astype(np.float32) * max_scale).astype(np.float16)
+                else:
+                    value_scale = np.float32(math.exp(float(score - maximum)))
+                acc = (
+                    acc.astype(np.float32)
+                    + value_scale * v_half[kv_head, token, :head_dim].astype(np.float32)
+                ).astype(np.float16)
+                total = np.float32(total * max_scale + value_scale)
+
+            partial_max[h, chunk] = maximum
+            partial_sum[h, chunk] = total
+            partial_acc[h, chunk, :head_dim] = acc.astype(np.float32)
+
+    out = np.zeros((num_heads, aligned), dtype=np.float32)
+    for h in range(num_heads):
+        maximum = np.float32(-np.inf)
+        total = np.float32(0.0)
+        for chunk in range(chunks):
+            chunk_sum = partial_sum[h, chunk]
+            if chunk_sum == 0.0:
+                continue
+            new_max = np.float32(max(maximum, partial_max[h, chunk]))
+            old_scale = (
+                np.float32(math.exp(float(maximum - new_max)))
+                if np.isfinite(maximum)
+                else np.float32(0.0)
+            )
+            chunk_scale = np.float32(math.exp(float(partial_max[h, chunk] - new_max)))
+            out[h, :head_dim] = (
+                out[h, :head_dim] * old_scale
+                + partial_acc[h, chunk, :head_dim] * chunk_scale
+            ).astype(np.float32)
+            total = np.float32(total * old_scale + chunk_sum * chunk_scale)
+            maximum = new_max
+        if total > 0.0:
+            out[h, :head_dim] = (out[h, :head_dim] / total).astype(np.float32)
+    return out
+
+
+def _fp32_single_reference(q, k_bits, v_bits, head_dim):
+    """The previous CK-style FP32 reduction, used only as a rejection oracle."""
+    num_heads, aligned = q.shape
+    num_kv_heads, _, _ = k_bits.shape
+    k = k_bits.view(np.float16).astype(np.float32)
+    v = v_bits.view(np.float16).astype(np.float32)
+    out = np.zeros((num_heads, aligned), dtype=np.float32)
+    scale = np.float32(1.0 / math.sqrt(head_dim))
+    for h in range(num_heads):
+        kv_head = h * num_kv_heads // num_heads
+        scores = np.sum(k[kv_head, :, :head_dim] * q[h, :head_dim], axis=1, dtype=np.float32)
+        scores = scores * scale
+        weights = np.exp(scores - np.max(scores)).astype(np.float32)
+        weights /= np.sum(weights, dtype=np.float32)
+        out[h, :head_dim] = weights @ v[kv_head, :, :head_dim]
+    return out
+
+
+def _inputs(seed, heads, kv_heads, kv_tokens, head_dim, aligned):
+    rng = np.random.default_rng(seed)
+    q = rng.normal(0.0, 0.55, (heads, aligned)).astype(np.float32)
+    k = rng.normal(0.0, 0.55, (kv_heads, kv_tokens, aligned)).astype(np.float32)
+    v = rng.normal(0.0, 0.75, (kv_heads, kv_tokens, aligned)).astype(np.float32)
+    if head_dim < aligned:
+        q[:, head_dim:] = 0.0
+        k[:, :, head_dim:] = 0.0
+        v[:, :, head_dim:] = 0.0
+    return q, _half_bits(k), _half_bits(v)
+
+
+def _run_explicit(q, k, v, head_dim, chunks):
+    heads, aligned = q.shape
+    kv_heads, kv_tokens, _ = k.shape
+    out = np.full_like(q, np.nan)
+    lib.attention_forward_decode_head_major_gqa_flash_f16cache_split(
+        _f32_ptr(q), _u16_ptr(k), _u16_ptr(v), _f32_ptr(out),
+        heads, kv_heads, kv_tokens, kv_tokens, head_dim, aligned, chunks,
+    )
+    return out
+
+
+@dataclass
+class Result:
+    name: str
+    diff: float
+    tolerance: float
+    passed: bool
+
+
+def _case(name, seed, heads, kv_heads, kv_tokens, head_dim, aligned, chunks, tolerance):
+    q, k, v = _inputs(seed, heads, kv_heads, kv_tokens, head_dim, aligned)
+    actual = _run_explicit(q, k, v, head_dim, chunks)
+    expected = _split_oracle(q, k, v, head_dim, chunks)
+    diff = float(np.max(np.abs(actual - expected)))
+    return Result(name, diff, tolerance, diff <= tolerance), (q, k, v, actual)
+
+
+def main():
+    results = []
+    below, below_data = _case(
+        "f16_split_below_threshold(KV=511,C=1)", 511, 8, 2, 511, 64, 64, 1, 2.0e-5,
+    )
+    results.append(below)
+    threshold, threshold_data = _case(
+        "f16_split_threshold(KV=512,C=4)", 512, 8, 2, 512, 64, 64, 4, 2.0e-5,
+    )
+    results.append(threshold)
+    qwen, qwen_data = _case(
+        "f16_split_qwen3vl(KV=1058,H=32,D=128,C=20)",
+        1058, 32, 8, 1058, 128, 128, 20, 2.0e-5,
+    )
+    results.append(qwen)
+    padded, _ = _case(
+        "f16_split_padded_gqa(KV=513,D=80,A=128,C=4)",
+        513, 8, 2, 513, 80, 128, 4, 2.0e-5,
+    )
+    results.append(padded)
+
+    threads = max(1, int(lib.ck_get_num_threads()))
+    try:
+        for name, data, chunks in (
+            ("llama_oracle_below(KV=511)", below_data, 1),
+            ("llama_oracle_threshold(KV=512)", threshold_data, threads),
+            ("llama_oracle_qwen3vl(KV=1058)", qwen_data, threads),
+        ):
+            q, k, v, _ = data
+            ck = _run_explicit(q, k, v, q.shape[1], chunks)
+            llama = _llama_split_output(q, k, v, q.shape[1], threads)
+            diff = float(np.max(np.abs(ck[:, :q.shape[1]] - llama)))
+            results.append(Result(name, diff, 2.0e-5, diff <= 2.0e-5))
+    except RuntimeError as exc:
+        print(f"llama.cpp oracle error: {exc}")
+        results.append(Result("llama_oracle_available", 1.0, 0.0, False))
+
+    q, k, v, _ = qwen_data
+    v_sensitive = _half_bits(v.view(np.float16).astype(np.float32) * np.float32(8.0))
+    split_out = _run_explicit(q, k, v_sensitive, 128, 20)
+    fp32_out = _fp32_single_reference(q, k, v_sensitive, 128)
+    contract_gap = float(np.max(np.abs(split_out - fp32_out)))
+    sensitivity_ok = contract_gap >= 5.0e-4
+    results.append(Result(
+        "reject_single_fp32_reduction(KV=1058)",
+        0.0 if sensitivity_ok else 1.0,
+        0.0,
+        sensitivity_ok,
+    ))
+
+    print(f"FP16 split-KV attention contract: CK threads={threads}, fp32_contract_gap={contract_gap:.6e}")
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        print(
+            f"{result.name}  max_diff={result.diff:.6e}  "
+            f"tol={result.tolerance:.1e}  [{status}]"
+        )
+    passed = sum(result.passed for result in results)
+    print(f"FP16 split-KV attention: {passed}/{len(results)} passed")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Qwen3-VL decode attribution exposed a llama.cpp CPU semantic boundary at KV 512 that ordinary flash-attention and kernel parity tests did not exercise. A reconstructed local reference is insufficient unless the actual GGML backend agrees.

## What

- Add an explicit-chunk FP16 split-KV attention oracle.
- Compare CK directly with `ggml_flash_attn_ext` using FP32 Q and FP16 K/V at KV 511, 512, and the Qwen3-VL KV 1058 / H32 / Hkv8 / D128 shape.
- Cover GQA, aligned padding, deterministic chunks, and an adversarial guard that rejects the old single-FP32 reduction.
- Run the contract from `make llamacpp-parity-full`.
- Register `FP16 Split-KV Decode Contract` as a named nightly kernel lane.
- Document the lane in `docs/site/test-report.html` so its eight subtests render as expandable rows.
- Record the full diagnosis and rejected production-routing experiment in `logs/2026-07-10-qwen3vl-split-kv-contract/README.md`.

## Result

- CK vs llama.cpp at Qwen3-VL shape: max abs `8.32e-6`, tolerance `2e-5`.
- Python contract oracle worst max abs: `1.61e-5`, tolerance `2e-5`.
- Single-FP32 rejection gap: `8.81e-4`.
- Nightly JSON/UI parser: 8/8 named rows, lane status pass.

Production routing remains unchanged. Applying the oracle to every decode layer did not move the canonical step-31 mismatch and worsened logit metrics, proving the remaining source is earlier in mixed prefill and should be fixed there.

## Validation

- `make test-attention-f16-split-kv` (8/8)
- 26 decoder parity tests
- `make test-flash-attention`
- staged `v7-regression-fast` and `v8-regression-fast`
- full pre-push build, kernel parity, Gemma3 E2E, v8 contracts, v7 training smoke, fast regressions, and training-kernel parity
- `git diff --check`