### PR TITLE
test(v8): gate Qwen3-VL vision encoder accuracy

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -258,6 +258,32 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/ck-regression-runs" build/regression-reports
           make regression-fast REGRESSION_ARGS="--run-root ${RUNNER_TEMP}/ck-regression-runs --report-root build/regression-reports" 2>&1 | tee build/regression_fast.log
 
+      - name: Prepare scheduled Qwen3-VL encoder parity
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          HF_HOME: ${{ runner.temp }}/huggingface
+        run: |
+          avail_kb=$(awk '/MemAvailable:/ {print $2}' /proc/meminfo)
+          free_kb=$(df -Pk "${RUNNER_TEMP}" | awk 'NR==2 {print $4}')
+          if [ "${avail_kb:-0}" -lt $((8 * 1024 * 1024)) ] || [ "${free_kb:-0}" -lt $((6 * 1024 * 1024)) ]; then
+            echo "Qwen3-VL encoder parity not eligible: needs 8 GiB available RAM and 6 GiB free disk"
+            exit 0
+          fi
+
+          mmproj=$(python -c 'from huggingface_hub import hf_hub_download; print(hf_hub_download(repo_id="Qwen/Qwen3-VL-8B-Instruct-GGUF", filename="mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf"))')
+          echo "V8_QWEN3VL_CACHED_MMPROJ=${mmproj}" >> "${GITHUB_ENV}"
+          echo "V8_VISION_ENCODER_ALLOW_NON_AVX512=1" >> "${GITHUB_ENV}"
+          echo "CK_LLAMA_CPP_ROOT=${GITHUB_WORKSPACE}/llama.cpp" >> "${GITHUB_ENV}"
+          echo "Scheduled Q8_0 encoder parity enabled with ${mmproj}"
+
+          if [ "${avail_kb:-0}" -ge $((16 * 1024 * 1024)) ] && [ "${free_kb:-0}" -ge $((18 * 1024 * 1024)) ]; then
+            decoder=$(python -c 'from huggingface_hub import hf_hub_download; print(hf_hub_download(repo_id="Qwen/Qwen3-VL-8B-Instruct-GGUF", filename="Qwen3VL-8B-Instruct-Q4_K_M.gguf"))')
+            echo "V8_QWEN3VL_CACHED_MODEL=${decoder}" >> "${GITHUB_ENV}"
+            echo "Scheduled Q4_K_M decoder plus Q8_0 encoder smoke enabled"
+          else
+            echo "Q4_K_M end-to-end smoke not eligible: needs 16 GiB available RAM and 18 GiB free disk"
+          fi
+
       - name: Run Nightly Test Suite
         run: |
           echo "=== Running Full Nightly Test Suite ==="

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,17 @@ V8_QWEN3VL_ENCODER_PARITY_IMAGE_MAX_TOKENS ?= 1024
 V8_QWEN3VL_ENCODER_PARITY_MIN_COSINE ?= 0.99
 V8_QWEN3VL_ENCODER_PARITY_MAX_RMSE ?= 0.03
 V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT ?= /opt/app-root/src/Software/llama.cpp
+V8_VISION_ENCODER_FAMILY ?= qwen3vl
+V8_VISION_ENCODER_MODE ?= all
+V8_VISION_ENCODER_OUTPUT ?= build/vision_encoder_accuracy
+V8_VISION_ENCODER_THREADS ?= 20
+V8_VISION_ENCODER_REQUIRE_ARTIFACTS ?= 0
+V8_VISION_ENCODER_ALLOW_NON_AVX512 ?= 0
+V8_VISION_ENCODER_FULL_LAYERS ?= 0
+V8_VISION_ENCODER_KEEP_ARTIFACTS ?= 0
+V8_QWEN3VL_BF16_CHECKPOINT ?=
+V8_QWEN3VL_BF16_RUNTIME ?=
+V8_QWEN3VL_BF16_WEIGHTS ?=
 V8_GEMMA4_MODEL ?= hf://unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf
 V8_GEMMA4_MMPROJ ?= hf://unsloth/gemma-4-E4B-it-GGUF/mmproj-F16.gguf
 V8_GEMMA4_CACHE_DIR ?= /opt/app-root/src/.cache/ck-engine-v8/models/unsloth--gemma-4-E4B-it-GGUF
@@ -1266,15 +1277,17 @@ test-head-major-q5-outproj-quick: $(LIB)
 
 test-v8-qwen3vl: $(LIB_VISION)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) tests/test_v8_qwen3vl_template.py
+	$(PYTHON) $(PYTHONFLAGS) tests/test_v8_vision_encoder_accuracy_gate.py
+	$(PYTHON) $(PYTHONFLAGS) tests/test_nightly_runner_artifact_status.py
 
 test-v8-qwen3vl-e2e-smoke:
 	@if [ ! -f "$(V8_QWEN3VL_CACHED_MODEL)" ] || [ ! -f "$(V8_QWEN3VL_CACHED_MMPROJ)" ]; then \
 		echo "SKIP: Qwen3-VL cached decoder/mmproj not found under $(V8_QWEN3VL_CACHE_DIR)"; \
 	else \
 		echo "Running cached v8 Qwen3-VL image -> mmproj -> decoder smoke..."; \
-		CK_NUM_THREADS=$${CK_NUM_THREADS:-24} OMP_NUM_THREADS=$${OMP_NUM_THREADS:-1} \
-			$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/ck_run_v8.py run "$(V8_QWEN3VL_MODEL)" \
-			--mmproj "hf://Qwen/Qwen3-VL-8B-Instruct-GGUF/mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf" \
+		CK_NUM_THREADS=$(V8_VISION_ENCODER_THREADS) OMP_NUM_THREADS=1 \
+			$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/ck_run_v8.py run "$(V8_QWEN3VL_CACHED_MODEL)" \
+			--mmproj "$(V8_QWEN3VL_CACHED_MMPROJ)" \
 			--image-path "$(V8_QWEN3VL_IMAGE)" \
 			--prompt "Explain this image." \
 			--context-len 1024 \
@@ -1393,6 +1406,28 @@ qwen3vl-encoder-prefix-parity:
 			--min-cosine $(V8_QWEN3VL_ENCODER_PARITY_MIN_COSINE) \
 			--max-rmse $(V8_QWEN3VL_ENCODER_PARITY_MAX_RMSE); \
 	fi
+
+vision-encoder-full:
+	CK_NUM_THREADS=$(V8_VISION_ENCODER_THREADS) OMP_NUM_THREADS=$(V8_VISION_ENCODER_THREADS) \
+		$(PYTHON) $(PYTHONFLAGS) version/v8/scripts/vision_encoder_accuracy_gate_v8.py \
+		--family "$(V8_VISION_ENCODER_FAMILY)" --mode "$(V8_VISION_ENCODER_MODE)" \
+		--output-dir "$(V8_VISION_ENCODER_OUTPUT)" --threads "$(V8_VISION_ENCODER_THREADS)" \
+		$(if $(wildcard $(V8_QWEN3VL_CACHED_MMPROJ)),--q4-mmproj "$(V8_QWEN3VL_CACHED_MMPROJ)",) \
+		$(if $(V8_QWEN3VL_BF16_CHECKPOINT),--bf16-checkpoint "$(V8_QWEN3VL_BF16_CHECKPOINT)",) \
+		$(if $(V8_QWEN3VL_BF16_RUNTIME),--bf16-runtime-dir "$(V8_QWEN3VL_BF16_RUNTIME)",) \
+		$(if $(V8_QWEN3VL_BF16_WEIGHTS),--bf16-weights-bump "$(V8_QWEN3VL_BF16_WEIGHTS)",) \
+		$(if $(filter 1,$(V8_VISION_ENCODER_REQUIRE_ARTIFACTS)),--require-artifacts,) \
+		$(if $(filter 1,$(V8_VISION_ENCODER_ALLOW_NON_AVX512)),--allow-non-avx512,) \
+		$(if $(filter 1,$(V8_VISION_ENCODER_FULL_LAYERS)),--full-layers,) \
+		$(if $(filter 1,$(V8_VISION_ENCODER_KEEP_ARTIFACTS)),--keep-artifacts,)
+
+vision-encoder-q4-full:
+	$(MAKE) vision-encoder-full V8_VISION_ENCODER_MODE=q4 V8_VISION_ENCODER_OUTPUT="$(V8_VISION_ENCODER_OUTPUT)/q4-only"
+
+vision-encoder-bf16-full:
+	$(MAKE) vision-encoder-full V8_VISION_ENCODER_MODE=bf16 V8_VISION_ENCODER_OUTPUT="$(V8_VISION_ENCODER_OUTPUT)/bf16-only"
+
+.PHONY: vision-encoder-full vision-encoder-q4-full vision-encoder-bf16-full
 
 test-deltanet: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) tests/test_deltanet.py $(ARGS)

--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -474,6 +474,20 @@
     </div>
 
     <div class="regression-section">
+      <h2>Vision Encoder Accuracy</h2>
+      <p class="regression-meta" id="vision-encoder-accuracy-meta">
+        No fresh artifact-backed encoder result was published by this run.
+      </p>
+      <div class="summary-cards" style="margin: 0 0 1rem 0;">
+        <div class="summary-card"><div class="value" id="vision-encoder-accuracy-status">-</div><div class="label">Overall</div></div>
+        <div class="summary-card"><div class="value" id="vision-encoder-q4-status">-</div><div class="label">Q8_0 vs llama.cpp</div></div>
+        <div class="summary-card"><div class="value" id="vision-encoder-bf16-status">-</div><div class="label">BF16 vs PyTorch</div></div>
+        <div class="summary-card"><div class="value" id="vision-encoder-layer-count">0</div><div class="label">Layer Checkpoints</div></div>
+      </div>
+      <div id="vision-encoder-accuracy-details" class="updated-time"></div>
+    </div>
+
+    <div class="regression-section">
       <h2>Vision Visualizer Artifacts</h2>
       <p class="regression-meta" id="vision-visualizer-meta">
         `make v8-visualizer-vision-artifacts` status is not available in this report yet.
@@ -747,6 +761,15 @@
       consumed, align-corners interpolation is selected, and M-RoPE arguments remain valid through generated calls. The target builds
       both engine and vision libraries first so hardware-independent M-RoPE checks cannot silently skip
       (<code>make nightly-bf16</code>)</li>
+    <li><strong>Vision Encoder Full Accuracy Gate</strong>: One local/nightly command runs Qwen3-VL Q8_0 mmproj parity against
+      llama.cpp, then BF16 safetensors parity against PyTorch when the checkpoint and AVX-512 BF16 runtime are available. The gate uses
+      a generated public <code>1152x896</code> form-like stress image, validates sparse encoder boundaries
+      (<code>0, 8, 16, 24, 26</code>) plus the final <code>1008x16384</code>-class prefix, and removes raw tensor dumps by default.
+      Use <code>make vision-encoder-full</code>; set <code>V8_VISION_ENCODER_REQUIRE_ARTIFACTS=1</code> on provisioned runners,
+      or <code>V8_VISION_ENCODER_FULL_LAYERS=1</code> for an exhaustive local sweep.</li>
+    <li><strong>Scheduled Q4 Vision Encoder Parity</strong>: Scheduled GitHub nightly runs download the Qwen3-VL Q8_0 mmproj only
+      when at least 8 GiB RAM and 6 GiB disk are available, then invoke the same <code>vision-encoder-full</code> target. Real BF16
+      tensor parity remains a periodic AVX-512 BF16 lane; synthetic BF16 conversion/lowering guards continue on every nightly.</li>
     <li><strong>FP16 Attention Contracts</strong>: Named numerical guards for llama.cpp-compatible unfused causal prefill and split-KV decode,
       including FP16 Q/K rounding, FP16 probability/value reduction, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding,
       the KV 511/512 semantic boundary, and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
@@ -794,7 +817,7 @@
   <div class="alert alert-info" style="margin-top: 1rem;">
     <span class="alert-icon">💡</span>
     <div>
-      <strong>Run locally:</strong> <code>make test</code> (kernel-focused), <code>make visualizer</code> (fast path), <code>make visualizer-full</code> (includes tiny train-runtime ASan checks), <code>make nightly</code> (full matrix).
+      <strong>Run locally:</strong> <code>make test</code> (kernel-focused), <code>make vision-encoder-full</code> (artifact-backed encoder parity), <code>make visualizer</code> (fast path), <code>make visualizer-full</code> (includes tiny train-runtime ASan checks), <code>make nightly</code> (full matrix).
       <br>
       <span style="color: var(--text-muted);">Nightly coverage now includes v7 kernel-map contracts, v7 backprop kernel parity, v8 vision kernel parity, published training family regression, visualizer runbook regression checks, and published <code>regression-fast</code> family summaries.</span>
     </div>
@@ -1069,6 +1092,7 @@ function renderResults(data) {
   document.getElementById('sub-tests-failed').textContent = subFailed;
   renderRegressionFast(data.regression_fast || null);
   renderArchitectureContracts(data.architecture_contracts || null);
+  renderVisionEncoderAccuracy(data.vision_encoder_accuracy || null);
   renderVisionVisualizer(data.vision_visualizer || null);
   renderKernelMapContracts(data.kernel_map_contracts || null);
   renderBackpropRegression(data.backprop_regression || null);
@@ -1213,6 +1237,30 @@ function contractBadge(status) {
   const cls = s === 'pass' ? 'pass' : s === 'fail' ? 'fail' : 'skip';
   const text = s === 'pass' ? 'PASS' : s === 'fail' ? 'FAIL' : s === 'warn' ? 'WARN' : s === 'partial' ? 'PARTIAL' : 'N/R';
   return `<span class="regression-badge ${cls}">${text}</span>`;
+}
+
+function renderVisionEncoderAccuracy(data) {
+  const meta = document.getElementById('vision-encoder-accuracy-meta');
+  const status = document.getElementById('vision-encoder-accuracy-status');
+  const q4 = document.getElementById('vision-encoder-q4-status');
+  const bf16 = document.getElementById('vision-encoder-bf16-status');
+  const layers = document.getElementById('vision-encoder-layer-count');
+  const details = document.getElementById('vision-encoder-accuracy-details');
+  if (!data) return;
+
+  const phases = data.phases || {};
+  const q4Phase = phases.q8_mmproj_llamacpp || phases.q4_llamacpp || {};
+  const bf16Phase = phases.bf16_pytorch || {};
+  const layerList = Array.isArray(data.layers) ? data.layers : [];
+  status.textContent = String(data.status || '-').toUpperCase();
+  q4.textContent = String(q4Phase.status || 'skip').toUpperCase();
+  bf16.textContent = String(bf16Phase.status || 'skip').toUpperCase();
+  layers.textContent = String(layerList.length);
+  meta.textContent = `family: ${data.family || '-'} | image: ${data.image_geometry ? data.image_geometry.join('x') : 'external'} | elapsed: ${Number(data.elapsed_sec || 0).toFixed(1)}s`;
+  const failures = Array.isArray(data.failures) ? data.failures : [];
+  details.innerHTML = failures.length
+    ? `<strong>Failures:</strong> ${failures.map(escapeHtml).join(' | ')}`
+    : `Checkpoints: ${layerList.join(', ') || '-'}; raw tensor dumps cleaned after metrics.`;
 }
 
 function renderVisionVisualizer(data) {

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1421,6 +1421,20 @@
     </div>
 
     <div class="regression-section">
+      <h2>Vision Encoder Accuracy</h2>
+      <p class="regression-meta" id="vision-encoder-accuracy-meta">
+        No fresh artifact-backed encoder result was published by this run.
+      </p>
+      <div class="summary-cards" style="margin: 0 0 1rem 0;">
+        <div class="summary-card"><div class="value" id="vision-encoder-accuracy-status">-</div><div class="label">Overall</div></div>
+        <div class="summary-card"><div class="value" id="vision-encoder-q4-status">-</div><div class="label">Q8_0 vs llama.cpp</div></div>
+        <div class="summary-card"><div class="value" id="vision-encoder-bf16-status">-</div><div class="label">BF16 vs PyTorch</div></div>
+        <div class="summary-card"><div class="value" id="vision-encoder-layer-count">0</div><div class="label">Layer Checkpoints</div></div>
+      </div>
+      <div id="vision-encoder-accuracy-details" class="updated-time"></div>
+    </div>
+
+    <div class="regression-section">
       <h2>Vision Visualizer Artifacts</h2>
       <p class="regression-meta" id="vision-visualizer-meta">
         `make v8-visualizer-vision-artifacts` status is not available in this report yet.
@@ -1694,6 +1708,15 @@
       consumed, align-corners interpolation is selected, and M-RoPE arguments remain valid through generated calls. The target builds
       both engine and vision libraries first so hardware-independent M-RoPE checks cannot silently skip
       (<code>make nightly-bf16</code>)</li>
+    <li><strong>Vision Encoder Full Accuracy Gate</strong>: One local/nightly command runs Qwen3-VL Q8_0 mmproj parity against
+      llama.cpp, then BF16 safetensors parity against PyTorch when the checkpoint and AVX-512 BF16 runtime are available. The gate uses
+      a generated public <code>1152x896</code> form-like stress image, validates sparse encoder boundaries
+      (<code>0, 8, 16, 24, 26</code>) plus the final <code>1008x16384</code>-class prefix, and removes raw tensor dumps by default.
+      Use <code>make vision-encoder-full</code>; set <code>V8_VISION_ENCODER_REQUIRE_ARTIFACTS=1</code> on provisioned runners,
+      or <code>V8_VISION_ENCODER_FULL_LAYERS=1</code> for an exhaustive local sweep.</li>
+    <li><strong>Scheduled Q4 Vision Encoder Parity</strong>: Scheduled GitHub nightly runs download the Qwen3-VL Q8_0 mmproj only
+      when at least 8 GiB RAM and 6 GiB disk are available, then invoke the same <code>vision-encoder-full</code> target. Real BF16
+      tensor parity remains a periodic AVX-512 BF16 lane; synthetic BF16 conversion/lowering guards continue on every nightly.</li>
     <li><strong>FP16 Attention Contracts</strong>: Named numerical guards for llama.cpp-compatible unfused causal prefill and split-KV decode,
       including FP16 Q/K rounding, FP16 probability/value reduction, FP16 online-softmax partials, FP32 ordered reduction, GQA/padding,
       the KV 511/512 semantic boundary, and the Qwen3-VL <code>KV=1058, H=32, D=128</code> shape
@@ -1741,7 +1764,7 @@
   <div class="alert alert-info" style="margin-top: 1rem;">
     <span class="alert-icon">💡</span>
     <div>
-      <strong>Run locally:</strong> <code>make test</code> (kernel-focused), <code>make visualizer</code> (fast path), <code>make visualizer-full</code> (includes tiny train-runtime ASan checks), <code>make nightly</code> (full matrix).
+      <strong>Run locally:</strong> <code>make test</code> (kernel-focused), <code>make vision-encoder-full</code> (artifact-backed encoder parity), <code>make visualizer</code> (fast path), <code>make visualizer-full</code> (includes tiny train-runtime ASan checks), <code>make nightly</code> (full matrix).
       <br>
       <span style="color: var(--text-muted);">Nightly coverage now includes v7 kernel-map contracts, v7 backprop kernel parity, v8 vision kernel parity, published training family regression, visualizer runbook regression checks, and published <code>regression-fast</code> family summaries.</span>
     </div>
@@ -2016,6 +2039,7 @@ function renderResults(data) {
   document.getElementById('sub-tests-failed').textContent = subFailed;
   renderRegressionFast(data.regression_fast || null);
   renderArchitectureContracts(data.architecture_contracts || null);
+  renderVisionEncoderAccuracy(data.vision_encoder_accuracy || null);
   renderVisionVisualizer(data.vision_visualizer || null);
   renderKernelMapContracts(data.kernel_map_contracts || null);
   renderBackpropRegression(data.backprop_regression || null);
@@ -2160,6 +2184,30 @@ function contractBadge(status) {
   const cls = s === 'pass' ? 'pass' : s === 'fail' ? 'fail' : 'skip';
   const text = s === 'pass' ? 'PASS' : s === 'fail' ? 'FAIL' : s === 'warn' ? 'WARN' : s === 'partial' ? 'PARTIAL' : 'N/R';
   return `<span class="regression-badge ${cls}">${text}</span>`;
+}
+
+function renderVisionEncoderAccuracy(data) {
+  const meta = document.getElementById('vision-encoder-accuracy-meta');
+  const status = document.getElementById('vision-encoder-accuracy-status');
+  const q4 = document.getElementById('vision-encoder-q4-status');
+  const bf16 = document.getElementById('vision-encoder-bf16-status');
+  const layers = document.getElementById('vision-encoder-layer-count');
+  const details = document.getElementById('vision-encoder-accuracy-details');
+  if (!data) return;
+
+  const phases = data.phases || {};
+  const q4Phase = phases.q8_mmproj_llamacpp || phases.q4_llamacpp || {};
+  const bf16Phase = phases.bf16_pytorch || {};
+  const layerList = Array.isArray(data.layers) ? data.layers : [];
+  status.textContent = String(data.status || '-').toUpperCase();
+  q4.textContent = String(q4Phase.status || 'skip').toUpperCase();
+  bf16.textContent = String(bf16Phase.status || 'skip').toUpperCase();
+  layers.textContent = String(layerList.length);
+  meta.textContent = `family: ${data.family || '-'} | image: ${data.image_geometry ? data.image_geometry.join('x') : 'external'} | elapsed: ${Number(data.elapsed_sec || 0).toFixed(1)}s`;
+  const failures = Array.isArray(data.failures) ? data.failures : [];
+  details.innerHTML = failures.length
+    ? `<strong>Failures:</strong> ${failures.map(escapeHtml).join(' | ')}`
+    : `Checkpoints: ${layerList.join(', ') || '-'}; raw tensor dumps cleaned after metrics.`;
 }
 
 function renderVisionVisualizer(data) {

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -533,6 +533,13 @@ MAKE_TARGETS = {
         "target": "test-v8-qwen3vl-e2e-smoke",
         "timeout_sec": 5400,
     },
+    "v8_vision_encoder_accuracy": {
+        "name": "v8 Vision Encoder Accuracy (AVX-512 artifact gate)",
+        "category": "bf16",
+        "target": "vision-encoder-full",
+        "timeout_sec": 21600,
+        "status_artifact": "build/vision_encoder_accuracy/summary.json",
+    },
     "v8_gemma4_vision_smoke": {
         "name": "v8 Gemma4 Vision Smoke",
         "category": "inference",
@@ -619,6 +626,7 @@ MAKE_TARGET_FAILURE_ARTIFACTS = {
     "v7-stabilization-nightly": ROOT / "version" / "v7" / ".cache" / "reports" / "training_stabilization_scorecard_latest.json",
     "test-architecture-contracts": ROOT / "version" / "v8" / ".cache" / "reports" / "architecture_contracts_latest.json",
     "v8-visualizer-vision-artifacts": ROOT / "version" / "v8" / ".cache" / "reports" / "vision_visualizer_latest.json",
+    "vision-encoder-full": ROOT / "build" / "vision_encoder_accuracy" / "summary.json",
 }
 
 
@@ -879,6 +887,13 @@ def run_make_target(target_info: dict, verbose: bool = False) -> TestResult:
                 perf_unit = target_info.get("perf_unit", "")
 
         status = "pass" if result.returncode == 0 else "fail"
+        status_artifact = target_info.get("status_artifact")
+        artifact_payload = None
+        if status_artifact:
+            artifact_payload = _load_json_if_fresh(ROOT / status_artifact, start_ts=start)
+            artifact_status = str((artifact_payload or {}).get("status") or "").lower()
+            if artifact_status in {"pass", "fail", "skip"}:
+                status = artifact_status
         error_msg = ""
         if status == "fail":
             # Look for error indicators in both stdout and stderr
@@ -1115,6 +1130,12 @@ def save_json_report(results: list[TestResult], filepath: Path, start_time: date
     )
     if vision_visualizer is not None:
         report["vision_visualizer"] = vision_visualizer
+    vision_encoder_accuracy = _load_json_if_fresh(
+        ROOT / "build" / "vision_encoder_accuracy" / "summary.json",
+        start_ts=start_time.timestamp(),
+    )
+    if vision_encoder_accuracy is not None:
+        report["vision_encoder_accuracy"] = vision_encoder_accuracy
     filepath.write_text(json.dumps(report, indent=2))
     print(f"\nJSON report saved to: {filepath}")
 

--- a/tests/test_nightly_runner_artifact_status.py
+++ b/tests/test_nightly_runner_artifact_status.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/nightly_runner.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("nightly_runner_artifact_test", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class NightlyArtifactStatusTests(unittest.TestCase):
+    def test_fresh_artifact_status_overrides_zero_exit(self) -> None:
+        runner = _load_runner()
+        target = {
+            "name": "artifact gate",
+            "category": "bf16",
+            "target": "fake-gate",
+            "timeout_sec": 10,
+            "status_artifact": "build/fake/summary.json",
+        }
+        completed = subprocess.CompletedProcess(["make", "fake-gate"], 0, stdout="", stderr="")
+        for artifact_status in ("pass", "skip", "fail"):
+            with self.subTest(status=artifact_status):
+                with mock.patch.object(runner.subprocess, "run", return_value=completed):
+                    with mock.patch.object(
+                        runner,
+                        "_load_json_if_fresh",
+                        return_value={"status": artifact_status},
+                    ):
+                        result = runner.run_make_target(target)
+                self.assertEqual(result.status, artifact_status)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v8_vision_encoder_accuracy_gate.py
+++ b/tests/test_v8_vision_encoder_accuracy_gate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "version/v8/scripts/vision_encoder_accuracy_gate_v8.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("vision_encoder_accuracy_gate_v8", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class VisionEncoderAccuracyGateTests(unittest.TestCase):
+    def test_relative_rmse_is_scale_aware(self) -> None:
+        import numpy as np
+        spec = importlib.util.spec_from_file_location("compare_qwen3vl_bf16", ROOT / "version/v8/scripts/compare_qwen3vl_bf16_vision_hidden_v8.py")
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        metrics = module._metrics(np.array([1000.0, -1000.0], dtype=np.float32), np.array([1010.0, -1010.0], dtype=np.float32))
+        self.assertAlmostEqual(metrics["rmse"], 10.0, places=5)
+        self.assertAlmostEqual(metrics["relative_rmse"], 0.01, places=5)
+
+    def test_large_public_fixture_is_deterministic_ppm(self) -> None:
+        gate = _load_gate()
+        with tempfile.TemporaryDirectory(prefix="vision_encoder_fixture_") as tmp:
+            first = Path(tmp) / "first.ppm"
+            second = Path(tmp) / "second.ppm"
+            gate._write_large_form(first)
+            gate._write_large_form(second)
+            data = first.read_bytes()
+            self.assertTrue(data.startswith(b"P6\n1152 896\n255\n"))
+            self.assertEqual(data, second.read_bytes())
+            self.assertEqual(len(data), len(b"P6\n1152 896\n255\n") + 1152 * 896 * 3)
+
+    def test_missing_artifact_is_skip_or_required_failure(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="vision_encoder_gate_") as tmp:
+            out = Path(tmp) / "skip"
+            base = [
+                sys.executable,
+                str(SCRIPT),
+                "--mode",
+                "q4",
+                "--allow-non-avx512",
+                "--output-dir",
+                str(out),
+            ]
+            skipped = subprocess.run(base, cwd=ROOT, check=False, capture_output=True, text=True)
+            self.assertEqual(skipped.returncode, 0, skipped.stdout + skipped.stderr)
+            self.assertEqual(json.loads((out / "summary.json").read_text())["status"], "skip")
+
+            required_out = Path(tmp) / "required"
+            required = subprocess.run(
+                [*base[:-1], str(required_out), "--require-artifacts"],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(required.returncode, 0)
+            report = json.loads((required_out / "summary.json").read_text())
+            self.assertEqual(report["status"], "fail")
+            self.assertTrue(report["failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version/v8/scripts/compare_qwen3vl_bf16_vision_hidden_v8.py
+++ b/version/v8/scripts/compare_qwen3vl_bf16_vision_hidden_v8.py
@@ -31,10 +31,14 @@ def _metrics(ref: np.ndarray, got: np.ndarray) -> dict[str, float]:
         raise RuntimeError(f"shape mismatch: ref={ref.shape} got={got.shape}")
     diff = got.astype(np.float32, copy=False) - ref.astype(np.float32, copy=False)
     denom = float(np.linalg.norm(ref) * np.linalg.norm(got))
+    rmse = float(math.sqrt(float(np.mean(diff * diff)))) if diff.size else 0.0
+    ref_rms = float(math.sqrt(float(np.mean(ref.astype(np.float32, copy=False) ** 2)))) if ref.size else 0.0
     return {
         "max_abs": float(np.max(np.abs(diff))) if diff.size else 0.0,
         "mean_abs": float(np.mean(np.abs(diff))) if diff.size else 0.0,
-        "rmse": float(math.sqrt(float(np.mean(diff * diff)))) if diff.size else 0.0,
+        "rmse": rmse,
+        "ref_rms": ref_rms,
+        "relative_rmse": rmse / ref_rms if ref_rms > 0.0 else (0.0 if rmse == 0.0 else float("inf")),
         "cosine": float(np.dot(ref.reshape(-1), got.reshape(-1)) / denom) if denom > 0.0 else 0.0,
     }
 
@@ -514,6 +518,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--threads", type=int, default=int(os.environ.get("CK_NUM_THREADS", "20") or "20"))
     ap.add_argument("--attn-implementation", choices=("auto", "eager", "sdpa"), default="auto")
     ap.add_argument("--skip-ck", action="store_true", help="Only run the PyTorch hook/reference side")
+    ap.add_argument("--min-cosine", type=float, default=None)
+    ap.add_argument("--max-rmse", type=float, default=None)
+    ap.add_argument("--max-abs", type=float, default=None)
+    ap.add_argument("--max-relative-rmse", type=float, default=None)
+    ap.add_argument("--final-max-rmse", type=float, default=None)
+    ap.add_argument("--final-max-abs", type=float, default=None)
     args = ap.parse_args(argv)
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
@@ -551,6 +561,21 @@ def main(argv: list[str] | None = None) -> int:
                 **_metrics(ref, ck),
             }
 
+    failures: list[str] = []
+    for selector, metrics in rows.items():
+        if args.min_cosine is not None and float(metrics["cosine"]) < args.min_cosine:
+            failures.append(f"{selector}: cosine {metrics['cosine']:.9f} < {args.min_cosine:.9f}")
+        if args.max_rmse is not None and float(metrics["rmse"]) > args.max_rmse:
+            failures.append(f"{selector}: rmse {metrics['rmse']:.9f} > {args.max_rmse:.9f}")
+        if args.max_abs is not None and float(metrics["max_abs"]) > args.max_abs:
+            failures.append(f"{selector}: max_abs {metrics['max_abs']:.9f} > {args.max_abs:.9f}")
+        if args.max_relative_rmse is not None and float(metrics["relative_rmse"]) > args.max_relative_rmse:
+            failures.append(f"{selector}: relative_rmse {metrics['relative_rmse']:.9f} > {args.max_relative_rmse:.9f}")
+        if selector == "vision_output" and args.final_max_rmse is not None and float(metrics["rmse"]) > args.final_max_rmse:
+            failures.append(f"{selector}: final rmse {metrics['rmse']:.9f} > {args.final_max_rmse:.9f}")
+        if selector == "vision_output" and args.final_max_abs is not None and float(metrics["max_abs"]) > args.final_max_abs:
+            failures.append(f"{selector}: final max_abs {metrics['max_abs']:.9f} > {args.final_max_abs:.9f}")
+
     report = {
         "checkpoint": str(args.checkpoint),
         "runtime_dir": str(args.runtime_dir),
@@ -564,11 +589,21 @@ def main(argv: list[str] | None = None) -> int:
         },
         "torch": torch_report,
         "comparisons": rows,
+        "thresholds": {
+            "min_cosine": args.min_cosine,
+            "max_rmse": args.max_rmse,
+            "max_abs": args.max_abs,
+            "max_relative_rmse": args.max_relative_rmse,
+            "final_max_rmse": args.final_max_rmse,
+            "final_max_abs": args.final_max_abs,
+        },
+        "failures": failures,
+        "status": "fail" if failures else "pass",
     }
     report_path = args.out_dir / "report.json"
     report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({"report": str(report_path), "comparisons": rows}, indent=2, sort_keys=True))
-    return 0
+    print(json.dumps({"report": str(report_path), "comparisons": rows, "failures": failures}, indent=2, sort_keys=True))
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":

--- a/version/v8/scripts/numeric_parity_qwen3vl_mmproj_v8.py
+++ b/version/v8/scripts/numeric_parity_qwen3vl_mmproj_v8.py
@@ -388,6 +388,7 @@ def _compile_mtmd_shim(output_dir: Path) -> Path:
         "-fPIC",
         "-O2",
         "-std=c++17",
+        *(["-DCK_MTMD_CLIP_OBJECT_API=1"] if "clip_embd_nbytes_by_img" not in (LLAMA_CPP_ROOT / "tools" / "mtmd" / "clip.h").read_text(encoding="utf-8", errors="ignore") else []),
         f"-I{LLAMA_CPP_ROOT / 'tools' / 'mtmd'}",
         f"-I{LLAMA_CPP_ROOT / 'ggml' / 'include'}",
         f"-I{LLAMA_CPP_ROOT / 'include'}",

--- a/version/v8/scripts/vision_encoder_accuracy_gate_v8.py
+++ b/version/v8/scripts/vision_encoder_accuracy_gate_v8.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Artifact-backed vision encoder accuracy gate.
+
+The gate deliberately uses the same implementation for local and nightly runs.
+It generates a public, deterministic large image so regressions that only occur
+with large visual grids are covered without committing private OCR documents.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+Q4_SUITE = SCRIPT_DIR / "qwen3vl_encoder_prefix_parity_suite_v8.py"
+BF16_SUITE = SCRIPT_DIR / "compare_qwen3vl_bf16_vision_hidden_v8.py"
+
+
+def _cpu_flags() -> set[str]:
+    try:
+        text = Path("/proc/cpuinfo").read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return set()
+    for line in text.splitlines():
+        if line.startswith(("flags", "Features")) and ":" in line:
+            return set(line.split(":", 1)[1].strip().split())
+    return set()
+
+
+def _write_large_form(path: Path, width: int = 1152, height: int = 896) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pixels = bytearray([248]) * (width * height * 3)
+
+    def rect(x0: int, y0: int, x1: int, y1: int, rgb: tuple[int, int, int]) -> None:
+        x0, x1 = max(0, x0), min(width, x1)
+        y0, y1 = max(0, y0), min(height, y1)
+        row = bytes(rgb) * max(0, x1 - x0)
+        for y in range(y0, y1):
+            start = (y * width + x0) * 3
+            pixels[start:start + len(row)] = row
+
+    # Generic form geometry: header, table rules, field strokes, and checkboxes.
+    rect(40, 32, width - 40, 38, (25, 48, 72))
+    rect(40, 70, 430, 78, (25, 48, 72))
+    for y in range(130, height - 48, 82):
+        rect(48, y, width - 48, y + 2, (105, 118, 126))
+        rect(72, y + 24, 330, y + 29, (42, 52, 58))
+        rect(390, y + 20, width - 90, y + 23, (120, 126, 132))
+        # Deterministic text-like bars expose spatial ordering without real data.
+        for word in range(7):
+            x = 390 + word * 86
+            bar = 30 + ((y // 2 + word * 17) % 46)
+            rect(x, y + 35, min(x + bar, width - 90), y + 39, (34, 38, 42))
+    for y in (170, 334, 498, 662):
+        rect(78, y, 98, y + 3, (20, 25, 30))
+        rect(78, y + 17, 98, y + 20, (20, 25, 30))
+        rect(78, y, 81, y + 20, (20, 25, 30))
+        rect(95, y, 98, y + 20, (20, 25, 30))
+        rect(82, y + 5, 95, y + 8, (35, 92, 55))
+        rect(88, y + 8, 92, y + 16, (35, 92, 55))
+
+    with path.open("wb") as out:
+        out.write(f"P6\n{width} {height}\n255\n".encode("ascii"))
+        out.write(pixels)
+
+
+def _run(cmd: list[str], *, env: dict[str, str], log: Path) -> None:
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("wb") as stream:
+        subprocess.run(cmd, cwd=REPO_ROOT, env=env, stdout=stream, stderr=subprocess.STDOUT, check=True)
+
+
+def _missing(paths: list[Path]) -> list[str]:
+    return [str(path) for path in paths if not path.exists()]
+
+
+def _cleanup_raw_tensors(root: Path) -> None:
+    for path in root.rglob("*.f32"):
+        path.unlink(missing_ok=True)
+
+
+def _phase(status: str, **values: Any) -> dict[str, Any]:
+    return {"status": status, **values}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Run the promoted v8 vision encoder accuracy gate.")
+    ap.add_argument("--family", choices=("qwen3vl",), default="qwen3vl")
+    ap.add_argument("--mode", choices=("all", "q4", "bf16"), default="all")
+    ap.add_argument("--output-dir", type=Path, default=Path("build/vision_encoder_accuracy"))
+    ap.add_argument("--q4-mmproj", type=Path)
+    ap.add_argument("--bf16-checkpoint", type=Path)
+    ap.add_argument("--bf16-runtime-dir", type=Path)
+    ap.add_argument("--bf16-weights-bump", type=Path)
+    ap.add_argument("--image", type=Path)
+    ap.add_argument("--threads", type=int, default=int(os.environ.get("CK_NUM_THREADS", "20") or "20"))
+    ap.add_argument("--full-layers", action="store_true")
+    ap.add_argument("--require-artifacts", action="store_true")
+    ap.add_argument("--allow-non-avx512", action="store_true")
+    ap.add_argument("--keep-artifacts", action="store_true")
+    ap.add_argument("--q4-min-cosine", type=float, default=0.99)
+    ap.add_argument("--q4-max-rmse", type=float, default=0.03)
+    ap.add_argument("--bf16-min-cosine", type=float, default=0.99)
+    ap.add_argument("--bf16-max-rmse", type=float, default=0.10)
+    ap.add_argument("--bf16-max-abs", type=float, default=2.0)
+    args = ap.parse_args(argv)
+
+    out_dir = args.output_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    image = args.image.resolve() if args.image else out_dir / "fixtures" / "synthetic_form_1152x896.ppm"
+    if args.image is None:
+        _write_large_form(image)
+
+    flags = _cpu_flags()
+    has_avx512 = "avx512f" in flags
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "family": args.family,
+        "mode": args.mode,
+        "image": str(image),
+        "image_geometry": [1152, 896] if args.image is None else None,
+        "cpu": {
+            "avx512f": has_avx512,
+            "avx512_bf16": bool({"avx512_bf16", "avx512bf16"} & flags),
+        },
+        "layers": list(range(27)) if args.full_layers else [0, 8, 16, 24, 26],
+        "phases": {},
+        "started_unix": time.time(),
+    }
+    failures: list[str] = []
+
+    if not has_avx512 and not args.allow_non_avx512:
+        report["status"] = "skip"
+        report["skip_reason"] = "AVX-512F is not visible; pass --allow-non-avx512 for compatibility testing"
+        (out_dir / "summary.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(report["skip_reason"])
+        return 1 if args.require_artifacts else 0
+
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(args.threads)
+    env["OMP_NUM_THREADS"] = str(args.threads)
+
+    if args.mode in {"all", "q4"}:
+        missing = _missing([args.q4_mmproj] if args.q4_mmproj else [])
+        if args.q4_mmproj is None:
+            missing = ["--q4-mmproj"]
+        if missing:
+            report["phases"]["q8_mmproj_llamacpp"] = _phase("skip", reason="missing " + ", ".join(missing))
+            if args.require_artifacts:
+                failures.append("q8_mmproj_llamacpp: required artifact missing")
+        else:
+            q4_out = out_dir / "q8_mmproj_llamacpp"
+            q4_runtime = out_dir / "runtime_q4"
+            cmd = [
+                sys.executable, str(Q4_SUITE),
+                "--gguf", str(args.q4_mmproj.resolve()),
+                "--image", str(image),
+                "--limit", "1",
+                "--output-dir", str(q4_out),
+                "--runtime-dir", str(q4_runtime),
+                "--image-max-tokens", "1024",
+                "--threads", str(args.threads),
+                "--ck-threads", str(args.threads),
+                "--min-cosine", str(args.q4_min_cosine),
+                "--max-rmse", str(args.q4_max_rmse),
+            ]
+            try:
+                _run(cmd, env=env, log=out_dir / "q8_mmproj_llamacpp.log")
+                report["phases"]["q8_mmproj_llamacpp"] = _phase("pass", report=str(q4_out / "summary.json"))
+            except subprocess.CalledProcessError as exc:
+                report["phases"]["q8_mmproj_llamacpp"] = _phase("fail", returncode=exc.returncode, log=str(out_dir / "q8_mmproj_llamacpp.log"))
+                failures.append("q8_mmproj_llamacpp parity failed")
+            finally:
+                if not args.keep_artifacts:
+                    shutil.rmtree(q4_runtime, ignore_errors=True)
+
+    if args.mode in {"all", "bf16"}:
+        required = [args.bf16_checkpoint, args.bf16_runtime_dir, args.bf16_weights_bump]
+        missing = ["BF16 checkpoint/runtime/weights"] if any(path is None for path in required) else _missing([path for path in required if path])
+        if importlib.util.find_spec("torch") is None:
+            missing.append("PyTorch")
+        if importlib.util.find_spec("transformers") is None:
+            missing.append("transformers")
+        if missing:
+            report["phases"]["bf16_pytorch"] = _phase("skip", reason="missing " + ", ".join(missing))
+            if args.require_artifacts:
+                failures.append("bf16_pytorch: required artifact or dependency missing")
+        else:
+            bf16_out = out_dir / "bf16_pytorch"
+            layers = list(range(27)) if args.full_layers else [0, 8, 16, 24, 26]
+            selectors = [f"layer_out@{layer}" for layer in layers] + ["vision_output"]
+            cmd = [
+                sys.executable, str(BF16_SUITE),
+                "--checkpoint", str(args.bf16_checkpoint.resolve()),
+                "--runtime-dir", str(args.bf16_runtime_dir.resolve()),
+                "--weights-bump", str(args.bf16_weights_bump.resolve()),
+                "--image", str(image),
+                "--out-dir", str(bf16_out),
+                "--threads", str(args.threads),
+                "--attn-implementation", "eager",
+                "--min-cosine", str(args.bf16_min_cosine),
+                "--max-relative-rmse", "0.10",
+                "--final-max-rmse", str(args.bf16_max_rmse),
+                "--final-max-abs", str(args.bf16_max_abs),
+            ]
+            for selector in selectors:
+                cmd.extend(["--selector", selector])
+            try:
+                _run(cmd, env=env, log=out_dir / "bf16_pytorch.log")
+                report["phases"]["bf16_pytorch"] = _phase("pass", report=str(bf16_out / "report.json"), selectors=selectors)
+            except subprocess.CalledProcessError as exc:
+                report["phases"]["bf16_pytorch"] = _phase("fail", returncode=exc.returncode, log=str(out_dir / "bf16_pytorch.log"), selectors=selectors)
+                failures.append("bf16_pytorch parity failed")
+            finally:
+                if not args.keep_artifacts:
+                    _cleanup_raw_tensors(bf16_out)
+
+    ran = [phase for phase in report["phases"].values() if phase["status"] != "skip"]
+    report["failures"] = failures
+    report["status"] = "fail" if failures else ("pass" if ran else "skip")
+    report["elapsed_sec"] = time.time() - report["started_unix"]
+    summary = out_dir / "summary.json"
+    summary.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"status": report["status"], "phases": report["phases"], "summary": str(summary)}, indent=2))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/tools/mtmd_clip_shim.cpp
+++ b/version/v8/tools/mtmd_clip_shim.cpp
@@ -366,15 +366,44 @@ size_t ck_mtmd_clip_embd_nbytes_by_img(void *handle_ptr, int img_w, int img_h) {
     if (!ctx || img_w <= 0 || img_h <= 0) {
         return 0;
     }
+#ifdef CK_MTMD_CLIP_OBJECT_API
+    clip_image_f32_ptr image(clip_image_f32_init());
+    image->set_size({img_w, img_h}, false, false);
+    const int tokens = clip_n_output_tokens(ctx, image.get());
+    const int embed_dim = clip_n_mmproj_embd(ctx);
+    return tokens > 0 && embed_dim > 0
+        ? (size_t) tokens * (size_t) embed_dim * sizeof(float)
+        : 0;
+#else
     return clip_embd_nbytes_by_img(ctx, img_w, img_h);
+#endif
 }
+
 
 int ck_mtmd_clip_encode_float_image(void *handle_ptr, int n_threads, float *img, int h, int w, float *vec) {
     clip_ctx *ctx = unwrap_ctx(handle_ptr);
     if (!ctx || !img || !vec || h <= 0 || w <= 0) {
         return 0;
     }
+#ifdef CK_MTMD_CLIP_OBJECT_API
+    clip_image_f32_ptr image(clip_image_f32_init());
+    image->set_size({w, h}, false, false);
+    image->cpy_buf(std::vector<float>(img, img + (size_t) h * (size_t) w * 3));
+    const int tokens = clip_n_output_tokens(ctx, image.get());
+    const int embed_dim = clip_n_mmproj_embd(ctx);
+    if (tokens <= 0 || embed_dim <= 0) {
+        return 0;
+    }
+    std::vector<float> output((size_t) tokens * (size_t) embed_dim, 0.0f);
+    if (!clip_image_encode(ctx, n_threads, image.get(), output)) {
+        return 0;
+    }
+    std::memcpy(vec, output.data(), output.size() * sizeof(float));
+    return 1;
+#else
     return clip_encode_float_image(ctx, n_threads, img, h, w, vec) ? 1 : 0;
+#endif
 }
+
 
 }


### PR DESCRIPTION
## Summary

- add a unified artifact-backed Qwen3-VL vision encoder accuracy gate
- compare Q8_0 GGUF against llama.cpp and BF16 safetensors against PyTorch when eligible
- publish truthful PASS, FAIL, and SKIP state in nightly JSON and the test-report UI
- use a deterministic public 1152x896 stress fixture and clean raw tensor/runtime artifacts by default
- support older and newer llama.cpp mtmd APIs

## Measured handoff results

| Lane | Prefix | Cosine | RMSE | Max abs |
|---|---:|---:|---:|---:|
| BF16 CK vs PyTorch | 1008 x 16384 | 0.997852 | 0.016293 | 1.783353 |
| Q8_0 CK vs llama.cpp | 1008 x 16384 | 0.999457 | 0.008560 | 1.777064 |

## Validation

- `make test-v8-qwen3vl`: PASS
  - 16 circuit tests
  - 3 accuracy-gate tests
  - 1 nightly artifact-status test
- `make vision-encoder-full`: correctly reports SKIP on this AVX2 host
- `git diff --check`: PASS
- pre-commit/full pre-push:
  - build and visualizer health: PASS
  - v8 E2E inference and inference contracts: PASS
  - v8 regression-fast: PASS
  - v7 training contract and training-kernel parity: PASS
  - v7 regression-fast: existing Gemma/Qwen2/Nanbeige parity failures reproduced; not represented as passing

## Scope

This is an accuracy gate and reporting change. It does not claim full Qwen3-VL BF16 or GGUF end-to-end parity, and it does not include the separate attention-numerics redesign.
