### PR TITLE
test(llama): add rolling upstream compatibility lane

### DIFF
--- a/.github/workflows/llamacpp-rolling-compat.yml
+++ b/.github/workflows/llamacpp-rolling-compat.yml
@@ -1,0 +1,85 @@
+name: llama.cpp Rolling Compatibility
+
+on:
+  workflow_dispatch:
+    inputs:
+      llama_ref:
+        description: llama.cpp ref to probe
+        required: false
+        default: HEAD
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  rolling-compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build python3-venv libomp-dev
+          python3 -m venv .venv
+          .venv/bin/pip install -r requirements.txt
+
+      - name: Probe rolling llama.cpp
+        id: probe
+        continue-on-error: true
+        env:
+          LLAMA_REF: ${{ inputs.llama_ref || 'HEAD' }}
+        run: |
+          .venv/bin/python scripts/run_llamacpp_rolling_compat.py \
+            --ref "$LLAMA_REF" \
+            --output-dir build/llamacpp_rolling
+
+      - name: Publish report summary
+        if: always()
+        run: |
+          .venv/bin/python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("build/llamacpp_rolling/report.json")
+          if not path.exists():
+              print("## llama.cpp rolling compatibility\n\nNo report was produced.", file=open(os.environ["GITHUB_STEP_SUMMARY"], "a"))
+              raise SystemExit(0)
+          data = json.loads(path.read_text())
+          llama = data["llama_cpp"]
+          lines = [
+              "## llama.cpp rolling compatibility",
+              "",
+              f"- Status: **{data['status'].upper()}**",
+              f"- CK: `{data['cke_commit'][:12]}`",
+              f"- Pinned oracle: `{llama['pinned_commit'][:12]}`",
+              f"- Rolling upstream: `{llama['rolling_commit'][:12]}`",
+              f"- Upstream commits since pin: {llama.get('commits_ahead_of_pin', 'unknown')}",
+              "- Authoritative oracle changed: **no**",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as stream:
+              stream.write("\n".join(lines) + "\n")
+          PY
+
+      - name: Upload rolling evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: llamacpp-rolling-compat
+          path: |
+            build/llamacpp_rolling/report.json
+            build/llamacpp_rolling/ck-build.log
+            build/llamacpp_rolling/quick-parity.log
+          if-no-files-found: warn
+
+      - name: Enforce rolling compatibility result
+        if: always()
+        run: |
+          test -f build/llamacpp_rolling/report.json
+          test "$(.venv/bin/python -c 'import json; print(json.load(open("build/llamacpp_rolling/report.json"))["status"])')" = pass

--- a/docs/notes/LLAMACPP_ROLLING_COMPATIBILITY.md
+++ b/docs/notes/LLAMACPP_ROLLING_COMPATIBILITY.md
@@ -1,0 +1,30 @@
+# llama.cpp Rolling Compatibility
+
+CK uses two distinct llama.cpp lanes:
+
+1. The repository gitlink is the authoritative numerical oracle. It is pinned,
+   reviewed, and deterministic.
+2. The rolling compatibility workflow probes current upstream `HEAD`. It
+   detects API, patch, build, numerical, and performance changes, but never
+   updates the authoritative pin.
+
+Run the metadata and patch-compatibility probe locally:
+
+```bash
+.venv/bin/python scripts/run_llamacpp_rolling_compat.py --resolve-only
+```
+
+Run the full rolling quick-parity probe:
+
+```bash
+.venv/bin/python scripts/run_llamacpp_rolling_compat.py
+```
+
+Evidence is written under `build/llamacpp_rolling/`. The JSON report records
+the CK commit, pinned and rolling llama.cpp commits, the upstream commit delta,
+patch applicability, and the rolling quick-parity result.
+
+A rolling failure is actionable compatibility evidence. It does not authorize
+changing tolerances, expected values, or the pinned oracle. Updating the pin
+requires a separate reviewed change with pinned and rolling results compared on
+the same hardware, model, prompts, thread settings, and numerical gates.

--- a/scripts/run_llamacpp_rolling_compat.py
+++ b/scripts/run_llamacpp_rolling_compat.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Probe current llama.cpp HEAD without changing CK's pinned parity oracle."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+LLAMA_REPO = "https://github.com/ggerganov/llama.cpp.git"
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: pathlib.Path = ROOT,
+    check: bool = True,
+    stdout: Any = subprocess.PIPE,
+    stderr: Any = subprocess.STDOUT,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=check,
+        text=True,
+        stdout=stdout,
+        stderr=stderr,
+        env=env,
+    )
+
+
+def git_output(args: list[str], *, cwd: pathlib.Path = ROOT) -> str:
+    return run(["git", *args], cwd=cwd).stdout.strip()
+
+
+def pinned_commit() -> str:
+    row = git_output(["ls-tree", "HEAD", "llama.cpp"])
+    fields = row.split()
+    if len(fields) < 3:
+        raise RuntimeError("HEAD does not contain a llama.cpp gitlink")
+    return fields[2]
+
+
+def remote_commit(ref: str) -> str:
+    rows = git_output(["ls-remote", LLAMA_REPO, ref]).splitlines()
+    if not rows:
+        raise RuntimeError(f"llama.cpp ref not found: {ref}")
+    return rows[0].split()[0]
+
+
+def clone_for_probe(path: pathlib.Path, rolling: str, pinned: str) -> None:
+    if (path / ".git").exists():
+        current = git_output(["rev-parse", "HEAD"], cwd=path)
+        has_pin = run(["git", "cat-file", "-e", pinned], cwd=path, check=False).returncode == 0
+        if current == rolling and has_pin:
+            return
+    shutil.rmtree(path, ignore_errors=True)
+    run(["git", "clone", "--filter=blob:none", "--no-checkout", LLAMA_REPO, str(path)])
+    run(["git", "fetch", "origin", rolling, pinned], cwd=path)
+    run(["git", "checkout", "--detach", rolling], cwd=path)
+
+
+def patch_status(probe: pathlib.Path, relative_path: str) -> dict[str, Any]:
+    patch = ROOT / relative_path
+    if not patch.exists():
+        return {"path": relative_path, "status": "missing"}
+    result = run(
+        ["git", "apply", "--check", str(patch)],
+        cwd=probe,
+        check=False,
+    )
+    return {
+        "path": relative_path,
+        "status": "applies" if result.returncode == 0 else "incompatible",
+        "detail": result.stdout.strip()[-2000:],
+    }
+
+
+def upstream_delta(probe: pathlib.Path, pinned: str, rolling: str, limit: int) -> tuple[int, list[dict[str, str]]]:
+    count = int(git_output(["rev-list", "--count", f"{pinned}..{rolling}"], cwd=probe))
+    lines = git_output(
+        ["log", f"--max-count={limit}", "--format=%H%x09%s", f"{pinned}..{rolling}"],
+        cwd=probe,
+    ).splitlines()
+    commits = []
+    for line in lines:
+        sha, _, subject = line.partition("\t")
+        commits.append({"commit": sha, "subject": subject})
+    return count, commits
+
+
+def write_report(path: pathlib.Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_quick_log(path: pathlib.Path) -> dict[str, Any]:
+    text = ANSI_RE.sub("", path.read_text(encoding="utf-8", errors="replace"))
+    summaries = re.findall(r"Passed:\s+(\d+)\s+Failed:\s+(\d+)\s+Skipped:\s+(\d+)", text)
+    performance = []
+    for speedup, ck_gflops, llama_gflops in re.findall(
+        r"Average CK/llama\.cpp speedup:\s+([0-9.]+)x.*?"
+        r"Average CK GFLOPS:\s+([0-9.]+).*?"
+        r"Average llama\.cpp GFLOPS:\s+([0-9.]+)",
+        text,
+        flags=re.DOTALL,
+    ):
+        performance.append(
+            {
+                "ck_over_llama_speedup": float(speedup),
+                "ck_gflops": float(ck_gflops),
+                "llama_gflops": float(llama_gflops),
+            }
+        )
+    result: dict[str, Any] = {"performance_summaries": performance}
+    if summaries:
+        passed, failed, skipped = summaries[-1]
+        result["smoketest"] = {"passed": int(passed), "failed": int(failed), "skipped": int(skipped)}
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ref", default="HEAD", help="Rolling llama.cpp ref to probe")
+    parser.add_argument("--output-dir", type=pathlib.Path, default=ROOT / "build" / "llamacpp_rolling")
+    parser.add_argument("--commit-limit", type=int, default=50)
+    parser.add_argument("--resolve-only", action="store_true", help="Resolve and inspect upstream without building")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir.resolve()
+    probe = output_dir / "llama.cpp"
+    report_path = output_dir / "report.json"
+    pinned = pinned_commit()
+    rolling = remote_commit(args.ref)
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "cke_commit": git_output(["rev-parse", "HEAD"]),
+        "llama_cpp": {"repository": LLAMA_REPO, "pinned_commit": pinned, "rolling_commit": rolling},
+        "authoritative_oracle_changed": False,
+        "status": "running",
+        "phases": {},
+    }
+
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        clone_for_probe(probe, rolling, pinned)
+        count, commits = upstream_delta(probe, pinned, rolling, args.commit_limit)
+        report["llama_cpp"]["commits_ahead_of_pin"] = count
+        report["llama_cpp"]["recent_delta"] = commits
+        patches = [
+            patch_status(probe, "patches/llama.patch"),
+            patch_status(probe, "patches/ck-engine-parity-bench.patch"),
+        ]
+        report["phases"]["patch_compatibility"] = {
+            "status": "pass" if all(item["status"] == "applies" for item in patches) else "fail",
+            "patches": patches,
+        }
+
+        if args.resolve_only:
+            report["phases"]["quick_parity"] = {"status": "skip", "reason": "resolve-only"}
+            report["status"] = report["phases"]["patch_compatibility"]["status"]
+            write_report(report_path, report)
+            print(report_path)
+            return 0 if report["status"] == "pass" else 1
+
+        log_path = output_dir / "quick-parity.log"
+        build_log_path = output_dir / "ck-build.log"
+        environment = os.environ.copy()
+        environment["LLAMA_CPP_COMMIT"] = rolling
+        environment["LLAMA_CPP_DIR"] = str(probe)
+        environment.setdefault("PYTHON_BIN", str(ROOT / ".venv" / "bin" / "python"))
+        with build_log_path.open("w", encoding="utf-8") as log:
+            build_result = run(
+                ["make", "build/libckernel_engine.so", "build/libck_parity.so"],
+                check=False,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                env=environment,
+            )
+        report["phases"]["ck_build"] = {
+            "status": "pass" if build_result.returncode == 0 else "fail",
+            "returncode": build_result.returncode,
+            "log": str(build_log_path),
+        }
+        if build_result.returncode != 0:
+            report["phases"]["quick_parity"] = {"status": "skip", "reason": "CK build failed"}
+            report["status"] = "fail"
+            write_report(report_path, report)
+            print(report_path)
+            return 1
+        with log_path.open("w", encoding="utf-8") as log:
+            result = run(
+                [str(ROOT / "scripts" / "run_parity_smoketest.sh"), "--quick"],
+                check=False,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                env=environment,
+            )
+        report["phases"]["quick_parity"] = {
+            "status": "pass" if result.returncode == 0 else "fail",
+            "returncode": result.returncode,
+            "log": str(log_path),
+            "summary": parse_quick_log(log_path),
+        }
+        report["status"] = (
+            "pass"
+            if report["phases"]["quick_parity"]["status"] == "pass"
+            and report["phases"]["patch_compatibility"]["status"] == "pass"
+            else "fail"
+        )
+    except Exception as exc:  # Preserve diagnostics even when upstream changes break setup.
+        report["status"] = "error"
+        report["error"] = f"{type(exc).__name__}: {exc}"
+
+    write_report(report_path, report)
+    print(report_path)
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_parity_smoketest.sh
+++ b/scripts/run_parity_smoketest.sh
@@ -14,7 +14,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
-LLAMA_DIR="$ROOT_DIR/llama.cpp"
+LLAMA_DIR="${LLAMA_CPP_DIR:-$ROOT_DIR/llama.cpp}"
 PATCHES_DIR="$ROOT_DIR/patches"
 BUILD_DIR="$ROOT_DIR/build"
 if [[ -z "${PYTHON_BIN:-}" && -x "$ROOT_DIR/.venv/bin/python" ]]; then

--- a/scripts/test_kernels_vs_llamacpp.py
+++ b/scripts/test_kernels_vs_llamacpp.py
@@ -48,11 +48,12 @@ BLOCK_Q4_0_SIZE = 18   # bytes per Q4_0 block
 def load_libraries():
     """Load both test libraries."""
     base_dir = Path(__file__).parent.parent
+    llama_dir = Path(os.environ.get("LLAMA_CPP_DIR", base_dir / "llama.cpp"))
 
     # Try to load llama.cpp kernel test library
     llama_paths = [
-        base_dir / "llama.cpp" / "libggml_kernel_test.so",
-        base_dir / "llama.cpp" / "build" / "libggml_kernel_test.so",
+        llama_dir / "libggml_kernel_test.so",
+        llama_dir / "build" / "libggml_kernel_test.so",
     ]
 
     libggml = None

--- a/tests/test_llamacpp_rolling_compat.py
+++ b/tests/test_llamacpp_rolling_compat.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run_llamacpp_rolling_compat.py"
+SPEC = importlib.util.spec_from_file_location("rolling_compat", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class RollingCompatReportTests(unittest.TestCase):
+    def test_parse_quick_log(self) -> None:
+        content = """
+PERFORMANCE SUMMARY
+  Average CK/llama.cpp speedup: 0.90x
+  Average CK GFLOPS:            7.26
+  Average llama.cpp GFLOPS:     9.77
+PARITY SMOKETEST SUMMARY
+  Passed:  6
+  Failed:  0
+  Skipped: 1
+"""
+        with tempfile.TemporaryDirectory() as temp:
+            path = pathlib.Path(temp) / "quick.log"
+            path.write_text(content, encoding="utf-8")
+            summary = MODULE.parse_quick_log(path)
+        self.assertEqual(summary["smoketest"], {"passed": 6, "failed": 0, "skipped": 1})
+        self.assertEqual(
+            summary["performance_summaries"],
+            [{"ck_over_llama_speedup": 0.9, "ck_gflops": 7.26, "llama_gflops": 9.77}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

CK needs to learn from aggressive llama.cpp development without allowing a moving upstream target to redefine numerical correctness. The repository gitlink remains the authoritative pinned oracle.

## What

- Add weekly and manually dispatched rolling-upstream compatibility workflow.
- Record pinned and rolling commits plus upstream commit delta.
- Check local instrumentation patch applicability.
- Build CK and current llama.cpp, then run quick direct parity.
- Parse test counts and CK/llama performance summaries into JSON.
- Upload raw report/build/parity logs.
- Allow external llama.cpp roots in the parity runner and Python adapter.
- Never update the authoritative pin automatically.

## First Live Result

- Pinned oracle: `dc6592431b90`
- Rolling upstream: `c92e806d1c81`
- Upstream delta: 1,520 commits
- Latest llama.cpp build: PASS
- CK build: PASS
- Quick parity: 6 passed, 0 failed, 1 skipped
- Direct quant numerical comparisons: PASS
- Quick benchmark summary: CK 10.07 GFLOPS, llama.cpp 13.12 GFLOPS, CK/llama 0.91x
- `patches/llama.patch`: incompatible with current upstream
- `patches/ck-engine-parity-bench.patch`: incompatible with current upstream

The rolling lane is intentionally red on patch incompatibility even though direct kernel parity passes. That identifies instrumentation/API maintenance without contaminating the pinned numerical baseline.

## Validation

- Full live rolling probe completed and produced JSON/log evidence.
- Parser unit test passes.
- Python compilation passes.
- Shell syntax and `git diff --check` pass.

The known v7 first-token baseline failures on Gemma, Qwen2, and Nanbeige remain unrelated and unchanged; no tolerance or status was relaxed.
