### PR TITLE
feat(v8): harden quantized linear numerical contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2875,10 +2875,12 @@ test-v8-template-circuit-audit:
 	@$(PYTHON) -m unittest tests.test_v8_template_circuit_audit -v
 
 .PHONY: test-numerical-contracts
-test-numerical-contracts:
+test-numerical-contracts: $(LIB)
 	@echo "Running v8 numerical contract validation..."
 	@$(PYTHON) -m py_compile version/v8/scripts/resolve_attention_contracts_v8.py
 	@$(PYTHON) tests/test_v8_attention_contracts.py
+	@$(PYTHON) unittest/test_attention_full.py
+	@$(PYTHON) unittest/test_attention_f16_split_kv.py
 	@mkdir -p build/v8/contracts
 	@$(PYTHON) version/v8/scripts/resolve_attention_contracts_v8.py --circuit qwen3_vl_vision --operation vision_encoder.attention --phase prefill --mode bringup --output build/v8/contracts/qwen3vl-vision-prefill.json >/dev/null
 	@$(PYTHON) version/v8/scripts/resolve_attention_contracts_v8.py --circuit qwen3vl --operation decoder.attention --phase decode --mode bringup --output build/v8/contracts/qwen3vl-decode.json >/dev/null

--- a/docs/site/_pages/v8-numerical-contracts.html
+++ b/docs/site/_pages/v8-numerical-contracts.html
@@ -97,6 +97,18 @@
 
 <p>Kernel maps also declare ISA dispatch, threading runtime, possible work partitions, dispatch mechanisms, and whether scheduling can alter reduction order. Q4/Q6 GEMM and GEMV maps therefore expose serial, row, column, or output-tile policies instead of hiding threadpool behavior in generated wrappers. GraphIR records this as <code>resolved_execution</code>, and LoweredIR plus call-ready IR hard-fail if the kernel ID changes. When partitioning changes arithmetic order, the numerical contract must define the corresponding reduction and merge behavior.</p>
 
+<h2>Scalar, Production, and Threadpool Evidence</h2>
+
+<p>Quantized linear maps bind three exact functions: the scalar contract oracle, the public production function, and the threadpool dispatch function. The compiler validates these names and carries them into IR; it does not rank or guess functions from ISA, dimensions, or benchmark results. Dimensions and thread counts remain ordinary function inputs.</p>
+
+<ol>
+  <li>Compare an external backend or independent mathematical oracle with the scalar contract implementation.</li>
+  <li>Compare the optimized public function with that scalar implementation.</li>
+  <li>Compare threadpool dispatch with the same scalar implementation at representative thread counts and shapes.</li>
+</ol>
+
+<p>Independent output rows or tiles must preserve each output's reduction order. Split-K is a different numerical contract and must declare its partial accumulator, partition, and merge order. Unavailable llama.cpp or PyTorch evidence is recorded as <code>unresolved</code>, never counted as a pass.</p>
+
 <div class="contract-note contract-bad">
   <strong>Hard-fail policy:</strong> agents must fix the circuit, canonical contract, or kernel map. They must not add fallbacks, silent defaults, bypass flags, or looser tolerances to make a new model compile.
 </div>
@@ -108,6 +120,7 @@
 <h2>Validation Commands</h2>
 
 <pre><code>make test-numerical-contracts
+make test-threadpool-parity
 PYTHONPATH=unittest .venv/bin/python unittest/test_attention_full.py -v
 V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT=./llama.cpp \
   make test-attention-f16-split-kv

--- a/docs/site/_pages/v8-numerical-contracts.html
+++ b/docs/site/_pages/v8-numerical-contracts.html
@@ -119,6 +119,8 @@
 
 <h2>Validation Commands</h2>
 
+<p><code>make test-numerical-contracts</code> is an executable gate, not only a schema check. It builds the engine and runs contract resolution, full attention numerics, and FP16 split-KV reduction cases. The focused commands below remain useful when attributing a failure.</p>
+
 <pre><code>make test-numerical-contracts
 make test-threadpool-parity
 PYTHONPATH=unittest .venv/bin/python unittest/test_attention_full.py -v

--- a/docs/site/v8-numerical-contracts.html
+++ b/docs/site/v8-numerical-contracts.html
@@ -1065,6 +1065,8 @@
 
 <h2>Validation Commands</h2>
 
+<p><code>make test-numerical-contracts</code> is an executable gate, not only a schema check. It builds the engine and runs contract resolution, full attention numerics, and FP16 split-KV reduction cases. The focused commands below remain useful when attributing a failure.</p>
+
 <pre><code>make test-numerical-contracts
 make test-threadpool-parity
 PYTHONPATH=unittest .venv/bin/python unittest/test_attention_full.py -v

--- a/docs/site/v8-numerical-contracts.html
+++ b/docs/site/v8-numerical-contracts.html
@@ -1043,6 +1043,18 @@
 
 <p>Kernel maps also declare ISA dispatch, threading runtime, possible work partitions, dispatch mechanisms, and whether scheduling can alter reduction order. Q4/Q6 GEMM and GEMV maps therefore expose serial, row, column, or output-tile policies instead of hiding threadpool behavior in generated wrappers. GraphIR records this as <code>resolved_execution</code>, and LoweredIR plus call-ready IR hard-fail if the kernel ID changes. When partitioning changes arithmetic order, the numerical contract must define the corresponding reduction and merge behavior.</p>
 
+<h2>Scalar, Production, and Threadpool Evidence</h2>
+
+<p>Quantized linear maps bind three exact functions: the scalar contract oracle, the public production function, and the threadpool dispatch function. The compiler validates these names and carries them into IR; it does not rank or guess functions from ISA, dimensions, or benchmark results. Dimensions and thread counts remain ordinary function inputs.</p>
+
+<ol>
+  <li>Compare an external backend or independent mathematical oracle with the scalar contract implementation.</li>
+  <li>Compare the optimized public function with that scalar implementation.</li>
+  <li>Compare threadpool dispatch with the same scalar implementation at representative thread counts and shapes.</li>
+</ol>
+
+<p>Independent output rows or tiles must preserve each output's reduction order. Split-K is a different numerical contract and must declare its partial accumulator, partition, and merge order. Unavailable llama.cpp or PyTorch evidence is recorded as <code>unresolved</code>, never counted as a pass.</p>
+
 <div class="contract-note contract-bad">
   <strong>Hard-fail policy:</strong> agents must fix the circuit, canonical contract, or kernel map. They must not add fallbacks, silent defaults, bypass flags, or looser tolerances to make a new model compile.
 </div>
@@ -1054,6 +1066,7 @@
 <h2>Validation Commands</h2>
 
 <pre><code>make test-numerical-contracts
+make test-threadpool-parity
 PYTHONPATH=unittest .venv/bin/python unittest/test_attention_full.py -v
 V8_QWEN3VL_ENCODER_PARITY_LLAMA_CPP_ROOT=./llama.cpp \
   make test-attention-f16-split-kv

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -408,7 +408,7 @@ MAKE_TARGETS = {
         "timeout_sec": 60,
     },
     "threadpool_parity": {
-        "name": "Thread Pool GEMV Parity (serial vs dispatch)",
+        "name": "Quantized Linear Scalar/Production/Threadpool Parity",
         "category": "parity",
         "target": "test-threadpool-parity",
         "timeout_sec": 300,
@@ -492,7 +492,7 @@ MAKE_TARGETS = {
         "timeout_sec": 600,
     },
     "v8_numerical_contracts": {
-        "name": "v8 Numerical Reduction Contracts",
+        "name": "v8 Numerical Kernel Contracts",
         "category": "parity",
         "target": "test-numerical-contracts",
         "timeout_sec": 300,

--- a/src/kernels/gemm_kernels_q4k_q8k.c
+++ b/src/kernels/gemm_kernels_q4k_q8k.c
@@ -134,7 +134,6 @@ static float dot_q4_k_q8_k_ref(const block_q4_K *w,
 {
     const int nb = k / QK_K;
     float sumf = 0.0f;
-    float sums[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
     for (int i = 0; i < nb; ++i) {
         uint8_t sc[8], m_val[8];
@@ -143,44 +142,26 @@ static float dot_q4_k_q8_k_ref(const block_q4_K *w,
         const float d = CK_FP16_TO_FP32(w[i].d) * x[i].d;
         const float dmin = CK_FP16_TO_FP32(w[i].dmin) * x[i].d;
 
-        int32_t aux32[8] = {0, 0, 0, 0, 0, 0, 0, 0};
         int sumi = 0;
         for (int j = 0; j < QK_K / 16; ++j) {
             sumi += (int)x[i].bsums[j] * (int)m_val[j / 2];
         }
 
-        int is = 0;
-        int q_offset = 0;
-
-        for (int j = 0; j < QK_K; j += 64) {
-            const uint8_t *qs = &w[i].qs[q_offset];
-            const int8_t *q8_lo = &x[i].qs[j];
-            const int8_t *q8_hi = &x[i].qs[j + 32];
-
+        int32_t scaled_sum = 0;
+        for (int group = 0; group < 4; ++group) {
+            const uint8_t *qs = &w[i].qs[group * 32];
+            const int8_t *q8_lo = &x[i].qs[group * 64];
+            const int8_t *q8_hi = q8_lo + 32;
+            int32_t lo = 0;
+            int32_t hi = 0;
             for (int l = 0; l < 32; ++l) {
-                int q4_val = qs[l] & 0x0F;
-                const int prod = q4_val * q8_lo[l];
-                aux32[l & 7] += (int)sc[is] * prod;
+                lo += (int32_t)(qs[l] & 0x0F) * (int32_t)q8_lo[l];
+                hi += (int32_t)(qs[l] >> 4) * (int32_t)q8_hi[l];
             }
-
-            for (int l = 0; l < 32; ++l) {
-                int q4_val = qs[l] >> 4;
-                const int prod = q4_val * q8_hi[l];
-                aux32[l & 7] += (int)sc[is + 1] * prod;
-            }
-
-            q_offset += 32;
-            is += 2;
+            scaled_sum += (int32_t)sc[2 * group] * lo;
+            scaled_sum += (int32_t)sc[2 * group + 1] * hi;
         }
-
-        for (int l = 0; l < 8; ++l) {
-            sums[l] += d * (float)aux32[l];
-        }
-        sumf -= dmin * (float)sumi;
-    }
-
-    for (int l = 0; l < 8; ++l) {
-        sumf += sums[l];
+        sumf += d * (float)scaled_sum - dmin * (float)sumi;
     }
     return sumf;
 }

--- a/tests/test_threadpool_parity.c
+++ b/tests/test_threadpool_parity.c
@@ -1,6 +1,6 @@
 /**
  * test_threadpool_parity.c - Numerical parity and speed comparison:
- *                             Serial GEMV/GEMM kernels vs Thread Pool dispatch variants
+ *                             Scalar/serial references vs production and threadpool variants
  *
  * Tests thread pool dispatch wrappers against serial kernels:
  *
@@ -23,8 +23,8 @@
  *   - OpenMP fork/join creates threads per #pragma region (~15-50us overhead)
  *   - Thread pool keeps N-1 pthreads alive, spin-waiting on atomics (~0.1us wake)
  *   - OpenMP + thread pool together causes 2N threads competing for N cores
- *   - This test validates that thread pool dispatch produces identical outputs
- *     to serial kernels, and measures the speedup from persistent pthreads.
+ *   - Q4_K/Q6_K production and threadpool routes are each checked against a
+ *     scalar contract oracle, then benchmarked against that reference.
  *
  * Validates:
  *   - Numerical parity (tolerance: 1e-3 abs)
@@ -157,6 +157,8 @@ extern void gemv_q8_0_q8_0(float *y, const void *W, const void *x_q8, int M, int
 extern void gemv_q5_0_q8_0(float *y, const void *W, const void *x_q8, int M, int K);
 extern void gemv_q6_k_q8_k(float *y, const void *W, const void *x_q8, int M, int K);
 extern void gemv_q4_k_q8_k(float *y, const void *W, const void *x_q8, int M, int K);
+extern void gemv_q6_k_q8_k_ref(float *y, const void *W, const void *x_q8, int M, int K);
+extern void gemv_q4_k_q8_k_ref(float *y, const void *W, const void *x_q8, int M, int K);
 extern void gemv_fused_q5_0_bias_dispatch(float *y, const void *W, const float *x,
                                            const float *bias, int M, int K);
 
@@ -189,8 +191,36 @@ extern void gemm_nt_q6_k_q8_k_parallel_dispatch(const void *A, const void *B,
                                                    const float *bias, float *C,
                                                    int M, int N, int K);
 extern void gemm_nt_q4_k_q8_k_parallel_dispatch(const void *A, const void *B,
-                                                   const float *bias, float *C,
-                                                   int M, int N, int K);
+                                                  const float *bias, float *C,
+                                                  int M, int N, int K);
+
+static void gemm_nt_q4_k_q8_k_scalar_oracle(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K)
+{
+    const size_t row_bytes = (size_t)(K / QK_K) * sizeof(block_q8_K);
+    for (int m = 0; m < M; ++m) {
+        float *row = C + (size_t)m * (size_t)N;
+        gemv_q4_k_q8_k_ref(row, B, (const char *)A + (size_t)m * row_bytes, N, K);
+        if (bias) {
+            for (int n = 0; n < N; ++n) row[n] += bias[n];
+        }
+    }
+}
+
+static void gemm_nt_q6_k_q8_k_scalar_oracle(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K)
+{
+    const size_t row_bytes = (size_t)(K / QK_K) * sizeof(block_q8_K);
+    for (int m = 0; m < M; ++m) {
+        float *row = C + (size_t)m * (size_t)N;
+        gemv_q6_k_q8_k_ref(row, B, (const char *)A + (size_t)m * row_bytes, N, K);
+        if (bias) {
+            for (int n = 0; n < N; ++n) row[n] += bias[n];
+        }
+    }
+}
 
 /* ============================================================================
  * Parity check (reused from test_gemv_omp_parity.c)
@@ -490,7 +520,7 @@ static int run_gemm_test(const char *test_name,
 
     printf("\n");
     printf("%-15s %6s %6s %6s  %10s %10s %8s  %s\n",
-           "Config", "M", "N", "K", "Serial(ms)", "Pool(ms)", "Speedup", "Parity");
+           "Config", "M", "N", "K", "Reference", "Candidate", "Speedup", "Parity");
     printf("------------------------------------------------------------------------------------\n");
 
     for (int c = 0; configs[c].name; c++) {
@@ -582,7 +612,7 @@ static int run_gemv_q_test(const char *test_name,
 
     printf("\n");
     printf("%-15s %8s %8s  %10s %10s %8s  %s\n",
-           "Config", "M", "K", "Serial(ms)", "Pool(ms)", "Speedup", "Parity");
+           "Config", "M", "K", "Reference", "Candidate", "Speedup", "Parity");
     printf("--------------------------------------------------------------------------------\n");
 
     for (int c = 0; configs[c].name; c++) {
@@ -739,16 +769,24 @@ int main(int argc, char **argv) {
      * ========================================================================= */
     printf("\n");
     printf("================================================================================\n");
-    printf("  TEST 3: gemv_q6_k_q8_k (serial) vs gemv_q6_k_q8_k_parallel_dispatch (pool)\n");
+    printf("  TEST 3: Q6_K GEMV scalar oracle vs production and threadpool\n");
     printf("================================================================================\n");
 
     total_fail += run_gemv_q_test(
-        "q6_k",
-        gemv_q6_k_q8_k, gemv_q6_k_q8_k_parallel_dispatch,
+        "q6_k_prod",
+        gemv_q6_k_q8_k_ref, gemv_q6_k_q8_k,
         QK_K, sizeof(block_q6_K),
         GEMV_WEIGHT_Q6_K,
         GEMV_ACT_Q8_K,
-        configs, warmup, iters, abs_tol, verbose
+        configs, warmup, iters, 1.0e-4f, verbose
+    );
+    total_fail += run_gemv_q_test(
+        "q6_k_pool",
+        gemv_q6_k_q8_k_ref, gemv_q6_k_q8_k_parallel_dispatch,
+        QK_K, sizeof(block_q6_K),
+        GEMV_WEIGHT_Q6_K,
+        GEMV_ACT_Q8_K,
+        configs, warmup, iters, 1.0e-4f, verbose
     );
 
     /* =========================================================================
@@ -757,16 +795,24 @@ int main(int argc, char **argv) {
      * ========================================================================= */
     printf("\n");
     printf("================================================================================\n");
-    printf("  TEST 4: gemv_q4_k_q8_k (serial) vs gemv_q4_k_q8_k_parallel_dispatch (pool)\n");
+    printf("  TEST 4: Q4_K GEMV scalar oracle vs production and threadpool\n");
     printf("================================================================================\n");
 
     total_fail += run_gemv_q_test(
-        "q4_k",
-        gemv_q4_k_q8_k, gemv_q4_k_q8_k_parallel_dispatch,
+        "q4_k_prod",
+        gemv_q4_k_q8_k_ref, gemv_q4_k_q8_k,
         QK_K, sizeof(block_q4_K),
         GEMV_WEIGHT_Q4_K,
         GEMV_ACT_Q8_K,
-        configs, warmup, iters, abs_tol, verbose
+        configs, warmup, iters, 1.0e-3f, verbose
+    );
+    total_fail += run_gemv_q_test(
+        "q4_k_pool",
+        gemv_q4_k_q8_k_ref, gemv_q4_k_q8_k_parallel_dispatch,
+        QK_K, sizeof(block_q4_K),
+        GEMV_WEIGHT_Q4_K,
+        GEMV_ACT_Q8_K,
+        configs, warmup, iters, 1.0e-3f, verbose
     );
 
     /* =========================================================================
@@ -965,8 +1011,7 @@ int main(int argc, char **argv) {
      * ========================================================================= */
     printf("\n");
     printf("================================================================================\n");
-    printf("  TEST 10: gemm_nt_q6_k_q8_k (serial) vs\n");
-    printf("          gemm_nt_q6_k_q8_k_parallel_dispatch (pool) [prefill]\n");
+    printf("  TEST 10: Q6_K GEMM scalar row oracle vs production and threadpool [prefill]\n");
     printf("================================================================================\n");
 
     /* Q6_K/Q8_K require K % 256 == 0 — filter configs accordingly */
@@ -983,15 +1028,23 @@ int main(int argc, char **argv) {
 
         if (q6k_count > 0) {
             total_fail += run_gemm_test(
-                "q6_k_q8_k",
-                gemm_nt_q6_k_q8_k, gemm_nt_q6_k_q8_k_parallel_dispatch,
+                "q6_k_prod",
+                gemm_nt_q6_k_q8_k_scalar_oracle, gemm_nt_q6_k_q8_k,
                 QK_K, sizeof(block_q8_K),   /* A = Q8_K */
                 QK_K, sizeof(block_q6_K),   /* B = Q6_K */
                 0,  /* B_is_q5 */
                 1,  /* A_is_q8_K */
                 1,  /* B_is_q6_K */
                 0,  /* B_is_q4_K */
-                q6k_configs, warmup, iters, abs_tol, verbose
+                q6k_configs, warmup, iters, 1.0e-4f, verbose
+            );
+            total_fail += run_gemm_test(
+                "q6_k_pool",
+                gemm_nt_q6_k_q8_k_scalar_oracle, gemm_nt_q6_k_q8_k_parallel_dispatch,
+                QK_K, sizeof(block_q8_K),
+                QK_K, sizeof(block_q6_K),
+                0, 1, 1, 0,
+                q6k_configs, warmup, iters, 1.0e-4f, verbose
             );
         } else {
             printf("\n  (Skipped: no configs with K %% 256 == 0)\n");
@@ -1004,8 +1057,7 @@ int main(int argc, char **argv) {
      * ========================================================================= */
     printf("\n");
     printf("================================================================================\n");
-    printf("  TEST 11: gemm_nt_q4_k_q8_k (serial) vs\n");
-    printf("          gemm_nt_q4_k_q8_k_parallel_dispatch (pool) [prefill]\n");
+    printf("  TEST 11: Q4_K GEMM scalar row oracle vs production and threadpool [prefill]\n");
     printf("================================================================================\n");
 
     {
@@ -1020,15 +1072,23 @@ int main(int argc, char **argv) {
 
         if (q4k_count > 0) {
             total_fail += run_gemm_test(
-                "q4_k_q8_k",
-                gemm_nt_q4_k_q8_k, gemm_nt_q4_k_q8_k_parallel_dispatch,
+                "q4_k_prod",
+                gemm_nt_q4_k_q8_k_scalar_oracle, gemm_nt_q4_k_q8_k,
                 QK_K, sizeof(block_q8_K),   /* A = Q8_K */
                 QK_K, sizeof(block_q4_K),   /* B = Q4_K */
                 0,  /* B_is_q5 */
                 1,  /* A_is_q8_K */
                 0,  /* B_is_q6_K */
                 1,  /* B_is_q4_K */
-                q4k_configs, warmup, iters, abs_tol, verbose
+                q4k_configs, warmup, iters, 1.0e-3f, verbose
+            );
+            total_fail += run_gemm_test(
+                "q4_k_pool",
+                gemm_nt_q4_k_q8_k_scalar_oracle, gemm_nt_q4_k_q8_k_parallel_dispatch,
+                QK_K, sizeof(block_q8_K),
+                QK_K, sizeof(block_q4_K),
+                0, 1, 0, 1,
+                q4k_configs, warmup, iters, 1.0e-3f, verbose
             );
         } else {
             printf("\n  (Skipped: no configs with K %% 256 == 0)\n");
@@ -1054,6 +1114,6 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    printf("\n  All thread pool dispatch kernels match serial output within tolerance.\n\n");
+    printf("\n  All production and threadpool kernels match their declared references.\n\n");
     return 0;
 }

--- a/tests/test_v8_attention_contracts.py
+++ b/tests/test_v8_attention_contracts.py
@@ -29,6 +29,7 @@ class AttentionContractV8Tests(unittest.TestCase):
         cls.vision_circuit_path = V8_ROOT / "circuits" / "qwen3_vl_vision.json"
         cls.vision_circuit = resolver.load_json(cls.vision_circuit_path)
         cls.contracts = resolver.load_json(resolver.DEFAULT_CONTRACTS)
+        cls.linear_contracts = resolver.load_json(resolver.DEFAULT_LINEAR_CONTRACTS)
         cls.kernels = resolver.load_kernel_capabilities()
 
     def resolve(self, phase: str, mode: str = "bringup"):
@@ -281,6 +282,41 @@ class AttentionContractV8Tests(unittest.TestCase):
                 self.assertEqual(threading["runtime"], "ck_threadpool")
                 self.assertIn("ck_threadpool_dispatch_n", threading["dispatch"])
                 self.assertEqual(threading["reduction_order_effect"], "none")
+                self.assertIn(capabilities[kernel_id]["numerical_contract"], self.linear_contracts["contracts"])
+                self.assertTrue(capabilities[kernel_id]["reference"]["function"].endswith("_ref"))
+                self.assertTrue(capabilities[kernel_id]["production"]["threaded_function"].endswith("_parallel_dispatch"))
+
+    def test_quantized_linear_registry_defines_complete_semantics(self) -> None:
+        resolver.validate_quantized_linear_contract_registry(copy.deepcopy(self.linear_contracts))
+
+    def test_quantized_linear_production_function_drift_is_a_hard_fault(self) -> None:
+        kernel = resolver.load_json(V8_ROOT / "kernel_maps" / "gemm_nt_q4_k_q8_k.json")
+        kernel["production"]["function"] = "wrong_function"
+        with self.assertRaisesRegex(resolver.ContractError, "production function drifts"):
+            resolver.validate_quantized_linear_kernel_capability(kernel, self.linear_contracts)
+
+    def test_quantized_linear_missing_scalar_reference_is_a_hard_fault(self) -> None:
+        kernel = resolver.load_json(V8_ROOT / "kernel_maps" / "gemv_q6_k_q8_k.json")
+        del kernel["reference"]["function"]
+        capability = {
+            key: kernel[key]
+            for key in (
+                "id", "op", "contract_schema_version", "numerical_contract",
+                "reference", "production", "implementation", "impl",
+            )
+        }
+        with self.assertRaisesRegex(resolver.ContractError, "(?s)HARD CONTRACT FAULT.*At reference.*function"):
+            resolver.validate_schema(
+                capability,
+                resolver.LINEAR_KERNEL_CAPABILITY_SCHEMA,
+                "mutated Q6 GEMV capability",
+            )
+
+    def test_quantized_linear_threading_must_match_reduction_contract(self) -> None:
+        kernel = resolver.load_json(V8_ROOT / "kernel_maps" / "gemv_q4_k_q8_k.json")
+        kernel["implementation"]["threading"]["reduction_order_effect"] = "contract_defined"
+        with self.assertRaisesRegex(resolver.ContractError, "threading contradicts"):
+            resolver.validate_quantized_linear_kernel_capability(kernel, self.linear_contracts)
 
 
 if __name__ == "__main__":

--- a/tests/test_v8_codegen_bridge.py
+++ b/tests/test_v8_codegen_bridge.py
@@ -272,6 +272,14 @@ class V8CodegenBridgeTests(unittest.TestCase):
             by_op["mlp_down"][0]["resolved_execution"]["kernel_id"],
             "gemv_q6_k_q8_k",
         )
+        self.assertEqual(
+            by_op["q_proj"][0]["resolved_execution"]["reference"]["function"],
+            "gemv_q4_k_q8_k_ref",
+        )
+        self.assertEqual(
+            by_op["mlp_down"][0]["resolved_execution"]["numerical_contract"],
+            "q6_k_x_q8_k_fp32_block_order",
+        )
 
         with tempfile.TemporaryDirectory(prefix="v8_qwen3vl_text_mrope_") as tmpdir:
             tmp = Path(tmpdir)
@@ -318,6 +326,14 @@ class V8CodegenBridgeTests(unittest.TestCase):
                 "none",
             )
             self.assertEqual(mlp_down_call["resolved_execution"]["kernel_id"], "gemv_q6_k_q8_k")
+            self.assertEqual(
+                q_proj_call["resolved_execution"]["production"]["function"],
+                "gemv_q4_k_q8_k",
+            )
+            self.assertEqual(
+                q_proj_call["resolved_execution"]["production"]["threaded_function"],
+                "gemv_q4_k_q8_k_parallel_dispatch",
+            )
             arg_map = {arg["name"]: arg["expr"] for arg in rope_call["args"]}
             self.assertEqual(arg_map["pos_offset"], "model->rope_pos")
             self.assertEqual(arg_map["section_0"], "1")

--- a/unittest/test_q6k_q8k_parity.py
+++ b/unittest/test_q6k_q8k_parity.py
@@ -370,6 +370,10 @@ def test_gemm_nt_q6k_q8k(lib):
         ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
         ctypes.c_int, ctypes.c_int, ctypes.c_int
     ]
+    lib.gemv_q6_k_q8_k_ref.argtypes = [
+        ctypes.POINTER(ctypes.c_float), ctypes.c_void_p,
+        ctypes.c_void_p, ctypes.c_int, ctypes.c_int
+    ]
 
     np.random.seed(456)
 
@@ -412,17 +416,33 @@ def test_gemm_nt_q6k_q8k(lib):
         M, N, K
     )
 
+    scalar_C = np.zeros((M, N), dtype=np.float32)
+    W_ctypes = (ctypes.c_ubyte * len(W_buffer)).from_buffer_copy(W_buffer)
+    for m in range(M):
+        x_ctypes = (ctypes.c_ubyte * len(X_blocks[m])).from_buffer_copy(X_blocks[m])
+        lib.gemv_q6_k_q8_k_ref(
+            scalar_C[m].ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            W_ctypes,
+            x_ctypes,
+            N,
+            K,
+        )
+
     mse = np.mean((C - ref_C) ** 2)
     max_diff = np.max(np.abs(C - ref_C))
+    scalar_external_diff = np.max(np.abs(scalar_C - ref_C))
+    production_scalar_diff = np.max(np.abs(C - scalar_C))
 
     print(f"  Shape:    ({M}, {N})")
     print(f"  MSE:      {mse:.6e}")
     print(f"  Max Diff: {max_diff:.6e}")
+    print(f"  Scalar vs Python: {scalar_external_diff:.6e}")
+    print(f"  Production vs Scalar: {production_scalar_diff:.6e}")
 
     tol = q6k_q8k_abs_tol()
     print(f"  Tolerance: {tol:.6e}")
 
-    if max_diff < tol:
+    if scalar_external_diff < tol and production_scalar_diff < tol:
         print(f"  {GREEN}PASS{RESET}")
         return True
     else:

--- a/version/v8/CONTRACT_POLICY.md
+++ b/version/v8/CONTRACT_POLICY.md
@@ -37,6 +37,8 @@ oracle. The required evidence ladder is external backend versus scalar oracle,
 optimized public function versus scalar oracle, and threadpool dispatch versus
 scalar oracle. Independent-output partitioning must not change reduction order.
 Split-K requires a distinct contract with partial dtype and merge order.
+`make test-numerical-contracts` must execute representative kernel numerics for
+declared reduction contracts; schema and resolver checks alone are insufficient.
 
 The supported v8 text circuits and Qwen3-VL routes must resolve attention before
 GraphIR construction. GraphIR records the required contract and resolved

--- a/version/v8/CONTRACT_POLICY.md
+++ b/version/v8/CONTRACT_POLICY.md
@@ -26,8 +26,17 @@ Agents and contributors must not:
 
 Threading belongs in execution capabilities. If worker partitioning changes an
 accumulation or merge order, the numerical contract must define that order too.
-A performance planner may rank only providers that already satisfy the complete
-semantic contract.
+The compiler must bind the exact kernel ID and public function named by the
+kernel map; it must not rank or guess functions from ISA, shape, or benchmark
+data. Dimensions and thread counts are function inputs. A named public function
+may dispatch internally only among implementations proven to satisfy its
+numerical contract.
+
+Quantized and reduced-precision linear kernels must name a scalar contract
+oracle. The required evidence ladder is external backend versus scalar oracle,
+optimized public function versus scalar oracle, and threadpool dispatch versus
+scalar oracle. Independent-output partitioning must not change reduction order.
+Split-K requires a distinct contract with partial dtype and merge order.
 
 The supported v8 text circuits and Qwen3-VL routes must resolve attention before
 GraphIR construction. GraphIR records the required contract and resolved

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -42,6 +42,11 @@ operator-generic: the current maps cover attention plus the hot Q4/Q6 GEMM and
 GEMV routes, including threadpool runtime, partition, dispatch, and reduction-
 order effects.
 
+Q4_K/Q6_K linear maps additionally bind an exact public function, threadpool
+entry point, scalar reference function, adapter, fixed comparison tolerance,
+and external-oracle status. The compiler validates and carries these bindings;
+it does not choose a different function from shape or performance heuristics.
+
 Canonical text bring-up examples:
 - `version/v8/scripts/cks-v8-run run hf://unsloth/gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf --context-len 1024 --force-compile --force-convert --chat-template=auto --generate-visualizer`
 - `version/v8/scripts/cks-v8-run run hf://Qwen/Qwen2-0.5B-Instruct-GGUF/qwen2-0_5b-instruct-q4_k_m.gguf --context-len 1024 --force-compile --force-convert --generate-visualizer`

--- a/version/v8/contracts/quantized_linear.json
+++ b/version/v8/contracts/quantized_linear.json
@@ -1,0 +1,25 @@
+{
+  "schema": "cke.quantized_linear_contracts",
+  "schema_version": 1,
+  "engine_contract_version": "8",
+  "contracts": {
+    "q4_k_x_q8_k_fp32_block_order": {
+      "status": "observed",
+      "weight": {"format": "q4_k", "block_size": 256, "layout": "ggml_q4_k"},
+      "activation": {"format": "q8_k", "block_size": 256, "layout": "ggml_q8_k", "quantization": "quantize_row_q8_k_ref"},
+      "dot": {"integer_accumulator": "int32", "block_scale_application": "q4_k_scale_and_min_after_integer_block_sums", "block_order": "ascending_k"},
+      "output": {"accumulator": "fp32", "bias": "after_complete_dot", "storage": "fp32"},
+      "parallel_reduction": {"kind": "independent_outputs", "reduction_order_effect": "none"},
+      "description": "Q4_K weights times Q8_K activations with scalar-reference block order and independent output partitioning."
+    },
+    "q6_k_x_q8_k_fp32_block_order": {
+      "status": "observed",
+      "weight": {"format": "q6_k", "block_size": 256, "layout": "ggml_q6_k"},
+      "activation": {"format": "q8_k", "block_size": 256, "layout": "ggml_q8_k", "quantization": "quantize_row_q8_k_ref"},
+      "dot": {"integer_accumulator": "int32", "block_scale_application": "q6_k_scale_after_integer_block_sums", "block_order": "ascending_k"},
+      "output": {"accumulator": "fp32", "bias": "after_complete_dot", "storage": "fp32"},
+      "parallel_reduction": {"kind": "independent_outputs", "reduction_order_effect": "none"},
+      "description": "Q6_K weights times Q8_K activations with scalar-reference block order and independent output partitioning."
+    }
+  }
+}

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -7534,6 +7534,43 @@
       "op": "gemm",
       "variant": "q4_k_w_q8_k_a",
       "contract_schema_version": 1,
+      "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+      "reference": {
+        "function": "gemv_q4_k_q8_k_ref",
+        "kind": "scalar_contract_oracle",
+        "adapter": "per_activation_row_then_bias",
+        "validation": {
+          "status": "observed",
+          "tests": [
+            "unittest/test_q4_k_q8_k_matvec.py",
+            "tests/test_threadpool_parity.c"
+          ],
+          "external_oracles": [
+            {
+              "backend": "numpy_dequantized_fp32",
+              "status": "observed",
+              "evidence": "unittest/test_q4_k_q8_k_matvec.py"
+            },
+            {
+              "backend": "llama.cpp",
+              "status": "unresolved",
+              "evidence": "No direct llama.cpp Q4_K x Q8_K GEMM oracle is currently wired."
+            }
+          ]
+        }
+      },
+      "production": {
+        "function": "gemm_nt_q4_k_q8_k",
+        "threaded_function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
+        "reference_comparison": {
+          "requirement": "contract_tolerance",
+          "absolute_tolerance": 0.001,
+          "relative_tolerance": 0.001,
+          "tests": [
+            "tests/test_threadpool_parity.c"
+          ]
+        }
+      },
       "implementation": {
         "isa_dispatch": "runtime",
         "threading": {
@@ -7688,7 +7725,8 @@
               ]
             }
           ],
-          "selection_policy": "Use canonical serial as the correctness fallback. Promote packed-meta candidates only when the circuit/template lowering has a packed weight layout available and the hardware sweep policy selects that candidate for the model shape."
+          "dispatch_owner": "gemm_nt_q4_k_q8_k_parallel_dispatch",
+          "selection_policy": "The DSL emits the exact public function. Only the declared production dispatcher may choose an internal parity-validated ISA, packing, or tiling variant; dimensions are function inputs, not compiler guesses."
         }
       },
       "constraints": {
@@ -8181,6 +8219,43 @@
       "op": "gemm",
       "variant": "q6_k_w_q8_k_a",
       "contract_schema_version": 1,
+      "numerical_contract": "q6_k_x_q8_k_fp32_block_order",
+      "reference": {
+        "function": "gemv_q6_k_q8_k_ref",
+        "kind": "scalar_contract_oracle",
+        "adapter": "per_activation_row_then_bias",
+        "validation": {
+          "status": "observed",
+          "tests": [
+            "unittest/test_q6k_q8k_parity.py",
+            "tests/test_threadpool_parity.c"
+          ],
+          "external_oracles": [
+            {
+              "backend": "python_scalar_contract",
+              "status": "observed",
+              "evidence": "unittest/test_q6k_q8k_parity.py"
+            },
+            {
+              "backend": "llama.cpp",
+              "status": "unresolved",
+              "evidence": "No direct llama.cpp Q6_K x Q8_K GEMM oracle is currently wired."
+            }
+          ]
+        }
+      },
+      "production": {
+        "function": "gemm_nt_q6_k_q8_k",
+        "threaded_function": "gemm_nt_q6_k_q8_k_parallel_dispatch",
+        "reference_comparison": {
+          "requirement": "contract_tolerance",
+          "absolute_tolerance": 0.0001,
+          "relative_tolerance": 0.0001,
+          "tests": [
+            "tests/test_threadpool_parity.c"
+          ]
+        }
+      },
       "implementation": {
         "isa_dispatch": "runtime",
         "threading": {
@@ -9405,6 +9480,43 @@
       "op": "gemv",
       "variant": "q4_k_w_q8_k_a_fp32_out",
       "contract_schema_version": 1,
+      "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+      "reference": {
+        "function": "gemv_q4_k_q8_k_ref",
+        "kind": "scalar_contract_oracle",
+        "adapter": "direct",
+        "validation": {
+          "status": "observed",
+          "tests": [
+            "unittest/test_q4_k_q8_k_matvec.py",
+            "tests/test_threadpool_parity.c"
+          ],
+          "external_oracles": [
+            {
+              "backend": "numpy_dequantized_fp32",
+              "status": "observed",
+              "evidence": "unittest/test_q4_k_q8_k_matvec.py"
+            },
+            {
+              "backend": "llama.cpp",
+              "status": "unresolved",
+              "evidence": "No direct llama.cpp Q4_K x Q8_K GEMV oracle is currently wired."
+            }
+          ]
+        }
+      },
+      "production": {
+        "function": "gemv_q4_k_q8_k",
+        "threaded_function": "gemv_q4_k_q8_k_parallel_dispatch",
+        "reference_comparison": {
+          "requirement": "contract_tolerance",
+          "absolute_tolerance": 0.001,
+          "relative_tolerance": 0.001,
+          "tests": [
+            "tests/test_threadpool_parity.c"
+          ]
+        }
+      },
       "implementation": {
         "isa_dispatch": "runtime",
         "threading": {
@@ -10150,6 +10262,43 @@
       "op": "gemv",
       "variant": "q6_k_w_q8_k_a_fp32_out",
       "contract_schema_version": 1,
+      "numerical_contract": "q6_k_x_q8_k_fp32_block_order",
+      "reference": {
+        "function": "gemv_q6_k_q8_k_ref",
+        "kind": "scalar_contract_oracle",
+        "adapter": "direct",
+        "validation": {
+          "status": "observed",
+          "tests": [
+            "unittest/test_q6k_q8k_parity.py",
+            "tests/test_threadpool_parity.c"
+          ],
+          "external_oracles": [
+            {
+              "backend": "python_scalar_contract",
+              "status": "observed",
+              "evidence": "unittest/test_q6k_q8k_parity.py"
+            },
+            {
+              "backend": "llama.cpp",
+              "status": "unresolved",
+              "evidence": "No direct llama.cpp Q6_K x Q8_K GEMV oracle is currently wired."
+            }
+          ]
+        }
+      },
+      "production": {
+        "function": "gemv_q6_k_q8_k",
+        "threaded_function": "gemv_q6_k_q8_k_parallel_dispatch",
+        "reference_comparison": {
+          "requirement": "contract_tolerance",
+          "absolute_tolerance": 0.0001,
+          "relative_tolerance": 0.0001,
+          "tests": [
+            "tests/test_threadpool_parity.c"
+          ]
+        }
+      },
       "implementation": {
         "isa_dispatch": "runtime",
         "threading": {

--- a/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
@@ -3,6 +3,30 @@
   "op": "gemm",
   "variant": "q4_k_w_q8_k_a",
   "contract_schema_version": 1,
+  "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+  "reference": {
+    "function": "gemv_q4_k_q8_k_ref",
+    "kind": "scalar_contract_oracle",
+    "adapter": "per_activation_row_then_bias",
+    "validation": {
+      "status": "observed",
+      "tests": ["unittest/test_q4_k_q8_k_matvec.py", "tests/test_threadpool_parity.c"],
+      "external_oracles": [
+        {"backend": "numpy_dequantized_fp32", "status": "observed", "evidence": "unittest/test_q4_k_q8_k_matvec.py"},
+        {"backend": "llama.cpp", "status": "unresolved", "evidence": "No direct llama.cpp Q4_K x Q8_K GEMM oracle is currently wired."}
+      ]
+    }
+  },
+  "production": {
+    "function": "gemm_nt_q4_k_q8_k",
+    "threaded_function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
+    "reference_comparison": {
+      "requirement": "contract_tolerance",
+      "absolute_tolerance": 0.001,
+      "relative_tolerance": 0.001,
+      "tests": ["tests/test_threadpool_parity.c"]
+    }
+  },
   "implementation": {
     "isa_dispatch": "runtime",
     "threading": {
@@ -89,7 +113,8 @@
           "requires": ["packed_weight_layout", "prefill_phase"]
         }
       ],
-      "selection_policy": "Use canonical serial as the correctness fallback. Promote packed-meta candidates only when the circuit/template lowering has a packed weight layout available and the hardware sweep policy selects that candidate for the model shape."
+      "dispatch_owner": "gemm_nt_q4_k_q8_k_parallel_dispatch",
+      "selection_policy": "The DSL emits the exact public function. Only the declared production dispatcher may choose an internal parity-validated ISA, packing, or tiling variant; dimensions are function inputs, not compiler guesses."
     }
   },
   "constraints": {

--- a/version/v8/kernel_maps/gemm_nt_q6_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q6_k_q8_k.json
@@ -3,6 +3,30 @@
   "op": "gemm",
   "variant": "q6_k_w_q8_k_a",
   "contract_schema_version": 1,
+  "numerical_contract": "q6_k_x_q8_k_fp32_block_order",
+  "reference": {
+    "function": "gemv_q6_k_q8_k_ref",
+    "kind": "scalar_contract_oracle",
+    "adapter": "per_activation_row_then_bias",
+    "validation": {
+      "status": "observed",
+      "tests": ["unittest/test_q6k_q8k_parity.py", "tests/test_threadpool_parity.c"],
+      "external_oracles": [
+        {"backend": "python_scalar_contract", "status": "observed", "evidence": "unittest/test_q6k_q8k_parity.py"},
+        {"backend": "llama.cpp", "status": "unresolved", "evidence": "No direct llama.cpp Q6_K x Q8_K GEMM oracle is currently wired."}
+      ]
+    }
+  },
+  "production": {
+    "function": "gemm_nt_q6_k_q8_k",
+    "threaded_function": "gemm_nt_q6_k_q8_k_parallel_dispatch",
+    "reference_comparison": {
+      "requirement": "contract_tolerance",
+      "absolute_tolerance": 0.0001,
+      "relative_tolerance": 0.0001,
+      "tests": ["tests/test_threadpool_parity.c"]
+    }
+  },
   "implementation": {
     "isa_dispatch": "runtime",
     "threading": {

--- a/version/v8/kernel_maps/gemv_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q4_k_q8_k.json
@@ -3,6 +3,30 @@
   "op": "gemv",
   "variant": "q4_k_w_q8_k_a_fp32_out",
   "contract_schema_version": 1,
+  "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+  "reference": {
+    "function": "gemv_q4_k_q8_k_ref",
+    "kind": "scalar_contract_oracle",
+    "adapter": "direct",
+    "validation": {
+      "status": "observed",
+      "tests": ["unittest/test_q4_k_q8_k_matvec.py", "tests/test_threadpool_parity.c"],
+      "external_oracles": [
+        {"backend": "numpy_dequantized_fp32", "status": "observed", "evidence": "unittest/test_q4_k_q8_k_matvec.py"},
+        {"backend": "llama.cpp", "status": "unresolved", "evidence": "No direct llama.cpp Q4_K x Q8_K GEMV oracle is currently wired."}
+      ]
+    }
+  },
+  "production": {
+    "function": "gemv_q4_k_q8_k",
+    "threaded_function": "gemv_q4_k_q8_k_parallel_dispatch",
+    "reference_comparison": {
+      "requirement": "contract_tolerance",
+      "absolute_tolerance": 0.001,
+      "relative_tolerance": 0.001,
+      "tests": ["tests/test_threadpool_parity.c"]
+    }
+  },
   "implementation": {
     "isa_dispatch": "runtime",
     "threading": {

--- a/version/v8/kernel_maps/gemv_q6_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q6_k_q8_k.json
@@ -3,6 +3,30 @@
   "op": "gemv",
   "variant": "q6_k_w_q8_k_a_fp32_out",
   "contract_schema_version": 1,
+  "numerical_contract": "q6_k_x_q8_k_fp32_block_order",
+  "reference": {
+    "function": "gemv_q6_k_q8_k_ref",
+    "kind": "scalar_contract_oracle",
+    "adapter": "direct",
+    "validation": {
+      "status": "observed",
+      "tests": ["unittest/test_q6k_q8k_parity.py", "tests/test_threadpool_parity.c"],
+      "external_oracles": [
+        {"backend": "python_scalar_contract", "status": "observed", "evidence": "unittest/test_q6k_q8k_parity.py"},
+        {"backend": "llama.cpp", "status": "unresolved", "evidence": "No direct llama.cpp Q6_K x Q8_K GEMV oracle is currently wired."}
+      ]
+    }
+  },
+  "production": {
+    "function": "gemv_q6_k_q8_k",
+    "threaded_function": "gemv_q6_k_q8_k_parallel_dispatch",
+    "reference_comparison": {
+      "requirement": "contract_tolerance",
+      "absolute_tolerance": 0.0001,
+      "relative_tolerance": 0.0001,
+      "tests": ["tests/test_threadpool_parity.c"]
+    }
+  },
   "implementation": {
     "isa_dispatch": "runtime",
     "threading": {

--- a/version/v8/schemas/quantized_linear_contract_registry.schema.json
+++ b/version/v8/schemas/quantized_linear_contract_registry.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.quantized_linear_contract_registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "schema_version", "engine_contract_version", "contracts"],
+  "properties": {
+    "schema": {"const": "cke.quantized_linear_contracts"},
+    "schema_version": {"const": 1},
+    "engine_contract_version": {"const": "8"},
+    "contracts": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {"$ref": "#/$defs/contract"}
+    }
+  },
+  "$defs": {
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "weight", "activation", "dot", "output", "parallel_reduction", "description"],
+      "properties": {
+        "status": {"enum": ["unresolved", "observed", "validated"]},
+        "weight": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["format", "block_size", "layout"],
+          "properties": {
+            "format": {"enum": ["q4_k", "q6_k", "q8_0", "bf16", "fp16", "fp32"]},
+            "block_size": {"type": "integer", "minimum": 1},
+            "layout": {"type": "string", "minLength": 1}
+          }
+        },
+        "activation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["format", "block_size", "layout", "quantization"],
+          "properties": {
+            "format": {"enum": ["q8_k", "q8_0", "bf16", "fp16", "fp32"]},
+            "block_size": {"type": "integer", "minimum": 1},
+            "layout": {"type": "string", "minLength": 1},
+            "quantization": {"type": "string", "minLength": 1}
+          }
+        },
+        "dot": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["integer_accumulator", "block_scale_application", "block_order"],
+          "properties": {
+            "integer_accumulator": {"enum": ["int32", "none"]},
+            "block_scale_application": {"type": "string", "minLength": 1},
+            "block_order": {"enum": ["ascending_k"]}
+          }
+        },
+        "output": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["accumulator", "bias", "storage"],
+          "properties": {
+            "accumulator": {"enum": ["fp32", "bf16", "fp16"]},
+            "bias": {"enum": ["after_complete_dot", "none"]},
+            "storage": {"enum": ["fp32", "bf16", "fp16"]}
+          }
+        },
+        "parallel_reduction": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "reduction_order_effect"],
+          "properties": {
+            "kind": {"enum": ["independent_outputs", "split_k"]},
+            "reduction_order_effect": {"enum": ["none", "contract_defined"]},
+            "partial_accumulator": {"enum": ["fp32", "bf16", "fp16"]},
+            "merge_order": {"type": "string", "minLength": 1}
+          }
+        },
+        "description": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/version/v8/schemas/quantized_linear_kernel_capability.schema.json
+++ b/version/v8/schemas/quantized_linear_kernel_capability.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.quantized_linear_kernel_capability",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "op", "contract_schema_version", "numerical_contract", "reference", "production", "implementation", "impl"],
+  "properties": {
+    "id": {"type": "string", "minLength": 1},
+    "op": {"enum": ["gemm", "gemv"]},
+    "contract_schema_version": {"const": 1},
+    "numerical_contract": {"type": "string", "minLength": 1},
+    "reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["function", "kind", "adapter", "validation"],
+      "properties": {
+        "function": {"type": "string", "minLength": 1},
+        "kind": {"const": "scalar_contract_oracle"},
+        "adapter": {"enum": ["direct", "per_activation_row", "per_activation_row_then_bias"]},
+        "validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "tests", "external_oracles"],
+          "properties": {
+            "status": {"enum": ["unresolved", "observed", "validated"]},
+            "tests": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+            "external_oracles": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["backend", "status", "evidence"],
+                "properties": {
+                  "backend": {"type": "string", "minLength": 1},
+                  "status": {"enum": ["unresolved", "observed", "validated"]},
+                  "evidence": {"type": "string", "minLength": 1}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "production": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["function", "threaded_function", "reference_comparison"],
+      "properties": {
+        "function": {"type": "string", "minLength": 1},
+        "threaded_function": {"type": "string", "minLength": 1},
+        "reference_comparison": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["requirement", "absolute_tolerance", "relative_tolerance", "tests"],
+          "properties": {
+            "requirement": {"enum": ["bit_exact", "contract_tolerance"]},
+            "absolute_tolerance": {"type": "number", "minimum": 0},
+            "relative_tolerance": {"type": "number", "minimum": 0},
+            "tests": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+          }
+        }
+      }
+    },
+    "implementation": {"type": "object"},
+    "impl": {
+      "type": "object",
+      "required": ["function"],
+      "properties": {"function": {"type": "string", "minLength": 1}}
+    }
+  }
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -132,13 +132,17 @@ def _load_kernel_execution_capabilities() -> Dict[str, Dict[str, Any]]:
 
 
 def _graph_ir_execution_metadata(capability: Dict[str, Any]) -> Dict[str, Any]:
-    return {
+    metadata = {
         "schema": "cke.graph_ir_execution_contract",
         "schema_version": 1,
         "kernel_id": capability["id"],
         "op": capability["op"],
         "implementation": copy.deepcopy(capability["implementation"]),
     }
+    for key in ("numerical_contract", "reference", "production"):
+        if capability.get(key) is not None:
+            metadata[key] = copy.deepcopy(capability[key])
+    return metadata
 
 
 def _validate_resolved_kernels_are_emitted(

--- a/version/v8/scripts/resolve_attention_contracts_v8.py
+++ b/version/v8/scripts/resolve_attention_contracts_v8.py
@@ -19,6 +19,7 @@ from jsonschema import Draft202012Validator
 V8_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = V8_ROOT.parents[1]
 DEFAULT_CONTRACTS = V8_ROOT / "contracts" / "attention_reductions.json"
+DEFAULT_LINEAR_CONTRACTS = V8_ROOT / "contracts" / "quantized_linear.json"
 DEFAULT_KERNELS = V8_ROOT / "kernel_maps"
 SCHEMA_ROOT = V8_ROOT / "schemas"
 CONTRACT_REGISTRY_SCHEMA = SCHEMA_ROOT / "attention_reduction_registry.schema.json"
@@ -26,6 +27,8 @@ CIRCUIT_REQUIREMENTS_SCHEMA = SCHEMA_ROOT / "attention_required_contracts.schema
 KERNEL_CAPABILITY_SCHEMA = SCHEMA_ROOT / "attention_kernel_capability.schema.json"
 KERNEL_EXECUTION_SCHEMA = SCHEMA_ROOT / "kernel_execution_capability.schema.json"
 RESOLVED_CONTRACT_SCHEMA = SCHEMA_ROOT / "resolved_attention_contract.schema.json"
+LINEAR_CONTRACT_REGISTRY_SCHEMA = SCHEMA_ROOT / "quantized_linear_contract_registry.schema.json"
+LINEAR_KERNEL_CAPABILITY_SCHEMA = SCHEMA_ROOT / "quantized_linear_kernel_capability.schema.json"
 VALID_STATES = {"unresolved", "observed", "validated"}
 AMBIGUOUS_IDS = {"fp16", "f16", "bf16", "fp32", "f32", "fast", "strict"}
 
@@ -102,6 +105,8 @@ def load_kernel_execution_capabilities(root: Path = DEFAULT_KERNELS) -> Dict[str
     if not root.is_dir():
         raise ContractError(f"Kernel-map directory does not exist: {root}")
     kernels: Dict[str, Any] = {}
+    linear_contracts = load_json(DEFAULT_LINEAR_CONTRACTS)
+    validate_quantized_linear_contract_registry(linear_contracts)
     for path in sorted(root.glob("*.json")):
         doc = load_json(path)
         if "contract_schema_version" not in doc:
@@ -126,6 +131,25 @@ def load_kernel_execution_capabilities(root: Path = DEFAULT_KERNELS) -> Dict[str
             "implementation": doc.get("implementation"),
         }
         validate_schema(capability, KERNEL_EXECUTION_SCHEMA, f"kernel execution capability {kernel_id}")
+        if capability["op"] in {"gemm", "gemv"}:
+            linear_capability = {
+                **capability,
+                "numerical_contract": doc.get("numerical_contract"),
+                "reference": doc.get("reference"),
+                "production": doc.get("production"),
+                "impl": doc.get("impl"),
+            }
+            validate_schema(
+                linear_capability,
+                LINEAR_KERNEL_CAPABILITY_SCHEMA,
+                f"quantized linear kernel capability {kernel_id}",
+            )
+            validate_quantized_linear_kernel_capability(linear_capability, linear_contracts)
+            capability.update(
+                numerical_contract=linear_capability["numerical_contract"],
+                reference=linear_capability["reference"],
+                production=linear_capability["production"],
+            )
         kernels[kernel_id] = {**capability, "source": str(path)}
     if not kernels:
         raise ContractError(f"No versioned kernel execution capabilities found under: {root}")
@@ -179,6 +203,63 @@ def validate_contract_registry(doc: Dict[str, Any]) -> None:
         partition = contract.get("partition")
         if not isinstance(partition, dict) or not partition.get("kind"):
             raise ContractError(f"reduction contract {contract_id}.partition requires kind")
+
+
+def validate_quantized_linear_contract_registry(doc: Dict[str, Any]) -> None:
+    validate_schema(doc, LINEAR_CONTRACT_REGISTRY_SCHEMA, "quantized linear contract registry")
+    for contract_id, contract in doc["contracts"].items():
+        validate_state(contract.get("status"), f"quantized linear contract {contract_id}")
+        parallel = contract["parallel_reduction"]
+        if parallel["kind"] == "independent_outputs" and parallel["reduction_order_effect"] != "none":
+            raise hard_contract_fault(
+                f"independent-output contract {contract_id!r} changes reduction order",
+                "Independent outputs do not share an accumulator.",
+                "set reduction_order_effect to none or declare a split_k contract.",
+            )
+        if parallel["kind"] == "split_k" and (
+            "partial_accumulator" not in parallel or "merge_order" not in parallel
+        ):
+            raise hard_contract_fault(
+                f"split-K contract {contract_id!r} is incomplete",
+                "partial_accumulator and merge_order are required for split-K.",
+                "declare the complete partitioned scalar-oracle semantics.",
+            )
+
+
+def validate_quantized_linear_kernel_capability(
+    kernel: Dict[str, Any],
+    registry: Dict[str, Any],
+) -> None:
+    kernel_id = kernel["id"]
+    contract_id = kernel["numerical_contract"]
+    contract = registry["contracts"].get(contract_id)
+    if contract is None:
+        raise hard_contract_fault(
+            f"kernel {kernel_id!r} names unknown numerical contract {contract_id!r}",
+            f"Registry: {DEFAULT_LINEAR_CONTRACTS}",
+            "add and validate the complete contract before binding the kernel.",
+        )
+    production = kernel["production"]
+    impl_function = kernel["impl"]["function"]
+    if production["function"] != impl_function:
+        raise hard_contract_fault(
+            f"kernel {kernel_id!r} production function drifts from impl.function",
+            f"production.function={production['function']!r}, impl.function={impl_function!r}",
+            "bind both fields to the exact public function emitted by codegen.",
+        )
+    threading = kernel["implementation"]["threading"]
+    if threading["runtime"] == "ck_threadpool" and not production.get("threaded_function"):
+        raise hard_contract_fault(
+            f"threaded kernel {kernel_id!r} has no threadpool entry point",
+            "A threadpool implementation must name the exact dispatch function.",
+            "set production.threaded_function and test it against the scalar oracle.",
+        )
+    if threading["reduction_order_effect"] != contract["parallel_reduction"]["reduction_order_effect"]:
+        raise hard_contract_fault(
+            f"kernel {kernel_id!r} threading contradicts {contract_id!r}",
+            "The kernel map and numerical contract disagree about reduction-order effects.",
+            "correct the map or define a distinct numerical contract.",
+        )
 
 
 def validate_kernel_overlay(doc: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Why

Q4_K/Q6_K GEMM and GEMV correctness must cover the exact public function and threadpool route, not only leaf SIMD kernels. Thread partitioning is part of the numerical contract because split-K or changed reduction order can alter model output.

## What

- Add strict Q4_K/Q6_K x Q8_K numerical-contract registries and schemas.
- Bind exact scalar-reference, production, and threadpool functions in kernel maps.
- Carry those bindings through GraphIR, LoweredIR, and call-ready IR.
- Hard-fail unknown contracts, function drift, missing threadpool entry points, and reduction-order contradictions.
- Compare scalar -> production -> threadpool for Q4/Q6 GEMV and GEMM.
- Expose the numerical and threadpool contract lanes in nightly documentation.

## Finding

The existing Q4_K scalar reference was incorrect by roughly 0.46-1.16 on valid current blocks. The corrected block-order oracle agrees with the independent dequantized FP32 reference, AVX2, AVX-VNNI, public dispatch, GEMM, and threadpool paths.

Q6 reporting now separates scalar-vs-Python error from production-vs-scalar error. No tolerance was relaxed. Direct llama.cpp Q4/Q6 GEMM oracle coverage remains explicitly `unresolved`.

## Validation

- `make test-numerical-contracts`: 22/22 pass
- `make test-threadpool-parity`: pass, including production and 20-thread Q4/Q6 GEMV/GEMM
- `unittest/test_q4_k_q8_k_matvec.py`: pass
- `unittest/test_q6k_q8k_parity.py`: 4/4 pass
- `tests/test_v8_codegen_bridge.py`: 9/9 pass
- `make test-v8-qwen3vl`: pass
- `make v8-regression-fast`: overall pass for Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige
- Pre-push: build, v8 E2E, v8 contracts, v7 training smoke, v8 regression, and v7 training-kernel parity pass

## Known Existing Gate

The staged/pre-push v7 inference regression reproduces existing first-token parity failures for Gemma, Qwen2, and Nanbeige. `v7-kernel-map-contracts` and the v7 training gates pass. This PR does not modify those v7 inference routes.