### PR TITLE
feat(v8): add canonical first-divergence attribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2886,6 +2886,12 @@ test-numerical-contracts: $(LIB)
 	@$(PYTHON) version/v8/scripts/resolve_attention_contracts_v8.py --circuit qwen3vl --operation decoder.attention --phase decode --mode bringup --output build/v8/contracts/qwen3vl-decode.json >/dev/null
 	@echo "Resolved plans: build/v8/contracts/"
 
+.PHONY: test-v8-parity-bisection
+test-v8-parity-bisection:
+	@echo "Running v8 canonical parity ABI and first-divergence tests..."
+	@$(PYTHON) -m py_compile version/v8/scripts/parity_bisect_v8.py
+	@$(PYTHON) -m unittest tests.test_v8_parity_bisection -v
+
 v8-model-kernel-inspect:
 	@target="$${MODEL:-$${CONFIG:-}}"; \
 	if [ -z "$$target" ]; then \

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -497,6 +497,12 @@ MAKE_TARGETS = {
         "target": "test-numerical-contracts",
         "timeout_sec": 300,
     },
+    "v8_parity_bisection": {
+        "name": "v8 Canonical First-Divergence",
+        "category": "parity",
+        "target": "test-v8-parity-bisection",
+        "timeout_sec": 300,
+    },
     "v8_template_circuit_audit": {
         "name": "v8 Template Circuit/Dataflow Audit",
         "category": "inference",

--- a/tests/test_v8_parity_bisection.py
+++ b/tests/test_v8_parity_bisection.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = REPO_ROOT / "version" / "v8" / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import parity_bisect_v8 as parity  # noqa: E402
+
+
+THRESHOLDS = {
+    "min_cosine": 0.9999,
+    "max_rmse": 1.0e-4,
+    "max_relative_rmse": 1.0e-4,
+    "max_abs": 1.0e-3,
+    "require_finite": True,
+}
+
+
+def _profile() -> dict:
+    checkpoints = {
+        name: {"producer": name.rsplit(".", 1)[0]}
+        for name in (
+            "vision.layer.0.output",
+            "vision.layer.8.output",
+            "vision.layer.1.output",
+            "vision.layer.4.output",
+        )
+    }
+    return {
+        "schema": "cke.v8.parity_bisection_profile",
+        "schema_version": 1,
+        "id": "synthetic-vision",
+        "circuit": "synthetic",
+        "reference_backend": "pytorch",
+        "candidate_backend": "cke",
+        "defaults": dict(THRESHOLDS),
+        "checkpoints": checkpoints,
+        "bisection": {
+            "root_group": "sparse",
+            "groups": {
+                "sparse": {
+                    "checkpoints": ["vision.layer.0.output", "vision.layer.8.output"],
+                    "expand_on_failure": {"vision.layer.8.output": "layers_1_8"},
+                },
+                "layers_1_8": {
+                    "checkpoints": ["vision.layer.1.output", "vision.layer.4.output"],
+                    "expand_on_failure": {},
+                },
+            },
+        },
+    }
+
+
+def _tensor(checkpoint: str, path: str, shape: list[int], axes: list[str], *, dtype: str = "fp32") -> dict:
+    return {
+        "checkpoint": checkpoint,
+        "path": path,
+        "format": "raw",
+        "dtype": dtype,
+        "shape": shape,
+        "axes": axes,
+        "canonical_axes": ["token", "head", "channel"],
+        "producer": checkpoint.rsplit(".", 1)[0],
+    }
+
+
+def _write_manifest(root: Path, name: str, backend: str, tensors: list[dict]) -> Path:
+    path = root / f"{name}.json"
+    path.write_text(json.dumps({
+        "schema": "cke.v8.parity_tensor_manifest",
+        "schema_version": 1,
+        "backend": backend,
+        "run": {"id": name},
+        "tensors": tensors,
+    }), encoding="utf-8")
+    return path
+
+
+class ParityBisectionTests(unittest.TestCase):
+    def test_canonical_axes_remove_storage_layout_difference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            root = Path(tmp_s)
+            logical = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+            head_major = logical.transpose(1, 0, 2).copy()
+            logical.tofile(root / "token_major.f32")
+            head_major.tofile(root / "head_major.f32")
+            ref_path = _write_manifest(root, "ref", "pytorch", [
+                _tensor("vision.layer.0.output", "token_major.f32", [2, 3, 4], ["token", "head", "channel"]),
+            ])
+            got_path = _write_manifest(root, "got", "cke", [
+                _tensor("vision.layer.0.output", "head_major.f32", [3, 2, 4], ["head", "token", "channel"]),
+            ])
+            ref_doc = parity._load_json(ref_path)
+            got_doc = parity._load_json(got_path)
+            parity.validate_manifest(ref_doc)
+            parity.validate_manifest(got_doc)
+            ref = parity.load_canonical_tensor(ref_path, ref_doc["tensors"][0])
+            got = parity.load_canonical_tensor(got_path, got_doc["tensors"][0])
+            np.testing.assert_array_equal(ref, got)
+
+    def test_bisection_reports_deepest_first_divergent_edge(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            root = Path(tmp_s)
+            checkpoints = list(_profile()["checkpoints"])
+            ref_tensors = []
+            got_tensors = []
+            for index, checkpoint in enumerate(checkpoints):
+                ref = np.full((2, 1, 4), index + 1, dtype=np.float32)
+                got = ref.copy()
+                if checkpoint in {"vision.layer.8.output", "vision.layer.4.output"}:
+                    got[1, 0, 2] += np.float32(0.1)
+                ref_name = f"ref_{index}.f32"
+                got_name = f"got_{index}.f32"
+                ref.tofile(root / ref_name)
+                got.tofile(root / got_name)
+                ref_tensors.append(_tensor(checkpoint, ref_name, [2, 1, 4], ["token", "head", "channel"]))
+                got_tensors.append(_tensor(checkpoint, got_name, [2, 1, 4], ["token", "head", "channel"]))
+            ref_path = _write_manifest(root, "ref", "pytorch", ref_tensors)
+            got_path = _write_manifest(root, "got", "cke", got_tensors)
+            report = parity.run_bisection(_profile(), ref_path, got_path)
+            self.assertEqual(report["status"], "fail")
+            self.assertEqual(report["first_observed_divergence"]["checkpoint"], "vision.layer.8.output")
+            self.assertEqual(report["first_divergence"]["checkpoint"], "vision.layer.4.output")
+            self.assertEqual([row["group"] for row in report["groups"]], ["sparse", "layers_1_8"])
+
+    def test_missing_granular_tensors_produces_bounded_next_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            root = Path(tmp_s)
+            ref = np.ones((2, 1, 4), dtype=np.float32)
+            got = ref.copy()
+            got[0, 0, 0] += np.float32(0.1)
+            ref.tofile(root / "ref.f32")
+            got.tofile(root / "got.f32")
+            checkpoint = "vision.layer.8.output"
+            ref_path = _write_manifest(root, "ref", "pytorch", [
+                _tensor(checkpoint, "ref.f32", [2, 1, 4], ["token", "head", "channel"]),
+            ])
+            got_path = _write_manifest(root, "got", "cke", [
+                _tensor(checkpoint, "got.f32", [2, 1, 4], ["token", "head", "channel"]),
+            ])
+            profile = _profile()
+            profile["bisection"]["groups"]["sparse"]["checkpoints"] = [checkpoint]
+            report = parity.run_bisection(profile, ref_path, got_path)
+            self.assertEqual(report["status"], "fail")
+            self.assertEqual(report["next_request"]["group"], "layers_1_8")
+            self.assertEqual(report["next_request"]["reason"], checkpoint)
+
+    def test_bf16_raw_export_is_compared_as_fp32(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            root = Path(tmp_s)
+            expected = np.array([1.0, -2.0, 0.5, 3.0], dtype=np.float32).reshape(1, 1, 4)
+            words = (expected.reshape(-1).view(np.uint32) >> np.uint32(16)).astype(np.uint16)
+            words.tofile(root / "tensor.bf16")
+            manifest_path = _write_manifest(root, "bf16", "pytorch", [
+                _tensor("vision.layer.0.output", "tensor.bf16", [1, 1, 4], ["token", "head", "channel"], dtype="bf16"),
+            ])
+            document = parity._load_json(manifest_path)
+            got = parity.load_canonical_tensor(manifest_path, document["tensors"][0])
+            np.testing.assert_array_equal(got, expected)
+
+    def test_unknown_profile_field_is_a_hard_fault(self) -> None:
+        profile = _profile()
+        profile["fallback"] = "accept"
+        with self.assertRaisesRegex(parity.ParityContractError, "HARD PARITY CONTRACT FAULT"):
+            parity.validate_profile(profile)
+
+    def test_duplicate_manifest_checkpoint_is_a_hard_fault(self) -> None:
+        tensor = _tensor("vision.layer.0.output", "unused.f32", [1, 1, 1], ["token", "head", "channel"])
+        document = {
+            "schema": "cke.v8.parity_tensor_manifest",
+            "schema_version": 1,
+            "backend": "cke",
+            "run": {"id": "duplicate"},
+            "tensors": [tensor, dict(tensor)],
+        }
+        with self.assertRaisesRegex(parity.ParityContractError, "duplicate checkpoint"):
+            parity.validate_manifest(document)
+
+    def test_profile_contract_must_match_both_backend_manifests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            root = Path(tmp_s)
+            value = np.ones((1, 1, 1), dtype=np.float32)
+            value.tofile(root / "value.f32")
+            checkpoint = "vision.layer.0.output"
+            ref_tensor = _tensor(checkpoint, "value.f32", [1, 1, 1], ["token", "head", "channel"])
+            got_tensor = dict(ref_tensor)
+            ref_tensor["contract"] = "mrope_full_width"
+            got_tensor["contract"] = "mrope_wrong_width"
+            ref_path = _write_manifest(root, "ref", "pytorch", [ref_tensor])
+            got_path = _write_manifest(root, "got", "cke", [got_tensor])
+            profile = _profile()
+            profile["checkpoints"][checkpoint]["contract"] = "mrope_full_width"
+            profile["bisection"]["groups"]["sparse"]["checkpoints"] = [checkpoint]
+            profile["bisection"]["groups"]["sparse"]["expand_on_failure"] = {}
+            with self.assertRaisesRegex(parity.ParityContractError, "contract.*does not match"):
+                parity.run_bisection(profile, ref_path, got_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version/v8/PARITY_BISECTION.md
+++ b/version/v8/PARITY_BISECTION.md
@@ -1,0 +1,98 @@
+# v8 Canonical First-Divergence Attribution
+
+Final-output similarity does not identify where two model executions first
+diverge. A high encoder-prefix cosine can still change mixed-prefill rankings
+and send greedy decoding down another token path. v8 therefore treats parity as
+a sequence of semantic graph checkpoints rather than a collection of ad hoc
+backend tensor names.
+
+The implementation uses *bisection* in its ordinary debugging sense: compare a
+small ordered set of graph boundaries, find the first failing interval, and
+repeat inside only that interval. It does not alter model execution, guess a
+kernel, or repair numerical behavior.
+
+## Ownership Boundaries
+
+- Circuits define producer/consumer topology and stable semantic checkpoint
+  names.
+- Kernel maps define exact numerical, reduction, and threading contracts.
+- Parity profiles define backend pairings, comparison thresholds, and the
+  sparse-to-granular bisection tree.
+- Backend adapters export tensor manifests using the canonical tensor ABI.
+- The bisection runner canonicalizes layouts, compares tensors, and reports the
+  first divergent semantic edge.
+
+Thresholds do not belong in circuits. Changing a test policy must not change
+the model circuit.
+
+## Tensor Manifest ABI
+
+Each backend emits `cke.v8.parity_tensor_manifest` JSON. Every tensor records:
+
+- semantic checkpoint name;
+- producer operation and optional numerical contract;
+- storage path and format;
+- dtype before canonical conversion;
+- physical shape and named axes;
+- canonical axis order.
+
+For example, CK may export `[head, token, channel]` while PyTorch exports
+`[token, head, channel]`. Both manifests set canonical axes to
+`[token, head, channel]`; the comparator transposes before computing metrics.
+This prevents layout differences from being reported as numerical failures.
+
+Missing artifacts are `unresolved`, never passing. Duplicate checkpoint names,
+unknown schema fields, incompatible axes, element-count mismatches, and
+canonical shape mismatches are hard faults.
+
+## Bounded Bisection
+
+A parity profile defines ordered groups. A sparse Qwen3-VL profile can start at
+layers 0, 8, 16, 24, 26, and the final projector. A failure at layer 16 can
+expand to layers 9-16. The first failing layer can then expand into norm, Q/K/V,
+pre/post-RoPE, attention, projection, residual, MLP, and layer-output edges.
+
+If granular tensors are absent, the report emits `next_request` containing only
+the next group and checkpoint names. Exporters can rerun that bounded request
+instead of dumping every tensor.
+
+## RoPE Rule
+
+RoPE and M-RoPE behavior must not be hardcoded in the first-divergence runner or
+added as model-name branches in code generation. Circuits must request explicit
+position-transform semantics; kernel maps must bind an exact implementation.
+The contract must include pairing convention, rotary width, position rank and
+axis layout, section interpretation, frequency/scaling precision, input/output
+dtype, and threading/reduction guarantees. The runner only verifies that both
+backend manifests name the same resolved contract before comparing tensors.
+
+## Metrics
+
+Every comparison reports:
+
+- finite-value status;
+- cosine similarity;
+- RMSE and relative RMSE;
+- mean and maximum absolute error;
+- worst logical coordinate and both values.
+
+The first sparse failure is retained as `first_observed_divergence`; after
+expansion, `first_divergence` names the deepest available failing edge.
+
+## Validation
+
+```bash
+make test-v8-parity-bisection
+
+.venv/bin/python version/v8/scripts/parity_bisect_v8.py \
+  --profile build/parity/profile.json \
+  --reference-manifest build/parity/pytorch/manifest.json \
+  --candidate-manifest build/parity/cke/manifest.json \
+  --json-out build/parity/report.json \
+  --summary
+```
+
+The initial tests cover physical-layout canonicalization, BF16 raw exports,
+deepest-edge attribution, bounded follow-up requests, duplicate checkpoints,
+and strict schema rejection. Backend adapters and mixed-prefill/teacher-forced
+stages build on the same semantic names.

--- a/version/v8/schemas/parity_bisection_profile.schema.json
+++ b/version/v8/schemas/parity_bisection_profile.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.parity_bisection_profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "schema_version", "id", "reference_backend", "candidate_backend", "defaults", "checkpoints", "bisection"],
+  "properties": {
+    "schema": {"const": "cke.v8.parity_bisection_profile"},
+    "schema_version": {"const": 1},
+    "id": {"type": "string", "minLength": 1},
+    "circuit": {"type": "string", "minLength": 1},
+    "reference_backend": {"type": "string", "minLength": 1},
+    "candidate_backend": {"type": "string", "minLength": 1},
+    "defaults": {"$ref": "#/$defs/thresholds"},
+    "checkpoints": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {"$ref": "#/$defs/checkpoint"}
+    },
+    "bisection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["root_group", "groups"],
+      "properties": {
+        "root_group": {"type": "string", "minLength": 1},
+        "groups": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {"$ref": "#/$defs/group"}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min_cosine", "max_rmse", "max_relative_rmse", "max_abs", "require_finite"],
+      "properties": {
+        "min_cosine": {"type": "number", "minimum": -1, "maximum": 1},
+        "max_rmse": {"type": "number", "minimum": 0},
+        "max_relative_rmse": {"type": "number", "minimum": 0},
+        "max_abs": {"type": "number", "minimum": 0},
+        "require_finite": {"type": "boolean"}
+      }
+    },
+    "checkpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["producer"],
+      "properties": {
+        "producer": {"type": "string", "minLength": 1},
+        "contract": {"type": "string", "minLength": 1},
+        "thresholds": {"$ref": "#/$defs/thresholds"}
+      }
+    },
+    "group": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpoints", "expand_on_failure"],
+      "properties": {
+        "checkpoints": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "expand_on_failure": {
+          "type": "object",
+          "additionalProperties": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/version/v8/schemas/parity_tensor_manifest.schema.json
+++ b/version/v8/schemas/parity_tensor_manifest.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.parity_tensor_manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "schema_version", "backend", "run", "tensors"],
+  "properties": {
+    "schema": {"const": "cke.v8.parity_tensor_manifest"},
+    "schema_version": {"const": 1},
+    "backend": {"type": "string", "minLength": 1},
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "model": {"type": "string"},
+        "source": {"type": "string"},
+        "commit": {"type": "string"},
+        "metadata": {"type": "object"}
+      }
+    },
+    "tensors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/tensor"}
+    }
+  },
+  "$defs": {
+    "tensor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["checkpoint", "path", "format", "dtype", "shape", "axes", "canonical_axes", "producer"],
+      "properties": {
+        "checkpoint": {"type": "string", "minLength": 1},
+        "path": {"type": "string", "minLength": 1},
+        "format": {"enum": ["raw", "npy"]},
+        "dtype": {"enum": ["fp32", "fp16", "bf16", "int32", "int64"]},
+        "shape": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 8,
+          "items": {"type": "integer", "minimum": 1}
+        },
+        "axes": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "canonical_axes": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "producer": {"type": "string", "minLength": 1},
+        "layer": {"type": "integer", "minimum": -1},
+        "contract": {"type": "string", "minLength": 1},
+        "occurrence": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -3823,6 +3823,12 @@ def _normalize_rope_layout_value(value: Any) -> str:
 
 
 def _resolve_rope_qk_kernel(config: Dict, template_kernels: Dict[str, Any]) -> str:
+    # Compatibility resolver only. Do not add model-name checks or new
+    # numerical behavior here. New RoPE/M-RoPE variants must declare a complete
+    # position-transform contract in the circuit and an exact implementation in
+    # a kernel map; lowering should consume that resolved binding. This legacy
+    # resolver remains temporarily for circuits not yet migrated to explicit
+    # RoPE contracts.
     rope_layout = _normalize_rope_layout_value(config.get("rope_layout"))
     rope_param_mode = str(config.get("rope_param_mode", "") or "").strip().lower()
     override = str(template_kernels.get("rope_qk", "") or "").strip()

--- a/version/v8/scripts/parity_bisect_v8.py
+++ b/version/v8/scripts/parity_bisect_v8.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Compare canonical tensor checkpoints and identify the first divergent edge.
+
+"Bisection" means progressively narrowing an ordered graph interval. The tool
+does not infer model semantics or modify execution: parity profiles provide the
+semantic names and thresholds, while backend manifests provide bounded tensor
+exports. Missing evidence remains unresolved.
+"""
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from jsonschema import Draft202012Validator
+
+
+V8_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_ROOT = V8_ROOT / "schemas"
+MANIFEST_SCHEMA = SCHEMA_ROOT / "parity_tensor_manifest.schema.json"
+PROFILE_SCHEMA = SCHEMA_ROOT / "parity_bisection_profile.schema.json"
+
+
+class ParityContractError(RuntimeError):
+    pass
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ParityContractError(f"cannot load JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ParityContractError(f"expected JSON object: {path}")
+    return value
+
+
+def _validate_schema(document: dict[str, Any], schema_path: Path, label: str) -> None:
+    schema = _load_json(schema_path)
+    errors = sorted(Draft202012Validator(schema).iter_errors(document), key=lambda e: list(e.path))
+    if not errors:
+        return
+    details = []
+    for error in errors[:12]:
+        location = ".".join(str(part) for part in error.path) or "<root>"
+        details.append(f"{location}: {error.message}")
+    raise ParityContractError(f"HARD PARITY CONTRACT FAULT in {label}: " + "; ".join(details))
+
+
+def validate_manifest(document: dict[str, Any], label: str = "tensor manifest") -> None:
+    _validate_schema(document, MANIFEST_SCHEMA, label)
+    seen: set[str] = set()
+    for tensor in document["tensors"]:
+        checkpoint = tensor["checkpoint"]
+        if checkpoint in seen:
+            raise ParityContractError(f"HARD PARITY CONTRACT FAULT: duplicate checkpoint {checkpoint!r} in {label}")
+        seen.add(checkpoint)
+        shape = tensor["shape"]
+        axes = tensor["axes"]
+        canonical = tensor["canonical_axes"]
+        if len(shape) != len(axes):
+            raise ParityContractError(
+                f"HARD PARITY CONTRACT FAULT: {checkpoint!r} shape rank {len(shape)} "
+                f"does not match axes rank {len(axes)}"
+            )
+        if set(axes) != set(canonical) or len(axes) != len(canonical):
+            raise ParityContractError(
+                f"HARD PARITY CONTRACT FAULT: {checkpoint!r} axes {axes} and "
+                f"canonical_axes {canonical} are not a permutation"
+            )
+
+
+def validate_profile(document: dict[str, Any]) -> None:
+    _validate_schema(document, PROFILE_SCHEMA, "bisection profile")
+    checkpoints = document["checkpoints"]
+    groups = document["bisection"]["groups"]
+    root = document["bisection"]["root_group"]
+    if root not in groups:
+        raise ParityContractError(f"HARD PARITY CONTRACT FAULT: unknown root group {root!r}")
+    for group_id, group in groups.items():
+        for checkpoint in group["checkpoints"]:
+            if checkpoint not in checkpoints:
+                raise ParityContractError(
+                    f"HARD PARITY CONTRACT FAULT: group {group_id!r} names unknown checkpoint {checkpoint!r}"
+                )
+        for checkpoint, child in group["expand_on_failure"].items():
+            if checkpoint not in group["checkpoints"]:
+                raise ParityContractError(
+                    f"HARD PARITY CONTRACT FAULT: group {group_id!r} expands checkpoint {checkpoint!r} "
+                    "that it does not evaluate"
+                )
+            if child not in groups:
+                raise ParityContractError(
+                    f"HARD PARITY CONTRACT FAULT: group {group_id!r} names unknown child group {child!r}"
+                )
+
+
+def _dtype(dtype: str) -> np.dtype[Any]:
+    return {
+        "fp32": np.dtype("<f4"),
+        "fp16": np.dtype("<f2"),
+        "bf16": np.dtype("<u2"),
+        "int32": np.dtype("<i4"),
+        "int64": np.dtype("<i8"),
+    }[dtype]
+
+
+def _to_fp32(array: np.ndarray, dtype: str) -> np.ndarray:
+    if dtype == "bf16":
+        words = np.asarray(array, dtype=np.uint16)
+        return (words.astype(np.uint32) << np.uint32(16)).view(np.float32)
+    return array.astype(np.float32, copy=False)
+
+
+def load_canonical_tensor(manifest_path: Path, tensor: dict[str, Any]) -> np.ndarray:
+    data_path = (manifest_path.parent / tensor["path"]).resolve()
+    if not data_path.is_file():
+        raise FileNotFoundError(data_path)
+    if tensor["format"] == "npy":
+        raw = np.load(data_path, allow_pickle=False)
+        expected_dtype = _dtype(tensor["dtype"])
+        if raw.dtype != expected_dtype:
+            raise ParityContractError(
+                f"HARD PARITY CONTRACT FAULT: {tensor['checkpoint']!r} declares "
+                f"{tensor['dtype']} but NPY stores {raw.dtype}"
+            )
+    else:
+        raw = np.fromfile(data_path, dtype=_dtype(tensor["dtype"]))
+    expected = math.prod(int(value) for value in tensor["shape"])
+    if int(raw.size) != expected:
+        raise ParityContractError(
+            f"HARD PARITY CONTRACT FAULT: {tensor['checkpoint']!r} contains {raw.size} elements, "
+            f"expected {expected} from shape {tensor['shape']}"
+        )
+    physical = _to_fp32(raw.reshape(tuple(tensor["shape"])), tensor["dtype"])
+    permutation = [tensor["axes"].index(axis) for axis in tensor["canonical_axes"]]
+    return np.ascontiguousarray(np.transpose(physical, axes=permutation), dtype=np.float32)
+
+
+def _metrics(reference: np.ndarray, candidate: np.ndarray) -> dict[str, Any]:
+    if reference.shape != candidate.shape:
+        raise ParityContractError(
+            f"HARD PARITY CONTRACT FAULT: canonical shape mismatch: "
+            f"reference={reference.shape}, candidate={candidate.shape}"
+        )
+    ref = reference.astype(np.float64, copy=False)
+    got = candidate.astype(np.float64, copy=False)
+    finite = bool(np.all(np.isfinite(ref)) and np.all(np.isfinite(got)))
+    if ref.size == 0:
+        raise ParityContractError("HARD PARITY CONTRACT FAULT: empty canonical tensor")
+    diff = got - ref
+    abs_diff = np.abs(diff)
+    max_flat = int(np.argmax(abs_diff))
+    max_coord = list(np.unravel_index(max_flat, reference.shape))
+    rmse = float(np.sqrt(np.mean(diff * diff)))
+    ref_rms = float(np.sqrt(np.mean(ref * ref)))
+    denom = float(np.linalg.norm(ref.reshape(-1)) * np.linalg.norm(got.reshape(-1)))
+    cosine = float(np.dot(ref.reshape(-1), got.reshape(-1)) / denom) if denom else (1.0 if np.array_equal(ref, got) else 0.0)
+    return {
+        "finite": finite,
+        "cosine": cosine,
+        "rmse": rmse,
+        "ref_rms": ref_rms,
+        "relative_rmse": rmse / ref_rms if ref_rms else (0.0 if rmse == 0.0 else float("inf")),
+        "mean_abs": float(np.mean(abs_diff)),
+        "max_abs": float(abs_diff.reshape(-1)[max_flat]),
+        "worst_coordinate": max_coord,
+        "worst_reference": float(ref.reshape(-1)[max_flat]),
+        "worst_candidate": float(got.reshape(-1)[max_flat]),
+    }
+
+
+def _thresholds(profile: dict[str, Any], checkpoint: str) -> dict[str, Any]:
+    return profile["checkpoints"][checkpoint].get("thresholds", profile["defaults"])
+
+
+def _evaluate(
+    checkpoint: str,
+    profile: dict[str, Any],
+    reference_path: Path,
+    reference_index: dict[str, dict[str, Any]],
+    candidate_path: Path,
+    candidate_index: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    base = {
+        "checkpoint": checkpoint,
+        "producer": profile["checkpoints"][checkpoint]["producer"],
+        "contract": profile["checkpoints"][checkpoint].get("contract"),
+        "thresholds": _thresholds(profile, checkpoint),
+    }
+    missing = []
+    if checkpoint not in reference_index:
+        missing.append("reference")
+    if checkpoint not in candidate_index:
+        missing.append("candidate")
+    if missing:
+        return {**base, "status": "unresolved", "missing": missing}
+    expected_producer = base["producer"]
+    expected_contract = base["contract"]
+    for backend, tensor in (("reference", reference_index[checkpoint]), ("candidate", candidate_index[checkpoint])):
+        if tensor["producer"] != expected_producer:
+            raise ParityContractError(
+                f"HARD PARITY CONTRACT FAULT: {backend} checkpoint {checkpoint!r} producer "
+                f"{tensor['producer']!r} does not match profile {expected_producer!r}"
+            )
+        if expected_contract is not None and tensor.get("contract") != expected_contract:
+            raise ParityContractError(
+                f"HARD PARITY CONTRACT FAULT: {backend} checkpoint {checkpoint!r} contract "
+                f"{tensor.get('contract')!r} does not match profile {expected_contract!r}"
+            )
+    try:
+        reference = load_canonical_tensor(reference_path, reference_index[checkpoint])
+        candidate = load_canonical_tensor(candidate_path, candidate_index[checkpoint])
+        metrics = _metrics(reference, candidate)
+    except FileNotFoundError as exc:
+        return {**base, "status": "unresolved", "missing_path": str(exc)}
+    thresholds = base["thresholds"]
+    failures = []
+    if thresholds["require_finite"] and not metrics["finite"]:
+        failures.append("non_finite")
+    if metrics["cosine"] < thresholds["min_cosine"]:
+        failures.append("cosine")
+    if metrics["rmse"] > thresholds["max_rmse"]:
+        failures.append("rmse")
+    if metrics["relative_rmse"] > thresholds["max_relative_rmse"]:
+        failures.append("relative_rmse")
+    if metrics["max_abs"] > thresholds["max_abs"]:
+        failures.append("max_abs")
+    return {**base, "status": "fail" if failures else "pass", "failures": failures, "metrics": metrics}
+
+
+def run_bisection(profile: dict[str, Any], reference_path: Path, candidate_path: Path) -> dict[str, Any]:
+    reference = _load_json(reference_path)
+    candidate = _load_json(candidate_path)
+    validate_manifest(reference, "reference tensor manifest")
+    validate_manifest(candidate, "candidate tensor manifest")
+    validate_profile(profile)
+    if reference["backend"] != profile["reference_backend"]:
+        raise ParityContractError(
+            f"reference backend {reference['backend']!r} does not match profile {profile['reference_backend']!r}"
+        )
+    if candidate["backend"] != profile["candidate_backend"]:
+        raise ParityContractError(
+            f"candidate backend {candidate['backend']!r} does not match profile {profile['candidate_backend']!r}"
+        )
+    ref_index = {row["checkpoint"]: row for row in reference["tensors"]}
+    got_index = {row["checkpoint"]: row for row in candidate["tensors"]}
+    groups = profile["bisection"]["groups"]
+    group_id = profile["bisection"]["root_group"]
+    visited: set[str] = set()
+    group_reports = []
+    first_observed_divergence = None
+    first_divergence = None
+    next_request = None
+    while group_id:
+        if group_id in visited:
+            raise ParityContractError(f"HARD PARITY CONTRACT FAULT: bisection cycle at group {group_id!r}")
+        visited.add(group_id)
+        group = groups[group_id]
+        rows = [
+            _evaluate(checkpoint, profile, reference_path, ref_index, candidate_path, got_index)
+            for checkpoint in group["checkpoints"]
+        ]
+        issue = next((row for row in rows if row["status"] != "pass"), None)
+        group_reports.append({"group": group_id, "comparisons": rows, "first_issue": issue})
+        if issue is None:
+            break
+        if issue["status"] == "fail":
+            if first_observed_divergence is None:
+                first_observed_divergence = issue
+            first_divergence = issue
+        child = group["expand_on_failure"].get(issue["checkpoint"])
+        if not child:
+            break
+        child_checkpoints = groups[child]["checkpoints"]
+        if any(checkpoint not in ref_index or checkpoint not in got_index for checkpoint in child_checkpoints):
+            next_request = {"group": child, "checkpoints": child_checkpoints, "reason": issue["checkpoint"]}
+            break
+        group_id = child
+    unresolved = any(
+        row["status"] == "unresolved"
+        for group in group_reports
+        for row in group["comparisons"]
+    )
+    status = "unresolved" if unresolved and first_divergence is None else ("fail" if first_divergence else "pass")
+    return {
+        "schema": "cke.v8.parity_bisection_report",
+        "schema_version": 1,
+        "profile": profile["id"],
+        "reference": {"backend": reference["backend"], "run": reference["run"]},
+        "candidate": {"backend": candidate["backend"], "run": candidate["run"]},
+        "status": status,
+        "first_observed_divergence": first_observed_divergence,
+        "first_divergence": first_divergence,
+        "next_request": next_request,
+        "groups": group_reports,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", type=Path, required=True)
+    parser.add_argument("--reference-manifest", type=Path, required=True)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        report = run_bisection(_load_json(args.profile), args.reference_manifest, args.candidate_manifest)
+    except ParityContractError as exc:
+        print(str(exc))
+        return 2
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.summary:
+        print(json.dumps({
+            "status": report["status"],
+            "first_divergence": report["first_divergence"],
+            "next_request": report["next_request"],
+            "report": str(args.json_out),
+        }, indent=2, sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Why: final-prefix cosine cannot locate the graph edge that changes mixed-prefill rankings. Parity diagnostics need a backend-neutral tensor ABI and bounded sparse-to-granular attribution instead of model-specific dump scripts.

What: add strict tensor-manifest and parity-profile schemas, named-axis canonicalization, BF16 export support, hierarchical first-divergence reports, bounded next-checkpoint requests, a nightly gate, and architecture documentation.

RoPE policy: mark the existing build_ir RoPE resolver as compatibility-only. Future RoPE/M-RoPE behavior must be declared by circuit numerical contracts and exact kernel-map bindings; agents must not add model-name branches to codegen.

Test: make test-v8-parity-bisection (7/7); py_compile; make test-numerical-contracts with pinned llama.cpp (22 contract, 7 full attention, 14/14 split-KV); git diff --check.