### PR TITLE
feat(v8): make kernel contracts authoritative

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -59,7 +59,7 @@ for path in "${STAGED_FILES[@]}"; do
         version/v7/scripts/*|version/v7/templates/*|version/v7/regression/*|version/v7/test_assets/*|version/v7/src/*|version/v7/kernel_maps/*|version/v7/README.md)
             should_run_v7_regression=1
             ;;
-        version/v8/scripts/*|version/v8/circuits/*|version/v8/contracts/*|version/v8/regression/*|version/v8/test_assets/*|version/v8/src/*|version/v8/kernel_maps/*|version/v8/README.md)
+        version/v8/scripts/*|version/v8/circuits/*|version/v8/contracts/*|version/v8/schemas/*|version/v8/regression/*|version/v8/test_assets/*|version/v8/src/*|version/v8/kernel_maps/*|version/v8/README.md)
             should_run_v8_regression=1
             ;;
     esac

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -113,7 +113,7 @@ case "${CK_PREPUSH_REGRESSION_FAST:-auto}" in
                 version/v7/scripts/*|version/v7/templates/*|version/v7/regression/*|version/v7/test_assets/*|version/v7/src/*|version/v7/kernel_maps/*|version/v7/README.md)
                     ck_should_run_v7_regression_fast=1
                     ;;
-                version/v8/scripts/*|version/v8/circuits/*|version/v8/contracts/*|version/v8/regression/*|version/v8/test_assets/*|version/v8/src/*|version/v8/kernel_maps/*|version/v8/README.md)
+                version/v8/scripts/*|version/v8/circuits/*|version/v8/contracts/*|version/v8/schemas/*|version/v8/regression/*|version/v8/test_assets/*|version/v8/src/*|version/v8/kernel_maps/*|version/v8/README.md)
                     ck_should_run_v8_regression_fast=1
                     ;;
             esac

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -220,6 +220,7 @@ jobs:
                   "version/v8/scripts/",
                   "version/v8/circuits/",
                   "version/v8/contracts/",
+                  "version/v8/schemas/",
                   "version/v8/kernel_maps/",
                   "version/v8/regression/",
                   "version/v8/test_assets/",

--- a/docs/site/_pages/architecture.html
+++ b/docs/site/_pages/architecture.html
@@ -32,12 +32,15 @@ deterministic DSL lowering
              ↓
 generated C</pre><p>Model definitions live in <code>version/v8/circuits/</code>. The historical embedded BUMP key remains <code>template</code> for serialized compatibility.</p></div>
     <div class="card"><h3 style="margin-top:0;">Semantic Selection</h3><p>Precision-sensitive operations declare <code>required_contracts</code>. Real kernel maps advertise <code>provides</code> and <code>supported_reductions</code>. Missing and ambiguous providers are compile-time errors.</p></div>
-    <div class="card"><h3 style="margin-top:0;">Behavior-Preserving Migration</h3><p>The resolver verifies that legacy lowering emitted the exact selected kernel. Qwen3-VL decoder and encoder IR1, layout, lowered IR, and call-ready IR were identical before and after integration.</p></div>
+    <div class="card"><h3 style="margin-top:0;">Authoritative Resolution</h3><p>The resolver selects the compatible kernel and contract before GraphIR construction. GraphIR records that decision; LoweredIR, call-ready IR, and generated C must preserve it without fallback or reselection.</p></div>
     <div class="card"><h3 style="margin-top:0;">Promotion Gate</h3><p>Leaf tests are necessary but insufficient. Public routing, threaded thresholds, stitched layer boundaries, full replay, persistent decode, and E2E behavior must agree before production validation.</p></div>
 </div>
 
 <h3>Why reduction is architecture</h3>
 <p>Attention is not fully specified by <code>softmax(QKᵀ)V</code>. Q/K rounding, score accumulation, online-softmax state, V accumulation, split thresholds, partial storage, and merge order can change logits. v8 records these as complete contracts instead of inferring them from strict-mode flags, cache dtypes, sequence lengths, or thread counts.</p>
+
+<h3>Why threading is a kernel capability</h3>
+<p>Threading metadata applies across attention, GEMM, GEMV, and other parallel operators. Kernel maps declare the runtime, work partition, dispatch mechanism, and whether parallel order changes a reduction. The performance planner may choose among semantically compatible implementations, but it cannot silently change accumulation order to gain speed.</p>
 
 <div class="card">
     <h3 style="margin-top: 0;">The "Website" Metaphor</h3>

--- a/docs/site/_pages/v8-numerical-contracts.html
+++ b/docs/site/_pages/v8-numerical-contracts.html
@@ -82,7 +82,8 @@
   <li>The resolver reads each active <code>required_contracts</code> entry for the requested phase.</li>
   <li>It matches op, phase, tensor dtype, layout, and complete reduction ID against executable kernel maps.</li>
   <li>Zero providers fail as unsupported. Multiple providers fail as ambiguous.</li>
-  <li>During migration, v8 validates that legacy lowering emitted the exact selected kernel ID. This keeps generated behavior unchanged.</li>
+  <li>The resolver selects the provider before GraphIR construction. Contract-bearing operations do not consult legacy circuit overrides or heuristic dispatch.</li>
+  <li>GraphIR records requirements and the resolved kernel/contract IDs. LoweredIR and call-ready IR carry that decision and hard-fail if a later stage changes it.</li>
   <li>Production promotion additionally requires validated circuit, contract definition, implementation route, stitched parity, and E2E evidence.</li>
 </ol>
 
@@ -90,7 +91,15 @@
 
 <p>The repository directory is now <code>version/v8/circuits</code>. Embedded BUMP metadata continues to use the historical <code>template</code> key, and chat templates keep their established name; changing serialized formats is not required to correct compiler architecture.</p>
 
-<p>The first integration is deliberately behavior-preserving. On the canonical Qwen3-VL artifacts, pre-contract and contracted builds produced identical <code>ir1.json</code>, <code>layout.json</code>, <code>lowered.json</code>, and <code>call.json</code> for both decoder and vision encoder. The five-family v8 regression also passed for Gemma3, Qwen2, Qwen3, Qwen3.5, and Nanbeige.</p>
+<p>The authoritative migration preserves executable behavior while making the decision visible. Contract metadata is added to GraphIR, LoweredIR, and call-ready IR, while kernel IDs, memory layout, call arguments, and generated C remain unchanged. Gemma3, Qwen2, Qwen3, Qwen3.5, Nanbeige, and Qwen3-VL attention routes resolve without legacy selection.</p>
+
+<h2>Threading Is an Execution Contract</h2>
+
+<p>Kernel maps also declare ISA dispatch, threading runtime, possible work partitions, dispatch mechanisms, and whether scheduling can alter reduction order. Q4/Q6 GEMM and GEMV maps therefore expose serial, row, column, or output-tile policies instead of hiding threadpool behavior in generated wrappers. GraphIR records this as <code>resolved_execution</code>, and LoweredIR plus call-ready IR hard-fail if the kernel ID changes. When partitioning changes arithmetic order, the numerical contract must define the corresponding reduction and merge behavior.</p>
+
+<div class="contract-note contract-bad">
+  <strong>Hard-fail policy:</strong> agents must fix the circuit, canonical contract, or kernel map. They must not add fallbacks, silent defaults, bypass flags, or looser tolerances to make a new model compile.
+</div>
 
 <div class="contract-note">
   <strong>Migration policy:</strong> add one operator family at a time. Record current semantics, add leaf and public-route tests, declare circuit requirements, enrich real kernel maps, prove generated artifact equivalence, run stitched parity, then promote the route.

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -978,12 +978,15 @@ deterministic DSL lowering
              ↓
 generated C</pre><p>Model definitions live in <code>version/v8/circuits/</code>. The historical embedded BUMP key remains <code>template</code> for serialized compatibility.</p></div>
     <div class="card"><h3 style="margin-top:0;">Semantic Selection</h3><p>Precision-sensitive operations declare <code>required_contracts</code>. Real kernel maps advertise <code>provides</code> and <code>supported_reductions</code>. Missing and ambiguous providers are compile-time errors.</p></div>
-    <div class="card"><h3 style="margin-top:0;">Behavior-Preserving Migration</h3><p>The resolver verifies that legacy lowering emitted the exact selected kernel. Qwen3-VL decoder and encoder IR1, layout, lowered IR, and call-ready IR were identical before and after integration.</p></div>
+    <div class="card"><h3 style="margin-top:0;">Authoritative Resolution</h3><p>The resolver selects the compatible kernel and contract before GraphIR construction. GraphIR records that decision; LoweredIR, call-ready IR, and generated C must preserve it without fallback or reselection.</p></div>
     <div class="card"><h3 style="margin-top:0;">Promotion Gate</h3><p>Leaf tests are necessary but insufficient. Public routing, threaded thresholds, stitched layer boundaries, full replay, persistent decode, and E2E behavior must agree before production validation.</p></div>
 </div>
 
 <h3>Why reduction is architecture</h3>
 <p>Attention is not fully specified by <code>softmax(QKᵀ)V</code>. Q/K rounding, score accumulation, online-softmax state, V accumulation, split thresholds, partial storage, and merge order can change logits. v8 records these as complete contracts instead of inferring them from strict-mode flags, cache dtypes, sequence lengths, or thread counts.</p>
+
+<h3>Why threading is a kernel capability</h3>
+<p>Threading metadata applies across attention, GEMM, GEMV, and other parallel operators. Kernel maps declare the runtime, work partition, dispatch mechanism, and whether parallel order changes a reduction. The performance planner may choose among semantically compatible implementations, but it cannot silently change accumulation order to gain speed.</p>
 
 <div class="card">
     <h3 style="margin-top: 0;">The "Website" Metaphor</h3>
@@ -1255,7 +1258,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-11 02:35</span>
+        <span class="folder-updated">Updated: 2026-07-11 03:52</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1279,6 +1282,8 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
+|-- .cache
+|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
 |-- contracts
@@ -1314,7 +1319,7 @@ version/v7
 `-- tools
     `-- src
 
-55 directories
+57 directories
 </pre>
 </div>
 

--- a/docs/site/assets/v8-numerical-contracts.svg
+++ b/docs/site/assets/v8-numerical-contracts.svg
@@ -47,7 +47,7 @@
   <text class="m" x="420" y="402">op + phase + dtype + layout + reduction contract</text>
   <text class="p" x="420" y="433">0 providers: fail before C generation</text>
   <text class="p" x="420" y="458">2+ providers: fail as ambiguous</text>
-  <text class="p" x="420" y="483">1 provider: verify legacy lowering emits that exact kernel ID</text>
+  <text class="p" x="420" y="483">1 provider: select before GraphIR; no heuristic reselection</text>
 
   <rect class="fail" x="75" y="355" width="260" height="120" rx="8"/>
   <text class="h" x="100" y="390">Compile-time rejection</text>
@@ -58,12 +58,12 @@
   <path class="line" d="M720 500 V555"/>
   <rect class="panel" x="145" y="555" width="260" height="130" rx="8"/>
   <text class="h" x="170" y="590">GraphIR</text>
-  <text class="p" x="170" y="620">Symbolic tensors and edges</text>
-  <text class="p" x="170" y="646">No addresses, no ISA choice</text>
+  <text class="p" x="170" y="620">Tensors, edges, requirements</text>
+  <text class="p" x="170" y="646">Exact provider + thread policy</text>
   <rect class="panel" x="475" y="555" width="260" height="130" rx="8"/>
   <text class="h" x="500" y="590">LoweredIR</text>
   <text class="p" x="500" y="620">Concrete kernels and buffers</text>
-  <text class="p" x="500" y="646">Validated contract attached</text>
+  <text class="p" x="500" y="646">Consumes provider; cannot reselect</text>
   <rect class="panel" x="805" y="555" width="260" height="130" rx="8"/>
   <text class="h" x="830" y="590">Call-ready IR</text>
   <text class="p" x="830" y="620">ABI arguments and dimensions</text>

--- a/docs/site/v8-numerical-contracts.html
+++ b/docs/site/v8-numerical-contracts.html
@@ -1028,7 +1028,8 @@
   <li>The resolver reads each active <code>required_contracts</code> entry for the requested phase.</li>
   <li>It matches op, phase, tensor dtype, layout, and complete reduction ID against executable kernel maps.</li>
   <li>Zero providers fail as unsupported. Multiple providers fail as ambiguous.</li>
-  <li>During migration, v8 validates that legacy lowering emitted the exact selected kernel ID. This keeps generated behavior unchanged.</li>
+  <li>The resolver selects the provider before GraphIR construction. Contract-bearing operations do not consult legacy circuit overrides or heuristic dispatch.</li>
+  <li>GraphIR records requirements and the resolved kernel/contract IDs. LoweredIR and call-ready IR carry that decision and hard-fail if a later stage changes it.</li>
   <li>Production promotion additionally requires validated circuit, contract definition, implementation route, stitched parity, and E2E evidence.</li>
 </ol>
 
@@ -1036,7 +1037,15 @@
 
 <p>The repository directory is now <code>version/v8/circuits</code>. Embedded BUMP metadata continues to use the historical <code>template</code> key, and chat templates keep their established name; changing serialized formats is not required to correct compiler architecture.</p>
 
-<p>The first integration is deliberately behavior-preserving. On the canonical Qwen3-VL artifacts, pre-contract and contracted builds produced identical <code>ir1.json</code>, <code>layout.json</code>, <code>lowered.json</code>, and <code>call.json</code> for both decoder and vision encoder. The five-family v8 regression also passed for Gemma3, Qwen2, Qwen3, Qwen3.5, and Nanbeige.</p>
+<p>The authoritative migration preserves executable behavior while making the decision visible. Contract metadata is added to GraphIR, LoweredIR, and call-ready IR, while kernel IDs, memory layout, call arguments, and generated C remain unchanged. Gemma3, Qwen2, Qwen3, Qwen3.5, Nanbeige, and Qwen3-VL attention routes resolve without legacy selection.</p>
+
+<h2>Threading Is an Execution Contract</h2>
+
+<p>Kernel maps also declare ISA dispatch, threading runtime, possible work partitions, dispatch mechanisms, and whether scheduling can alter reduction order. Q4/Q6 GEMM and GEMV maps therefore expose serial, row, column, or output-tile policies instead of hiding threadpool behavior in generated wrappers. GraphIR records this as <code>resolved_execution</code>, and LoweredIR plus call-ready IR hard-fail if the kernel ID changes. When partitioning changes arithmetic order, the numerical contract must define the corresponding reduction and merge behavior.</p>
+
+<div class="contract-note contract-bad">
+  <strong>Hard-fail policy:</strong> agents must fix the circuit, canonical contract, or kernel map. They must not add fallbacks, silent defaults, bypass flags, or looser tolerances to make a new model compile.
+</div>
 
 <div class="contract-note">
   <strong>Migration policy:</strong> add one operator family at a time. Record current semantics, add leaf and public-route tests, declare circuit requirements, enrich real kernel maps, prove generated artifact equivalence, run stitched parity, then promote the route.

--- a/requirements-v8.txt
+++ b/requirements-v8.txt
@@ -4,6 +4,7 @@ torch
 safetensors
 requests
 tqdm
+jsonschema>=4.18
 huggingface_hub
 gguf
 tokenizers

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 safetensors
 requests
 tqdm
+jsonschema>=4.18

--- a/tests/test_build_ir_v8_scaffold.py
+++ b/tests/test_build_ir_v8_scaffold.py
@@ -30,6 +30,12 @@ build_ir_v8 = _load_module("build_ir_v8_for_tests", V8_BUILD_PATH)
 
 def _normalized_template_doc(doc: dict) -> dict:
     normalized = json.loads(json.dumps(doc))
+    normalized.pop("required_contracts", None)
+    kernels = normalized.get("kernels")
+    if isinstance(kernels, dict):
+        for key in list(kernels):
+            if key.startswith("attn"):
+                kernels.pop(key)
     flags = normalized.get("flags")
     if isinstance(flags, dict):
         for key in build_ir_v8._FORBIDDEN_TEMPLATE_FLAG_KEYS:

--- a/tests/test_v8_attention_contracts.py
+++ b/tests/test_v8_attention_contracts.py
@@ -103,7 +103,7 @@ class AttentionContractV8Tests(unittest.TestCase):
         circuit["required_contracts"]["decoder.attention"]["phases"]["decode"]["requires"][
             "numerics.attention_reduction"
         ] = "fp32_online"
-        with self.assertRaisesRegex(resolver.ContractError, "No kernel satisfies circuit requirements"):
+        with self.assertRaisesRegex(resolver.ContractError, "HARD CONTRACT FAULT: no kernel provides"):
             resolver.resolve_contract(
                 circuit,
                 copy.deepcopy(self.contracts),
@@ -150,7 +150,7 @@ class AttentionContractV8Tests(unittest.TestCase):
             map_path.write_text(json.dumps(base_map), encoding="utf-8")
             duplicate["base_kernel_map"] = str(map_path)
             kernels["kernels"]["attention_decode_duplicate"] = duplicate
-            with self.assertRaisesRegex(resolver.ContractError, "Ambiguous kernel selection"):
+            with self.assertRaisesRegex(resolver.ContractError, "HARD CONTRACT FAULT: multiple kernels provide"):
                 resolver.resolve_contract(
                     copy.deepcopy(self.circuit),
                     copy.deepcopy(self.contracts),
@@ -159,6 +159,128 @@ class AttentionContractV8Tests(unittest.TestCase):
                     phase="decode",
                     mode="bringup",
                 )
+
+    def test_unknown_circuit_contract_field_is_a_hard_fault(self) -> None:
+        circuit = copy.deepcopy(self.circuit)
+        circuit["required_contracts"]["decoder.attention"]["phases"]["decode"]["fallback"] = "fp32"
+        with self.assertRaisesRegex(resolver.ContractError, "(?s)HARD CONTRACT FAULT.*fallback"):
+            resolver.resolve_contract(
+                circuit,
+                copy.deepcopy(self.contracts),
+                copy.deepcopy(self.kernels),
+                operation="decoder.attention",
+                phase="decode",
+                mode="bringup",
+            )
+
+    def test_missing_template_op_binding_is_a_hard_fault(self) -> None:
+        circuit = copy.deepcopy(self.circuit)
+        del circuit["required_contracts"]["decoder.attention"]["template_ops"]
+        with self.assertRaisesRegex(resolver.ContractError, "(?s)HARD CONTRACT FAULT.*template_ops"):
+            resolver.resolve_contract(
+                circuit,
+                copy.deepcopy(self.contracts),
+                copy.deepcopy(self.kernels),
+                operation="decoder.attention",
+                phase="decode",
+                mode="bringup",
+            )
+
+    def test_unknown_reduction_semantic_is_a_hard_fault(self) -> None:
+        contracts = copy.deepcopy(self.contracts)
+        contracts["contracts"]["fp32_online"]["magic_accumulator"] = "fast"
+        with self.assertRaisesRegex(resolver.ContractError, "(?s)HARD CONTRACT FAULT.*magic_accumulator"):
+            resolver.validate_contract_registry(contracts)
+
+    def test_unknown_kernel_capability_field_is_a_hard_fault(self) -> None:
+        kernels = copy.deepcopy(self.kernels)
+        kernels["kernels"]["attention_forward_decode_head_major_gqa_flash_f16cache"][
+            "supported_reductions"
+        ]["f16_online_fp32_merge"]["allow_fallback"] = True
+        with self.assertRaisesRegex(resolver.ContractError, "(?s)HARD CONTRACT FAULT.*allow_fallback"):
+            resolver.validate_kernel_overlay(kernels)
+
+    def test_hard_fault_instructs_agents_not_to_bypass(self) -> None:
+        circuit = copy.deepcopy(self.circuit)
+        circuit["required_contracts"]["decoder.attention"]["phases"]["decode"]["requires"][
+            "numerics.attention_reduction"
+        ] = "fp32_online"
+        with self.assertRaises(resolver.ContractError) as raised:
+            resolver.resolve_contract(
+                circuit,
+                copy.deepcopy(self.contracts),
+                copy.deepcopy(self.kernels),
+                operation="decoder.attention",
+                phase="decode",
+                mode="bringup",
+            )
+        self.assertIn("Do not add a fallback", str(raised.exception))
+
+    def test_supported_v8_circuits_resolve_without_legacy_attention(self) -> None:
+        cases = (
+            ("gemma3", "decoder.sliding_attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided_sliding"),
+            ("gemma3", "decoder.sliding_attention", "decode", "attention_forward_decode_head_major_gqa_flash_sliding"),
+            ("qwen2", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided"),
+            ("qwen2", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash"),
+            ("qwen3", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided"),
+            ("qwen3", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash"),
+            ("qwen35", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided"),
+            ("qwen35", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash"),
+            ("llama", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided_f16kv"),
+            ("llama", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash_f16kv"),
+            ("qwen3vl", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided"),
+            ("qwen3vl", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash_f16cache"),
+            ("qwen3_vl_vision", "vision_encoder.attention", "prefill", "attention_forward_full_head_major_gqa_flash_strided"),
+        )
+        for circuit_name, operation, phase, expected in cases:
+            with self.subTest(circuit=circuit_name, phase=phase):
+                path = V8_ROOT / "circuits" / f"{circuit_name}.json"
+                result = resolver.resolve_contract(
+                    resolver.load_json(path),
+                    copy.deepcopy(self.contracts),
+                    copy.deepcopy(self.kernels),
+                    operation=operation,
+                    phase=phase,
+                    mode="bringup",
+                    source_circuit_path=path,
+                )
+                self.assertEqual(result["kernel"]["id"], expected)
+                self.assertIn(result["implementation"]["threading"]["runtime"], {"serial", "ck_threadpool"})
+                self.assertTrue(result["implementation"]["threading"]["work_partition"])
+
+    def test_execution_schema_is_operator_generic(self) -> None:
+        resolver.validate_schema(
+            {
+                "id": "gemm_nt_q4_k_q8_k",
+                "op": "gemm",
+                "contract_schema_version": 1,
+                "implementation": {
+                    "isa_dispatch": "runtime",
+                    "threading": {
+                        "runtime": "ck_threadpool",
+                        "work_partition": ["output_tiles"],
+                        "dispatch": ["ck_threadpool_dispatch_n"],
+                        "reduction_order_effect": "none",
+                    },
+                },
+            },
+            resolver.KERNEL_EXECUTION_SCHEMA,
+            "synthetic GEMM execution capability",
+        )
+
+    def test_hot_quant_gemm_and_gemv_maps_declare_threading(self) -> None:
+        capabilities = resolver.load_kernel_execution_capabilities()["kernels"]
+        for kernel_id in (
+            "gemm_nt_q4_k_q8_k",
+            "gemm_nt_q6_k_q8_k",
+            "gemv_q4_k_q8_k",
+            "gemv_q6_k_q8_k",
+        ):
+            with self.subTest(kernel=kernel_id):
+                threading = capabilities[kernel_id]["implementation"]["threading"]
+                self.assertEqual(threading["runtime"], "ck_threadpool")
+                self.assertIn("ck_threadpool_dispatch_n", threading["dispatch"])
+                self.assertEqual(threading["reduction_order_effect"], "none")
 
 
 if __name__ == "__main__":

--- a/tests/test_v8_codegen_bridge.py
+++ b/tests/test_v8_codegen_bridge.py
@@ -264,6 +264,14 @@ class V8CodegenBridgeTests(unittest.TestCase):
 
         self.assertEqual(by_op["rope_qk"][0]["kernel"], "mrope_qk_text")
         self.assertEqual(by_op["attn"][0]["kernel"], "attention_forward_decode_head_major_gqa_flash_f16cache")
+        self.assertEqual(
+            by_op["q_proj"][0]["resolved_execution"]["implementation"]["threading"]["runtime"],
+            "ck_threadpool",
+        )
+        self.assertEqual(
+            by_op["mlp_down"][0]["resolved_execution"]["kernel_id"],
+            "gemv_q6_k_q8_k",
+        )
 
         with tempfile.TemporaryDirectory(prefix="v8_qwen3vl_text_mrope_") as tmpdir:
             tmp = Path(tmpdir)
@@ -296,12 +304,20 @@ class V8CodegenBridgeTests(unittest.TestCase):
             layout_doc = json.loads(layout_path.read_text(encoding="utf-8"))
             rope_call = next(op for op in call_doc["operations"] if op["op"] == "rope_qk")
             attn_call = next(op for op in call_doc["operations"] if op["op"] == "attn")
+            q_proj_call = next(op for op in call_doc["operations"] if op["op"] == "q_proj")
+            mlp_down_call = next(op for op in call_doc["operations"] if op["op"] == "mlp_down")
             kv_store_call = next(op for op in call_doc["operations"] if op["op"] == "kv_cache_store")
             kv_buf = next(buf for buf in layout_doc["memory"]["activations"]["buffers"] if buf["name"] == "kv_cache")
             self.assertEqual(rope_call["function"], "mrope_qk_text")
             self.assertEqual(attn_call["function"], "attention_forward_decode_head_major_gqa_flash_f16cache")
             self.assertEqual(kv_store_call["function"], "kv_cache_store_f16")
             self.assertEqual(kv_buf["dtype"], "fp16")
+            self.assertEqual(q_proj_call["resolved_execution"]["kernel_id"], "gemv_q4_k_q8_k")
+            self.assertEqual(
+                q_proj_call["resolved_execution"]["implementation"]["threading"]["reduction_order_effect"],
+                "none",
+            )
+            self.assertEqual(mlp_down_call["resolved_execution"]["kernel_id"], "gemv_q6_k_q8_k")
             arg_map = {arg["name"]: arg["expr"] for arg in rope_call["args"]}
             self.assertEqual(arg_map["pos_offset"], "model->rope_pos")
             self.assertEqual(arg_map["section_0"], "1")

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -143,7 +143,7 @@ def _make_qwen3vl_manifest() -> dict:
 
 class V8Qwen3VLTemplateTests(unittest.TestCase):
 
-    def test_numerical_contract_validation_preserves_generated_artifacts(self) -> None:
+    def test_authoritative_contract_preserves_behavior_and_reaches_call_ir(self) -> None:
         manifest = _make_qwen3vl_manifest()
         with tempfile.TemporaryDirectory(prefix="v8_qwen3vl_contract_equivalence_") as td:
             root = Path(td)
@@ -169,8 +169,37 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
 
             with mock.patch.object(build_ir_v8, "_resolve_manifest_numerical_contracts", return_value=[]):
                 legacy = generate("legacy")
+
+            # A stale legacy override must not influence a contract-bearing op.
+            manifest["template"]["kernels"]["attn"] = "attention_forward_causal_head_major_gqa_flash"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
             contracted = generate("contracted")
-            self.assertEqual(contracted, legacy)
+
+            def without_contract_metadata(value):
+                if isinstance(value, dict):
+                    return {
+                        key: without_contract_metadata(item)
+                        for key, item in value.items()
+                        if key not in {"required_contract", "resolved_contract"}
+                    }
+                if isinstance(value, list):
+                    return [without_contract_metadata(item) for item in value]
+                return value
+
+            self.assertEqual(without_contract_metadata(contracted), legacy)
+
+            expected_kernel = "attention_forward_full_head_major_gqa_flash_strided"
+            for artifact in ("ir1", "lowered", "call"):
+                doc = contracted[artifact]
+                operations = doc if isinstance(doc, list) else doc.get("operations", doc.get("ops", []))
+                attn = next(item for item in operations if item.get("op") == "attn")
+                self.assertEqual(attn["required_contract"]["numerics.attention_reduction"], "f16_kv_fp32_online")
+                self.assertEqual(attn["resolved_contract"]["contract_id"], "f16_kv_fp32_online")
+                self.assertEqual(attn["resolved_contract"]["kernel_id"], expected_kernel)
+                if artifact == "call":
+                    self.assertEqual(attn["function"], expected_kernel)
+                else:
+                    self.assertEqual(attn["kernel"], expected_kernel)
 
     def test_qwen3vl_invalid_vision_mrope_sections_fail_lowering(self) -> None:
         manifest = _make_qwen3vl_manifest()

--- a/version/v8/CONTRACT_POLICY.md
+++ b/version/v8/CONTRACT_POLICY.md
@@ -1,0 +1,35 @@
+# v8 Contract Hard-Fail Policy
+
+Numerical and execution contracts are release gates. A contract error means the
+circuit requirement, canonical contract, or executable kernel map is incomplete
+or incompatible.
+
+## Required response to a contract failure
+
+1. Identify the first invalid or unresolved operation.
+2. Correct the circuit semantics, canonical contract, or kernel capability.
+3. Add or update leaf, public-route, stitched, and E2E evidence.
+4. Re-run `make test-numerical-contracts` and the affected model-family sweep.
+
+## Forbidden responses
+
+Agents and contributors must not:
+
+- add a fallback provider;
+- add a silent default;
+- ignore an unknown schema field;
+- relax a numerical tolerance;
+- downgrade a hard fault to a warning;
+- add an environment variable or CLI flag that bypasses resolution;
+- restore a model-specific attention selection in codegen;
+- claim a route is validated without named reference evidence.
+
+Threading belongs in execution capabilities. If worker partitioning changes an
+accumulation or merge order, the numerical contract must define that order too.
+A performance planner may rank only providers that already satisfy the complete
+semantic contract.
+
+The supported v8 text circuits and Qwen3-VL routes must resolve attention before
+GraphIR construction. GraphIR records the required contract and resolved
+provider. LoweredIR and call-ready IR may carry that decision but may not replace
+or reinterpret it.

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -19,6 +19,7 @@ What is included here right now:
 - `tools/ir_visualizer.html`
 - `circuits/*`
 - `contracts/*`
+- `schemas/*`
 - `kernel_maps/*`
 
 The active compiler input is:
@@ -28,10 +29,18 @@ weights + circuits + kernel maps -> deterministic DSL lowering -> generated C
 ```
 
 Circuits declare graph structure and required semantics. Kernel maps advertise
-complete numerical contracts. `build_ir_v8.py` resolves those requirements and
-then verifies that legacy lowering emitted the same uniquely selected provider.
-This keeps migration behavior-preserving while moving parity discoveries out of
-ad hoc runtime dispatch.
+complete numerical and execution capabilities, including threadpool partition
+policies. `build_ir_v8.py` resolves those requirements before GraphIR is built.
+GraphIR, LoweredIR, and call-ready IR carry the same provider and contract IDs;
+later stages hard-fail if they differ. See `CONTRACT_POLICY.md` before changing a
+contract failure: fallbacks, silent defaults, tolerance relaxation, and bypass
+flags are forbidden.
+
+Every versioned kernel execution capability is also recorded as
+`resolved_execution` in GraphIR and preserved through call-ready IR. This is
+operator-generic: the current maps cover attention plus the hot Q4/Q6 GEMM and
+GEMV routes, including threadpool runtime, partition, dispatch, and reduction-
+order effects.
 
 Canonical text bring-up examples:
 - `version/v8/scripts/cks-v8-run run hf://unsloth/gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf --context-len 1024 --force-compile --force-convert --chat-template=auto --generate-visualizer`

--- a/version/v8/circuits/README.md
+++ b/version/v8/circuits/README.md
@@ -50,7 +50,7 @@ These files describe compute graphs.
 - The lowerer should only see declared operations, graph edges, and stitch
   points. It should not branch on names like DeepStack, MoE, SSM, encoder, or
   decoder.
-- If a model needs side paths, the template should express them via generic
+- If a model needs side paths, the circuit should express them via generic
   control primitives such as `branch`, `collect`, and `stitch`.
 - If a model needs routed experts later, that should extend the same contract
   with `route`, `dispatch`, and `combine`.
@@ -59,6 +59,11 @@ These files describe compute graphs.
   schema for future bring-up.
 - `required_contracts` entries state semantic requirements only. Zero matching
   providers and multiple matching providers are compile-time errors.
+- Contract-bearing operations name the circuit op IDs they govern through
+  `template_ops`. The resolver selects the provider before GraphIR construction;
+  lowering and codegen may not select a replacement.
+- Unknown or incomplete contract fields are hard faults. Follow
+  `version/v8/CONTRACT_POLICY.md`; do not introduce a fallback or bypass.
 
 ## File naming
 

--- a/version/v8/circuits/gemma3.json
+++ b/version/v8/circuits/gemma3.json
@@ -85,6 +85,24 @@
     "rope_qk": "rope_forward_qk",
     "rope_init": "rope_precompute_cache_split"
   },
+  "required_contracts": {
+    "decoder.sliding_attention": {
+      "op": "attention_sliding",
+      "template_ops": ["attn_sliding"],
+      "phases": {
+        "prefill": {
+          "requires": {"execution.phase": "prefill", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "Sliding prefill contract tests and v8 Gemma3 E2E regression pass."
+        },
+        "decode": {
+          "requires": {"execution.phase": "decode", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "Sliding decode contract tests and v8 Gemma3 E2E regression pass."
+        }
+      }
+    }
+  },
   "sequence": ["decoder"],
   "block_types": {
     "decoder": {

--- a/version/v8/circuits/llama.json
+++ b/version/v8/circuits/llama.json
@@ -53,9 +53,25 @@
     }
   },
   "kernels": {
-    "rope_qk": "rope_forward_qk_pairwise",
-    "attn_prefill": "attention_forward_causal_head_major_gqa_flash_strided_f16kv",
-    "attn_decode": "attention_forward_decode_head_major_gqa_flash_f16kv"
+    "rope_qk": "rope_forward_qk_pairwise"
+  },
+  "required_contracts": {
+    "decoder.attention": {
+      "op": "attention",
+      "template_ops": ["attn"],
+      "phases": {
+        "prefill": {
+          "requires": {"execution.phase": "prefill", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "f16_online_single_range"},
+          "validation": "observed",
+          "evidence": "Nanbeige v8 E2E regression passes; dedicated leaf llama oracle promotion remains open."
+        },
+        "decode": {
+          "requires": {"execution.phase": "decode", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "f16_online_single_range"},
+          "validation": "observed",
+          "evidence": "Nanbeige v8 E2E regression passes; dedicated leaf llama oracle promotion remains open."
+        }
+      }
+    }
   },
   "sequence": ["decoder"],
   "block_types": {

--- a/version/v8/circuits/qwen2.json
+++ b/version/v8/circuits/qwen2.json
@@ -79,6 +79,24 @@
   "kernels": {
     "rope_qk": "rope_forward_qk"
   },
+  "required_contracts": {
+    "decoder.attention": {
+      "op": "attention",
+      "template_ops": ["attn"],
+      "phases": {
+        "prefill": {
+          "requires": {"execution.phase": "prefill", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "v8 Qwen2 E2E regression and causal attention parity pass."
+        },
+        "decode": {
+          "requires": {"execution.phase": "decode", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "v8 Qwen2 E2E regression and decode attention parity pass."
+        }
+      }
+    }
+  },
   "sequence": ["decoder"],
   "block_types": {
     "decoder": {

--- a/version/v8/circuits/qwen3.json
+++ b/version/v8/circuits/qwen3.json
@@ -89,6 +89,24 @@
   "kernels": {
     "rope_qk": "rope_forward_qk"
   },
+  "required_contracts": {
+    "decoder.attention": {
+      "op": "attention",
+      "template_ops": ["attn"],
+      "phases": {
+        "prefill": {
+          "requires": {"execution.phase": "prefill", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "v8 Qwen3 E2E regression and causal attention parity pass."
+        },
+        "decode": {
+          "requires": {"execution.phase": "decode", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "v8 Qwen3 E2E regression and decode attention parity pass."
+        }
+      }
+    }
+  },
   "sequence": ["decoder"],
   "block_types": {
     "decoder": {

--- a/version/v8/circuits/qwen35.json
+++ b/version/v8/circuits/qwen35.json
@@ -87,6 +87,24 @@
       "required_call_args": {}
     }
   },
+  "required_contracts": {
+    "decoder.attention": {
+      "op": "attention",
+      "template_ops": ["attn"],
+      "phases": {
+        "prefill": {
+          "requires": {"execution.phase": "prefill", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "v8 Qwen3.5 E2E regression validates dense-attention layers; recurrent layers use a separate state contract."
+        },
+        "decode": {
+          "requires": {"execution.phase": "decode", "tensor.q.dtype": "fp32", "tensor.kv.dtype": "fp32", "tensor.layout": "head_major", "numerics.attention_reduction": "fp32_online"},
+          "validation": "validated",
+          "evidence": "v8 Qwen3.5 E2E regression validates dense-attention decode layers; recurrent layers use a separate state contract."
+        }
+      }
+    }
+  },
   "sequence": ["decoder"],
   "block_types": {
     "decoder": {

--- a/version/v8/circuits/qwen3_vl_vision.json
+++ b/version/v8/circuits/qwen3_vl_vision.json
@@ -94,6 +94,7 @@
   "required_contracts": {
     "vision_encoder.attention": {
       "op": "attention",
+      "template_ops": ["attn"],
       "phases": {
         "prefill": {
           "requires": {

--- a/version/v8/circuits/qwen3vl.json
+++ b/version/v8/circuits/qwen3vl.json
@@ -99,13 +99,24 @@
     }
   },
   "kernels": {
-    "rope_qk": "mrope_qk_text",
-    "attn_decode": "attention_forward_decode_head_major_gqa_flash"
+    "rope_qk": "mrope_qk_text"
   },
   "required_contracts": {
     "decoder.attention": {
       "op": "attention",
+      "template_ops": ["attn"],
       "phases": {
+        "prefill": {
+          "requires": {
+            "execution.phase": "prefill",
+            "tensor.q.dtype": "fp32",
+            "tensor.kv.dtype": "fp32",
+            "tensor.layout": "head_major",
+            "numerics.attention_reduction": "fp32_online"
+          },
+          "validation": "observed",
+          "evidence": "Mixed-prefix full replay remains the production gate; the selected causal FP32 route has leaf coverage."
+        },
         "decode": {
           "requires": {
             "execution.phase": "decode",

--- a/version/v8/contracts/attention_reductions.json
+++ b/version/v8/contracts/attention_reductions.json
@@ -49,6 +49,26 @@
         "reference": "PyTorch with K/V explicitly rounded through FP16"
       }
     },
+    "f16_online_single_range": {
+      "status": "observed",
+      "q_compute": "fp16_rounded",
+      "k_compute": "fp16_rounded",
+      "score_accumulator": "fp32",
+      "softmax_statistics": "fp32",
+      "value_compute": "fp16_rounded",
+      "value_accumulator": "fp16_rounded_each_update",
+      "partial_storage": "none",
+      "partial_merge": "none",
+      "partition": {
+        "kind": "single_range"
+      },
+      "description": "Single-range llama-compatible attention with FP16-rounded Q/K/V and FP16-rounded value updates.",
+      "validation": {
+        "test": "make llamacpp-parity-full",
+        "cases": ["Nanbeige prefill", "Nanbeige decode"],
+        "reference": "llama.cpp GGML attention; promotion remains blocked on a dedicated leaf oracle"
+      }
+    },
     "f16_online_fp32_merge": {
       "status": "validated",
       "q_compute": "fp16_rounded",

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -600,6 +600,45 @@
       "op": "attention",
       "variant": "decode_head_major_gqa_flash",
       "mode": "decode",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "decode"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp32"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "fp32_online"
+        ]
+      },
+      "supported_reductions": {
+        "fp32_online": {
+          "status": "validated",
+          "function": "attention_forward_decode_head_major_gqa_flash",
+          "explicit_selector": true,
+          "notes": "Validated FP32 single-token decode route."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": [
+            "independent_heads"
+          ],
+          "dispatch": [
+            "inline"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "activation": "fp32",
         "output": "fp32"
@@ -670,6 +709,45 @@
       "op": "attention",
       "variant": "decode_head_major_gqa_flash_f16kv",
       "mode": "decode",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "decode"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp32"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "f16_online_single_range"
+        ]
+      },
+      "supported_reductions": {
+        "f16_online_single_range": {
+          "status": "observed",
+          "function": "attention_forward_decode_head_major_gqa_flash_f16kv",
+          "explicit_selector": true,
+          "notes": "Single-range FP16-rounded Q/K/V compatibility route; dedicated oracle promotion remains open."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "scalar",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": [
+            "serial"
+          ],
+          "dispatch": [
+            "inline"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
       "quant": {
         "activation": "fp32",
         "output": "fp32"
@@ -809,6 +887,46 @@
       "id": "attention_forward_causal_head_major_gqa_flash_strided",
       "op": "attention",
       "variant": "causal_flash_fp32",
+      "mode": "prefill",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "prefill"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp32"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "fp32_online"
+        ]
+      },
+      "supported_reductions": {
+        "fp32_online": {
+          "status": "validated",
+          "function": "attention_forward_causal_head_major_gqa_flash_strided",
+          "explicit_selector": true,
+          "notes": "Validated causal FP32 online-softmax prefill route."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "independent_query_blocks"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "weight": "none",
         "activation": "fp32",
@@ -994,6 +1112,46 @@
       "id": "attention_forward_causal_head_major_gqa_flash_strided_f16kv",
       "op": "attention",
       "variant": "causal_flash_fp32_f16kv",
+      "mode": "prefill",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "prefill"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp32"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "f16_online_single_range"
+        ]
+      },
+      "supported_reductions": {
+        "f16_online_single_range": {
+          "status": "observed",
+          "function": "attention_forward_causal_head_major_gqa_flash_strided_f16kv",
+          "explicit_selector": true,
+          "notes": "Single-range FP16-rounded Q/K/V compatibility route; dedicated oracle promotion remains open."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "scalar",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": [
+            "serial"
+          ],
+          "dispatch": [
+            "inline"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
       "quant": {
         "weight": "none",
         "activation": "fp32",
@@ -1330,6 +1488,46 @@
       "id": "attention_forward_causal_head_major_gqa_flash_strided_sliding",
       "op": "attention_sliding",
       "variant": "causal_flash_fp32_sliding",
+      "mode": "prefill",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "prefill"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp32"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "fp32_online"
+        ]
+      },
+      "supported_reductions": {
+        "fp32_online": {
+          "status": "validated",
+          "function": "attention_forward_causal_head_major_gqa_flash_strided_sliding",
+          "explicit_selector": true,
+          "notes": "Validated sliding-window FP32 online-softmax prefill route."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "independent_query_blocks"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "weight": "none",
         "activation": "fp32",
@@ -1836,6 +2034,7 @@
       "op": "attention",
       "variant": "decode_head_major_gqa_flash_f16cache",
       "mode": "decode",
+      "contract_schema_version": 1,
       "provides": {
         "execution.phase": [
           "decode"
@@ -1859,6 +2058,19 @@
           "function": "attention_forward_decode_head_major_gqa_flash_f16cache",
           "explicit_selector": false,
           "notes": "Current generated v8 route. The explicit selector API is validated separately and will replace this ABI after E2E promotion."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "kv_chunks_by_workers"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "contract_defined"
         }
       },
       "quant": {
@@ -2035,6 +2247,45 @@
       "op": "attention_sliding",
       "variant": "decode_flash_fp32_sliding",
       "mode": "decode",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "decode"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp32"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "fp32_online"
+        ]
+      },
+      "supported_reductions": {
+        "fp32_online": {
+          "status": "validated",
+          "function": "attention_forward_decode_head_major_gqa_flash_sliding",
+          "explicit_selector": true,
+          "notes": "Validated sliding-window FP32 single-token decode route."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": [
+            "independent_heads"
+          ],
+          "dispatch": [
+            "inline"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "activation": "fp32",
         "output": "fp32"
@@ -2610,6 +2861,7 @@
       "op": "attention",
       "variant": "full_flash_fp32",
       "mode": "prefill",
+      "contract_schema_version": 1,
       "provides": {
         "execution.phase": [
           "prefill"
@@ -2633,6 +2885,19 @@
           "function": "attention_forward_full_head_major_gqa_flash_strided",
           "explicit_selector": false,
           "notes": "Legacy v8 ABI with validated FP32 Q and FP16-rounded K/V semantics."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "independent_query_blocks"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "none"
         }
       },
       "quant": {
@@ -7268,6 +7533,25 @@
       "id": "gemm_nt_q4_k_q8_k",
       "op": "gemm",
       "variant": "q4_k_w_q8_k_a",
+      "contract_schema_version": 1,
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "serial",
+            "independent_rows",
+            "independent_columns",
+            "output_tiles"
+          ],
+          "dispatch": [
+            "inline",
+            "ck_threadpool_dispatch_n",
+            "internal_threaded"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "weight": "q4_k",
         "activation": "q8_k",
@@ -7896,6 +8180,23 @@
       "id": "gemm_nt_q6_k_q8_k",
       "op": "gemm",
       "variant": "q6_k_w_q8_k_a",
+      "contract_schema_version": 1,
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "serial",
+            "independent_rows",
+            "output_tiles"
+          ],
+          "dispatch": [
+            "inline",
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "weight": "q6_k",
         "activation": "q8_k",
@@ -9103,6 +9404,22 @@
       "id": "gemv_q4_k_q8_k",
       "op": "gemv",
       "variant": "q4_k_w_q8_k_a_fp32_out",
+      "contract_schema_version": 1,
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "serial",
+            "independent_rows"
+          ],
+          "dispatch": [
+            "inline",
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "weight": "q4_k",
         "activation": "q8_k",
@@ -9832,6 +10149,22 @@
       "id": "gemv_q6_k_q8_k",
       "op": "gemv",
       "variant": "q6_k_w_q8_k_a_fp32_out",
+      "contract_schema_version": 1,
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "serial",
+            "independent_rows"
+          ],
+          "dispatch": [
+            "inline",
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "none"
+        }
+      },
       "quant": {
         "weight": "q6_k",
         "activation": "q8_k",

--- a/version/v8/kernel_maps/attention_decode_flash.json
+++ b/version/v8/kernel_maps/attention_decode_flash.json
@@ -3,6 +3,31 @@
   "op": "attention",
   "variant": "decode_head_major_gqa_flash",
   "mode": "decode",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["decode"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp32"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["fp32_online"]
+  },
+  "supported_reductions": {
+    "fp32_online": {
+      "status": "validated",
+      "function": "attention_forward_decode_head_major_gqa_flash",
+      "explicit_selector": true,
+      "notes": "Validated FP32 single-token decode route."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "serial",
+      "work_partition": ["independent_heads"],
+      "dispatch": ["inline"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "activation": "fp32",
     "output": "fp32"

--- a/version/v8/kernel_maps/attention_decode_flash_f16kv.json
+++ b/version/v8/kernel_maps/attention_decode_flash_f16kv.json
@@ -3,6 +3,31 @@
   "op": "attention",
   "variant": "decode_head_major_gqa_flash_f16kv",
   "mode": "decode",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["decode"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp32"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["f16_online_single_range"]
+  },
+  "supported_reductions": {
+    "f16_online_single_range": {
+      "status": "observed",
+      "function": "attention_forward_decode_head_major_gqa_flash_f16kv",
+      "explicit_selector": true,
+      "notes": "Single-range FP16-rounded Q/K/V compatibility route; dedicated oracle promotion remains open."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "scalar",
+    "threading": {
+      "runtime": "serial",
+      "work_partition": ["serial"],
+      "dispatch": ["inline"],
+      "reduction_order_effect": "contract_defined"
+    }
+  },
   "quant": {
     "activation": "fp32",
     "output": "fp32"

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided.json
@@ -2,6 +2,32 @@
   "id": "attention_forward_causal_head_major_gqa_flash_strided",
   "op": "attention",
   "variant": "causal_flash_fp32",
+  "mode": "prefill",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["prefill"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp32"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["fp32_online"]
+  },
+  "supported_reductions": {
+    "fp32_online": {
+      "status": "validated",
+      "function": "attention_forward_causal_head_major_gqa_flash_strided",
+      "explicit_selector": true,
+      "notes": "Validated causal FP32 online-softmax prefill route."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["independent_query_blocks"],
+      "dispatch": ["ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "weight": "none",
     "activation": "fp32",

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_f16kv.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_f16kv.json
@@ -2,6 +2,32 @@
   "id": "attention_forward_causal_head_major_gqa_flash_strided_f16kv",
   "op": "attention",
   "variant": "causal_flash_fp32_f16kv",
+  "mode": "prefill",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["prefill"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp32"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["f16_online_single_range"]
+  },
+  "supported_reductions": {
+    "f16_online_single_range": {
+      "status": "observed",
+      "function": "attention_forward_causal_head_major_gqa_flash_strided_f16kv",
+      "explicit_selector": true,
+      "notes": "Single-range FP16-rounded Q/K/V compatibility route; dedicated oracle promotion remains open."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "scalar",
+    "threading": {
+      "runtime": "serial",
+      "work_partition": ["serial"],
+      "dispatch": ["inline"],
+      "reduction_order_effect": "contract_defined"
+    }
+  },
   "quant": {
     "weight": "none",
     "activation": "fp32",

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_sliding.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_flash_strided_sliding.json
@@ -2,6 +2,32 @@
   "id": "attention_forward_causal_head_major_gqa_flash_strided_sliding",
   "op": "attention_sliding",
   "variant": "causal_flash_fp32_sliding",
+  "mode": "prefill",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["prefill"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp32"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["fp32_online"]
+  },
+  "supported_reductions": {
+    "fp32_online": {
+      "status": "validated",
+      "function": "attention_forward_causal_head_major_gqa_flash_strided_sliding",
+      "explicit_selector": true,
+      "notes": "Validated sliding-window FP32 online-softmax prefill route."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["independent_query_blocks"],
+      "dispatch": ["ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "weight": "none",
     "activation": "fp32",

--- a/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_f16cache.json
+++ b/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_f16cache.json
@@ -3,6 +3,7 @@
   "op": "attention",
   "variant": "decode_head_major_gqa_flash_f16cache",
   "mode": "decode",
+  "contract_schema_version": 1,
   "provides": {
     "execution.phase": ["decode"],
     "tensor.q.dtype": ["fp32"],
@@ -16,6 +17,15 @@
       "function": "attention_forward_decode_head_major_gqa_flash_f16cache",
       "explicit_selector": false,
       "notes": "Current generated v8 route. The explicit selector API is validated separately and will replace this ABI after E2E promotion."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["kv_chunks_by_workers"],
+      "dispatch": ["ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "contract_defined"
     }
   },
   "quant": {

--- a/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_sliding.json
+++ b/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_sliding.json
@@ -3,6 +3,31 @@
   "op": "attention_sliding",
   "variant": "decode_flash_fp32_sliding",
   "mode": "decode",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["decode"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp32"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["fp32_online"]
+  },
+  "supported_reductions": {
+    "fp32_online": {
+      "status": "validated",
+      "function": "attention_forward_decode_head_major_gqa_flash_sliding",
+      "explicit_selector": true,
+      "notes": "Validated sliding-window FP32 single-token decode route."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "serial",
+      "work_partition": ["independent_heads"],
+      "dispatch": ["inline"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "activation": "fp32",
     "output": "fp32"

--- a/version/v8/kernel_maps/attention_forward_full_head_major_gqa_flash_strided.json
+++ b/version/v8/kernel_maps/attention_forward_full_head_major_gqa_flash_strided.json
@@ -3,6 +3,7 @@
   "op": "attention",
   "variant": "full_flash_fp32",
   "mode": "prefill",
+  "contract_schema_version": 1,
   "provides": {
     "execution.phase": ["prefill"],
     "tensor.q.dtype": ["fp32"],
@@ -16,6 +17,15 @@
       "function": "attention_forward_full_head_major_gqa_flash_strided",
       "explicit_selector": false,
       "notes": "Legacy v8 ABI with validated FP32 Q and FP16-rounded K/V semantics."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["independent_query_blocks"],
+      "dispatch": ["ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "none"
     }
   },
   "quant": {

--- a/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
@@ -2,6 +2,16 @@
   "id": "gemm_nt_q4_k_q8_k",
   "op": "gemm",
   "variant": "q4_k_w_q8_k_a",
+  "contract_schema_version": 1,
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["serial", "independent_rows", "independent_columns", "output_tiles"],
+      "dispatch": ["inline", "ck_threadpool_dispatch_n", "internal_threaded"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "weight": "q4_k",
     "activation": "q8_k",

--- a/version/v8/kernel_maps/gemm_nt_q6_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q6_k_q8_k.json
@@ -2,6 +2,16 @@
   "id": "gemm_nt_q6_k_q8_k",
   "op": "gemm",
   "variant": "q6_k_w_q8_k_a",
+  "contract_schema_version": 1,
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["serial", "independent_rows", "output_tiles"],
+      "dispatch": ["inline", "ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "weight": "q6_k",
     "activation": "q8_k",

--- a/version/v8/kernel_maps/gemv_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q4_k_q8_k.json
@@ -2,6 +2,16 @@
   "id": "gemv_q4_k_q8_k",
   "op": "gemv",
   "variant": "q4_k_w_q8_k_a_fp32_out",
+  "contract_schema_version": 1,
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["serial", "independent_rows"],
+      "dispatch": ["inline", "ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "weight": "q4_k",
     "activation": "q8_k",

--- a/version/v8/kernel_maps/gemv_q6_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q6_k_q8_k.json
@@ -2,6 +2,16 @@
   "id": "gemv_q6_k_q8_k",
   "op": "gemv",
   "variant": "q6_k_w_q8_k_a_fp32_out",
+  "contract_schema_version": 1,
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["serial", "independent_rows"],
+      "dispatch": ["inline", "ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "none"
+    }
+  },
   "quant": {
     "weight": "q6_k",
     "activation": "q8_k",

--- a/version/v8/schemas/attention_kernel_capability.schema.json
+++ b/version/v8/schemas/attention_kernel_capability.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.attention_kernel_capability",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "op", "mode", "contract_schema_version", "provides", "supported_reductions", "implementation", "impl"],
+  "properties": {
+    "id": {"type": "string", "minLength": 1},
+    "op": {"enum": ["attention", "attention_sliding"]},
+    "mode": {"enum": ["prefill", "decode"]},
+    "contract_schema_version": {"const": 1},
+    "provides": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["execution.phase", "tensor.q.dtype", "tensor.kv.dtype", "tensor.layout", "numerics.attention_reduction"],
+      "properties": {
+        "execution.phase": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["prefill", "decode"]}},
+        "tensor.q.dtype": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["fp32", "fp16", "bf16"]}},
+        "tensor.kv.dtype": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["fp32", "fp16", "bf16"]}},
+        "tensor.layout": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["head_major", "token_major"]}},
+        "numerics.attention_reduction": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "supported_reductions": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["status", "function", "explicit_selector", "notes"],
+        "properties": {
+          "status": {"enum": ["unresolved", "observed", "validated"]},
+          "function": {"type": "string", "minLength": 1},
+          "explicit_selector": {"type": "boolean"},
+          "selector": {"type": ["string", "null"]},
+          "notes": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["isa_dispatch", "threading"],
+      "properties": {
+        "isa_dispatch": {"enum": ["runtime", "compile_time", "scalar"]},
+        "threading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["runtime", "work_partition", "dispatch", "reduction_order_effect"],
+          "properties": {
+            "runtime": {"enum": ["serial", "ck_threadpool"]},
+            "work_partition": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["serial", "independent_heads", "independent_query_blocks", "kv_chunks_by_workers"]}},
+            "dispatch": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["inline", "ck_threadpool_dispatch_n"]}},
+            "reduction_order_effect": {"enum": ["none", "contract_defined", "implementation_defined"]}
+          }
+        }
+      }
+    },
+    "impl": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["function"],
+      "properties": {"function": {"type": "string", "minLength": 1}}
+    }
+  }
+}

--- a/version/v8/schemas/attention_reduction_registry.schema.json
+++ b/version/v8/schemas/attention_reduction_registry.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.attention_reduction_registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "schema_version", "engine_contract_version", "required_semantic_fields", "contracts"],
+  "properties": {
+    "schema": {"const": "cke.attention_reduction_contracts"},
+    "schema_version": {"const": 1},
+    "engine_contract_version": {"const": "8"},
+    "required_semantic_fields": {
+      "const": [
+        "q_compute",
+        "k_compute",
+        "score_accumulator",
+        "softmax_statistics",
+        "value_compute",
+        "value_accumulator",
+        "partial_storage",
+        "partial_merge",
+        "partition"
+      ]
+    },
+    "contracts": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {"$ref": "#/$defs/reduction"}
+    }
+  },
+  "$defs": {
+    "reduction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "q_compute",
+        "k_compute",
+        "score_accumulator",
+        "softmax_statistics",
+        "value_compute",
+        "value_accumulator",
+        "partial_storage",
+        "partial_merge",
+        "partition",
+        "description"
+      ],
+      "properties": {
+        "status": {"enum": ["unresolved", "observed", "validated"]},
+        "q_compute": {"enum": ["fp32", "fp16", "fp16_rounded", "bf16", "bf16_rounded"]},
+        "k_compute": {"enum": ["fp32", "fp16", "fp16_rounded", "bf16", "bf16_rounded"]},
+        "score_accumulator": {"enum": ["fp32", "fp16", "bf16"]},
+        "softmax_statistics": {"enum": ["fp32", "fp16", "bf16"]},
+        "value_compute": {"enum": ["fp32", "fp16", "fp16_rounded", "bf16", "bf16_rounded"]},
+        "value_accumulator": {"enum": ["fp32", "fp16", "fp16_rounded_each_update", "bf16", "bf16_rounded_each_update"]},
+        "partial_storage": {"enum": ["none", "fp32", "fp16", "bf16"]},
+        "partial_merge": {"enum": ["none", "fp32_chunk_order", "fp16_chunk_order", "bf16_chunk_order"]},
+        "partition": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": {
+            "kind": {"enum": ["single_range", "kv_chunks_by_workers"]},
+            "threshold": {"type": "integer", "minimum": 1},
+            "below_threshold_chunks": {"type": "integer", "minimum": 1},
+            "at_or_above_threshold_chunks": {"enum": ["runtime_worker_count"]}
+          }
+        },
+        "description": {"type": "string", "minLength": 1},
+        "validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["test", "cases", "reference"],
+          "properties": {
+            "test": {"type": "string", "minLength": 1},
+            "cases": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+            "reference": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    }
+  }
+}

--- a/version/v8/schemas/attention_required_contracts.schema.json
+++ b/version/v8/schemas/attention_required_contracts.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.attention_required_contracts",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["required_contracts"],
+  "properties": {
+    "required_contracts": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["op", "template_ops", "phases"],
+        "properties": {
+          "op": {"enum": ["attention", "attention_sliding"]},
+          "template_ops": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"enum": ["attn", "attn_sliding"]}
+          },
+          "phases": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "prefill": {"$ref": "#/$defs/request"},
+              "decode": {"$ref": "#/$defs/request"}
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requires", "validation", "evidence"],
+      "properties": {
+        "requires": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "execution.phase",
+            "tensor.q.dtype",
+            "tensor.kv.dtype",
+            "tensor.layout",
+            "numerics.attention_reduction"
+          ],
+          "properties": {
+            "execution.phase": {"enum": ["prefill", "decode"]},
+            "tensor.q.dtype": {"enum": ["fp32", "fp16", "bf16"]},
+            "tensor.kv.dtype": {"enum": ["fp32", "fp16", "bf16"]},
+            "tensor.layout": {"enum": ["head_major", "token_major"]},
+            "numerics.attention_reduction": {"type": "string", "minLength": 1}
+          }
+        },
+        "validation": {"enum": ["unresolved", "observed", "validated"]},
+        "evidence": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/version/v8/schemas/kernel_execution_capability.schema.json
+++ b/version/v8/schemas/kernel_execution_capability.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.kernel_execution_capability",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "op", "contract_schema_version", "implementation"],
+  "properties": {
+    "id": {"type": "string", "minLength": 1},
+    "op": {"type": "string", "minLength": 1},
+    "contract_schema_version": {"const": 1},
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["isa_dispatch", "threading"],
+      "properties": {
+        "isa_dispatch": {"enum": ["runtime", "compile_time", "scalar"]},
+        "threading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["runtime", "work_partition", "dispatch", "reduction_order_effect"],
+          "properties": {
+            "runtime": {"enum": ["serial", "ck_threadpool", "openmp"]},
+            "work_partition": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"enum": [
+                "serial",
+                "independent_rows",
+                "independent_columns",
+                "independent_heads",
+                "independent_query_blocks",
+                "kv_chunks_by_workers",
+                "output_tiles",
+                "split_k"
+              ]}
+            },
+            "dispatch": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"enum": ["inline", "ck_threadpool_dispatch_n", "openmp_parallel_for", "internal_threaded"]}
+            },
+            "reduction_order_effect": {"enum": ["none", "contract_defined", "implementation_defined"]}
+          }
+        }
+      }
+    }
+  }
+}

--- a/version/v8/schemas/resolved_attention_contract.schema.json
+++ b/version/v8/schemas/resolved_attention_contract.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.resolved_attention_contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "schema_version", "engine_contract_version", "circuit", "operation",
+    "template_ops", "phase", "resolution_mode", "kernel", "reduction", "implementation", "request_status",
+    "requirements", "production_blockers", "inputs"
+  ],
+  "properties": {
+    "schema": {"const": "cke.resolved_attention_contract"},
+    "schema_version": {"const": 1},
+    "engine_contract_version": {"const": "8"},
+    "circuit": {"type": ["string", "null"]},
+    "operation": {"type": "string", "minLength": 1},
+    "template_ops": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["attn", "attn_sliding"]}},
+    "phase": {"enum": ["prefill", "decode"]},
+    "resolution_mode": {"enum": ["bringup", "production"]},
+    "kernel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "function", "implementation_status", "explicit_selector", "selector"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "function": {"type": "string", "minLength": 1},
+        "implementation_status": {"enum": ["unresolved", "observed", "validated"]},
+        "explicit_selector": {"type": "boolean"},
+        "selector": {"type": ["string", "null"]}
+      }
+    },
+    "reduction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "definition_status", "semantics"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "definition_status": {"enum": ["unresolved", "observed", "validated"]},
+        "semantics": {"type": "object", "minProperties": 9}
+      }
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["isa_dispatch", "threading"],
+      "properties": {
+        "isa_dispatch": {"enum": ["runtime", "compile_time", "scalar"]},
+        "threading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["runtime", "work_partition", "dispatch", "reduction_order_effect"],
+          "properties": {
+            "runtime": {"enum": ["serial", "ck_threadpool"]},
+            "work_partition": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["serial", "independent_heads", "independent_query_blocks", "kv_chunks_by_workers"]}},
+            "dispatch": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["inline", "ck_threadpool_dispatch_n"]}},
+            "reduction_order_effect": {"enum": ["none", "contract_defined", "implementation_defined"]}
+          }
+        }
+      }
+    },
+    "request_status": {"enum": ["unresolved", "observed", "validated"]},
+    "requirements": {"type": "object", "minProperties": 5},
+    "production_blockers": {"type": "array", "items": {"type": "string"}},
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["circuit", "circuit_sha256"],
+      "properties": {
+        "circuit": {"type": ["string", "null"]},
+        "circuit_sha256": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """
-build_ir_v8.py - Complete IR Pipeline: Template + Quant → IR1 → Fusion → Layout
+build_ir_v8.py - Complete IR Pipeline: Circuit + Quant + Contracts → GraphIR → Lowering
 
 PIPELINE (4 stages):
-    1. IR1 Generation: Template + Quant Summary → Kernel IDs
+    1. GraphIR Generation: Circuit requirements + quant summary → resolved kernel IDs
     2. Fusion Pass: Combine consecutive kernels using registry-driven patterns
     3. Memory Layout: Plan activation buffers and weight offsets
     4. Output: IR1 JSON + Memory Layout JSON
 
 Stage 1 - IR1 Generation (Direct mapping, no intermediate abstractions):
-    1. Parse template sequence (what ops to run)
+    1. Parse circuit sequence and required contracts (what math to run)
     2. Read quant summary from manifest (what dtypes for weights)
-    3. Map template ops → kernel ops → concrete kernel IDs
+    3. Resolve contract-bearing ops, then map remaining circuit ops to kernel IDs
     4. Return: List of kernel function names
 
 Stage 2 - Fusion Pass:
@@ -44,9 +44,10 @@ OUTPUTS:
     - Layout JSON: Fused kernels + memory layout with explicit offsets
 
 LOWERING CONTRACT:
-    - The builder must stay architecture-agnostic.
-    - Templates declare operations, graph structure, and stitch points.
-    - The lowerer only expands declared operations into kernel ops / kernel IDs.
+    - The builder must stay model-family agnostic.
+    - Circuits declare operations, graph structure, stitch points, and semantics.
+    - The resolver selects contract-bearing providers before GraphIR construction.
+    - The lowerer consumes resolved providers and may not reselect them.
     - Do not teach the lowerer model names such as MoE, DeepStack, SSM, etc.
     - If a model needs branching, routing, collect, or stitch behavior, that
       contract belongs in the template as explicit operations or graph edges.
@@ -121,19 +122,82 @@ def _resolve_manifest_numerical_contracts(
     return plans
 
 
+def _load_kernel_execution_capabilities() -> Dict[str, Dict[str, Any]]:
+    resolver = _load_numerical_contract_resolver()
+    document = resolver.load_kernel_execution_capabilities()
+    kernels = document.get("kernels")
+    if not isinstance(kernels, dict):
+        raise RuntimeError("HARD CONTRACT FAULT: kernel execution capability registry is malformed.")
+    return kernels
+
+
+def _graph_ir_execution_metadata(capability: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "schema": "cke.graph_ir_execution_contract",
+        "schema_version": 1,
+        "kernel_id": capability["id"],
+        "op": capability["op"],
+        "implementation": copy.deepcopy(capability["implementation"]),
+    }
+
+
 def _validate_resolved_kernels_are_emitted(
     plans: List[Dict[str, Any]],
     arranged_kernels: List[Dict[str, Any]],
 ) -> None:
-    emitted = {str(item.get("kernel", "")) for item in arranged_kernels}
     for plan in plans:
         selected = str((plan.get("kernel") or {}).get("id", ""))
-        if selected and selected not in emitted:
+        template_ops = {str(item) for item in plan.get("template_ops", [])}
+        governed = [item for item in arranged_kernels if str(item.get("op", "")) in template_ops]
+        if not governed:
             raise RuntimeError(
-                f"Numerical contract selected kernel {selected!r} for "
-                f"{plan.get('operation')}.{plan.get('phase')}, but legacy lowering emitted "
-                f"{sorted(item for item in emitted if item)}"
+                f"HARD CONTRACT FAULT: resolved operation {plan.get('operation')}.{plan.get('phase')} "
+                f"governs {sorted(template_ops)}, but GraphIR emitted none of those operations. "
+                "Fix the circuit operation binding; do not bypass contract validation."
             )
+        for item in governed:
+            emitted = str(item.get("kernel", ""))
+            resolved = item.get("resolved_contract") if isinstance(item.get("resolved_contract"), dict) else {}
+            if emitted != selected or resolved.get("kernel_id") != selected:
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: GraphIR operation {item.get('op')} selected {emitted!r}, "
+                    f"but authoritative resolution requires {selected!r} for "
+                    f"{plan.get('operation')}.{plan.get('phase')}. Fix the circuit or kernel map; "
+                    "do not add a fallback or validation bypass."
+                )
+
+
+def _index_numerical_contract_plans(
+    plans: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    indexed: Dict[str, Dict[str, Any]] = {}
+    for plan in plans:
+        for template_op in plan.get("template_ops", []):
+            op = str(template_op).strip()
+            if not op:
+                continue
+            existing = indexed.get(op)
+            if existing is not None:
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: template op {op!r} is governed by both "
+                    f"{existing.get('operation')!r} and {plan.get('operation')!r}. "
+                    "Make circuit contract bindings unique; do not rely on declaration order."
+                )
+            indexed[op] = plan
+    return indexed
+
+
+def _graph_ir_contract_metadata(plan: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "schema": "cke.graph_ir_numerical_contract",
+        "schema_version": 1,
+        "operation": plan["operation"],
+        "phase": plan["phase"],
+        "contract_id": plan["reduction"]["id"],
+        "kernel_id": plan["kernel"]["id"],
+        "function": plan["kernel"]["function"],
+        "implementation": copy.deepcopy(plan["implementation"]),
+    }
 
 
 def _entry_offset(entry: Dict[str, Any]) -> int:
@@ -4575,6 +4639,8 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
             config = manifest.get("config", {})
 
     numerical_contract_plans = _resolve_manifest_numerical_contracts(manifest, mode)
+    numerical_contract_by_template_op = _index_numerical_contract_plans(numerical_contract_plans)
+    kernel_execution_capabilities = _load_kernel_execution_capabilities()
     for plan in numerical_contract_plans:
         print(
             "  [contract/numerics] "
@@ -4990,6 +5056,23 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
         # kernels slower for inference. Each decode token calls kernels 500+ times,
         # so thread management overhead dominates. Needs persistent thread pool.
         use_parallel = False  # Was: prefer_parallel and op in PARALLEL_OPS
+
+        # Contract-bearing operations are selected before GraphIR is built.
+        # Legacy template overrides and heuristic dispatch are not consulted.
+        resolved_plan = numerical_contract_by_template_op.get(op)
+        if resolved_plan is not None:
+            if resolved_plan.get("phase") != mode:
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: resolved {op!r} plan is for "
+                    f"{resolved_plan.get('phase')!r}, not active mode {mode!r}."
+                )
+            return [str(resolved_plan["kernel"]["id"])]
+        if op in {"attn", "attn_sliding"} and numerical_contract_plans:
+            raise RuntimeError(
+                f"HARD CONTRACT FAULT: circuit {template.get('name', '<embedded>')!r} declares "
+                f"numerical contracts, but attention template op {op!r} has no authoritative binding. "
+                "Fix required_contracts.template_ops; do not fall back to legacy attention selection."
+            )
 
         # Template-specified kernel overrides (keeps IR dumb and data-driven)
         if op == "rope_qk":
@@ -5757,6 +5840,19 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
 
     print(f"\n✓ Pass 1: Generated {len(arranged_kernels)} kernel calls")
 
+    # GraphIR records the selected provider's execution capability for every
+    # versioned kernel map. Later stages may carry it but must not reinterpret it.
+    for arranged in arranged_kernels:
+        kernel_id = str(arranged.get("kernel", ""))
+        capability = kernel_execution_capabilities.get(kernel_id)
+        if capability is not None:
+            arranged["resolved_execution"] = _graph_ir_execution_metadata(capability)
+        plan = numerical_contract_by_template_op.get(str(arranged.get("op", "")))
+        if plan is None:
+            continue
+        arranged["required_contract"] = copy.deepcopy(plan["requirements"])
+        arranged["resolved_contract"] = _graph_ir_contract_metadata(plan)
+
     # ═══════════════════════════════════════════════════════════
     # PASS 1.5: Add dataflow information
     # For each op, record what it reads from and writes to
@@ -6209,6 +6305,16 @@ def apply_fusion_pass(ir1_ops: List[Dict], registry: Dict, mode: str, no_fusion:
                     removed_ops = fused_ops[i:i+seq_len]
                     removed_kernels = [op.get("kernel") or op.get("function", "?") for op in removed_ops]
 
+                    governed = [op for op in removed_ops if op.get("resolved_contract")]
+                    if governed:
+                        governed_names = [op.get("op") for op in governed]
+                        raise RuntimeError(
+                            "HARD CONTRACT FAULT: fusion attempted to replace contract-bearing "
+                            f"GraphIR operations {governed_names} with {fused_id!r}. "
+                            "Declare and resolve a compatible fused-kernel contract before enabling "
+                            "this fusion; do not silently discard the resolved provider."
+                        )
+
                     print(f"\n  Fusion opportunity at position {i}:")
                     print(f"    Replacing: {' + '.join(removed_kernels)}")
                     print(f"    With:      {fused_id}")
@@ -6576,6 +6682,23 @@ def generate_ir_lower_1(
             "bias_for": ir_op.get("bias_for"),
             "dataflow": ir_op.get("dataflow", {}),  # Preserve dataflow for memory planner
         }
+        if ir_op.get("required_contract") is not None:
+            lowered_op["required_contract"] = copy.deepcopy(ir_op["required_contract"])
+        if ir_op.get("resolved_contract") is not None:
+            lowered_op["resolved_contract"] = copy.deepcopy(ir_op["resolved_contract"])
+            if lowered_op["resolved_contract"].get("kernel_id") != kernel_id:
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: LoweredIR received kernel {kernel_id!r}, but GraphIR "
+                    f"resolved {lowered_op['resolved_contract'].get('kernel_id')!r}. "
+                    "Lowering must consume the resolved provider without reselection."
+                )
+        if ir_op.get("resolved_execution") is not None:
+            lowered_op["resolved_execution"] = copy.deepcopy(ir_op["resolved_execution"])
+            if lowered_op["resolved_execution"].get("kernel_id") != kernel_id:
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: LoweredIR received kernel {kernel_id!r}, but GraphIR "
+                    f"execution metadata names {lowered_op['resolved_execution'].get('kernel_id')!r}."
+                )
         if ir_op.get("_auto_inserted"):
             lowered_op["_auto_inserted"] = True
 
@@ -6823,8 +6946,18 @@ def generate_ir_lower_1(
                 op["inputs"].pop("k", None)
                 op["inputs"].pop("v", None)
             elif op["op"] in ("attn", "attn_sliding") and "attention" in op["kernel"]:
-                # Switch to decode attention kernel (sliding vs non-sliding)
-                if op["op"] == "attn_sliding":
+                resolved_contract = op.get("resolved_contract") if isinstance(op.get("resolved_contract"), dict) else None
+                if resolved_contract is not None:
+                    decode_kernel = str(resolved_contract["kernel_id"])
+                    if force_decode_attn_regular:
+                        raise RuntimeError(
+                            "HARD CONTRACT FAULT: CK_V7_DECODE_ATTN_REGULAR attempted to override "
+                            f"resolved kernel {decode_kernel!r}. Semantic runtime flags cannot override "
+                            "an authoritative GraphIR contract."
+                        )
+                # Legacy circuits without a declared contract retain their
+                # existing compatibility selection until they are migrated.
+                elif op["op"] == "attn_sliding":
                     decode_kernel = template_kernels.get("attn_sliding_decode") or "attention_forward_decode_head_major_gqa_flash_sliding"
                 else:
                     if force_decode_attn_regular:
@@ -8482,6 +8615,22 @@ def generate_ir_lower_2(
             "outputs": {},
             "params": {},
         }
+        if ir_op.get("required_contract") is not None:
+            lowered_op["required_contract"] = copy.deepcopy(ir_op["required_contract"])
+        if ir_op.get("resolved_contract") is not None:
+            lowered_op["resolved_contract"] = copy.deepcopy(ir_op["resolved_contract"])
+            if lowered_op["resolved_contract"].get("kernel_id") != ir_op["kernel"]:
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: memory lowering received kernel {ir_op['kernel']!r}, "
+                    f"but GraphIR resolved {lowered_op['resolved_contract'].get('kernel_id')!r}."
+                )
+        if ir_op.get("resolved_execution") is not None:
+            lowered_op["resolved_execution"] = copy.deepcopy(ir_op["resolved_execution"])
+            if lowered_op["resolved_execution"].get("kernel_id") != ir_op["kernel"]:
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: memory lowering received kernel {ir_op['kernel']!r}, "
+                    f"but execution metadata names {lowered_op['resolved_execution'].get('kernel_id')!r}."
+                )
         if "_kv_cache_read_layer" in ir_op:
             lowered_op["_kv_cache_read_layer"] = int(ir_op["_kv_cache_read_layer"])
 
@@ -10635,7 +10784,14 @@ def generate_ir_lower_3(lowered_ir: Dict, mode: str) -> Dict:
                 "errors": op_errors,
             })
 
-        call_ops.append({
+        resolved_contract = copy.deepcopy(op.get("resolved_contract")) if op.get("resolved_contract") else None
+        if resolved_contract is not None and resolved_contract.get("function") != func:
+            raise RuntimeError(
+                f"HARD CONTRACT FAULT: call-ready IR function {func!r} differs from resolved "
+                f"function {resolved_contract.get('function')!r} for {resolved_contract.get('operation')}. "
+                "Code generation must emit the resolved decision without reselection."
+            )
+        call_op = {
             "idx": op.get("idx", -1),
             "function": func,
             "op": op.get("op", ""),
@@ -10644,7 +10800,20 @@ def generate_ir_lower_3(lowered_ir: Dict, mode: str) -> Dict:
             "args": args,
             "errors": op_errors,
             "warnings": op_warnings,
-        })
+        }
+        if op.get("required_contract") is not None:
+            call_op["required_contract"] = copy.deepcopy(op["required_contract"])
+        if resolved_contract is not None:
+            call_op["resolved_contract"] = resolved_contract
+        resolved_execution = copy.deepcopy(op.get("resolved_execution")) if op.get("resolved_execution") else None
+        if resolved_execution is not None:
+            if resolved_execution.get("kernel_id") != op.get("kernel"):
+                raise RuntimeError(
+                    f"HARD CONTRACT FAULT: call-ready IR kernel {op.get('kernel')!r} differs from "
+                    f"execution metadata {resolved_execution.get('kernel_id')!r}."
+                )
+            call_op["resolved_execution"] = resolved_execution
+        call_ops.append(call_op)
 
     lowered_call = {
         "format": "lowered-ir-v3",

--- a/version/v8/scripts/resolve_attention_contracts_v8.py
+++ b/version/v8/scripts/resolve_attention_contracts_v8.py
@@ -13,17 +13,34 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
+from jsonschema import Draft202012Validator
+
 
 V8_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = V8_ROOT.parents[1]
 DEFAULT_CONTRACTS = V8_ROOT / "contracts" / "attention_reductions.json"
 DEFAULT_KERNELS = V8_ROOT / "kernel_maps"
+SCHEMA_ROOT = V8_ROOT / "schemas"
+CONTRACT_REGISTRY_SCHEMA = SCHEMA_ROOT / "attention_reduction_registry.schema.json"
+CIRCUIT_REQUIREMENTS_SCHEMA = SCHEMA_ROOT / "attention_required_contracts.schema.json"
+KERNEL_CAPABILITY_SCHEMA = SCHEMA_ROOT / "attention_kernel_capability.schema.json"
+KERNEL_EXECUTION_SCHEMA = SCHEMA_ROOT / "kernel_execution_capability.schema.json"
+RESOLVED_CONTRACT_SCHEMA = SCHEMA_ROOT / "resolved_attention_contract.schema.json"
 VALID_STATES = {"unresolved", "observed", "validated"}
 AMBIGUOUS_IDS = {"fp16", "f16", "bf16", "fp32", "f32", "fast", "strict"}
 
 
 class ContractError(RuntimeError):
     pass
+
+
+def hard_contract_fault(summary: str, detail: str, remediation: str) -> ContractError:
+    return ContractError(
+        "HARD CONTRACT FAULT: " + summary + "\n"
+        "  " + detail + "\n"
+        "  Fix: " + remediation + "\n"
+        "  Do not add a fallback, silent default, tolerance relaxation, or validation bypass."
+    )
 
 
 def load_json(path: Path) -> Dict[str, Any]:
@@ -39,9 +56,27 @@ def load_json(path: Path) -> Dict[str, Any]:
     return doc
 
 
+def validate_schema(instance: Dict[str, Any], schema_path: Path, context: str) -> None:
+    schema = load_json(schema_path)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(instance),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    if not errors:
+        return
+    error = errors[0]
+    location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+    raise hard_contract_fault(
+        f"{context} violates {schema_path.name}",
+        f"At {location}: {error.message}",
+        "correct the circuit, reduction registry, or kernel map so it satisfies the versioned schema.",
+    )
+
+
 def load_kernel_capabilities(root: Path = DEFAULT_KERNELS) -> Dict[str, Any]:
     if not root.is_dir():
         raise ContractError(f"Kernel-map directory does not exist: {root}")
+    load_kernel_execution_capabilities(root)
     kernels: Dict[str, Any] = {}
     for path in sorted(root.glob("*.json")):
         doc = load_json(path)
@@ -57,6 +92,45 @@ def load_kernel_capabilities(root: Path = DEFAULT_KERNELS) -> Dict[str, Any]:
         raise ContractError(f"No numerical kernel capabilities found under: {root}")
     return {
         "schema": "cke.kernel_numerical_contracts",
+        "schema_version": 1,
+        "engine_contract_version": "8",
+        "kernels": kernels,
+    }
+
+
+def load_kernel_execution_capabilities(root: Path = DEFAULT_KERNELS) -> Dict[str, Any]:
+    if not root.is_dir():
+        raise ContractError(f"Kernel-map directory does not exist: {root}")
+    kernels: Dict[str, Any] = {}
+    for path in sorted(root.glob("*.json")):
+        doc = load_json(path)
+        if "contract_schema_version" not in doc:
+            continue
+        kernel_id = str(doc.get("id", "")).strip()
+        if not kernel_id:
+            raise hard_contract_fault(
+                "versioned kernel map has no id",
+                f"File: {path}",
+                "add a stable kernel-map id.",
+            )
+        if kernel_id in kernels:
+            raise hard_contract_fault(
+                f"duplicate kernel capability id {kernel_id!r}",
+                f"Files: {kernels[kernel_id]['source']} and {path}",
+                "give each executable provider a unique id.",
+            )
+        capability = {
+            "id": kernel_id,
+            "op": doc.get("op"),
+            "contract_schema_version": doc.get("contract_schema_version"),
+            "implementation": doc.get("implementation"),
+        }
+        validate_schema(capability, KERNEL_EXECUTION_SCHEMA, f"kernel execution capability {kernel_id}")
+        kernels[kernel_id] = {**capability, "source": str(path)}
+    if not kernels:
+        raise ContractError(f"No versioned kernel execution capabilities found under: {root}")
+    return {
+        "schema": "cke.kernel_execution_capabilities",
         "schema_version": 1,
         "engine_contract_version": "8",
         "kernels": kernels,
@@ -87,6 +161,7 @@ def validate_state(value: Any, context: str) -> str:
 
 
 def validate_contract_registry(doc: Dict[str, Any]) -> None:
+    validate_schema(doc, CONTRACT_REGISTRY_SCHEMA, "attention reduction registry")
     require_keys(doc, ("contracts", "required_semantic_fields"), "attention contract registry")
     contracts = doc["contracts"]
     fields = doc["required_semantic_fields"]
@@ -125,6 +200,30 @@ def validate_kernel_overlay(doc: Dict[str, Any]) -> None:
                 f"Kernel capability {kernel_id} points to map with id {base_map.get('id')!r}: {map_path}"
             )
         base_function = (base_map.get("impl") or {}).get("function")
+        validate_schema(
+            {
+                "id": kernel_id,
+                "op": kernel.get("op"),
+                "contract_schema_version": kernel.get("contract_schema_version"),
+                "implementation": kernel.get("implementation"),
+            },
+            KERNEL_EXECUTION_SCHEMA,
+            f"kernel execution capability {kernel_id}",
+        )
+        validate_schema(
+            {
+                "id": kernel_id,
+                "op": kernel.get("op"),
+                "mode": kernel.get("mode"),
+                "contract_schema_version": kernel.get("contract_schema_version"),
+                "provides": kernel.get("provides"),
+                "supported_reductions": kernel.get("supported_reductions"),
+                "implementation": kernel.get("implementation"),
+                "impl": {"function": base_function},
+            },
+            KERNEL_CAPABILITY_SCHEMA,
+            f"kernel capability {kernel_id}",
+        )
         provides = kernel["provides"]
         if not isinstance(provides, dict) or not provides:
             raise ContractError(f"Kernel capability {kernel_id}.provides must be a non-empty object")
@@ -184,12 +283,18 @@ def resolve_contract(
         raise ContractError(f"Unknown resolution mode: {mode}")
 
     operations = circuit_doc.get("required_contracts")
+    validate_schema(
+        {"required_contracts": operations},
+        CIRCUIT_REQUIREMENTS_SCHEMA,
+        f"circuit {circuit_doc.get('name') or '<embedded>'} attention requirements",
+    )
     if not isinstance(operations, dict) or operation not in operations:
         raise ContractError(f"Circuit does not declare operation contract: {operation}")
     operation_doc = operations[operation]
     if not isinstance(operation_doc, dict):
         raise ContractError(f"Circuit operation {operation} must be an object")
-    require_keys(operation_doc, ("op", "phases"), f"circuit operation {operation}")
+    require_keys(operation_doc, ("op", "template_ops", "phases"), f"circuit operation {operation}")
+    template_ops = operation_doc["template_ops"]
     phases = operation_doc["phases"]
     if not isinstance(phases, dict) or phase not in phases:
         raise ContractError(f"Circuit operation {operation} does not declare phase: {phase}")
@@ -224,12 +329,22 @@ def resolve_contract(
         if isinstance(supported, dict) and reduction_id in supported:
             candidates.append((candidate_id, candidate))
     if not candidates:
-        raise ContractError(
-            f"No kernel satisfies circuit requirements for {operation}.{phase}: {json.dumps(requires, sort_keys=True)}"
+        available = [
+            f"{candidate_id}: {json.dumps(candidate.get('provides', {}), sort_keys=True)}"
+            for candidate_id, candidate in kernels.items()
+            if candidate.get("op") == operation_doc["op"]
+        ]
+        raise hard_contract_fault(
+            f"no kernel provides {operation}.{phase}",
+            "Required: " + json.dumps(requires, sort_keys=True)
+            + ("; available attention providers: " + " | ".join(available) if available else "; no providers exist"),
+            "correct the circuit requirement or add and validate a compatible executable kernel map.",
         )
     if len(candidates) > 1:
-        raise ContractError(
-            f"Ambiguous kernel selection for {operation}.{phase}: {[item[0] for item in candidates]}"
+        raise hard_contract_fault(
+            f"multiple kernels provide {operation}.{phase}",
+            f"Matching providers: {[item[0] for item in candidates]}",
+            "make kernel capabilities mutually exclusive or add an explicit semantic requirement that selects one provider.",
         )
     kernel_id, kernel = candidates[0]
     supported = kernel.get("supported_reductions")
@@ -258,12 +373,13 @@ def resolve_contract(
 
     source_path = source_circuit_path.resolve() if source_circuit_path else None
 
-    return {
+    result = {
         "schema": "cke.resolved_attention_contract",
         "schema_version": 1,
         "engine_contract_version": "8",
         "circuit": circuit_doc.get("name"),
         "operation": operation,
+        "template_ops": template_ops,
         "phase": phase,
         "resolution_mode": mode,
         "kernel": {
@@ -278,6 +394,7 @@ def resolve_contract(
             "definition_status": contract_state,
             "semantics": {key: contract[key] for key in contract_doc["required_semantic_fields"]}
         },
+        "implementation": kernel["implementation"],
         "request_status": request_state,
         "requirements": requires,
         "production_blockers": blockers,
@@ -286,6 +403,8 @@ def resolve_contract(
             "circuit_sha256": sha256_file(source_path) if source_path else None
         }
     }
+    validate_schema(result, RESOLVED_CONTRACT_SCHEMA, f"resolved contract {operation}.{phase}")
+    return result
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Why

Numerical parity and thread scheduling both depend on the exact provider, reduction, partition, and dispatch semantics. Previously, valid leaf kernels could still be stitched through a different production route because lowering verified or inferred decisions after selection.

## What

- Add strict Draft 2020-12 schemas for circuit attention requirements, reduction definitions, attention providers, resolved plans, and operator-generic execution capabilities.
- Hard-fail unknown fields, incomplete contracts, missing providers, ambiguous providers, later-stage reselection, incompatible fusion, and semantic environment overrides.
- Make attention resolution authoritative before GraphIR for Gemma3, Qwen2, Qwen3, Qwen3.5, Llama/Nanbeige, Qwen3-VL decoder, and Qwen3-VL vision.
- Carry `required_contract`, `resolved_contract`, and operator-generic `resolved_execution` through GraphIR, LoweredIR, and call-ready IR.
- Declare threadpool runtime, partition, dispatch, and reduction-order effects for attention and hot Q4/Q6 GEMM/GEMV maps.
- Add an explicit no-fallback/no-bypass policy for agents and contributors.
- Update architecture documentation and generated site pages.

## Validation

- `make test-numerical-contracts`: 18/18
- `make test-v8-qwen3vl`: 17/17 circuit tests, 3/3 gates, 1/1 nightly status
- `tests/test_v8_codegen_bridge.py`: 9/9
- `tests/test_build_ir_v8_scaffold.py`: 5/5
- `unittest/test_attention_full.py`: 7/7
- `make test-attention-sliding`: PASS
- llama-backed `make test-attention-f16-split-kv`: 14/14
- `make v8-regression-fast`: PASS across Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige release contracts
- JSON schema/map/circuit parse, SVG XML parse, `py_compile`, and `git diff --check`: PASS

## Existing v7 gate status

The staged repository pre-commit hook was run. `v7-kernel-map-contracts` passed. The broad v7 fast family gate reproduced existing first-token parity failures for Gemma, Qwen2, and Nanbeige; this PR does not touch v7 runtime or circuits, and those failures are not represented as passing.

## Scope

This PR makes attention semantic resolution authoritative and makes execution metadata operator-generic. Q4/Q6 GEMM/GEMV execution policies are now carried and checked through IR, but their numerical semantic contracts remain a subsequent operator-family migration rather than being guessed here.
