### PR TITLE
fix(test): keep optional ggml oracle out of litmus

### DIFF
--- a/unittest/test_lm_head_litmus.py
+++ b/unittest/test_lm_head_litmus.py
@@ -492,16 +492,11 @@ def main():
             norm_sources = {os.path.normpath(s) for s in extra_sources}
             strict_src = os.path.normpath("src/ckernel_strict.c")
             threadpool_src = os.path.normpath("src/ck_threadpool.c")
-            attention_src = os.path.normpath("src/kernels/attention_kernels.c")
-            attention_oracle_src = os.path.normpath("src/kernels/attention_oracle_ggml.c")
             # ckernel_strict.c now references global threadpool helpers.
             # Ensure standalone litmus links the required implementation.
             if strict_src in norm_sources and threadpool_src not in norm_sources:
                 extra_sources.append("src/ck_threadpool.c")
                 norm_sources.add(threadpool_src)
-            # attention_kernels.c now depends on the split strict/oracle helper.
-            if attention_src in norm_sources and attention_oracle_src not in norm_sources:
-                extra_sources.append("src/kernels/attention_oracle_ggml.c")
             cmd.extend(extra_sources)
             cmd.insert(1, openmp_flag(cc))
             if "src/ck_threadpool.c" in extra_sources and "-lpthread" not in cmd:


### PR DESCRIPTION
## Why

Both nightly rows `LM Head Litmus` and `Litmus Test` failed because the standalone litmus compiler unconditionally injected `src/kernels/attention_oracle_ggml.c`. That optional strict-parity source requires llama.cpp GGML headers and is not part of a normal standalone attention build; `attention_oracle_ggml.h` already provides disabled-build stubs.

The nightly workflow remains intentionally non-blocking and continues all test lanes. This change removes both reported failures at their shared root.

## Validation

- `make litmus PYTHON=/home/antshiv/Workspace/C-Kernel-Engine/.venv/bin/python`
- LM head + CE litmus passed
- loss/logits/d_logits/d_hidden/d_weights numerical checks passed
- pre-commit passed
- full pre-push passed