### PR TITLE
fix(attention): match llama fp16 prefill contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1997,11 +1997,25 @@ test-flash-attention: $(LIB)
 test_flash_attention: test-flash-attention
 
 test-attention-f16-split-kv: $(LIB)
-	@echo "Running FP16 split-KV decode attention contract tests..."
+	@echo "Running FP16 prefill/decode attention contract tests..."
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH \
 		$(PYTHON) $(PYTHONFLAGS) unittest/test_attention_f16_split_kv.py
 
 .PHONY: test-attention-f16-split-kv
+
+test-v8-dump-alignment:
+	@echo "Running v8 stitched dump alignment contract tests..."
+	@$(PYTHON) $(PYTHONFLAGS) unittest/test_v8_dump_alignment.py
+
+.PHONY: test-v8-dump-alignment
+
+qwen3vl-parity-guards:
+	@$(MAKE) --no-print-directory test-attention-f16-split-kv
+	@$(MAKE) --no-print-directory test-v8-dump-alignment
+	@$(MAKE) --no-print-directory test-v8-vision-kernels
+	@$(MAKE) --no-print-directory nightly-bf16
+
+.PHONY: qwen3vl-parity-guards
 
 # GEMM benchmark comparing CKernel (Native + MKL if available) vs PyTorch
 bench_gemm:

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1686,10 +1686,15 @@
     <li><strong>v8 Vision Kernel Parity</strong>: Vision kernel parity for patch extraction/reconstruction, tiled position embeddings,
       Qwen3-VL resized position interpolation order, spatial merge/reorder, feature concat/slice, and vision M-RoPE
       (<code>make test-v8-vision-kernels</code>)</li>
-    <li><strong>FP16 Split-KV Decode Contract</strong>: Named numerical guards for the llama.cpp-compatible decode reduction contract,
-      including FP16 Q/K rounding, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding, the KV 511/512 semantic boundary,
-      and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
+    <li><strong>FP16 Attention Contracts</strong>: Named numerical guards for llama.cpp-compatible unfused causal prefill and split-KV decode,
+      including FP16 Q/K rounding, FP16 probability/value reduction, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding,
+      the KV 511/512 semantic boundary, and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
       (<code>make test-attention-f16-split-kv</code>)</li>
+    <li><strong>v8 Stitched Dump Alignment</strong>: Guards canonical output-projection aliases and preserves absolute CK/llama
+      source-token provenance when mixed-prefix dumps are rebased for per-token comparison
+      (<code>make test-v8-dump-alignment</code>)</li>
+    <li><strong>Qwen3-VL Parity Guard Sweep</strong>: Local aggregate for GGUF FP16 attention contracts, stitched dump alignment,
+      shared vision kernels, and the BF16 parity lane (<code>make qwen3vl-parity-guards</code>)</li>
     <li><strong>Llama Pairwise RoPE Contract</strong>: explicit regression for consecutive-pair RoPE layout selection plus kernel-level pairwise forward coverage and timing
       (<code>version/v7/scripts/parity/test_check_decode_attention_contract.py</code>, <code>unittest/test_rope.py</code>)</li>
     <li><strong>Sliding-Window Contract</strong>: Explicit sliding attention prefill/decode contract test

--- a/logs/2026-07-10-qwen3vl-avx2-attention/README.md
+++ b/logs/2026-07-10-qwen3vl-avx2-attention/README.md
@@ -1,0 +1,87 @@
+# Qwen3-VL AVX2 Attention Parity
+
+## Scope
+
+Canonical GGUF replay on AVX2 using:
+
+- decoder: Qwen3VL-8B-Instruct-Q4_K_M.gguf
+- image: local canonical `ocr/1 81.jpg` converted through the shared PPM path
+- visual prefix: 1008 x 16384, grid 36 x 28
+- context: 4096
+- threads: 20
+- prompt: `Extract visible form fields as compact JSON.`
+- llama.cpp: repository-pinned commit
+
+Private OCR images and model weights are not committed.
+
+## Root Cause
+
+The strict causal prefill path used FP32 Q/K dot products and an FP32 value reduction. llama.cpp's unfused GGUF graph uses a different numerical contract:
+
+1. Q and K are rounded to FP16 before the score dot product.
+2. Scaled softmax is evaluated in FP32.
+3. Softmax probabilities are rounded to FP16.
+4. V is rounded to FP16 before the value reduction.
+
+At layer 0, head 25, generated step 31:
+
+| Comparison | Max abs | RMSE |
+|---|---:|---:|
+| FP32 CK-style scores vs llama scores | 0.02710 | 0.00750 |
+| FP16 Q/K scores vs llama scores | 0.0000153 | 0.00000273 |
+| New strict attention, identical llama inputs | 0.0000000149 | 0.00000000114 |
+| New strict attention, CK upstream inputs | 0.00000451 | 0.000000186 |
+
+The Q4_K output projection was ruled out. Feeding llama's `kqv_out` through CK's layer-0 Q4_K x Q8_K projection, bias, and weight view reproduced llama `kqv_wo` within 2.38e-7 max. The projection amplified an upstream attention delta; it did not create it.
+
+## End-to-End Result
+
+| Run | First mismatch | Result |
+|---|---:|---|
+| Previous strict baseline | 31 | CK `":` vs llama `_name` |
+| New FP16-unfused strict attention, 32 tokens | none | 32/32 persistent tokens matched |
+| New FP16-unfused strict attention, 64 tokens | 44 | CK `form` vs llama `section` |
+| Full replay at step 44 | 44 | Still mismatched; not KV-state-only |
+
+The generated output remained coherent JSON through the shared prefix. This is a material parity improvement, not full 64-token closure.
+
+## Step-44 Attribution
+
+The bounded layer sweep shows accumulation rather than a new circuit discontinuity:
+
+| Boundary | Max abs |
+|---|---:|
+| layer 0 output | 0.00279 |
+| layer 4 output | 0.09347 |
+| layer 16 output | 0.22189 |
+| layer 28 output | 0.85219 |
+| layer 35 output | 9.60400 |
+
+Layer-0 granular replay remains tight through projections, then diverges first at attention:
+
+| Boundary | Max abs |
+|---|---:|
+| attention norm | 4.5e-8 |
+| Q projection | 2.68e-7 |
+| K projection | 1.79e-7 |
+| V projection | 3.7e-8 |
+| Q norm | 3.34e-6 |
+| K norm | 4.58e-5 |
+| attention output | 1.64e-4 |
+| post-attention residual | 4.60e-4 |
+| layer output | 2.79e-3 |
+
+## Guards Added
+
+- `unfused_f16_causal(T=17,H=4,D=32)` in `unittest/test_attention_f16_split_kv.py`
+- absolute source-token provenance after mixed-prefix rebasing
+- canonical llama `kqv_wo` to CK output-projection alignment
+- `make test-v8-dump-alignment`
+- `make qwen3vl-parity-guards`
+- nightly/report row for stitched dump alignment
+
+The aggregate guard includes the existing BF16 nightly lane. The GGUF FP16 cache contract is not applied to BF16 arithmetic.
+
+## Next Target
+
+At step 44, determine the exact llama AUTO flash-attention reduction contract. The new implementation is exact against llama's unfused graph, but the canonical AUTO model path still differs at `kqv_out`. Keep performance work disabled until the 64-token Q4_K_M replay is parity-clean.

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -391,10 +391,16 @@ MAKE_TARGETS = {
         "timeout_sec": 1800,
     },
     "attention_f16_split_kv": {
-        "name": "FP16 Split-KV Decode Contract",
+        "name": "FP16 Prefill/Decode Attention Contracts",
         "category": "kernels",
         "target": "test-attention-f16-split-kv",
         "timeout_sec": 180,
+    },
+    "v8_dump_alignment": {
+        "name": "v8 Stitched Dump Alignment",
+        "category": "parity",
+        "target": "test-v8-dump-alignment",
+        "timeout_sec": 60,
     },
     "threadpool_parity": {
         "name": "Thread Pool GEMV Parity (serial vs dispatch)",

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -830,6 +830,55 @@ static CK_NOINLINE CK_OPTNONE float ck_ggml_vec_dot_f32_contig(const float *x,
 #endif
 }
 
+static inline float ck_attention_dot_f16_unfused_llama(const uint16_t *x,
+                                                        const uint16_t *y,
+                                                        int n)
+{
+    int i = 0;
+#if defined(__AVX2__) && defined(__F16C__)
+    __m256 sum0 = _mm256_setzero_ps();
+    __m256 sum1 = _mm256_setzero_ps();
+    __m256 sum2 = _mm256_setzero_ps();
+    __m256 sum3 = _mm256_setzero_ps();
+    const int n32 = n & ~31;
+    for (; i < n32; i += 32) {
+        const __m256 x0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i)));
+        const __m256 y0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i)));
+        const __m256 x1 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i + 8)));
+        const __m256 y1 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i + 8)));
+        const __m256 x2 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i + 16)));
+        const __m256 y2 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i + 16)));
+        const __m256 x3 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (x + i + 24)));
+        const __m256 y3 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *) (y + i + 24)));
+#if defined(__FMA__)
+        sum0 = _mm256_fmadd_ps(x0, y0, sum0);
+        sum1 = _mm256_fmadd_ps(x1, y1, sum1);
+        sum2 = _mm256_fmadd_ps(x2, y2, sum2);
+        sum3 = _mm256_fmadd_ps(x3, y3, sum3);
+#else
+        sum0 = _mm256_add_ps(sum0, _mm256_mul_ps(x0, y0));
+        sum1 = _mm256_add_ps(sum1, _mm256_mul_ps(x1, y1));
+        sum2 = _mm256_add_ps(sum2, _mm256_mul_ps(x2, y2));
+        sum3 = _mm256_add_ps(sum3, _mm256_mul_ps(x3, y3));
+#endif
+    }
+    sum0 = _mm256_add_ps(sum0, sum2);
+    sum1 = _mm256_add_ps(sum1, sum3);
+    sum0 = _mm256_add_ps(sum0, sum1);
+    const __m128 pair = _mm_add_ps(
+        _mm256_castps256_ps128(sum0),
+        _mm256_extractf128_ps(sum0, 1));
+    const __m128 half = _mm_hadd_ps(pair, pair);
+    float result = _mm_cvtss_f32(_mm_hadd_ps(half, half));
+#else
+    float result = 0.0f;
+#endif
+    for (; i < n; ++i) {
+        result += CK_FP16_TO_FP32(x[i]) * CK_FP16_TO_FP32(y[i]);
+    }
+    return result;
+}
+
 static CK_NOINLINE CK_OPTNONE float ck_attention_strict_scale_f32(int head_dim)
 {
     // Keep strict parity on the precise libm sqrtf path. icx -O3 on AVX2 was
@@ -3307,6 +3356,98 @@ static int ck_attention_pick_active_threads(const ck_threadpool_t *pool, int tot
     return active < 1 ? 1 : active;
 }
 
+static int ck_attention_strict_unfused_f16_enabled(void)
+{
+    const char *value = getenv("CK_STRICT_ATTN_F16_UNFUSED");
+    return !value || !value[0] || strcmp(value, "0") != 0;
+}
+
+static int attention_forward_head_major_gqa_unfused_f16_strict(
+    const float *q,
+    const float *k,
+    const float *v,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens,
+    int causal,
+    float scale,
+    int debug_layer_id)
+{
+    const int T = num_tokens;
+    const size_t kv_head_stride = (size_t) kv_stride_tokens * (size_t) aligned_head_dim;
+    const size_t kv_half_count = (size_t) T * (size_t) aligned_head_dim;
+    uint16_t *k_half = (uint16_t *) malloc(kv_half_count * sizeof(uint16_t));
+    uint16_t *v_half = (uint16_t *) malloc(kv_half_count * sizeof(uint16_t));
+    if (!k_half || !v_half) {
+        free(k_half);
+        free(v_half);
+        return 0;
+    }
+    uint16_t *q_half = (uint16_t *) alloca((size_t) aligned_head_dim * sizeof(uint16_t));
+    uint16_t *prob_half = (uint16_t *) alloca((size_t) T * sizeof(uint16_t));
+    uint16_t *v_col_half = (uint16_t *) alloca((size_t) T * sizeof(uint16_t));
+    float *raw_scores = (float *) alloca((size_t) T * sizeof(float));
+    float *logits = (float *) alloca((size_t) T * sizeof(float));
+    int cached_kv_head = -1;
+
+    for (int h = 0; h < num_heads; ++h) {
+        const int kv_head = (int) ((long long) h * (long long) num_kv_heads /
+                                   (long long) num_heads);
+        const float *k_head = k + (size_t) kv_head * kv_head_stride;
+        const float *v_head = v + (size_t) kv_head * kv_head_stride;
+        if (kv_head != cached_kv_head) {
+            for (size_t idx = 0; idx < kv_half_count; ++idx) {
+                k_half[idx] = CK_FP32_TO_FP16(k_head[idx]);
+                v_half[idx] = CK_FP32_TO_FP16(v_head[idx]);
+            }
+            cached_kv_head = kv_head;
+        }
+
+        for (int i = 0; i < T; ++i) {
+            const float *q_vec = q + qkv_index(h, i, 0, T, aligned_head_dim);
+            float *out_vec = output + qkv_index(h, i, 0, T, aligned_head_dim);
+            const int kv_tokens = causal ? i + 1 : T;
+            for (int d = 0; d < aligned_head_dim; ++d) {
+                q_half[d] = CK_FP32_TO_FP16(q_vec[d]);
+            }
+            for (int j = 0; j < kv_tokens; ++j) {
+                raw_scores[j] = ck_attention_dot_f16_unfused_llama(
+                    q_half,
+                    k_half + (size_t) j * (size_t) aligned_head_dim,
+                    head_dim);
+                logits[j] = raw_scores[j] * scale;
+            }
+
+            const float max_score = ck_vec_max_f32_contig(logits, kv_tokens);
+            const double sum = ck_ggml_vec_soft_max_row(kv_tokens, logits, logits, max_score);
+            const float inv_sum = sum > 0.0 ? (float) (1.0 / sum) : 0.0f;
+            for (int j = 0; j < kv_tokens; ++j) {
+                logits[j] *= inv_sum;
+                prob_half[j] = CK_FP32_TO_FP16(logits[j]);
+            }
+            for (int d = 0; d < head_dim; ++d) {
+                for (int j = 0; j < kv_tokens; ++j) {
+                    v_col_half[j] = v_half[(size_t) j * (size_t) aligned_head_dim + (size_t) d];
+                }
+                out_vec[d] = ck_attention_dot_f16_unfused_llama(prob_half, v_col_half, kv_tokens);
+            }
+            for (int d = head_dim; d < aligned_head_dim; ++d) {
+                out_vec[d] = 0.0f;
+            }
+            ck_attention_vec_dump_selected_query(raw_scores, logits, out_vec, NULL,
+                                                 kv_tokens, head_dim,
+                                                 debug_layer_id, h, i);
+        }
+    }
+    free(k_half);
+    free(v_half);
+    return 1;
+}
+
 static void attention_forward_head_major_gqa_flash_impl(const float *q,
                                                         const float *k,
                                                         const float *v,
@@ -3338,6 +3479,15 @@ static void attention_forward_head_major_gqa_flash_impl(const float *q,
         const int debug_layer_id = ck_attention_vec_dump_enabled()
             ? ck_attention_vec_dump_next_layer_id()
             : -1;
+        if (causal && ck_attention_strict_unfused_f16_enabled()) {
+            if (attention_forward_head_major_gqa_unfused_f16_strict(
+                    q, k, v, output,
+                    num_heads, num_kv_heads, num_tokens,
+                    head_dim, aligned_head_dim, kv_stride_tokens,
+                    causal, strict_scale, debug_layer_id)) {
+                return;
+            }
+        }
 #if CK_ENABLE_LLAMA_CPP_PARITY
         if (!causal &&
             ck_attention_full_ggml_graph_oracle_multihead(q,

--- a/unittest/test_attention_f16_split_kv.py
+++ b/unittest/test_attention_f16_split_kv.py
@@ -34,6 +34,14 @@ lib.attention_forward_decode_head_major_gqa_flash_f16cache_split.argtypes = _SPL
 lib.attention_forward_decode_head_major_gqa_flash_f16cache_split.restype = None
 lib.ck_get_num_threads.argtypes = []
 lib.ck_get_num_threads.restype = ctypes.c_int
+lib.ck_set_strict_parity.argtypes = [ctypes.c_int]
+lib.ck_set_strict_parity.restype = None
+lib.attention_forward_causal_head_major_gqa_flash_strided.argtypes = [
+    _FLOAT_P, _FLOAT_P, _FLOAT_P, _FLOAT_P,
+    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+    ctypes.c_int, ctypes.c_int,
+]
+lib.attention_forward_causal_head_major_gqa_flash_strided.restype = None
 
 
 _LLAMA_HELPER_SOURCE = r"""
@@ -297,6 +305,65 @@ def _fp32_single_reference(q, k_bits, v_bits, head_dim):
     return out
 
 
+def _unfused_f16_causal_reference(q, k, v):
+    heads, tokens, head_dim = q.shape
+    kv_heads = k.shape[0]
+    qh = q.astype(np.float16).astype(np.float32)
+    kh = k.astype(np.float16).astype(np.float32)
+    vh = v.astype(np.float16).astype(np.float32)
+    scale = np.float32(1.0 / math.sqrt(head_dim))
+    out = np.zeros_like(q)
+    for h in range(heads):
+        kv_head = h * kv_heads // heads
+        for token in range(tokens):
+            count = token + 1
+            scores = np.sum(
+                kh[kv_head, :count] * qh[h, token][None, :],
+                axis=1,
+                dtype=np.float32,
+            ) * scale
+            probs = np.exp(scores - np.max(scores)).astype(np.float32)
+            probs /= np.sum(probs, dtype=np.float32)
+            probs = probs.astype(np.float16).astype(np.float32)
+            out[h, token] = np.sum(
+                vh[kv_head, :count] * probs[:, None],
+                axis=0,
+                dtype=np.float32,
+            )
+    return out
+
+
+def _unfused_f16_causal_case():
+    rng = np.random.default_rng(20260710)
+    heads, kv_heads, tokens, head_dim = 4, 2, 17, 32
+    q = rng.normal(0.0, 0.7, (heads, tokens, head_dim)).astype(np.float32)
+    k = rng.normal(0.0, 0.7, (kv_heads, tokens, head_dim)).astype(np.float32)
+    v = rng.normal(0.0, 0.9, (kv_heads, tokens, head_dim)).astype(np.float32)
+    actual = np.zeros_like(q)
+    old = os.environ.get("CK_STRICT_ATTN_F16_UNFUSED")
+    try:
+        os.environ["CK_STRICT_ATTN_F16_UNFUSED"] = "1"
+        lib.ck_set_strict_parity(1)
+        lib.attention_forward_causal_head_major_gqa_flash_strided(
+            _f32_ptr(q), _f32_ptr(k), _f32_ptr(v), _f32_ptr(actual),
+            heads, kv_heads, tokens, head_dim, head_dim, tokens,
+        )
+    finally:
+        lib.ck_set_strict_parity(0)
+        if old is None:
+            os.environ.pop("CK_STRICT_ATTN_F16_UNFUSED", None)
+        else:
+            os.environ["CK_STRICT_ATTN_F16_UNFUSED"] = old
+    expected = _unfused_f16_causal_reference(q, k, v)
+    diff = float(np.max(np.abs(actual - expected)))
+    return Result(
+        "unfused_f16_causal(T=17,H=4,D=32)",
+        diff,
+        3.0e-5,
+        diff <= 3.0e-5,
+    )
+
+
 def _inputs(seed, heads, kv_heads, kv_tokens, head_dim, aligned):
     rng = np.random.default_rng(seed)
     q = rng.normal(0.0, 0.55, (heads, aligned)).astype(np.float32)
@@ -338,6 +405,7 @@ def _case(name, seed, heads, kv_heads, kv_tokens, head_dim, aligned, chunks, tol
 
 def main():
     results = []
+    results.append(_unfused_f16_causal_case())
     below, below_data = _case(
         "f16_split_below_threshold(KV=511,C=1)", 511, 8, 2, 511, 64, 64, 1, 2.0e-5,
     )

--- a/unittest/test_v8_dump_alignment.py
+++ b/unittest/test_v8_dump_alignment.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Regression checks for rebased stitched-parity dump alignment."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "version" / "v8" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import decoder_first_token_parity_v8 as parity  # noqa: E402
+
+
+def main() -> int:
+    dump = parity.parity_test_v7.ParityDump
+    llama = [
+        dump(0, "kqv_wo", np.array([float(token), 2.0], dtype=np.float32), token, "fp32",
+             source_token_id=token,
+             source_name=f"kqv_wo-0-token-{token:06d}-occ-000")
+        for token in range(41, 86)
+    ]
+    ck_rows = np.array([[float(token), 2.0] for token in range(41, 86)], dtype=np.float32)
+    ck = [
+        dump(0, "attn_out", ck_rows, 0, "fp32"),
+    ]
+
+    llama = parity._trim_llama_prefill_decode_dumps(
+        llama, prompt_start_token=41, prompt_token_count=45,
+    )
+    ck = parity._expand_ck_prefill_decode_dumps(
+        ck, llama, prompt_start_token=1013, prompt_token_count=45,
+    )
+    report = parity._compare_dump_sets(
+        ck, llama, atol=0.0, rtol=0.0, pass_filter="decode",
+    )
+    row = report["results"][0]
+    assert row["op"] == "out_proj", row
+    assert row["status"] == "PASS", row
+    assert row["ck_token"] == 44 and row["llama_token"] == 44, row
+    assert row["ck_source_token"] == 1057, row
+    assert row["llama_source_token"] == 85, row
+    assert row["llama_source_name"] == "kqv_wo-0-token-000085-occ-000", row
+
+    filters = parity._ck_dump_filter_names("kqv_wo-0")
+    assert filters == "kqv_wo-0,attn_out-0", filters
+    print("v8 dump alignment: PASS (out_proj alias + absolute token provenance)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/decoder_first_token_parity_v8.py
+++ b/version/v8/scripts/decoder_first_token_parity_v8.py
@@ -389,6 +389,8 @@ def _load_llama_dump_dir(dump_dir: Path) -> list[Any]:
                     data,
                     int(row.get("token_id", 0) or 0),
                     dtype_name,
+                    source_token_id=int(row.get("token_id", 0) or 0),
+                    source_name=str(row.get("name", "")),
                 )
             )
     return dumps
@@ -419,7 +421,10 @@ def _summarize_statuses(results: list[dict[str, Any]]) -> dict[str, int]:
 
 
 def _canonical_dump_op_name(op_name: str) -> str:
-    return str(op_name)
+    name = str(op_name)
+    if name in {"attn_out", "kqv_wo"}:
+        return "out_proj"
+    return name
 
 
 def _ck_dump_filter_names(dump_names: str) -> str:
@@ -432,7 +437,10 @@ def _ck_dump_filter_names(dump_names: str) -> str:
             continue
         layer_id, canonical_name = parity_test_v7._normalize_layer_and_op(-1, raw_name)
         canonical_filter = f"{canonical_name}-{layer_id}" if layer_id >= 0 else canonical_name
-        for candidate in (raw_name, canonical_filter):
+        candidates = [raw_name, canonical_filter]
+        if canonical_name == "kqv_wo":
+            candidates.append(f"attn_out-{layer_id}" if layer_id >= 0 else "attn_out")
+        for candidate in candidates:
             if candidate not in seen:
                 seen.add(candidate)
                 expanded.append(candidate)
@@ -463,6 +471,8 @@ def _augment_legacy_kqv_aliases(dumps: list[Any]) -> list[Any]:
                 np.array(dump.data, copy=True),
                 int(getattr(dump, "token_id", 0)),
                 str(dump.dtype),
+                source_token_id=int(getattr(dump, "source_token_id", dump.token_id)),
+                source_name=getattr(dump, "source_name", None),
             )
         )
         seen.add(alias_key)
@@ -484,6 +494,8 @@ def _augment_legacy_kqv_aliases(dumps: list[Any]) -> list[Any]:
                 np.array(dump.data, copy=True),
                 int(getattr(dump, "token_id", 0)),
                 str(dump.dtype),
+                source_token_id=int(getattr(dump, "source_token_id", dump.token_id)),
+                source_name=getattr(dump, "source_name", None),
             )
         )
         seen.add(alias_key)
@@ -586,6 +598,7 @@ def _expand_ck_prefill_decode_dumps(
         return list(ck_dumps)
 
     prompt_start = max(0, int(prompt_start_token))
+    source_prompt_start = prompt_start
     rebased: list[Any] = []
     for dump in ck_dumps:
         token_id = int(getattr(dump, "token_id", 0))
@@ -600,6 +613,8 @@ def _expand_ck_prefill_decode_dumps(
                 np.array(dump.data, copy=True),
                 token_id - prompt_start,
                 str(dump.dtype),
+                source_token_id=int(getattr(dump, "source_token_id", token_id)),
+                source_name=getattr(dump, "source_name", None),
             )
         )
     if len({int(getattr(dump, "token_id", 0)) for dump in rebased}) >= prompt_token_count:
@@ -629,7 +644,7 @@ def _expand_ck_prefill_decode_dumps(
             expanded.append(dump)
             continue
 
-        prompt_start = batch_rows - prompt_token_count
+        row_start = batch_rows - prompt_token_count
         head_major = (
             len(row_shape) == 2
             and row_shape[0] > 0
@@ -662,7 +677,7 @@ def _expand_ck_prefill_decode_dumps(
                     # index shape metadata does not imply NumPy/C-order transpose.
                     row = tensor[:, token_idx, :].copy()
             else:
-                start = (prompt_start + prompt_idx) * row_elems
+                start = (row_start + prompt_idx) * row_elems
                 end = start + row_elems
                 row = flat[start:end].copy()
                 if row_shape and int(np.prod(np.array(row_shape, dtype=np.int64))) == row.size:
@@ -674,6 +689,8 @@ def _expand_ck_prefill_decode_dumps(
                     row,
                     prompt_idx,
                     str(dump.dtype),
+                    source_token_id=int(source_prompt_start + prompt_idx),
+                    source_name=getattr(dump, "source_name", None),
                 )
             )
     return expanded
@@ -723,6 +740,8 @@ def _trim_llama_prefill_decode_dumps(
                     np.array(dump.data, copy=True),
                     int(token_rebase[token_id]),
                     str(dump.dtype),
+                    source_token_id=int(getattr(dump, "source_token_id", token_id)),
+                    source_name=getattr(dump, "source_name", None),
                 )
             )
     return trimmed
@@ -798,6 +817,8 @@ def _compare_dump_sets(
                     "token": int(ck_dump.token_id),
                     "ck_token": int(ck_dump.token_id),
                     "llama_token": None,
+                    "ck_source_token": int(getattr(ck_dump, "source_token_id", ck_dump.token_id)),
+                    "ck_source_name": getattr(ck_dump, "source_name", None),
                     "ck_candidates": len(ck_candidates),
                     "llama_candidates": 0,
                     "alignment_ambiguous": bool(ambiguous),
@@ -819,6 +840,10 @@ def _compare_dump_sets(
                 "token": int(ck_dump.token_id),
                 "ck_token": int(ck_dump.token_id),
                 "llama_token": int(llama_dump.token_id),
+                "ck_source_token": int(getattr(ck_dump, "source_token_id", ck_dump.token_id)),
+                "llama_source_token": int(getattr(llama_dump, "source_token_id", llama_dump.token_id)),
+                "ck_source_name": getattr(ck_dump, "source_name", None),
+                "llama_source_name": getattr(llama_dump, "source_name", None),
                 "ck_candidates": len(ck_candidates),
                 "llama_candidates": len(llama_candidates),
                 "alignment_ambiguous": bool(ambiguous),

--- a/version/v8/scripts/parity_test_v8.py
+++ b/version/v8/scripts/parity_test_v8.py
@@ -138,12 +138,15 @@ class ParityDump:
     """Represents a single tensor dump."""
 
     def __init__(self, layer_id: int, op_name: str, data: np.ndarray,
-                 token_id: int, dtype: str):
+                 token_id: int, dtype: str, *, source_token_id: int | None = None,
+                 source_name: str | None = None):
         self.layer_id = layer_id
         self.op_name = op_name
         self.data = data
         self.token_id = token_id
         self.dtype = dtype
+        self.source_token_id = token_id if source_token_id is None else source_token_id
+        self.source_name = source_name
 
     def __repr__(self):
         return f"ParityDump(layer={self.layer_id}, op={self.op_name}, " \


### PR DESCRIPTION
## Why

Qwen3-VL 8B Q4_K_M strict AVX2 replay diverged from llama.cpp at generated step 31. The first material difference was the causal attention reduction contract: CK retained FP32 boundaries while llama.cpp's unfused GGUF graph rounds Q/K, probabilities, and V through FP16.

## What

- add a strict-only llama-compatible FP16 causal prefill path
- preserve absolute source-token/name provenance through stitched dump rebasing
- align llama `kqv_wo` with CK `attn_out` for output-projection comparison
- add FP16 prefill/decode, stitched-alignment, vision, and BF16 Qwen3-VL guards
- expose stitched dump alignment in nightly and the docs test report
- record the bounded investigation in `logs/2026-07-10-qwen3vl-avx2-attention/README.md`

## Result

- previous Q4_K_M strict mismatch: step 31
- new 32-token run: 32/32 matched
- new 64-token first mismatch: step 44
- step-44 full replay also mismatches, so this PR does **not** claim complete 64-token parity
- normal production fast attention is unchanged; the new contract is strict-parity only

## Validation

- `make qwen3vl-parity-guards`
  - FP16 attention: 9/9
  - vision kernels: pass
  - stitched dump alignment: pass
  - BF16 nightly: 12/12
- staged `v7-regression-fast` and `v8-regression-fast`
- full pre-push: build, kernel parity, Gemma3 v8 E2E, v8 inference contracts, v7 training smoke, v7/v8 fast regressions, and v7 training-kernel parity all passed
- Python `py_compile`
- `git diff --check`

## Next

Match llama.cpp AUTO flash-attention semantics at step 44, then rerun the canonical 64-token Q4_K_M replay before resuming performance work.