### PR TITLE
fix(v8): harden Qwen3-VL BF16 mixed prefill

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,7 +13,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT_DIR" ]; then
+    ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
 HOME_DIR="${HOME:-$ROOT_DIR}"
 
 RED='\033[0;31m'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,7 +12,10 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT_DIR" ]; then
+    ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
 
 # Colors
 RED='\033[0;31m'
@@ -33,6 +36,11 @@ if [ -n "$CK_SKIP_PREPUSH" ]; then
 fi
 
 cd "$ROOT_DIR"
+
+PREPUSH_ROOT="${CK_PREPUSH_ROOT:-${HOME:-$ROOT_DIR}/.cache/ck-engine/prepush}"
+PREPUSH_REGRESSION_ROOT="${PREPUSH_ROOT}/regression"
+PREPUSH_TRAIN_REPORT_ROOT="${PREPUSH_ROOT}/training-reports"
+mkdir -p "$PREPUSH_REGRESSION_ROOT" "$PREPUSH_TRAIN_REPORT_ROOT"
 
 failed=0
 declare -A CK_PUSH_SHA_SEEN=()
@@ -464,15 +472,18 @@ fi
 # =============================================================================
 if [ "$ck_should_run_v7_regression_fast" = "1" ] || [ "$ck_should_run_v8_regression_fast" = "1" ]; then
     echo -e "${YELLOW}[5.5/6]${NC} Running fast regression..."
+    rm -rf "${PREPUSH_REGRESSION_ROOT}/runs" "${PREPUSH_REGRESSION_ROOT}/reports"
+    mkdir -p "${PREPUSH_REGRESSION_ROOT}/runs" "${PREPUSH_REGRESSION_ROOT}/reports"
+    echo -e "${YELLOW}  ↳ disk-backed run root: ${PREPUSH_REGRESSION_ROOT}${NC}"
     regression_pids=()
     regression_names=()
     if [ "$ck_should_run_v7_regression_fast" = "1" ]; then
-        make --no-print-directory v7-regression-fast REGRESSION_ARGS="--run-root /tmp/ck-prepush-regression/runs/v7 --report-root /tmp/ck-prepush-regression/reports/v7" > /tmp/ck_regression_fast_v7.log 2>&1 &
+        make --no-print-directory v7-regression-fast REGRESSION_ARGS="--run-root ${PREPUSH_REGRESSION_ROOT}/runs/v7 --report-root ${PREPUSH_REGRESSION_ROOT}/reports/v7" > /tmp/ck_regression_fast_v7.log 2>&1 &
         regression_pids+=("$!")
         regression_names+=("v7")
     fi
     if [ "$ck_should_run_v8_regression_fast" = "1" ]; then
-        make --no-print-directory v8-regression-fast REGRESSION_ARGS="--run-root /tmp/ck-prepush-regression/runs/v8 --report-root /tmp/ck-prepush-regression/reports/v8" > /tmp/ck_regression_fast_v8.log 2>&1 &
+        make --no-print-directory v8-regression-fast REGRESSION_ARGS="--run-root ${PREPUSH_REGRESSION_ROOT}/runs/v8 --report-root ${PREPUSH_REGRESSION_ROOT}/reports/v8" > /tmp/ck_regression_fast_v8.log 2>&1 &
         regression_pids+=("$!")
         regression_names+=("v8")
     fi
@@ -494,7 +505,7 @@ fi
 # =============================================================================
 if [ "${CK_V7_KERNEL_PARITY_TRAIN:-1}" = "1" ]; then
     echo -e "${YELLOW}[6/6]${NC} Running training-kernel parity gate..."
-    if make --no-print-directory v7-kernel-parity-train > /tmp/ck_v7_kernel_parity_train.log 2>&1; then
+    if make --no-print-directory v7-kernel-parity-train V7_REPORT_DIR="${PREPUSH_TRAIN_REPORT_ROOT}" > /tmp/ck_v7_kernel_parity_train.log 2>&1; then
         echo -e "${GREEN}  ✓ v7 training-kernel parity passed${NC}"
     else
         echo -e "${RED}  ✗ v7 training-kernel parity failed${NC}"

--- a/Makefile
+++ b/Makefile
@@ -1969,6 +1969,8 @@ test-bf16: $(LIB) test-libs
 	echo "BF16 Python kernel tests completed."
 	@echo "Running v8 BF16 safetensors/lowering guardrails..."
 	$(PYTHON) $(PYTHONFLAGS) $(PY_TESTS_BF16_V8)
+	@echo "Running v8 BF16 file-backed BUMP allocator guardrail..."
+	$(PYTHON) $(PYTHONFLAGS) unittest/test_bump_alloc_mixed.py
 
 test-v4-q4k:
 	@if [ -z "$(GGUF_PATH)" ]; then \

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -332,6 +332,11 @@ TEST_SUITES = {
         ROOT / "version" / "v8" / "scripts" / "bf16_safetensors_lowering_guard_v8.py",
         timeout_sec=180,
     ),
+    "v8_bf16_file_backed_bump": TestSuite(
+        "v8 BF16 file-backed BUMP",
+        "bf16",
+        UNITTEST_DIR / "test_bump_alloc_mixed.py",
+    ),
 
     # Quantization tests
     # NOTE: test_quant_kernels.py and test_q4_k_quantize.py removed - use llamacpp-parity-full
@@ -781,6 +786,27 @@ def run_python_test(suite: TestSuite, verbose: bool = False) -> TestResult:
         # Parse sub-test results from output
         sub_tests = parse_sub_tests(result.stdout)
 
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        explicit_skip = next(
+            (
+                line.strip()
+                for line in combined_output.splitlines()
+                if "skipping this test" in line.lower() or line.strip().lower().startswith("test skipped:")
+            ),
+            "",
+        )
+
+        if result.returncode == 0 and explicit_skip:
+            return TestResult(
+                name=suite.name,
+                category=suite.category,
+                status="skip",
+                duration_sec=duration,
+                stdout=_trim_output(result.stdout, PASS_STDOUT_CHARS),
+                stderr=_trim_output(result.stderr, PASS_STDERR_CHARS),
+                error_msg=explicit_skip,
+                sub_tests=sub_tests,
+            )
         if result.returncode == 0:
             return TestResult(
                 name=suite.name,

--- a/src/ckernel_alloc.c
+++ b/src/ckernel_alloc.c
@@ -34,12 +34,6 @@ static size_t align_up_bytes(size_t n, size_t align)
     return (n + align - 1) & ~(align - 1);
 }
 
-static size_t align_down_bytes(size_t n, size_t align)
-{
-    if (align == 0) return n;
-    return n & ~(align - 1);
-}
-
 static int record_allocation(void *ptr, size_t len, int was_mmap)
 {
     ck_huge_alloc_entry_t *entry = malloc(sizeof(*entry));
@@ -176,22 +170,10 @@ static int ck_bump_alloc_try_mixed(ck_bump_alloc_t *alloc, const char *weights_p
         fprintf(stderr, "ck_bump_alloc_init: invalid bump layout for mixed fallback\n");
         return -1;
     }
-    if (alloc->weights_base != 0) {
-        fprintf(stderr,
-                "ck_bump_alloc_init: mixed fallback currently requires weights_base == 0 (got %zu)\n",
-                alloc->weights_base);
-        return -1;
-    }
-    if (alloc->weights_base != align_down_bytes(alloc->weights_base, page_size)) {
-        fprintf(stderr,
-                "ck_bump_alloc_init: mixed fallback requires page-aligned weights_base (got %zu, page %zu)\n",
-                alloc->weights_base, page_size);
-        return -1;
-    }
 
     mapped_len = align_up_bytes(alloc->total_size, page_size);
-    prefix_len = alloc->weights_base;
-    weights_len = alloc->activations_base - alloc->weights_base;
+    prefix_len = 0;
+    weights_len = alloc->activations_base;
     weights_map_len = align_up_bytes(weights_len, page_size);
     runtime_map_start = align_up_bytes(alloc->activations_base, page_size);
 
@@ -239,7 +221,7 @@ static int ck_bump_alloc_try_mixed(ck_bump_alloc_t *alloc, const char *weights_p
     }
 
     if (weights_map_len > 0) {
-        void *mapped = mmap(base + alloc->weights_base, weights_map_len,
+        void *mapped = mmap(base, weights_map_len,
                             PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, fd, 0);
         if (mapped == MAP_FAILED) {
             fprintf(stderr, "ck_bump_alloc_init: weights mmap failed: %s\n", strerror(errno));

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -998,7 +998,6 @@ def _write_tiny_qwen3vl_checkpoint(checkpoint: Path) -> None:
                     "max_position_embeddings": 64,
                     "rope_theta": 5000000.0,
                     "rms_norm_eps": 1e-6,
-                    "tie_word_embeddings": False,
                     "rope_scaling": {
                         "mrope_interleaved": True,
                         "mrope_section": [1, 1, 2],
@@ -1123,6 +1122,56 @@ def test_qwen3vl_safetensors_auto_text_ignores_vision(tmp_path: Path) -> None:
     assert "layer.0.q_norm" in names
     assert "layer.0.k_norm" in names
     assert "output.weight" in names
+    assert manifest["config"]["tie_word_embeddings"] is False
+    assert manifest["config"]["num_deepstack_layers"] == 1
+
+    real_out = tmp_path / "out_qwen3vl_text_real"
+    real_out.mkdir()
+    subprocess.run(
+        [
+            sys.executable, str(script),
+            "--checkpoint", str(checkpoint),
+            "--output", str(real_out / "weights.bump"),
+            "--config-out", str(real_out / "config.json"),
+            "--manifest-out", str(real_out / "weights_manifest.json"),
+            "--arch", "auto",
+        ],
+        check=True,
+    )
+    real_manifest = json.loads((real_out / "weights_manifest.json").read_text(encoding="utf-8"))
+    preview_offsets = {entry["name"]: entry["file_offset"] for entry in manifest["entries"]}
+    real_offsets = {entry["name"]: entry["file_offset"] for entry in real_manifest["entries"]}
+    assert preview_offsets == real_offsets
+    assert (real_out / "weights.bump").stat().st_size > 0
+
+    build_ir = Path("version/v8/scripts/build_ir_v8.py")
+    lowered = out / "lowered_text.json"
+    call = out / "call_text.json"
+    layout = out / "layout_text.json"
+    subprocess.run(
+        [
+            sys.executable, str(build_ir),
+            "--manifest", str(out / "weights_manifest.json"),
+            "--mode", "decode",
+            "--output", str(out / "ir1_text.json"),
+            "--layout-output", str(layout),
+            "--lowered-output", str(lowered),
+            "--call-output", str(call),
+            "--context-len", "4",
+        ],
+        check=True,
+    )
+    text_ops = json.loads(lowered.read_text(encoding="utf-8"))["operations"]
+    layer0_projection_ops = {
+        op["op"]: op["kernel"] for op in text_ops
+        if op.get("layer") == 0 and op.get("op") in {"q_proj", "k_proj", "v_proj"}
+    }
+    assert layer0_projection_ops == {
+        "q_proj": "gemm_nt_bf16",
+        "k_proj": "gemm_nt_bf16",
+        "v_proj": "gemm_nt_bf16",
+    }
+    assert not any(op.get("op") == "qkv_proj" for op in text_ops)
 
 
 def test_qwen3vl_safetensors_vision_maps_temporal_patch_split(tmp_path: Path) -> None:

--- a/unittest/test_bump_alloc_mixed.py
+++ b/unittest/test_bump_alloc_mixed.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Regression test for file-backed BUMP arenas with a nonzero metadata header."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MixedBumpAllocatorTest(unittest.TestCase):
+    @unittest.skipUnless(os.name == "posix", "mixed file-backed allocator is Linux/POSIX-only")
+    def test_nonzero_weights_base_maps_absolute_file_offsets(self) -> None:
+        source = r'''
+#include "ckernel_alloc.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    if (argc != 2) return 10;
+    ck_bump_alloc_t alloc;
+    if (ck_bump_alloc_init(&alloc, argv[1], 8192, 3, 4096) != 0) return 11;
+    if (alloc.mode != CK_BUMP_MODE_MIXED_FILE_BACKED) return 12;
+    for (int i = 0; i < 4096; ++i) {
+        if (alloc.base[i] != (uint8_t)(i % 251)) return 13;
+    }
+    alloc.base[4096] = 0xA5;
+    if (alloc.base[4096] != 0xA5) return 14;
+    ck_bump_alloc_free(&alloc);
+    return 0;
+}
+'''
+        with tempfile.TemporaryDirectory(prefix="ck_bump_mixed_") as td:
+            work = Path(td)
+            bump = work / "weights.bump"
+            bump.write_bytes(bytes(i % 251 for i in range(4096)))
+            src = work / "probe.c"
+            exe = work / "probe"
+            src.write_text(source, encoding="ascii")
+            subprocess.run(
+                [
+                    os.environ.get("CC", "cc"),
+                    "-std=c11",
+                    "-I",
+                    str(ROOT / "include"),
+                    str(src),
+                    str(ROOT / "src/ckernel_alloc.c"),
+                    "-lpthread",
+                    "-o",
+                    str(exe),
+                ],
+                check=True,
+            )
+            env = dict(os.environ)
+            env["CK_BUMP_FORCE_MIXED"] = "1"
+            subprocess.run([str(exe), str(bump)], check=True, env=env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -5095,7 +5095,8 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             if weight_dtype == "fp32":
                 weight_dtype = header_quant.get(weight_info[0], weight_dtype)
             weight_dtype = str(weight_dtype or "fp32").lower()
-            if op in BF16_DENSE_MATMUL_OPS and weight_dtype == "bf16":
+            force_split_dense_qkv = op == "qkv_proj"
+            if op in BF16_DENSE_MATMUL_OPS and weight_dtype == "bf16" and not force_split_dense_qkv:
                 return ["gemm_nt_bf16"]
             kernel_prefer_q8_activation = _prefer_q8_activation_for_op(op, prefer_q8_activation)
             if op in ("mlp_gate_up", "mlp_up", "mlp_down") and prefer_fp32_mlp_matmuls:
@@ -5116,7 +5117,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                 # Preserve the reference contract flow: select the FP32-activation
                 # kernel first, then remap to the internal Q8 contract adapter.
                 kernel_prefer_q8_activation = False
-            kernel_id = find_kernel(
+            kernel_id = None if force_split_dense_qkv else find_kernel(
                 registry, op=kernel_op, quant={"weight": weight_dtype}, mode=mode,
                 prefer_q8_activation=kernel_prefer_q8_activation,
                 prefer_parallel=use_parallel

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -2752,7 +2752,7 @@ static int do_init(const char *weights_path) {{
     g_model->bump_size = g_model->bump_alloc.total_size;
     memset(g_model->bump + BUMP_ACT_OFFSET, 0, g_model->bump_size - BUMP_ACT_OFFSET);
 
-    g_model->bump_weights = g_model->bump + BUMP_WEIGHTS_OFFSET;
+    g_model->bump_weights = g_model->bump; /* Manifest runtime offsets are absolute. */
     g_model->activations = (float*)(g_model->bump + BUMP_ACT_OFFSET);
     g_model->kv_cache = (float*)(g_model->bump + A_KV_CACHE);
     g_model->kv_cache_f16 = (uint16_t*)(g_model->bump + A_KV_CACHE);

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -1052,7 +1052,10 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
     cfg.setdefault("rope_param_mode", "per_layer_direct")
     cfg.setdefault("rms_eps", text.get("rms_norm_eps", text.get("rms_norm_epsilon", 1e-6)))
     cfg.setdefault("rms_norm_eps", cfg.get("rms_eps"))
-    cfg.setdefault("tie_word_embeddings", bool(text.get("tie_word_embeddings", True)))
+    cfg.setdefault(
+        "tie_word_embeddings",
+        bool(text.get("tie_word_embeddings", hf.get("tie_word_embeddings", True))),
+    )
     if arch == "nemotron_h":
         layer_kinds = _parse_nemotron_h_pattern(str(text.get("hybrid_override_pattern") or ""), int(cfg.get("num_layers") or 0))
         mamba_num_heads = int(text.get("mamba_num_heads") or 0)
@@ -1321,6 +1324,7 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "video_token_id": int(hf.get("video_token_id") or 0),
             "vision_start_token_id": int(hf.get("vision_start_token_id") or 0),
             "vision_end_token_id": int(hf.get("vision_end_token_id") or 0),
+            "num_deepstack_layers": len((hf.get("vision_config") or {}).get("deepstack_visual_indexes") or []),
         })
         if mrope:
             cfg["mrope_sections"] = [int(v) for v in mrope] + ([0] if len(mrope) == 3 else [])
@@ -1804,10 +1808,11 @@ def main() -> int:
 
     config = _build_config(model_dir, arch, args.config_template)
     refs = _refs_for_arch(arch, config, headers)
+    tokenizer_payloads, tokenizer_contract, special_tokens = _tokenizer_payloads_from_json(model_dir, int(config.get("vocab_size") or 0))
     missing: list[str] = []
     entries_preview: list[dict[str, Any]] = []
     dtype_table: list[int] = []
-    offset = DATA_START + 4 + len(refs)
+    offset = DATA_START + 4 + len(refs) + len(tokenizer_payloads)
     for ref in refs:
         for src in ref.source_names:
             if src not in headers:
@@ -1832,8 +1837,6 @@ def main() -> int:
     if missing:
         uniq = sorted(set(missing))
         raise SystemExit("Missing required safetensors tensors:\n  " + "\n  ".join(uniq[:80]))
-
-    tokenizer_payloads, tokenizer_contract, special_tokens = _tokenizer_payloads_from_json(model_dir, int(config.get("vocab_size") or 0))
 
     audit = _build_source_audit(arch, headers, refs)
     audit_out = args.audit_out or (args.manifest_out.parent / "conversion_audit.json")


### PR DESCRIPTION
## Why

Qwen3-VL BF16 mixed prefill produced NaNs and invalid weight views because conversion, lowering, generated runtime offsets, and file-backed allocation disagreed. Nightly also reported unsupported AVX-512 BF16 tests as passes on AVX2-only hosts.

## What

- honor root-level `tie_word_embeddings=false`
- lower separate BF16 Q/K/V tensors as separate projections
- use absolute manifest offsets from the BUMP base
- include tokenizer dtype bytes in dry-run offset planning
- support nonzero BUMP headers in mixed file-backed mmap
- add dry-run/real offset and file-backed allocator guards
- report explicit unsupported-ISA BF16 exits as skipped
- expose the allocator guard in BF16 nightly
- make pre-commit/pre-push work from linked worktrees
- move large pre-push artifacts off tmpfs by default

## Validation

- `make nightly-bf16`: 3 passed, 10 hardware skips, 0 failed on AVX2
- `make test-bf16`: passed; native AVX-512 BF16 cases skipped on this host
- focused Qwen3-VL safetensors conversion/lowering test: passed
- v8 fast regression: passed
- v7 kernel-map contracts: passed
- v7 training contract smoke: passed
- v7 training-kernel parity: passed
- pre-push build, visualizer, E2E and v8 contracts: passed

Existing v7 Gemma/Qwen2/Nanbeige fast-regression failures remain and are not represented as passing.

## Xeon signoff required

This AVX2 host validates conversion, graph/lowering, offsets, mmap, and software/reference semantics. A Xeon with AVX-512 BF16/AMX must run native BF16 validation before merge:

```bash
git fetch origin
git switch fix-qwen3vl-bf16-mixed-prefill
make nightly-bf16
make test-bf16
```

Then rerun the canonical Qwen3-VL BF16 mixed-prefill comparison and report first-token/top-k/logit metrics plus the first teacher-forced divergence.