### PR TITLE
fix(v8/vision): align Qwen3-VL BF16 semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4052,7 +4052,7 @@ nightly-baseline:
 nightly-kernels:
 	@$(PYTHON) scripts/nightly_runner.py --category kernels
 
-nightly-bf16:
+nightly-bf16: $(LIB) $(LIB_VISION)
 	@$(PYTHON) scripts/nightly_runner.py --category bf16
 
 nightly-quant:

--- a/docs/site/_pages/cke-throughput-unit.html
+++ b/docs/site/_pages/cke-throughput-unit.html
@@ -306,6 +306,68 @@ nodes_needed =
     traffic.
 </p>
 
+<h2>Memory Placement Is a Scheduling Problem</h2>
+
+<p>
+    Capacity and throughput cannot be separated from placement. Accelerator
+    systems often move selected activations, parameters, or optimizer state
+    from scarce HBM into host DRAM. CPU-native execution removes that specific
+    host-to-device boundary for CPU-resident state, but it does not remove data
+    movement. Cache fills, DRAM traffic, NUMA hops, network transfers, and
+    storage reads still have to be placed and scheduled against useful work.
+</p>
+
+<p>
+    NVIDIA's JAX host-offloading study provides a useful measured example. On
+    its DeepSeek-V3 671B configuration, optimized activation offloading with a
+    latency-hiding scheduler and pipelined copies reached 908.2 TFLOPs/s/device,
+    compared with 578.3 TFLOPs/s/device for no offload with activation
+    rematerialization. But host offloading without those scheduling mechanisms
+    reached only 541.6 TFLOPs/s/device. The placement policy created capacity;
+    overlap determined whether that capacity translated into throughput.
+</p>
+
+<p>
+    The same study reported a smaller but equally important result for Llama
+    3.1 405B: QKV offloading with latency hiding improved throughput by 2.9%,
+    while disabling latency hiding made the offloaded run slower than the
+    no-offload baseline. The 70.9 GiB host allocation represented QKV storage
+    across all layers, while scan-based backward execution needed only one
+    layer's QKV activations resident on the GPU at a time. This is a lifetime
+    and scheduling result, not a raw bandwidth claim.
+</p>
+
+<p>CKE should apply the same discipline to CPU nodes and clusters:</p>
+
+<ul>
+    <li><strong>Place by lifetime:</strong> keep the active layer, tile, KV/state window, or optimizer shard near the compute that consumes it.</li>
+    <li><strong>Overlap explicitly:</strong> prefetch the next tile or shard while the current kernel performs useful work.</li>
+    <li><strong>Budget staging memory:</strong> double buffers and prefetched data consume capacity even when they improve throughput.</li>
+    <li><strong>Measure exposed transfer time:</strong> a transfer hidden behind compute and the same transfer on the critical path have different performance consequences.</li>
+    <li><strong>Keep rematerialization in the comparison:</strong> recomputing an activation may cost less than moving it, depending on arithmetic intensity and topology.</li>
+</ul>
+
+<pre><code>effective_step_time =
+    useful_compute_time
+  + exposed_memory_time
+  + exposed_network_time
+  + synchronization_time
+
+staging_capacity = resident_working_set + prefetched_buffers + in_flight_outputs</code></pre>
+
+<p>
+    This refines the CKU interpretation. Logical active bytes describe the
+    model state needed by the operation. Physical bytes include every movement
+    required by the chosen placement plan. A valid CKU report must state what
+    was resident, what was transferred or rematerialized, how much transfer was
+    overlapped, and which movement remained on the critical path.
+</p>
+
+<p>
+    Reference:
+    <a href="https://developer.nvidia.com/blog/reducing-high-bandwidth-memory-bottlenecks-in-jax-based-llm-training-with-host-offloading/" target="_blank" rel="noopener noreferrer">NVIDIA, Reducing High-Bandwidth Memory Bottlenecks in JAX-Based LLM Training with Host Offloading</a>.
+</p>
+
 <h2>What CKE Optimizes</h2>
 
 <p>
@@ -316,7 +378,7 @@ nodes_needed =
 <ul>
     <li><strong>Kernel layout:</strong> Q4/Q5/Q6/Q8 formats, packed layouts, SIMD-friendly loops, and shape-gated dispatch.</li>
     <li><strong>Memory layout:</strong> contiguous bump files, planned activation buffers, cache-aligned sections, and deterministic offsets.</li>
-    <li><strong>Runtime scheduling:</strong> prefill vs decode kernels, persistent thread pools, batching, and pipeline staging.</li>
+    <li><strong>Runtime scheduling:</strong> prefill vs decode kernels, persistent thread pools, batching, lifetime-aware placement, asynchronous prefetch, and pipeline staging.</li>
     <li><strong>Linux tuning:</strong> CPU affinity, huge pages, NUMA placement, cache behavior, and perf/VTune/Advisor measurement.</li>
     <li><strong>Cluster scaling:</strong> model/layer ownership, activation movement, gradient movement, MPI/RDMA paths, and topology-aware placement.</li>
 </ul>

--- a/docs/site/_pages/mega_fusion.html
+++ b/docs/site/_pages/mega_fusion.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mega-Fused Attention - C-Kernel-Engine</title>
-    <link rel="stylesheet" href="style.css">
     <style>
         /* SVG Viewer Styles */
         .svg-viewer {
@@ -658,7 +657,7 @@ mega_fused_attention_decode():
 <h2>References</h2>
 
 <ul>
-    <li><a href="MEGA_FUSED.md">Original Mega-Fusion Proposal</a></li>
+    <li><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/blob/main/docs/MEGA_FUSED.md" target="_blank" rel="noopener noreferrer">Original Mega-Fusion Proposal</a></li>
     <li><a href="https://arxiv.org/abs/2205.14135">Flash Attention (Dao et al.)</a></li>
     <li><a href="profiling.html">Profiling Guide</a> - Verify speedup with perf</li>
 </ul>

--- a/docs/site/_pages/memory-reality.html
+++ b/docs/site/_pages/memory-reality.html
@@ -532,8 +532,8 @@ CPU (2TB server): FITS with 1.8TB headroom
     <div class="card">
         <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
         <p>GPU vs CPU memory comparison for LLM inference:</p>
-        <a href="../assets/memory-reality-infographic.svg" target="_blank">
-            <img src="../assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
+        <a href="assets/memory-reality-infographic.svg" target="_blank">
+            <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
         </a>
         <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
     </div>

--- a/docs/site/_pages/scaling.html
+++ b/docs/site/_pages/scaling.html
@@ -1887,8 +1887,8 @@ Total Memory = Model Weights + KV Cache
 <div class="card" style="max-width: 800px;">
     <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
     <p>GPU vs CPU memory comparison for LLM inference:</p>
-    <a href="../assets/memory-reality-infographic.svg" target="_blank">
-        <img src="../assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
+    <a href="assets/memory-reality-infographic.svg" target="_blank">
+        <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
     </a>
     <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
 </div>

--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -737,6 +737,25 @@
       </ul>
     </li>
     <li><strong>Kernel Unit Tests</strong>: Individual kernel parity with PyTorch</li>
+    <li><strong>v8 Vision Kernel Parity</strong>: Vision kernel parity for patch extraction/reconstruction, tiled position embeddings,
+      Qwen3-VL resized position interpolation order, spatial merge/reorder, feature concat/slice, and vision M-RoPE
+      (<code>make test-v8-vision-kernels</code>)</li>
+    <li><strong>Qwen3-VL Template/Codegen Contracts</strong>: Synthetic GGUF/BF16-independent guards for Qwen3-VL circuit lowering,
+      align-corners position-kernel selection, valid vision M-RoPE width/sections, and bounded semantic tensor exports
+      (<code>make test-v8-qwen3vl</code>)</li>
+    <li><strong>v8 BF16 Safetensors Lowering</strong>: Synthetic BF16 conversion and lowering guard that asserts all vision weights are
+      consumed, align-corners interpolation is selected, and M-RoPE arguments remain valid through generated calls. The target builds
+      both engine and vision libraries first so hardware-independent M-RoPE checks cannot silently skip
+      (<code>make nightly-bf16</code>)</li>
+    <li><strong>FP16 Attention Contracts</strong>: Named numerical guards for llama.cpp-compatible unfused causal prefill and split-KV decode,
+      including FP16 Q/K rounding, FP16 probability/value reduction, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding,
+      the KV 511/512 semantic boundary, and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
+      (<code>make test-attention-f16-split-kv</code>)</li>
+    <li><strong>v8 Stitched Dump Alignment</strong>: Guards canonical output-projection aliases and preserves absolute CK/llama
+      source-token provenance when mixed-prefix dumps are rebased for per-token comparison
+      (<code>make test-v8-dump-alignment</code>)</li>
+    <li><strong>Qwen3-VL Parity Guard Sweep</strong>: Local aggregate for GGUF FP16 attention contracts, stitched dump alignment,
+      shared vision kernels, and the BF16 parity lane (<code>make qwen3vl-parity-guards</code>)</li>
     <li><strong>Llama Pairwise RoPE Contract</strong>: explicit regression for consecutive-pair RoPE layout selection plus kernel-level pairwise forward coverage and timing
       (<code>version/v7/scripts/parity/test_check_decode_attention_contract.py</code>, <code>unittest/test_rope.py</code>)</li>
     <li><strong>Sliding-Window Contract</strong>: Explicit sliding attention prefill/decode contract test
@@ -777,7 +796,7 @@
     <div>
       <strong>Run locally:</strong> <code>make test</code> (kernel-focused), <code>make visualizer</code> (fast path), <code>make visualizer-full</code> (includes tiny train-runtime ASan checks), <code>make nightly</code> (full matrix).
       <br>
-      <span style="color: var(--text-muted);">Nightly coverage now includes v7 kernel-map contracts, v7 backprop kernel parity, published training family regression, visualizer runbook regression checks, and published <code>regression-fast</code> family summaries.</span>
+      <span style="color: var(--text-muted);">Nightly coverage now includes v7 kernel-map contracts, v7 backprop kernel parity, v8 vision kernel parity, published training family regression, visualizer runbook regression checks, and published <code>regression-fast</code> family summaries.</span>
     </div>
   </div>
 

--- a/docs/site/_partials/api_content.html
+++ b/docs/site/_partials/api_content.html
@@ -1206,7 +1206,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill (v3 optimized)</p>
         </div>
 
 
@@ -1246,7 +1246,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_rmsnorm_qkv_scratch_size(int hidden)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_rmsnorm_qkv_prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused prefill.</p>
         </div>
 
 
@@ -1462,7 +1462,7 @@ test_parity.py::test_rmsnorm_parity</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void unfused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * x_norm, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for benchmarking comparison.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for comparison.</p>
         </div>
 
     </div>
@@ -2350,7 +2350,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_mlp_swiglu_prefill_bias(const float * x, const float * W_gate, const float * W_up, const float * W_down, const float * B_gate, const float * B_up, const float * B_down, float * output, int seq_len, int hidden, int intermediate, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP (Gate + Up + SwiGLU + Down) for prefill with biases.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP for prefill with proper tiling.</p>
         </div>
 
 
@@ -2380,7 +2380,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_mlp_swiglu_scratch_size(int intermediate)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_mlp_swiglu_prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused MLP.</p>
         </div>
 
 
@@ -4237,7 +4237,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_bool</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out_val)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -4347,7 +4347,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_string</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out_str)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -4966,8 +4966,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_murmurhash3_str</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * key, uint32_t seed)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * str, uint32_t seed)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">MurmurHash3-32bit for string (null-terminated).</p>
         </div>
 
 
@@ -5626,8 +5626,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_merge</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left, int32_t right, int32_t merged)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left_id, int32_t right_id, int32_t merged_id, int32_t priority)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a BPE merge rule.</p>
         </div>
 
 
@@ -5646,8 +5646,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_token</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int len)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int32_t id, float score)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a token to vocabulary.</p>
         </div>
 
 
@@ -5697,7 +5697,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_decode(const CKTokenizer * tok, const int32_t * ids, int num_ids, char * text, int max_len)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Decode token IDs to text.</p>
         </div>
 
 
@@ -5717,7 +5717,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_encode(const CKTokenizer * tok, const char * text, int text_len, int32_t * ids, int max_ids)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Encode text to token IDs using greedy longest-match.</p>
         </div>
 
 
@@ -5996,7 +5996,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_lookup</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token, int len)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -6216,8 +6216,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_vocab_size</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get vocabulary size.</p>
         </div>
 
 
@@ -10038,7 +10038,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">print_usage</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * argv0)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * prog)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -10918,7 +10918,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_dim</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKV2AlignInfo * align, CKDimKind kind)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, CKDimKind kind, int tokens_override)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -10928,7 +10928,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_shape_elems</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKV2AlignInfo * align, const CKDimToken * shape)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, const CKDimToken * shape, int tokens_override)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-08 15:23</span>
+        <span class="folder-updated">Updated: 2026-07-10 21:47</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -26,8 +26,6 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
-|-- .cache
-|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
 |-- contracts
@@ -63,7 +61,7 @@ version/v7
 `-- tools
     `-- src
 
-57 directories
+55 directories
 </pre>
 </div>
 

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2225,7 +2226,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused RMSNorm + QKV projection for prefill (v3 optimized)</p>
         </div>
 
 
@@ -2265,7 +2266,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_rmsnorm_qkv_scratch_size(int hidden)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_rmsnorm_qkv_prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused prefill.</p>
         </div>
 
 
@@ -2481,7 +2482,7 @@ test_parity.py::test_rmsnorm_parity</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void unfused_rmsnorm_qkv_prefill(const float * x, const float * gamma, const float * Wq, const float * Wk, const float * Wv, float * x_norm, float * Q, float * K, float * V, int seq_len, int hidden, int q_dim, int kv_dim, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for benchmarking comparison.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Unfused version for comparison.</p>
         </div>
 
     </div>
@@ -3369,7 +3370,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void fused_mlp_swiglu_prefill_bias(const float * x, const float * W_gate, const float * W_up, const float * W_down, const float * B_gate, const float * B_up, const float * B_down, float * output, int seq_len, int hidden, int intermediate, float * scratch)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP (Gate + Up + SwiGLU + Down) for prefill with biases.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Fused MLP for prefill with proper tiling.</p>
         </div>
 
 
@@ -3399,7 +3400,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t fused_mlp_swiglu_scratch_size(int intermediate)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch buffer size for fused_mlp_swiglu_prefill.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get scratch size for fused MLP.</p>
         </div>
 
 
@@ -5256,7 +5257,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_bool</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out_val)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -5366,7 +5367,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_string</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out_str)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -5985,8 +5986,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_murmurhash3_str</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * key, uint32_t seed)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * str, uint32_t seed)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">MurmurHash3-32bit for string (null-terminated).</p>
         </div>
 
 
@@ -6645,8 +6646,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_merge</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left, int32_t right, int32_t merged)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left_id, int32_t right_id, int32_t merged_id, int32_t priority)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a BPE merge rule.</p>
         </div>
 
 
@@ -6665,8 +6666,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_token</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int len)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int32_t id, float score)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a token to vocabulary.</p>
         </div>
 
 
@@ -6716,7 +6717,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_decode(const CKTokenizer * tok, const int32_t * ids, int num_ids, char * text, int max_len)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Decode token IDs to text.</p>
         </div>
 
 
@@ -6736,7 +6737,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_encode(const CKTokenizer * tok, const char * text, int text_len, int32_t * ids, int max_ids)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Encode text to token IDs using greedy longest-match.</p>
         </div>
 
 
@@ -7015,7 +7016,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_lookup</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token, int len)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -7235,8 +7236,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_vocab_size</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get vocabulary size.</p>
         </div>
 
 
@@ -11057,7 +11058,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">print_usage</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * argv0)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void print_usage(const char * prog)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -11937,7 +11938,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_dim</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKV2AlignInfo * align, CKDimKind kind)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_dim(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, CKDimKind kind, int tokens_override)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -11947,7 +11948,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">resolve_shape_elems</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKV2AlignInfo * align, const CKDimToken * shape)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t resolve_shape_elems(const CKModelConfig * cfg, const CKIRV2AlignInfo * align, const CKDimToken * shape, int tokens_override)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -12976,7 +12977,7 @@ rmsnorm_backward(d_norm_out, input, gamma, rstd_cache, d_input, d_gamma, tokens,
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture-links.html
+++ b/docs/site/architecture-links.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1065,6 +1066,16 @@
         <a class="runbook-link" href="kernel-tuning-methodology.html">Open Methodology</a>
     </div>
     <div class="runbook-card">
+        <h3>Stitched Divergence Harness</h3>
+        <p>Backend parity method for finding the first CK-vs-reference tensor boundary across llama.cpp/mtmd GGUF lanes and future PyTorch adapters.</p>
+        <div class="runbook-tags">
+            <span class="runbook-tag">CKDMP</span>
+            <span class="runbook-tag">llama.cpp/mtmd</span>
+            <span class="runbook-tag">first divergence</span>
+        </div>
+        <a class="runbook-link" href="divergence-harness.html">Open Harness Guide</a>
+    </div>
+    <div class="runbook-card">
         <h3>v7 SVG Dataset Runbook</h3>
         <p>Operator workflow to generate Stage A pretraining and Stage B midtraining SVG corpora from <code>docs/site/assets/*.svg</code>, then hand off to v7 training.</p>
         <div class="runbook-tags">
@@ -1184,6 +1195,8 @@
                 <span class="subtitle">Notebook-driven and module-driven authoring entrypoints for the same <code>v7</code> runtime</span></li>
             <li><a href="testing.html">Testing</a>
                 <span class="subtitle">Numerical parity verification</span></li>
+            <li><a href="divergence-harness.html">Stitched Divergence Harness</a>
+                <span class="subtitle">First failing tensor boundary across CK and reference backends</span></li>
         </ul>
     </div>
 </div>
@@ -1241,7 +1254,7 @@
         </tr>
             <tr>
                 <td><strong>Debugging & profiling</strong></td>
-                <td><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>, <a href="profiling.html">Profiling</a>, <a href="v7-profiling.html">v7 Profiling Runbook</a>, <a href="testing.html">Testing</a>, <a href="v7-cross-entropy-parity.html">v7 CE Parity Deep Dive</a>, <a href="v7-backprop-ir.html#v7-runtime-stitch-graph">v7 Runtime Stitch Graph</a>, <a href="v7-runbook.html">v7 Runbook</a>, <a href="v7-python-authoring.html">v7 Python Authoring Guide</a></td>
+                <td><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a>, <a href="profiling.html">Profiling</a>, <a href="v7-profiling.html">v7 Profiling Runbook</a>, <a href="testing.html">Testing</a>, <a href="divergence-harness.html">Stitched Divergence Harness</a>, <a href="v7-cross-entropy-parity.html">v7 CE Parity Deep Dive</a>, <a href="v7-backprop-ir.html#v7-runtime-stitch-graph">v7 Runtime Stitch Graph</a>, <a href="v7-runbook.html">v7 Runbook</a>, <a href="v7-python-authoring.html">v7 Python Authoring Guide</a></td>
             </tr>
             <tr>
                 <td><strong>Operator train + compute workflow</strong></td>
@@ -1477,7 +1490,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1228,7 +1229,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-08 15:23</span>
+        <span class="folder-updated">Updated: 2026-07-10 21:47</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1252,8 +1253,6 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
-|-- .cache
-|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
 |-- contracts
@@ -1289,7 +1288,7 @@ version/v7
 `-- tools
     `-- src
 
-57 directories
+55 directories
 </pre>
 </div>
 
@@ -1568,7 +1567,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1251,6 +1252,68 @@ nodes_needed =
     traffic.
 </p>
 
+<h2>Memory Placement Is a Scheduling Problem</h2>
+
+<p>
+    Capacity and throughput cannot be separated from placement. Accelerator
+    systems often move selected activations, parameters, or optimizer state
+    from scarce HBM into host DRAM. CPU-native execution removes that specific
+    host-to-device boundary for CPU-resident state, but it does not remove data
+    movement. Cache fills, DRAM traffic, NUMA hops, network transfers, and
+    storage reads still have to be placed and scheduled against useful work.
+</p>
+
+<p>
+    NVIDIA's JAX host-offloading study provides a useful measured example. On
+    its DeepSeek-V3 671B configuration, optimized activation offloading with a
+    latency-hiding scheduler and pipelined copies reached 908.2 TFLOPs/s/device,
+    compared with 578.3 TFLOPs/s/device for no offload with activation
+    rematerialization. But host offloading without those scheduling mechanisms
+    reached only 541.6 TFLOPs/s/device. The placement policy created capacity;
+    overlap determined whether that capacity translated into throughput.
+</p>
+
+<p>
+    The same study reported a smaller but equally important result for Llama
+    3.1 405B: QKV offloading with latency hiding improved throughput by 2.9%,
+    while disabling latency hiding made the offloaded run slower than the
+    no-offload baseline. The 70.9 GiB host allocation represented QKV storage
+    across all layers, while scan-based backward execution needed only one
+    layer's QKV activations resident on the GPU at a time. This is a lifetime
+    and scheduling result, not a raw bandwidth claim.
+</p>
+
+<p>CKE should apply the same discipline to CPU nodes and clusters:</p>
+
+<ul>
+    <li><strong>Place by lifetime:</strong> keep the active layer, tile, KV/state window, or optimizer shard near the compute that consumes it.</li>
+    <li><strong>Overlap explicitly:</strong> prefetch the next tile or shard while the current kernel performs useful work.</li>
+    <li><strong>Budget staging memory:</strong> double buffers and prefetched data consume capacity even when they improve throughput.</li>
+    <li><strong>Measure exposed transfer time:</strong> a transfer hidden behind compute and the same transfer on the critical path have different performance consequences.</li>
+    <li><strong>Keep rematerialization in the comparison:</strong> recomputing an activation may cost less than moving it, depending on arithmetic intensity and topology.</li>
+</ul>
+
+<pre><code>effective_step_time =
+    useful_compute_time
+  + exposed_memory_time
+  + exposed_network_time
+  + synchronization_time
+
+staging_capacity = resident_working_set + prefetched_buffers + in_flight_outputs</code></pre>
+
+<p>
+    This refines the CKU interpretation. Logical active bytes describe the
+    model state needed by the operation. Physical bytes include every movement
+    required by the chosen placement plan. A valid CKU report must state what
+    was resident, what was transferred or rematerialized, how much transfer was
+    overlapped, and which movement remained on the critical path.
+</p>
+
+<p>
+    Reference:
+    <a href="https://developer.nvidia.com/blog/reducing-high-bandwidth-memory-bottlenecks-in-jax-based-llm-training-with-host-offloading/" target="_blank" rel="noopener noreferrer">NVIDIA, Reducing High-Bandwidth Memory Bottlenecks in JAX-Based LLM Training with Host Offloading</a>.
+</p>
+
 <h2>What CKE Optimizes</h2>
 
 <p>
@@ -1261,7 +1324,7 @@ nodes_needed =
 <ul>
     <li><strong>Kernel layout:</strong> Q4/Q5/Q6/Q8 formats, packed layouts, SIMD-friendly loops, and shape-gated dispatch.</li>
     <li><strong>Memory layout:</strong> contiguous bump files, planned activation buffers, cache-aligned sections, and deterministic offsets.</li>
-    <li><strong>Runtime scheduling:</strong> prefill vs decode kernels, persistent thread pools, batching, and pipeline staging.</li>
+    <li><strong>Runtime scheduling:</strong> prefill vs decode kernels, persistent thread pools, batching, lifetime-aware placement, asynchronous prefetch, and pipeline staging.</li>
     <li><strong>Linux tuning:</strong> CPU affinity, huge pages, NUMA placement, cache behavior, and perf/VTune/Advisor measurement.</li>
     <li><strong>Cluster scaling:</strong> model/layer ownership, activation movement, gradient movement, MPI/RDMA paths, and topology-aware placement.</li>
 </ul>
@@ -1545,7 +1608,7 @@ CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/codegen.html
+++ b/docs/site/codegen.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1766,7 +1767,7 @@ static size_t bump(size_t *off, size_t bytes) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2216,7 +2217,7 @@ With weight tying: W = E  (same matrix!)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/contributing.html
+++ b/docs/site/contributing.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1276,7 +1277,7 @@ make test</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions-dynamic.html
+++ b/docs/site/decisions-dynamic.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1462,7 +1463,7 @@ details.adr pre {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions.html
+++ b/docs/site/decisions.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1936,7 +1937,7 @@ weight_mapping:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deltanet-deep-dive.html
+++ b/docs/site/deltanet-deep-dive.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2189,7 +2190,7 @@ void recurrent_conv_state_update_forward(
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deterministic-memory.html
+++ b/docs/site/deterministic-memory.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1617,7 +1618,7 @@ class TrainingObserver:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/developer-guide.html
+++ b/docs/site/developer-guide.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1736,7 +1737,7 @@ make emit CONFIG=x.json OUT=out.c  # Generate runtime</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/divergence-harness.html
+++ b/docs/site/divergence-harness.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gemma4 Speculative Pair Design  | C-Kernel-Engine</title>
-    <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <title>Stitched Divergence Harness | C-Kernel-Engine</title>
+    <meta name="description" content="How C-Kernel-Engine compares generated C against llama.cpp, mtmd, and future PyTorch adapters by dumping matched tensors and finding the first divergent layer/op boundary.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html">
-    <meta property="og:title" content="Gemma4 Speculative Pair Design  | C-Kernel-Engine">
-    <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/divergence-harness.html">
+    <meta property="og:title" content="Stitched Divergence Harness | C-Kernel-Engine">
+    <meta property="og:description" content="How C-Kernel-Engine compares generated C against llama.cpp, mtmd, and future PyTorch adapters by dumping matched tensors and finding the first divergent layer/op boundary.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/divergence-harness.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -947,237 +947,343 @@
     </header>
     <main>
 
-<h1>Gemma4 Speculative Pair Design</h1>
+<div class="container">
+  <h1>Stitched Divergence Harness</h1>
+  <p class="lead">
+    How C-Kernel-Engine finds the first numerical divergence between generated C,
+    llama.cpp/mtmd, and future PyTorch adapters without guessing from end-to-end output.
+  </p>
 
-<p>
-    This page is the implementation plan for pairing a full Gemma4 backbone with the small
-    <code>google/gemma-4-E4B-it-assistant</code> drafter model. The assistant is not a standalone
-    chatbot. It is a speculative/MTP draft decoder that consumes the backbone hidden stream and
-    proposes candidate tokens for the backbone to verify.
-</p>
+  <div class="alert alert-info">
+    <strong>Core rule:</strong>
+    the harness does not dynamically understand every backend by itself.
+    It compares backends through explicit adapters that dump the same named tensors,
+    at the same layer/op boundaries, in the same logical layout.
+  </div>
 
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+  <h2>Why This Exists</h2>
+  <p>
+    Kernel unit tests prove that an isolated function can be correct. They do not prove
+    that a full model circuit is stitched correctly. A model can still fail because of
+    tensor layout, positional semantics, weight interpretation, preprocessing, quantized
+    activation contracts, residual timing, or a dump boundary mismatch.
+  </p>
+  <p>
+    The stitched divergence harness answers a narrower and more useful question:
+    <strong>where is the first boundary where CK stops matching the reference?</strong>
+    Once that boundary is known, the fix can target one kernel, one conversion rule,
+    one transpose, or one template seam instead of the whole transformer.
+  </p>
+
+  <h2>Current Backend Contract</h2>
+  <table>
+    <tr>
+      <th>Backend</th>
+      <th>Current role</th>
+      <th>How tensors are obtained</th>
+      <th>Status</th>
+    </tr>
+    <tr>
+      <td><code>CK generated C</code></td>
+      <td>Test implementation</td>
+      <td>Generated code emits <code>ck_dump_tensor(...)</code> records when built with parity dumping.</td>
+      <td>Implemented for v8 text and Qwen3-VL vision paths.</td>
+    </tr>
+    <tr>
+      <td><code>llama.cpp + mtmd</code></td>
+      <td>GGUF reference for Qwen3-VL and quantized inference</td>
+      <td>A local C++ shim links against llama.cpp/mtmd and writes selected ggml tensors into CKDMP format.</td>
+      <td>Implemented for the current Qwen3-VL GGUF lane.</td>
+    </tr>
+    <tr>
+      <td><code>llama.cpp decoder helper</code></td>
+      <td>Reference for token replay and logits</td>
+      <td>Persistent greedy replay and full replay compare CK logits/top-k against llama.cpp.</td>
+      <td>Implemented for v8 multimodal decode parity.</td>
+    </tr>
+    <tr>
+      <td><code>PyTorch / safetensors</code></td>
+      <td>BF16/full-precision reference lane</td>
+      <td>Requires a PyTorch adapter that emits the same named tensors and layouts as CKDMP.</td>
+      <td>Available in model-specific scripts, not yet the default backend for stitched Qwen3-VL GGUF parity.</td>
+    </tr>
+  </table>
+
+  <div class="alert alert-warning">
+    <strong>Do not mix reference lanes casually.</strong>
+    For Qwen3-VL AVX2 GGUF parity, enforce llama.cpp/mtmd. For BF16 safetensors
+    circuit bring-up, use PyTorch. The same harness structure can support both,
+    but only when each backend exposes equivalent tensor boundaries.
+  </div>
+
+  <h2>Does CK Patch llama.cpp?</h2>
+  <p>
+    The current Qwen3-VL GGUF lane does not rewrite llama.cpp at test time. CK builds
+    a small local adapter:
+    <code>version/v8/tools/mtmd_clip_shim.cpp</code>.
+    That shim includes the local llama.cpp/mtmd headers, initializes the mtmd clip
+    context, registers a ggml evaluation callback, and writes selected tensors to
+    the same CKDMP dump format used by generated CK code.
+  </p>
+  <p>
+    This is deliberately different from hard-forking the reference. The reference
+    remains llama.cpp's graph and weights. CK only adds an observation surface around it.
+    If upstream llama.cpp changes its private mtmd APIs or removes the callback seam,
+    the adapter must be updated, or the local llama.cpp checkout must carry the minimal
+    callback support needed for parity dumps.
+  </p>
+
+  <h2>Dump Format</h2>
+  <p>
+    Both CK and reference adapters write <code>dump.bin</code> using the CKDMP record
+    format from <code>version/v8/src/ck_parity_dump.h</code>:
+  </p>
+  <ul>
+    <li>128-byte record header</li>
+    <li><code>layer_id</code></li>
+    <li><code>op_name</code></li>
+    <li>dtype and rank metadata</li>
+    <li>shape and element count</li>
+    <li>token id for decode paths</li>
+    <li>flat tensor payload, usually converted to float32 for comparison</li>
+  </ul>
+  <p>
+    The comparison layer matches records by normalized operation name, layer, shape,
+    and candidate order. Alias handling maps names such as <code>attn_output</code>
+    to llama-side names such as <code>attn_out</code> when the two backends use
+    different labels for the same graph boundary.
+  </p>
+
+  <h2>How CK Dumps Tensors</h2>
+  <p>
+    CK is easier to instrument because the model runtime is generated C. The v8 codegen
+    path can emit dump calls at known IR boundaries:
+  </p>
+  <pre><code>ck_dump_tensor((float*)buffer, layer_id, "ffn_up_b", element_count);
+ck_dump_tensor_head_major_token_major(q_buffer, layer_id, "Qcur", heads, tokens, head_dim);</code></pre>
+  <p>
+    Environment variables constrain the dump so a full 8B model does not fill scratch:
+  </p>
+  <ul>
+    <li><code>CK_PARITY_DIR</code> selects the CK dump directory.</li>
+    <li><code>CK_PARITY_LAYER_FILTER</code> restricts layers.</li>
+    <li><code>CK_PARITY_OP_FILTER</code> restricts operation names.</li>
+    <li><code>--granular-test</code> emits dump/cutpoint metadata during codegen.</li>
+    <li><code>--ck-stop-layer</code> or <code>--ck-stop-op</code> returns early after a target boundary.</li>
+  </ul>
+
+  <h2>How llama.cpp / mtmd Dumps Tensors</h2>
+  <p>
+    The llama.cpp side is adapter-driven. The Qwen3-VL mmproj adapter compiles
+    <code>mtmd_clip_shim.cpp</code> into a shared object, loads llama.cpp
+    <code>libmtmd.so</code>, and calls <code>clip_encode_float_image</code>.
+    The shim's callback receives ggml tensors as llama.cpp evaluates the graph.
+  </p>
+  <p>
+    The shim uses these controls:
+  </p>
+  <ul>
+    <li><code>CK_LLAMA_PARITY_DIR</code> writes llama's <code>dump.bin</code>.</li>
+    <li><code>CK_LLAMA_PARITY_NAMES</code> selects tensors such as <code>Qcur</code>, <code>kqv_out</code>, or <code>attn_out</code>.</li>
+    <li><code>CK_LLAMA_PARITY_LAYER</code> restricts to one layer.</li>
+    <li><code>CK_LLAMA_PARITY_ALL=1</code> dumps every visible tensor, used only for deep diagnostics.</li>
+    <li><code>CK_LLAMA_PARITY_META=1</code> writes tensor shape/stride metadata as JSONL.</li>
+  </ul>
+  <p>
+    Quantized, fp16, bf16, and integer tensors are flattened into a comparable fp32
+    payload. That means the dump compares the logical value at the selected boundary,
+    not necessarily the raw packed bytes. Raw packed-byte checks are separate tests
+    for weight conversion and quant block contracts.
+  </p>
+
+  <h2>How PyTorch Fits</h2>
+  <p>
+    PyTorch is not automatically interchangeable with llama.cpp. It can become a
+    stitched backend only when it implements the same adapter contract:
+  </p>
+  <ol>
+    <li>Run the same canonical input and prompt.</li>
+    <li>Register hooks or use a traced graph to capture named layer/op boundaries.</li>
+    <li>Normalize layout to CK's logical comparison layout.</li>
+    <li>Write CKDMP or a format converted losslessly into CKDMP.</li>
+    <li>Use the same alias map and thresholds as the CK-vs-reference comparator.</li>
+  </ol>
+  <p>
+    For BF16/safetensors bring-up, PyTorch is the better reference because it removes
+    GGUF quantization and llama.cpp packing decisions from the equation. For GGUF
+    deployment parity, llama.cpp is the stronger reference because it exercises the
+    same file format, quantized tensor semantics, image path, and token replay behavior
+    expected in production.
+  </p>
+
+  <h2>Stitched Runner Flow</h2>
+  <p>
+    <code>version/v8/scripts/stitched_parity_v8.py</code> runs stages from cheap and
+    broad to expensive and granular:
+  </p>
+  <ol>
+    <li>
+      <strong>Bridge generation.</strong>
+      CK builds the image/text bridge and writes <code>bridge_report.json</code>
+      plus <code>prefix.f32</code>.
+    </li>
+    <li>
+      <strong>Encoder numeric parity.</strong>
+      CK's final vision prefix is compared against llama.cpp/mtmd output.
+      If this fails, decoder debugging stops because the prefix is already wrong.
+    </li>
+    <li>
+      <strong>Persistent multi-token parity.</strong>
+      If the prefix is acceptable, CK and llama.cpp run greedy token replay.
+      The report records first mismatch step, token ids, top-k overlap, cosine, RMSE,
+      and logits metrics.
+    </li>
+    <li>
+      <strong>Granular attribution.</strong>
+      If a coarse stage fails, the runner dumps selected layer/op tensors and reports
+      the first failing boundary.
+    </li>
+  </ol>
+
+  <pre><code>.venv/bin/python version/v8/scripts/stitched_parity_v8.py \
+  --template qwen3vl \
+  --mode fast \
+  --decoder-gguf models/Qwen3-VL-8B-Instruct-GGUF/Qwen3VL-8B-Instruct-Q4_K_M.gguf \
+  --mmproj-gguf models/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf \
+  --image-path build/qwen3vl_avx2_fresh_bridge_20260708/1_81_canonical.ppm \
+  --prompt "Extract visible form fields as compact JSON." \
+  --workdir build/stitched_parity/qwen3vl_avx2_canonical \
+  --ctx-len 4096 \
+  --threads 20 \
+  --top-k 16 \
+  --max-new-tokens 64 \
+  --image-max-tokens 1024 \
+  --phase-timeout-sec 1800 \
+  --log-byte-limit 1048576</code></pre>
+
+  <h2>How It Decides Where To Break</h2>
+  <p>
+    The system does not infer a graph cut from arbitrary source code. The cutpoints
+    come from the generated IR/codegen boundary map and backend-specific dump names.
+    For Qwen3-VL vision, the useful layer boundaries include:
+  </p>
+  <ul>
+    <li><code>inp_pos_emb</code></li>
+    <li><code>patch_bias</code></li>
+    <li><code>ln1</code></li>
+    <li><code>Qcur</code>, <code>Kcur</code>, <code>Vcur</code></li>
+    <li><code>Qcur_rope</code>, <code>Kcur_rope</code></li>
+    <li><code>kqv_out</code></li>
+    <li><code>attn_out</code> / <code>attn_output</code></li>
+    <li><code>ffn_inp</code>, <code>ffn_inp_normed</code></li>
+    <li><code>ffn_up_b</code>, <code>ffn_out</code></li>
+    <li><code>layer_out</code></li>
+  </ul>
+  <p>
+    A failure like <code>kqv_out PASS</code> followed by <code>attn_output FAIL</code>
+    immediately narrows the search to the output-projection boundary, transpose/layout
+    before projection, activation quantization, weight view, residual add, or a naming
+    mismatch around that exact dump.
+  </p>
+
+  <h2>Report Semantics</h2>
+  <p>
+    A stitched report is designed to be pasted into a PR or agent handoff. Important
+    fields are:
+  </p>
+  <ul>
+    <li><code>status</code>: pass/fail/timeout.</li>
+    <li><code>failure_stage</code>: bridge, encoder_numeric, multitoken, or granular.</li>
+    <li><code>encoder_numeric_metrics</code>: cosine, RMSE, max abs, mean abs.</li>
+    <li><code>first_mismatch</code>: generated token step and CK/llama token ids.</li>
+    <li><code>first_granular_issue</code>: layer, op, diff metrics, divergent index.</li>
+    <li><code>commands.log</code>: exact subprocess commands and trimmed output.</li>
+  </ul>
+
+  <h2>Adding A New Model Or Backend</h2>
+  <p>
+    New compatibility work should add the following pieces before optimizing kernels:
+  </p>
+  <ol>
+    <li>
+      <strong>Canonical run spec:</strong> model files, checksums, prompt, context length,
+      thread count, image/audio preprocessing, and deterministic sampling settings.
+    </li>
+    <li>
+      <strong>CK dump map:</strong> generated code emits named tensors at stable IR boundaries.
+    </li>
+    <li>
+      <strong>Reference adapter:</strong> llama.cpp, PyTorch, or another backend emits the
+      same boundaries in CKDMP-compatible form.
+    </li>
+    <li>
+      <strong>Alias map:</strong> normalize names such as <code>attn_output</code> vs
+      <code>attn_out</code>, and document any boundary that is not semantically identical.
+    </li>
+    <li>
+      <strong>Layout contract:</strong> define whether the comparison is token-major,
+      head-major, row-major, packed, or unpacked logical fp32.
+    </li>
+    <li>
+      <strong>Thresholds:</strong> strict where the math should be exact, looser only where
+      the reference intentionally differs by dtype or quantization.
+    </li>
+    <li>
+      <strong>Fallback triage:</strong> if full output fails, rerun layer 0, then layer range,
+      then op-specific dumps.
+    </li>
+  </ol>
+
+  <h2>Known Failure Modes</h2>
+  <div class="grid grid-2">
+    <div class="card">
+      <h3>Duplicate Tensor Names</h3>
+      <p>
+        If CK dumps both pre-projection and post-projection tensors as
+        <code>attn_output</code>, the comparator may select the wrong candidate.
+        Use unique names such as <code>attn_context</code>, <code>out_proj_in</code>,
+        and <code>attn_output</code>.
+      </p>
     </div>
-    <div>
-        <strong>Analogy</strong><br>
-        In the header/body/footer mental model, the backbone is the authoritative target decoder.
-        The assistant is a secondary draft decoder. The bridge between them behaves like an
-        encoder-to-decoder handoff because the backbone exports hidden state and the assistant
-        consumes it, but the backbone is still a decoder, not a vision-style encoder.
+    <div class="card">
+      <h3>Layout Mismatch</h3>
+      <p>
+        CK often stores attention scratch in head-major layout while references expose
+        token-major tensors. Dump helpers must normalize logical order before comparison.
+      </p>
     </div>
+    <div class="card">
+      <h3>Reference Boundary Mismatch</h3>
+      <p>
+        A name match is not enough. Verify whether the reference tensor is before bias,
+        after bias, before residual, after residual, before activation, or after activation.
+      </p>
+    </div>
+    <div class="card">
+      <h3>Scratch Explosion</h3>
+      <p>
+        Full-model dumps are enormous. Use layer filters, op filters, early CK stop,
+        log byte caps, and weight-pruning after each phase.
+      </p>
+    </div>
+  </div>
+
+  <h2>Operational Guidance</h2>
+  <ul>
+    <li>For AVX2 GGUF Qwen3-VL: use llama.cpp/mtmd as the enforced backend.</li>
+    <li>For BF16 safetensors template bring-up: use PyTorch as the reference backend.</li>
+    <li>Do not optimize a fast path until stitched parity identifies the first failing boundary.</li>
+    <li>Do not relax tolerances to hide a top-1 flip or long-decode drift.</li>
+    <li>When a kernel unit test passes but stitched parity fails, suspect layout, conversion, or graph semantics before rewriting the kernel.</li>
+    <li>When a reference adapter changes, record the llama.cpp commit or PyTorch model revision in the report.</li>
+  </ul>
+
+  <div class="alert alert-success">
+    <strong>What good looks like:</strong>
+    a failed run should say "layer 0, op attn_output, kqv_out passed, output projection boundary failed",
+    not merely "OCR answer is wrong". That is the difference between model debugging and guessing.
+  </div>
 </div>
-
-<h2>Target Shape</h2>
-
-<pre><code>prompt tokens
-  -&gt; Gemma4 E4B backbone prefill
-  -&gt; backbone KV cache + hidden stream
-  -&gt; decode loop:
-       backbone step exports hidden state H_t [1, 2560]
-       assistant_pre_projection(H_t) -&gt; draft stream [1, 256]
-       assistant 4-layer draft decoder proposes token candidates
-       backbone verifies proposed token(s)
-       accepted tokens are emitted; rejected token falls back to backbone</code></pre>
-
-<p>
-    The first working milestone should draft and verify one token. After that is correct, increase
-    <code>draft_tokens</code> to 2, 4, and 8 and measure acceptance rate versus throughput.
-</p>
-
-<h2>Composite Template</h2>
-
-<p>
-    The clean CKE implementation should be a composite circuit, not two unrelated model folders
-    joined through ad hoc Python. A future template can be named:
-</p>
-
-<pre><code>version/v8/templates/gemma4_speculative_pair.json</code></pre>
-
-<p>
-    The template should declare three blocks:
-</p>
-
-<table>
-    <thead>
-        <tr>
-            <th>Block</th>
-            <th>Role</th>
-            <th>Existing Template</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>target</code></td>
-            <td>Authoritative Gemma4 backbone that owns final correctness.</td>
-            <td><code>gemma4.json</code></td>
-        </tr>
-        <tr>
-            <td><code>draft</code></td>
-            <td>Small assistant/MTP model that proposes candidate tokens.</td>
-            <td><code>gemma4_assistant.json</code></td>
-        </tr>
-        <tr>
-            <td><code>verify</code></td>
-            <td>Accept/reject loop that compares draft tokens against target logits.</td>
-            <td>New runtime loop, not a neural layer.</td>
-        </tr>
-    </tbody>
-</table>
-
-<h2>Weight Namespaces</h2>
-
-<p>
-    First implementation should keep the two weight files separate for auditability:
-</p>
-
-<pre><code>/tmp/ck-gemma4-e4b-runtime/weights.bump
-/tmp/ck-gemma4-assistant-runtime/weights.bump</code></pre>
-
-<p>
-    The composite manifest can refer to both namespaces:
-</p>
-
-<pre><code>{
-  "model": "gemma4_speculative_pair",
-  "target": {
-    "template": "gemma4",
-    "weights": "target.weights.bump",
-    "hidden_export": "target_hidden_stream",
-    "hidden_size": 2560
-  },
-  "draft": {
-    "template": "gemma4_assistant",
-    "weights": "assistant.weights.bump",
-    "assistant_role": "mtp_drafter",
-    "backbone_hidden_size": 2560,
-    "hidden_size": 256
-  },
-  "bridge": {
-    "source": "target_hidden_stream",
-    "dest": "draft.backbone_stream",
-    "shape": ["T", 2560]
-  }
-}</code></pre>
-
-<p>
-    Later, the compiler can merge both into one BUMP file with target and assistant regions. That is
-    an optimization, not a requirement for the first correct runtime.
-</p>
-
-<h2>IR Contract</h2>
-
-<p>
-    The composite lowering should make the bridge explicit:
-</p>
-
-<pre><code>target.decode_step
-  outputs:
-    target_logits
-    target_hidden_stream
-    target_kv_cache
-
-draft.decode_step
-  inputs:
-    draft_token_ids
-    draft.backbone_stream &lt;- target_hidden_stream
-  outputs:
-    draft_logits
-    draft_candidate_tokens
-
-verify.step
-  inputs:
-    draft_candidate_tokens
-    target_logits
-  outputs:
-    accepted_tokens
-    rejected_token</code></pre>
-
-<p>
-    The generated C should expose explicit functions instead of hiding the protocol:
-</p>
-
-<pre><code>int ck_gemma4_pair_prefill(...);
-int ck_gemma4_pair_decode_one(...);
-int ck_gemma4_pair_draft_tokens(...);
-int ck_gemma4_pair_verify_tokens(...);
-int ck_gemma4_pair_generate_speculative(...);</code></pre>
-
-<h2>Memory Plan</h2>
-
-<p>
-    Required buffers should be visible in <code>layout_decode.json</code>:
-</p>
-
-<ul>
-    <li><code>target_main_stream</code> for Gemma4 backbone hidden state.</li>
-    <li><code>target_kv_cache</code> for the authoritative target cache.</li>
-    <li><code>draft_backbone_stream</code> for assistant input, shape <code>[T, 2560]</code>.</li>
-    <li><code>draft_main_stream</code> for assistant hidden state, shape <code>[T, 256]</code>.</li>
-    <li><code>draft_kv_cache</code> for the assistant cache.</li>
-    <li><code>draft_logits</code> and <code>target_logits</code>.</li>
-    <li><code>accepted_tokens</code>, <code>candidate_tokens</code>, and verifier scratch.</li>
-</ul>
-
-<h2>Xeon Validation Plan</h2>
-
-<p>
-    On the high-memory Xeon box, build both runtimes first:
-</p>
-
-<pre><code>.venv/bin/python version/v8/scripts/ck_run_v8.py run \
-  hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf \
-  --run /tmp/ck-gemma4-e4b-runtime \
-  --context-len 2048 \
-  --force-convert --force-compile \
-  --prompt 'Give me a detailed example of C code.' \
-  --chat-template gemma4 \
-  --max-tokens 64 \
-  --temperature 0.0
-
-.venv/bin/python version/v8/scripts/ck_run_v8.py run \
-  hf://google/gemma-4-E4B-it-assistant \
-  --run /tmp/ck-gemma4-assistant-runtime \
-  --context-len 2048 \
-  --force-convert --force-compile \
-  --generate-only \
-  --chat-template none \
-  --allow-raw-prompt</code></pre>
-
-<p>
-    Then validate in this order:
-</p>
-
-<ol>
-    <li>Backbone-only coherent decode.</li>
-    <li>Assistant-only compile and load smoke. Do not expect standalone chat.</li>
-    <li>Backbone decode exports <code>target_hidden_stream</code> with shape <code>[1, 2560]</code>.</li>
-    <li>Assistant consumes that stream and produces draft logits.</li>
-    <li>One-token draft and target verification match the Python reference protocol.</li>
-    <li>Multi-token speculative loop reports drafted, accepted, rejected, and acceptance rate.</li>
-</ol>
-
-<h2>Success Metrics</h2>
-
-<p>
-    The first useful dashboard should compare:
-</p>
-
-<ul>
-    <li><code>backbone_only_tok_per_sec</code></li>
-    <li><code>speculative_tok_per_sec</code></li>
-    <li><code>draft_tokens_per_batch</code></li>
-    <li><code>accepted_tokens</code> / <code>drafted_tokens</code></li>
-    <li><code>target_verify_ms</code></li>
-    <li><code>assistant_draft_ms</code></li>
-</ul>
-
-<p>
-    A failed acceptance rate is still useful data. It means the bridge, tokenizer, positional policy,
-    or hidden-state handoff is wrong. A high acceptance rate with no speedup means the protocol is
-    correct but the verifier is still too serial.
-</p>
     </main>
 
     <!-- SVG Viewer Overlay (shared across all pages) -->

--- a/docs/site/flash_attention.html
+++ b/docs/site/flash_attention.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1723,7 +1724,7 @@ pthread_setaffinity_np(pthread_self(),
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout-temp.html
+++ b/docs/site/gemm-memory-layout-temp.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1401,7 +1402,7 @@ for (m_tile = 0; m_tile < M; m_tile += MB) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout.html
+++ b/docs/site/gemm-memory-layout.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1657,7 +1658,7 @@ Token 2: offset 1972    ✗ Kernel expects 1904!</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-optimization.html
+++ b/docs/site/gemm-optimization.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2555,7 +2556,7 @@ gemm_microkernel_packed(A, B, C, M, N, K);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-bump.html
+++ b/docs/site/gguf-bump.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1837,7 +1838,7 @@ make gguf-to-bump GGUF=models/qwen2.5-3b-instruct-q4_k_m.gguf
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-conversion.html
+++ b/docs/site/gguf-conversion.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2185,7 +2186,7 @@ with open(output_path, "w+b") as f:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1574,7 +1575,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-08 15:23</span>
+        <span class="folder-updated">Updated: 2026-07-10 21:47</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1598,8 +1599,6 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
-|-- .cache
-|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
 |-- contracts
@@ -1635,7 +1634,7 @@ version/v7
 `-- tools
     `-- src
 
-57 directories
+55 directories
 </pre>
 </div>
 
@@ -1914,7 +1913,7 @@ version/v7
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-pipeline.html
+++ b/docs/site/ir-pipeline.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2266,7 +2267,7 @@ python version/v6.6/tools/open_ir_visualizer.py Qwen--Qwen3-0.6B-GGUF</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-v2.html
+++ b/docs/site/ir-v2.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1662,7 +1663,7 @@ Page 2 (2-3GB)   → DRAM Bank 2 (Layer 12-17)
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/iteration-philosophy.html
+++ b/docs/site/iteration-philosophy.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2580,7 +2581,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernel-tuning-methodology.html
+++ b/docs/site/kernel-tuning-methodology.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1576,7 +1577,7 @@ tie one profiler dot back to one function, one tensor layout, and one source pat
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernels.html
+++ b/docs/site/kernels.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1406,7 +1407,7 @@ out     = S_new^T * q_hat</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/mega_fusion.html
+++ b/docs/site/mega_fusion.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -951,7 +952,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mega-Fused Attention - C-Kernel-Engine</title>
-    <link rel="stylesheet" href="style.css">
     <style>
         /* SVG Viewer Styles */
         .svg-viewer {
@@ -1602,7 +1602,7 @@ mega_fused_attention_decode():
 <h2>References</h2>
 
 <ul>
-    <li><a href="MEGA_FUSED.md">Original Mega-Fusion Proposal</a></li>
+    <li><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/blob/main/docs/MEGA_FUSED.md" target="_blank" rel="noopener noreferrer">Original Mega-Fusion Proposal</a></li>
     <li><a href="https://arxiv.org/abs/2205.14135">Flash Attention (Dao et al.)</a></li>
     <li><a href="profiling.html">Profiling Guide</a> - Verify speedup with perf</li>
 </ul>
@@ -1946,7 +1946,7 @@ mega_fused_attention_decode():
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-reality.html
+++ b/docs/site/memory-reality.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1476,8 +1477,8 @@ CPU (2TB server): FITS with 1.8TB headroom
     <div class="card">
         <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
         <p>GPU vs CPU memory comparison for LLM inference:</p>
-        <a href="../assets/memory-reality-infographic.svg" target="_blank">
-            <img src="../assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
+        <a href="assets/memory-reality-infographic.svg" target="_blank">
+            <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
         </a>
         <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
     </div>
@@ -1718,7 +1719,7 @@ CPU (2TB server): FITS with 1.8TB headroom
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-safety.html
+++ b/docs/site/memory-safety.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1925,7 +1926,7 @@ echo "=== All memory safety checks passed ==="</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2428,7 +2429,7 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/prefill-performance-roadmap.html
+++ b/docs/site/prefill-performance-roadmap.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1360,7 +1361,7 @@ make profile-v8-prefill-perf-stat</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/profiling.html
+++ b/docs/site/profiling.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1637,7 +1638,7 @@ make flamegraph       # Generate SVG flamegraph</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/pytorch-parity.html
+++ b/docs/site/pytorch-parity.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1339,7 +1340,7 @@ make litmus</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/q6-prefill-roofline.html
+++ b/docs/site/q6-prefill-roofline.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1297,7 +1298,7 @@ CK_NUM_THREADS=12 OMP_NUM_THREADS=1 CK_Q6K_Q8K_SIMD=1 \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quant-formats.html
+++ b/docs/site/quant-formats.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1619,7 +1620,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-math-temp.html
+++ b/docs/site/quantization-math-temp.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1383,7 +1384,7 @@ for (int ib = 0; ib < nb; ib++) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-visuals.html
+++ b/docs/site/quantization-visuals.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1515,7 +1516,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization.html
+++ b/docs/site/quantization.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2393,7 +2394,7 @@ void matmul_q4(float* out, const float* x, const tensor* W) {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1683,7 +1684,7 @@ firefox build/flamegraph.svg</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/research.html
+++ b/docs/site/research.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1631,7 +1632,7 @@ K = [K_rope (with position), K_nope (from latent)]</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2829,8 +2830,8 @@ Total Memory = Model Weights + KV Cache
 <div class="card" style="max-width: 800px;">
     <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
     <p>GPU vs CPU memory comparison for LLM inference:</p>
-    <a href="../assets/memory-reality-infographic.svg" target="_blank">
-        <img src="../assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
+    <a href="assets/memory-reality-infographic.svg" target="_blank">
+        <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
     </a>
     <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
 </div>
@@ -3392,7 +3393,7 @@ That's it. For any model size.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sentencepiece.html
+++ b/docs/site/sentencepiece.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1875,7 +1876,7 @@ ck_tokenizer_free(tok);</code></pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/simd-architecture.html
+++ b/docs/site/simd-architecture.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2368,7 +2369,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,270 +2,274 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/divergence-harness.html</loc>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-mla-kimi.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-10</lastmod>
   </url>
 </urlset>

--- a/docs/site/spec-training-method.html
+++ b/docs/site/spec-training-method.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -3777,7 +3778,7 @@ Next run:</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1419,7 +1420,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec17-curriculum-blueprint.html
+++ b/docs/site/spec17-curriculum-blueprint.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1475,7 +1476,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec19-textbook-routing-mixture.html
+++ b/docs/site/spec19-textbook-routing-mixture.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1588,7 +1589,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spectrum.html
+++ b/docs/site/spectrum.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1766,7 +1767,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1686,9 +1686,17 @@
     <li><strong>v8 Vision Kernel Parity</strong>: Vision kernel parity for patch extraction/reconstruction, tiled position embeddings,
       Qwen3-VL resized position interpolation order, spatial merge/reorder, feature concat/slice, and vision M-RoPE
       (<code>make test-v8-vision-kernels</code>)</li>
+    <li><strong>Qwen3-VL Template/Codegen Contracts</strong>: Synthetic GGUF/BF16-independent guards for Qwen3-VL circuit lowering,
+      align-corners position-kernel selection, valid vision M-RoPE width/sections, and bounded semantic tensor exports
+      (<code>make test-v8-qwen3vl</code>)</li>
+    <li><strong>v8 BF16 Safetensors Lowering</strong>: Synthetic BF16 conversion and lowering guard that asserts all vision weights are
+      consumed, align-corners interpolation is selected, and M-RoPE arguments remain valid through generated calls. The target builds
+      both engine and vision libraries first so hardware-independent M-RoPE checks cannot silently skip
+      (<code>make nightly-bf16</code>)</li>
     <li><strong>FP16 Attention Contracts</strong>: Named numerical guards for llama.cpp-compatible unfused causal prefill and split-KV decode,
       including FP16 Q/K rounding, FP16 probability/value reduction, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding,
-      the KV 511/512 semantic boundary, and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
+      the KV 511/512 semantic boundary,
+      and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
       (<code>make test-attention-f16-split-kv</code>)</li>
     <li><strong>v8 Stitched Dump Alignment</strong>: Guards canonical output-projection aliases and preserves absolute CK/llama
       source-token provenance when mixed-prefix dumps are rebased for per-token comparison

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1695,8 +1696,7 @@
       (<code>make nightly-bf16</code>)</li>
     <li><strong>FP16 Attention Contracts</strong>: Named numerical guards for llama.cpp-compatible unfused causal prefill and split-KV decode,
       including FP16 Q/K rounding, FP16 probability/value reduction, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding,
-      the KV 511/512 semantic boundary,
-      and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
+      the KV 511/512 semantic boundary, and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
       (<code>make test-attention-f16-split-kv</code>)</li>
     <li><strong>v8 Stitched Dump Alignment</strong>: Guards canonical output-projection aliases and preserves absolute CK/llama
       source-token provenance when mixed-prefix dumps are rebased for per-token comparison
@@ -2751,7 +2751,7 @@ document.addEventListener('DOMContentLoaded', loadResults);
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-viewer.html
+++ b/docs/site/test-viewer.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1389,7 +1390,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -968,6 +969,15 @@ permalink: /testing/
     the Qwen3-VL encoder parity closure and postmortem now live at
     <a href="/vision-encoder-parity/">Vision Encoder Parity</a>.
     That page documents the actual failure mode, the debugging sequence, and the regressions to watch for on future encoder ports.
+  </div>
+
+  <div class="alert alert-info">
+    <strong>Stitched divergence harness:</strong>
+    backend-level parity now uses a staged harness that compares CK against
+    llama.cpp/mtmd for GGUF paths and can be extended to PyTorch when a matching
+    tensor-dump adapter exists. See
+    <a href="/divergence-harness/">Stitched Divergence Harness</a> for the backend
+    contract, dump format, and first-divergence workflow.
   </div>
 
   <div class="alert alert-warning">
@@ -1883,7 +1893,7 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/threadpool.html
+++ b/docs/site/threadpool.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2830,7 +2831,7 @@ make test-threadpool-parity-verbose
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/tokenizer.html
+++ b/docs/site/tokenizer.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2317,7 +2318,7 @@ True BPE (merge rules applied in order):
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-curriculum.html
+++ b/docs/site/training-curriculum.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1850,7 +1851,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-intuition.html
+++ b/docs/site/training-intuition.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2257,7 +2258,7 @@ report:    version/v7/tools/ir_visualizer.html (or generated ir_report*.html)</c
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-lessons-learned.html
+++ b/docs/site/training-lessons-learned.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1843,7 +1844,7 @@ AFTER TRAINING:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-backprop-ir.html
+++ b/docs/site/v7-backprop-ir.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2012,7 +2013,7 @@ version/v7/scripts/cks-v7-run init \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-cross-entropy-parity.html
+++ b/docs/site/v7-cross-entropy-parity.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1399,7 +1400,7 @@ CK_NUM_THREADS=8 python version/v7/scripts/train_parity_epochs_v7.py \
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-grad-accum-windows.html
+++ b/docs/site/v7-grad-accum-windows.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1329,7 +1330,7 @@ at accumulation boundary:
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-parity-checklist.html
+++ b/docs/site/v7-parity-checklist.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1528,7 +1529,7 @@ PY</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-profiling.html
+++ b/docs/site/v7-profiling.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1447,7 +1448,7 @@ python3 version/v7/tools/open_ir_visualizer.py --generate --run /tmp/v7_ht_threa
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-python-authoring.html
+++ b/docs/site/v7-python-authoring.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1600,7 +1601,7 @@ python3 version/v7/examples/python_module_api_tiny_lm_v7.py --run-name py-module
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-runbook.html
+++ b/docs/site/v7-runbook.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -5610,7 +5611,7 @@ python3 scripts/ck_chat.py --help</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-svg-dataset-runbook.html
+++ b/docs/site/v7-svg-dataset-runbook.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1658,7 +1659,7 @@ tail -n 20 "$RUN/autopilot/summary.jsonl"</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-training-progression-playbook.html
+++ b/docs/site/v7-training-progression-playbook.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1578,7 +1579,7 @@ jq -r '.status, (.stages // [])' "$RUN/training_parity_regimen_latest.json" 2>/d
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-visualizer-test-runbook.html
+++ b/docs/site/v7-visualizer-test-runbook.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1929,7 +1930,7 @@ document.querySelectorAll('.copy-btn').forEach(btn => {
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-mla-kimi.html
+++ b/docs/site/v8-mla-kimi.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1402,7 +1403,7 @@ make build/libckernel_engine.so
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1743,7 +1744,7 @@ make v8-visualizer-vision-artifacts</pre>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1944,7 +1945,7 @@
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/version-history.html
+++ b/docs/site/version-history.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -2683,7 +2684,7 @@ console.log('Roadmap: ' + versionData.roadmap.map(v => 'v' + v.major).join(' →
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -916,6 +916,7 @@
                         <a href="v7-runbook.html">v7 Inference + Training Runbook<small>Copy/paste train + infer workflow</small></a>
                         <a href="v7-svg-dataset-runbook.html">v7 SVG Dataset Runbook<small>Pretrain + midtrain data generation</small></a>
                         <a href="testing.html">Testing<small>Numerical parity verification</small></a>
+                        <a href="divergence-harness.html">Stitched Divergence Harness<small>llama.cpp/PyTorch tensor attribution</small></a>
                         <a href="threadpool.html">Thread Pool<small>Persistent pthreads, dispatch</small></a>
                     </div>
                 </div>
@@ -1330,7 +1331,7 @@ permalink: /vision-encoder-parity/
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-08</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
             </div>
         </div>
     </footer>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -3273,6 +3273,13 @@ void embedding_forward_bf16_fp32(const int32_t *token_ids,
 	                                      int embed_dim,
 	                                      int merge_size,
 	                                      int source_grid_size);
+	void position_embeddings_add_tiled_2d_align_corners(float *x,
+	                                                    const float *position_embd,
+	                                                    int grid_h,
+	                                                    int grid_w,
+	                                                    int embed_dim,
+	                                                    int merge_size,
+	                                                    int source_grid_size);
 	void position_embeddings_add_gemma4v_xy(float *x,
 	                                       const float *position_embd,
 	                                       int grid_h,

--- a/logs/2026-07-10-qwen3vl-bf16-vision-parity/README.md
+++ b/logs/2026-07-10-qwen3vl-bf16-vision-parity/README.md
@@ -1,0 +1,50 @@
+# Qwen3-VL BF16 Vision Parity
+
+## Scope
+
+This change hardens the Qwen3-VL safetensors/BF16 vision path around two semantic contracts:
+
+1. Learned 2D position embeddings use PyTorch bilinear `align_corners=True` coordinates.
+2. Vision M-RoPE uses frequency-pair width `head_dim / 2` with valid repeated axis sections.
+
+The real model measurements below were produced on the Xeon BF16 system using the canonical private OCR image. The
+image and model weights are not committed.
+
+## Xeon Result
+
+| Boundary | Before | After |
+|---|---:|---:|
+| Position RMSE | 0.00794 | 0.00116 |
+| Post-RoPE Q cosine | 0.6167 | 0.999970 |
+| Layer-0 output projection cosine | - | 0.999985 |
+| Final prefix cosine | 0.308 | 0.996712 |
+| Deepstack slice cosine | - | 0.9991-0.9999 |
+
+The remaining real-model drift is concentrated in the main final projector path. Full BF16 end-to-end parity is not
+claimed.
+
+## Regression Guards
+
+- numerical C-vs-PyTorch align-corners interpolation, maximum observed error `8.34e-7`
+- synthetic safetensors conversion and all-28-weight consumption
+- interpolation-policy preservation through IR and kernel selection
+- vision M-RoPE width and section arguments preserved through call lowering
+- invalid M-RoPE sections fail lowering instead of silently disabling rotation
+- bounded semantic exports for Q/K/V, RoPE, attention, normalization, and projection boundaries
+- named nightly row for the 16-test Qwen3-VL template/codegen contract suite
+- self-building `make nightly-bf16`, including the vision library required by the M-RoPE guard
+
+## Validation
+
+- `make test-v8-vision-kernels`
+- `make test-v8-qwen3vl` (`16/16`)
+- `make nightly-bf16` (`12/12`)
+- Python syntax checks for changed scripts
+- `git diff --check`
+
+## Next Xeon Target
+
+Run the canonical BF16 image through bounded captures at `post_ln`, `projector_fc1`, projector GELU, `projector_fc2`,
+each deepstack slice, and final concatenation. Compare CK against PyTorch at each boundary and report cosine, RMSE,
+maximum absolute error, and worst row. This will distinguish accumulated BF16 rounding from projector layout, bias,
+activation, or concatenation semantics.

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -516,6 +516,12 @@ MAKE_TARGETS = {
         "target": "test-v8-vision-kernels",
         "timeout_sec": 300,
     },
+    "qwen3vl_template_contracts": {
+        "name": "Qwen3-VL Template/Codegen Contracts",
+        "category": "inference",
+        "target": "test-v8-qwen3vl",
+        "timeout_sec": 600,
+    },
     "v8_qwen3vl_vision_smoke": {
         "name": "v8 Qwen3-VL Vision Smoke",
         "category": "inference",

--- a/src/kernels/vision_kernels.c
+++ b/src/kernels/vision_kernels.c
@@ -289,6 +289,55 @@ CK_VISION_NOINLINE CK_VISION_OPTNONE void position_embeddings_add_tiled_2d(float
     }
 }
 
+void position_embeddings_add_tiled_2d_align_corners(float *x,
+                                                     const float *position_embd,
+                                                     int grid_h,
+                                                     int grid_w,
+                                                     int embed_dim,
+                                                     int merge_size,
+                                                     int source_grid_size)
+{
+    if (x == NULL || position_embd == NULL || grid_h <= 0 || grid_w <= 0 ||
+        embed_dim <= 0 || merge_size <= 0 || source_grid_size <= 0) {
+        return;
+    }
+
+    const float y_scale = grid_h > 1
+        ? (float)(source_grid_size - 1) / (float)(grid_h - 1)
+        : 0.0f;
+    const float x_scale = grid_w > 1
+        ? (float)(source_grid_size - 1) / (float)(grid_w - 1)
+        : 0.0f;
+
+    for (int tok = 0; tok < grid_h * grid_w; ++tok) {
+        const int row_major = tile_order_index_2d(tok, grid_h, grid_w, merge_size);
+        const int dst_y = row_major / grid_w;
+        const int dst_x = row_major % grid_w;
+        const float src_y = (float)dst_y * y_scale;
+        const float src_x = (float)dst_x * x_scale;
+        const int y0 = (int)src_y;
+        const int x0 = (int)src_x;
+        const int y1 = y0 + 1 < source_grid_size ? y0 + 1 : y0;
+        const int x1 = x0 + 1 < source_grid_size ? x0 + 1 : x0;
+        const float dy = src_y - (float)y0;
+        const float dx = src_x - (float)x0;
+        const float w00 = (1.0f - dy) * (1.0f - dx);
+        const float w01 = (1.0f - dy) * dx;
+        const float w10 = dy * (1.0f - dx);
+        const float w11 = dy * dx;
+        const float *p00 = position_embd + ((size_t)y0 * source_grid_size + x0) * embed_dim;
+        const float *p01 = position_embd + ((size_t)y0 * source_grid_size + x1) * embed_dim;
+        const float *p10 = position_embd + ((size_t)y1 * source_grid_size + x0) * embed_dim;
+        const float *p11 = position_embd + ((size_t)y1 * source_grid_size + x1) * embed_dim;
+        float *dst = x + (size_t)tok * embed_dim;
+
+        for (int d = 0; d < embed_dim; ++d) {
+            const float pos = p00[d] * w00 + p01[d] * w01 + p10[d] * w10 + p11[d] * w11;
+            dst[d] += pos;
+        }
+    }
+}
+
 /**
  * Build merged 2D vision position IDs in the layout expected by vision M-RoPE.
  *

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -140,6 +140,29 @@ def _make_qwen3vl_manifest() -> dict:
 
 class V8Qwen3VLTemplateTests(unittest.TestCase):
 
+    def test_qwen3vl_invalid_vision_mrope_sections_fail_lowering(self) -> None:
+        manifest = _make_qwen3vl_manifest()
+        manifest["config"]["vision_mrope_n_dims"] = 2
+        manifest["config"]["vision_mrope_sections"] = [2, 2, 2, 2]
+        with tempfile.TemporaryDirectory(prefix="v8_qwen3vl_invalid_mrope_") as td:
+            td_path = Path(td)
+            manifest_path = td_path / "weights_manifest.json"
+            manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+            with self.assertRaisesRegex(
+                ValueError,
+                "vision M-RoPE sections exceed available frequency pairs",
+            ):
+                build_ir_v8.main(
+                    [
+                        "--manifest", str(manifest_path),
+                        "--mode", "prefill",
+                        "--output", str(td_path / "ir1.json"),
+                        "--layout-output", str(td_path / "layout.json"),
+                        "--lowered-output", str(td_path / "lowered.json"),
+                        "--call-output", str(td_path / "call.json"),
+                    ]
+                )
+
     def test_qwen3vl_mmproj_position_grid_size_uses_square_side(self) -> None:
         class FakeTensor:
             dims = [2304, 1152]
@@ -396,6 +419,7 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
 
     def test_qwen3vl_codegen_smoke_emits_c(self) -> None:
         manifest = _make_qwen3vl_manifest()
+        manifest["config"]["position_interpolation_policy"] = "align_corners_bilinear"
         with tempfile.TemporaryDirectory(prefix="v8_qwen3vl_codegen_") as td:
             td_path = Path(td)
             manifest_path = td_path / "weights_manifest.json"
@@ -434,6 +458,10 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             pos_embed = next(op for op in call_ops if op.get("op") == "position_embeddings")
             pos_grid = next(arg for arg in pos_embed.get("args", []) if arg.get("name") == "source_grid_size")
             self.assertEqual(pos_grid.get("expr"), "48")
+            self.assertEqual(
+                pos_embed.get("function"),
+                "position_embeddings_add_tiled_2d_align_corners",
+            )
             split_qkv = next(op for op in call_ops if op.get("op") == "split_qkv_packed")
             self.assertEqual(split_qkv.get("function"), "split_qkv_packed_head_major_forward")
             qkv_packed_proj = next(op for op in call_ops if op.get("op") == "qkv_packed_proj")
@@ -525,6 +553,16 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             self.assertIn("ck_strict_mtmd_clip_encode_planar_f32", text)
             self.assertIn("gelu_ggml_inplace", text)
             self.assertIn("layernorm_naive_serial_matched_precision", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"qkv_packed\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"q_proj\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"k_proj\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"v_proj\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"rope_q\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"rope_k\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"attn_out_head_major\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"out_proj\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"ln1\"", text)
+            self.assertIn("ck_debug_export_hidden(model, 0, \"ffn_inp_normed\"", text)
             self.assertIn("feature_concat", text)
             self.assertIn("transpose_attn_out_to_token_major", text)
             self.assertNotIn("transpose_inplace();", text)

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -1172,8 +1172,9 @@ def test_qwen3vl_safetensors_vision_maps_temporal_patch_split(tmp_path: Path) ->
         "v.patch_embd.weight.1",
     ]
     assert manifest["config"]["rope_layout"] == "multi_section_2d"
-    assert manifest["config"]["vision_mrope_n_dims"] == 4
+    assert manifest["config"]["vision_mrope_n_dims"] == 2
     assert manifest["config"]["vision_mrope_sections"] == [1, 1, 1, 1]
+    assert manifest["config"]["position_interpolation_policy"] == "align_corners_bilinear"
     assert (out / "weights.bump").stat().st_size > 0
 
     build_ir = Path("version/v8/scripts/build_ir_v8.py")
@@ -1205,6 +1206,12 @@ def test_qwen3vl_safetensors_vision_maps_temporal_patch_split(tmp_path: Path) ->
     )
     lowered_ops = json.loads(lowered.read_text(encoding="utf-8"))["operations"]
     kernels_by_op = {op["op"]: op.get("kernel") for op in lowered_ops}
+    assert kernels_by_op["position_embeddings"] == "position_embeddings_add_tiled_2d_align_corners"
+    call_ops = json.loads(call.read_text(encoding="utf-8"))["operations"]
+    rope_call = next(op for op in call_ops if op["op"] == "rope_qk")
+    rope_args = {arg["name"]: arg["expr"] for arg in rope_call["args"]}
+    assert rope_args["n_dims"] == "2"
+    assert [rope_args[f"section_{i}"] for i in range(4)] == ["1", "1", "1", "1"]
     for op_name in (
         "patch_proj",
         "patch_proj_aux",

--- a/unittest/test_vision.py
+++ b/unittest/test_vision.py
@@ -56,6 +56,17 @@ lib.position_embeddings_add_tiled_2d.argtypes = [
 ]
 lib.position_embeddings_add_tiled_2d.restype = None
 
+lib.position_embeddings_add_tiled_2d_align_corners.argtypes = [
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+]
+lib.position_embeddings_add_tiled_2d_align_corners.restype = None
+
 lib.vision_position_ids_2d_merge.argtypes = [
     ctypes.POINTER(ctypes.c_int32),
     ctypes.c_int,
@@ -230,6 +241,22 @@ def run_c_position_embeddings_add_tiled_2d(
         embed_dim,
         merge_size,
         source_grid_size,
+    )
+    return out
+
+
+def run_c_position_embeddings_add_tiled_2d_align_corners(
+    x: torch.Tensor,
+    pos: torch.Tensor,
+    grid_h: int,
+    grid_w: int,
+    merge_size: int,
+    source_grid_size: int,
+) -> torch.Tensor:
+    out = x.clone()
+    _, embed_dim = out.shape
+    lib.position_embeddings_add_tiled_2d_align_corners(
+        tensor_to_ptr(out), tensor_to_ptr(pos), grid_h, grid_w, embed_dim, merge_size, source_grid_size
     )
     return out
 
@@ -503,6 +530,32 @@ def _ref_position_embeddings_add_tiled_2d(
     return torch.from_numpy(x_np)
 
 
+def _ref_position_embeddings_add_tiled_2d_align_corners(
+    x: torch.Tensor,
+    pos: torch.Tensor,
+    grid_h: int,
+    grid_w: int,
+    merge_size: int,
+    source_grid_size: int,
+) -> torch.Tensor:
+    ys = torch.linspace(0, source_grid_size - 1, grid_h, dtype=torch.float32)
+    xs = torch.linspace(0, source_grid_size - 1, grid_w, dtype=torch.float32)
+    y0 = ys.to(torch.long)
+    x0 = xs.to(torch.long)
+    y1 = (y0 + 1).clamp(max=source_grid_size - 1)
+    x1 = (x0 + 1).clamp(max=source_grid_size - 1)
+    dy = ys - y0
+    dx = xs - x0
+    table = pos.view(source_grid_size, source_grid_size, -1)
+    interp = (
+        table[y0[:, None], x0[None, :]] * ((1 - dy)[:, None] * (1 - dx)[None, :])[..., None]
+        + table[y0[:, None], x1[None, :]] * ((1 - dy)[:, None] * dx[None, :])[..., None]
+        + table[y1[:, None], x0[None, :]] * (dy[:, None] * (1 - dx)[None, :])[..., None]
+        + table[y1[:, None], x1[None, :]] * (dy[:, None] * dx[None, :])[..., None]
+    ).reshape(grid_h * grid_w, -1)
+    return x + interp.index_select(0, _tile_order_indices(grid_h, grid_w, merge_size))
+
+
 def _ref_add_stream_reorder_2d(
     main_input: torch.Tensor,
     aux_input: torch.Tensor,
@@ -665,6 +718,23 @@ def test_position_embeddings_add_tiled_2d_qwen3vl_resize_order(
 
     if diff > 2e-6:
         raise AssertionError("position_embeddings_add_tiled_2d Qwen3-VL resize order mismatch!")
+
+
+def test_position_embeddings_add_tiled_2d_align_corners():
+    grid_h, grid_w, source_grid_size, embed_dim, merge_size = 6, 10, 4, 8, 2
+    g = torch.Generator().manual_seed(4410)
+    x = torch.randn(grid_h * grid_w, embed_dim, generator=g)
+    pos = torch.randn(source_grid_size * source_grid_size, embed_dim, generator=g)
+    ref = _ref_position_embeddings_add_tiled_2d_align_corners(
+        x, pos, grid_h, grid_w, merge_size, source_grid_size
+    )
+    out_c = run_c_position_embeddings_add_tiled_2d_align_corners(
+        x, pos, grid_h, grid_w, merge_size, source_grid_size
+    )
+    diff = max_diff(out_c, ref)
+    print(f"\n--- Testing align-corners tiled position embeddings (max diff {diff:.2e}) ---")
+    if diff > 2e-6:
+        raise AssertionError("align-corners tiled position embeddings mismatch")
 
 
 def test_rowwise_bias_add(tokens=2304, embed_dim=1152):
@@ -1012,6 +1082,7 @@ if __name__ == "__main__":
     test_position_embeddings_add()
     test_position_embeddings_add_tiled_2d()
     test_position_embeddings_add_tiled_2d_qwen3vl_resize_order()
+    test_position_embeddings_add_tiled_2d_align_corners()
     test_vision_position_ids()
     test_vision_position_ids(grid_h=6, grid_w=6, merge_size=3)
     test_rowwise_bias_add()

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -1629,6 +1629,41 @@
         }
       ]
     },
+    "position_embeddings_add_tiled_2d_align_corners": {
+      "note": "Add align-corners position embeddings to an activation stream already laid out in merged-tile order.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "x",
+          "source": "output:x"
+        },
+        {
+          "cast": "const float*",
+          "name": "position_embd",
+          "source": "weight:pos_emb"
+        },
+        {
+          "name": "grid_h",
+          "source": "dim:vision_grid_h"
+        },
+        {
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "merge_size",
+          "source": "dim:merge_size"
+        },
+        {
+          "name": "source_grid_size",
+          "source": "dim:source_grid_size"
+        }
+      ]
+    },
     "position_embeddings_add_tiled_2d": {
       "note": "Add position embeddings to an activation stream already laid out in merged-tile order.",
       "params": [

--- a/version/v8/kernel_maps/position_embeddings_add_tiled_2d_align_corners.json
+++ b/version/v8/kernel_maps/position_embeddings_add_tiled_2d_align_corners.json
@@ -1,0 +1,41 @@
+{
+  "id": "position_embeddings_add_tiled_2d_align_corners",
+  "op": "position_embeddings",
+  "variant": "absolute_learned_inplace_tiled_2d_align_corners_fp32",
+  "quant": {
+    "weight": "fp32",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": ["T", "E"],
+      "desc": "Token-major activation stream already arranged in merged-tile order"
+    }
+  ],
+  "weights": [
+    {
+      "name": "pos_emb",
+      "dtype": "fp32",
+      "shape": ["P", "E"],
+      "desc": "Learned position embeddings stored in row-major patch order"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "x",
+      "dtype": "fp32",
+      "shape": ["T", "E"],
+      "desc": "In-place updated activation stream"
+    }
+  ],
+  "dims": ["grid_h", "grid_w", "embed_dim", "merge_size", "source_grid_size"],
+  "impl": {
+    "function": "position_embeddings_add_tiled_2d_align_corners",
+    "c_declaration": "void position_embeddings_add_tiled_2d_align_corners(float *x, const float *position_embd, int grid_h, int grid_w, int embed_dim, int merge_size, int source_grid_size);",
+    "sources": ["src/kernels/vision_kernels.c"]
+  },
+  "notes": "Add align-corners bilinearly interpolated learned position embeddings to a stream in merged-tile traversal."
+}

--- a/version/v8/scripts/bf16_safetensors_lowering_guard_v8.py
+++ b/version/v8/scripts/bf16_safetensors_lowering_guard_v8.py
@@ -284,8 +284,9 @@ def run_guard(workdir: Path) -> None:
     )
     manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
     assert manifest["config"]["rope_layout"] == "multi_section_2d"
-    assert manifest["config"]["vision_mrope_n_dims"] == 4
+    assert manifest["config"]["vision_mrope_n_dims"] == 2
     assert manifest["config"]["vision_mrope_sections"] == [1, 1, 1, 1]
+    assert manifest["config"]["position_interpolation_policy"] == "align_corners_bilinear"
 
     lowered = out / "lowered_vision.json"
     call = out / "lowered_vision_call.json"
@@ -313,6 +314,12 @@ def run_guard(workdir: Path) -> None:
     )
     lowered_ops = json.loads(lowered.read_text(encoding="utf-8"))["operations"]
     kernels_by_op = {op["op"]: op.get("kernel") for op in lowered_ops}
+    assert kernels_by_op["position_embeddings"] == "position_embeddings_add_tiled_2d_align_corners"
+    call_ops = json.loads(call.read_text(encoding="utf-8"))["operations"]
+    rope_call = next(op for op in call_ops if op["op"] == "rope_qk")
+    rope_args = {arg["name"]: arg["expr"] for arg in rope_call["args"]}
+    assert rope_args["n_dims"] == "2"
+    assert [rope_args[f"section_{idx}"] for idx in range(4)] == ["1", "1", "1", "1"]
     for op_name in (
         "patch_proj",
         "patch_proj_aux",

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -3722,6 +3722,20 @@ def _resolve_rope_qk_kernel(config: Dict, template_kernels: Dict[str, Any]) -> s
     return "rope_forward_qk"
 
 
+def _resolve_position_embeddings_kernel(config: Dict, template_kernels: Dict[str, Any]) -> str:
+    kernel_spec = template_kernels.get("position_embeddings")
+    if isinstance(kernel_spec, dict):
+        policy = str(config.get("position_interpolation_policy", "default") or "default").strip().lower()
+        selected = kernel_spec.get(policy) or kernel_spec.get("default")
+        if not selected:
+            raise ValueError(
+                "position_embeddings kernel map has no entry for policy "
+                f"{policy!r} and no default"
+            )
+        return str(selected)
+    return str(kernel_spec or "position_embeddings_add_tiled_2d")
+
+
 def _attention_contract_is_causal(template: Dict[str, Any], config: Dict[str, Any]) -> bool:
     contract = template.get("contract", {}) if isinstance(template.get("contract"), dict) else {}
     attention_contract = contract.get("attention_contract", {}) if isinstance(contract.get("attention_contract"), dict) else {}
@@ -4914,6 +4928,8 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         if op == "mrope_qk":
             override = str(template_kernels.get("mrope_qk", "") or "").strip()
             return [override or "mrope_qk_vision"]
+        if op == "position_embeddings":
+            return [_resolve_position_embeddings_kernel(config, template_kernels)]
         if op == "kv_cache_store_shared_q":
             return ["kv_cache_store_shared_q"]
         if op == "assistant_layer_scale":
@@ -9550,6 +9566,12 @@ def generate_ir_lower_2(
                 default_section = max(1, int(params.get("head_dim", 0) or 0) // 4)
                 sections = [default_section, default_section, default_section, default_section]
             params.setdefault("n_dims", int(config.get("vision_mrope_n_dims", max(1, int(params.get("head_dim", 0) or 0) // 2))))
+            rope_pairs = min(int(params["n_dims"]), max(1, int(params.get("head_dim", 0) or 0) // 2))
+            if int(sections[0]) + int(sections[1]) > rope_pairs:
+                raise ValueError(
+                    "vision M-RoPE sections exceed available frequency pairs: "
+                    f"sections={sections} n_dims={params['n_dims']} head_dim={params.get('head_dim')}"
+                )
             params.setdefault("section_0", int(sections[0]))
             params.setdefault("section_1", int(sections[1]))
             params.setdefault("section_2", int(sections[2]))

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -1534,7 +1534,19 @@ def emit_op(
                 f'{row_count_expr});'
             )
 
-    if op_name == "patchify":
+    if op_name == "qkv_packed_proj":
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        count_expr = _mul_expr(
+            _hidden_arg("M", "rows", "tokens"),
+            _hidden_arg("N", "out_dim"),
+        )
+        _emit_hidden_export(out_expr, "qkv_packed", count_expr)
+        _emit_hidden_export_last_row(
+            out_expr,
+            "qkv_packed",
+            _hidden_arg("N", "out_dim"),
+        )
+    elif op_name == "patchify":
         patch_h = f"(({_hidden_arg('H')}) / ({_hidden_arg('P')}))" if _hidden_arg("H") and _hidden_arg("P") else None
         patch_w = f"(({_hidden_arg('W')}) / ({_hidden_arg('P')}))" if _hidden_arg("W") and _hidden_arg("P") else None
         patch_dim = _mul_expr(_hidden_arg("C"), _hidden_arg("P"), _hidden_arg("P"))
@@ -1547,9 +1559,17 @@ def emit_op(
         _emit_hidden_export_last_row(out_expr, label, _hidden_arg("N", "out_dim", "embed_dim"))
     elif op_name in ("position_embeddings", "patch_bias_add", "add_stream"):
         out_expr = _hidden_arg("x", "main_inout", "output", "out", "c", "y")
-        count_expr = _mul_expr(_hidden_arg("grid_h", "rows", "tokens"), _hidden_arg("grid_w"), _hidden_arg("embed_dim"))
-        if count_expr is None:
-            count_expr = _mul_expr(_hidden_arg("rows", "tokens", "num_tokens"), _hidden_arg("dim", "embed_dim"))
+        if op_name == "patch_bias_add":
+            count_expr = _mul_expr(
+                _hidden_arg("rows", "tokens", "num_tokens"),
+                _hidden_arg("dim", "embed_dim"),
+            )
+        else:
+            count_expr = _mul_expr(
+                _hidden_arg("grid_h", "rows", "tokens"),
+                _hidden_arg("grid_w"),
+                _hidden_arg("embed_dim"),
+            )
         label = {
             "position_embeddings": "vision_position_embeddings",
             "patch_bias_add": "vision_patch_bias",
@@ -1574,22 +1594,78 @@ def emit_op(
         label = "vision_projector_out" if op_name == "projector_fc2" else "vision_projector_fc1"
         _emit_hidden_export(out_expr, label, count_expr)
         _emit_hidden_export_last_row(out_expr, label, _hidden_arg("N", "out_dim", "embed_dim"))
+    elif op_name == "split_qkv_packed":
+        rows = _hidden_arg("rows", "num_tokens", "tokens")
+        _emit_hidden_export(_hidden_arg("q"), "q_proj", _mul_expr(rows, _hidden_arg("q_dim")))
+        _emit_hidden_export(_hidden_arg("k"), "k_proj", _mul_expr(rows, _hidden_arg("k_dim")))
+        _emit_hidden_export(_hidden_arg("v"), "v_proj", _mul_expr(rows, _hidden_arg("v_dim")))
+    elif op_name in ("rope_qk", "mrope_qk"):
+        q_count = _mul_expr(
+            _hidden_arg("num_heads"),
+            _hidden_arg("num_tokens", "tokens", "rows"),
+            _hidden_arg("aligned_head_dim", "head_dim"),
+        )
+        k_count = _mul_expr(
+            _hidden_arg("num_kv_heads", "num_heads"),
+            _hidden_arg("num_tokens", "tokens", "rows"),
+            _hidden_arg("aligned_head_dim", "head_dim"),
+        )
+        _emit_hidden_export(_hidden_arg("q"), "rope_q", q_count)
+        _emit_hidden_export(_hidden_arg("k"), "rope_k", k_count)
+    elif op_name in ("out_proj", "attn_out_proj"):
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        count_expr = _mul_expr(
+            _hidden_arg("M", "rows", "tokens"),
+            _hidden_arg("N", "out_dim", "embed_dim"),
+        )
+        _emit_hidden_export(out_expr, "out_proj", count_expr)
+        _emit_hidden_export_last_row(out_expr, "out_proj", _hidden_arg("N", "out_dim", "embed_dim"))
+    elif op_name == "attn":
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        count_expr = _mul_expr(
+            _hidden_arg("num_heads"),
+            _hidden_arg("num_tokens", "tokens", "rows"),
+            _hidden_arg("aligned_head_dim", "head_dim"),
+        )
+        _emit_hidden_export(out_expr, "attn_out_head_major", count_expr)
     elif op_name == "residual_add":
-        out_expr = _hidden_raw(_hidden_arg("output", "out", "c", "y"))
-        residual_expr = _hidden_raw(_hidden_arg("b"))
+        out_expr = _hidden_arg("output", "out", "c", "y")
+        residual_expr = _hidden_arg("b")
+        row_dim = _hidden_arg("aligned_embed_dim", "embed_dim", "dim") or "EMBED_DIM"
+        count_expr = _mul_expr(_hidden_arg("tokens", "num_tokens", "rows"), row_dim)
         if op_instance_idx == 0 and residual_expr:
-            lines.append(f'    ck_debug_export_hidden(model, {layer}, "after_attn_residual", (const float*){residual_expr}, EMBED_DIM);')
-            _emit_hidden_export_last_row(residual_expr, "after_attn_residual", "EMBED_DIM")
+            _emit_hidden_export(residual_expr, "after_attn_residual", count_expr)
+            _emit_hidden_export_last_row(residual_expr, "after_attn_residual", row_dim)
         elif op_instance_idx == 1 and residual_expr:
-            lines.append(f'    ck_debug_export_hidden(model, {layer}, "ffn_residual", (const float*){residual_expr}, EMBED_DIM);')
-            _emit_hidden_export_last_row(residual_expr, "ffn_residual", "EMBED_DIM")
+            _emit_hidden_export(residual_expr, "ffn_residual", count_expr)
+            _emit_hidden_export_last_row(residual_expr, "ffn_residual", row_dim)
         if out_expr:
             if op_instance_idx == 0:
-                lines.append(f'    ck_debug_export_hidden(model, {layer}, "after_attn", (const float*){out_expr}, EMBED_DIM);')
-                _emit_hidden_export_last_row(out_expr, "after_attn", "EMBED_DIM")
+                _emit_hidden_export(out_expr, "after_attn", count_expr)
+                _emit_hidden_export_last_row(out_expr, "after_attn", row_dim)
             elif op_instance_idx == 1:
-                lines.append(f'    ck_debug_export_hidden(model, {layer}, "layer_out", (const float*){out_expr}, EMBED_DIM);')
-                _emit_hidden_export_last_row(out_expr, "layer_out", "EMBED_DIM")
+                _emit_hidden_export(out_expr, "layer_out", count_expr)
+                _emit_hidden_export_last_row(out_expr, "layer_out", row_dim)
+    elif op_name == "layernorm":
+        out_expr = _hidden_arg("output", "out", "x", "y")
+        count_expr = _mul_expr(
+            _hidden_arg("tokens", "num_tokens", "rows"),
+            _hidden_arg("d_model", "embed_dim", "dim"),
+        )
+        if str(section or "") == "footer":
+            label = "post_ln"
+        elif op_instance_idx == 0:
+            label = "ln1"
+        elif op_instance_idx == 1:
+            label = "ffn_inp_normed"
+        else:
+            label = "layernorm"
+        _emit_hidden_export(out_expr, label, count_expr)
+        _emit_hidden_export_last_row(
+            out_expr,
+            label,
+            _hidden_arg("d_model", "embed_dim", "dim"),
+        )
     elif op_name == "rmsnorm":
         out_expr = _hidden_arg("output", "out", "x", "y")
         if op_instance_idx == 0:
@@ -1917,7 +1993,13 @@ def emit_op(
             if _same_op("position_embeddings"):
                 _emit_dump(_get_arg("x"), "inp_pos_emb", _mul_expr(_get_arg("grid_h"), _get_arg("grid_w"), _get_arg("embed_dim")))
                 return _return_lines(append_stop=True)
-            if _same_op("layernorm", "layernorm_forward_unrolled_slice", "layernorm_forward_rolled_slice"):
+            if _same_op(
+                "layernorm",
+                "layernorm_fp32_exact",
+                "layernorm_naive_serial_matched_precision",
+                "layernorm_forward_unrolled_slice",
+                "layernorm_forward_rolled_slice",
+            ):
                 dump_label = None
                 if str(section or "") == "footer":
                     dump_label = "post_ln"

--- a/version/v8/scripts/compare_qwen3vl_bf16_vision_hidden_v8.py
+++ b/version/v8/scripts/compare_qwen3vl_bf16_vision_hidden_v8.py
@@ -125,6 +125,7 @@ def _torch_captures(
         ) -> torch.Tensor:
             wanted = wanted_by_layer.get(layer, set())
             internal = {
+                "qkv_packed",
                 "q_proj",
                 "k_proj",
                 "v_proj",
@@ -143,8 +144,11 @@ def _torch_captures(
                 )
 
             seq_length = hidden_states.shape[0]
+            packed_qkv = attn.qkv(hidden_states)
+            if "qkv_packed" in wanted:
+                captures[f"qkv_packed@{layer}"] = packed_qkv.contiguous().detach().cpu().float()
             query_states, key_states, value_states = (
-                attn.qkv(hidden_states).reshape(seq_length, 3, attn.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
+                packed_qkv.reshape(seq_length, 3, attn.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
             )
             if "q_proj" in wanted:
                 captures[f"q_proj@{layer}"] = query_states.permute(1, 0, 2).contiguous().detach().cpu().float()
@@ -269,7 +273,7 @@ def _torch_captures(
         block = model.blocks[layer]
         if "ln1" in wanted:
             handles.append(block.norm1.register_forward_hook(make_norm1_hook(layer)))
-        if {"q_proj", "k_proj", "v_proj", "rope_q", "rope_k", "attn_out_head_major", "out_proj"} & wanted:
+        if {"qkv_packed", "q_proj", "k_proj", "v_proj", "rope_q", "rope_k", "attn_out_head_major", "out_proj"} & wanted:
             original_forward = block.attn.forward
             original_attn_forwards.append((block.attn, original_forward))
             block.attn.forward = make_attn_forward(block.attn, layer, original_forward)  # type: ignore[method-assign]
@@ -297,10 +301,12 @@ def _torch_captures(
 
     try:
         with torch.no_grad():
-            if {"vision_patch_sum", "vision_position_embeddings"} & frontend_wanted:
+            if {"vision_patch_sum", "vision_patch_bias", "vision_position_embeddings"} & frontend_wanted:
                 patch_sum = model.patch_embed(pixel_values)
                 if "vision_patch_sum" in frontend_wanted:
                     captures["vision_patch_sum"] = patch_sum.detach().cpu().float()
+                if "vision_patch_bias" in frontend_wanted:
+                    captures["vision_patch_bias"] = patch_sum.detach().cpu().float()
                 if "vision_position_embeddings" in frontend_wanted:
                     pos_embeds = model.fast_pos_embed_interpolate(grid)
                     captures["vision_position_embeddings"] = (patch_sum + pos_embeds).detach().cpu().float()
@@ -312,6 +318,9 @@ def _torch_captures(
             attn.forward = original_forward  # type: ignore[method-assign]
         for handle in handles:
             handle.remove()
+
+    if "vision_output" in frontend_wanted:
+        captures["vision_output"] = torch.cat([final, *deepstack], dim=-1).detach().cpu().float()
 
     prefix_orders: dict[str, dict[str, float]] = {}
     if torch_prefix is not None and torch_prefix.exists():
@@ -472,7 +481,20 @@ def _run_ck_selector(args: argparse.Namespace, selector: str, numeric: Any) -> n
         planar_image=planar_image,
         output_name=selector,
     )
-    return _array_to_np(data)
+    result = _array_to_np(data)
+    base_name, _ = _parse_selector(selector)
+    head_major_names = {"q_proj", "k_proj", "v_proj", "rope_q", "rope_k", "attn_out_head_major"}
+    if base_name in head_major_names:
+        head_dim = int(cfg.get("head_dim") or cfg.get("aligned_head_dim") or 0)
+        if base_name in {"q_proj", "rope_q", "attn_out_head_major"}:
+            heads = int(cfg.get("num_heads") or cfg.get("vision_num_heads") or 0)
+        else:
+            heads = int(cfg.get("num_kv_heads") or cfg.get("vision_num_kv_heads") or cfg.get("num_heads") or 0)
+        row_width = heads * head_dim
+        if row_width > 0 and result.size % row_width == 0:
+            tokens = result.size // row_width
+            result = result.reshape(tokens, heads, head_dim).transpose(1, 0, 2).copy().reshape(-1)
+    return result
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -1359,12 +1359,9 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
                 preproc = json.loads(preproc_path.read_text(encoding="utf-8"))
             except Exception:
                 preproc = {}
-        if head_dim == 72:
-            vision_mrope_sections = [16, 24, 24, 16]
-        elif head_dim > 0:
-            base = max(1, head_dim // 4)
-            rem = max(0, head_dim - base * 4)
-            vision_mrope_sections = [base + (1 if i < rem else 0) for i in range(4)]
+        if head_dim > 0:
+            axis_pairs = max(1, head_dim // 4)
+            vision_mrope_sections = [axis_pairs, axis_pairs, axis_pairs, axis_pairs]
         else:
             vision_mrope_sections = [1, 1, 1, 1]
         cfg.update({
@@ -1400,6 +1397,7 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "vision_grid_h": grid,
             "vision_grid_w": grid,
             "position_grid_size": grid,
+            "position_interpolation_policy": "align_corners_bilinear",
             "vision_num_patches": pos_rows,
             "spatial_merge_size": merge,
             "spatial_merge_factor": merge_factor,
@@ -1418,7 +1416,7 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "preproc_image_size": int(preproc.get("size", {}).get("shortest_edge", 0) or 0) if isinstance(preproc.get("size"), dict) else 0,
             "rope_layout": "multi_section_2d",
             "vision_mrope_sections": vision_mrope_sections,
-            "vision_mrope_n_dims": int(head_dim),
+            "vision_mrope_n_dims": max(1, int(head_dim) // 2),
             "vision_mrope_freq_base": 10000.0,
             "vision_mrope_freq_scale": 1.0,
             "vision_mrope_ext_factor": 0.0,

--- a/version/v8/templates/qwen3_vl_vision.json
+++ b/version/v8/templates/qwen3_vl_vision.json
@@ -78,7 +78,10 @@
     "patch_proj": "gemm_nt_fp32_exact",
     "patch_proj_aux": "gemm_nt_fp32_exact",
     "add_stream": "add_stream_reorder_2d",
-    "position_embeddings": "position_embeddings_add_tiled_2d",
+    "position_embeddings": {
+      "default": "position_embeddings_add_tiled_2d",
+      "align_corners_bilinear": "position_embeddings_add_tiled_2d_align_corners"
+    },
     "spatial_merge": "spatial_merge_contiguous_tiled",
     "branch_spatial_merge": "spatial_merge_contiguous_tiled",
     "layernorm": "layernorm_fp32_exact",


### PR DESCRIPTION
## Why

Qwen3-VL safetensors vision lowering used the wrong position interpolation coordinates and invalid vision M-RoPE dimensions. On the BF16 Xeon lane this caused substantial prefix drift and could make RoPE silently do nothing.

## What

- add PyTorch-compatible bilinear align-corners tiled position interpolation
- emit vision M-RoPE pair width as `head_dim / 2` with repeated axis sections
- reject invalid M-RoPE section/width combinations during lowering
- preserve interpolation policy through conversion, IR, kernel maps, and generated calls
- add bounded semantic exports for Q/K/V, RoPE, attention, normalization, and projector boundaries
- make `nightly-bf16` build engine and vision libraries so the M-RoPE guard cannot silently skip
- add a named 16-test Qwen3-VL template/codegen nightly row and docs coverage

## Xeon real-model result

Canonical `ocr/1 81.jpg`:

| Boundary | Before | After |
|---|---:|---:|
| Position RMSE | 0.00794 | 0.00116 |
| Post-RoPE Q cosine | 0.6167 | 0.999970 |
| Layer-0 output projection cosine | - | 0.999985 |
| Final prefix cosine | 0.308 | 0.996712 |
| Deepstack slices | - | 0.9991-0.9999 |

Full BF16 parity is not claimed. Remaining drift is concentrated in the main final projector path.

## Validation

- `make test-v8-vision-kernels`: pass; align-corners max error `8.34e-7`
- `make test-v8-qwen3vl`: 16/16
- `make nightly-bf16`: 12/12
- `v8-regression-fast`: pass
- pre-push build, Gemma3 E2E, v8 inference contracts, v7 training smoke, and training-kernel parity: pass
- Python `py_compile`
- `git diff --check`

The broad v7 family gate reproduced existing Gemma/Qwen2/Nanbeige parity/coherence failures unrelated to this v8 vision patch; these are not represented as passing.

## Research

`logs/2026-07-10-qwen3vl-bf16-vision-parity/README.md`