### PR TITLE
refactor(v8/dsl): remove family runtime defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2891,7 +2891,7 @@ test-numerical-contracts: $(LIB)
 	@$(PYTHON) version/v8/scripts/resolve_attention_contracts_v8.py --circuit qwen3vl --operation decoder.attention --phase decode --mode bringup --output build/v8/contracts/qwen3vl-decode.json >/dev/null
 	@echo "Resolved plans: build/v8/contracts/"
 
-.PHONY: test-bf16-xray xray-vision-parity
+.PHONY: test-bf16-xray xray-vision-parity test-v8-dsl-policy test-v8-dsl
 test-bf16-xray:
 	@echo "Running bounded numerical X-ray architecture tests..."
 	@$(PYTHON) -m py_compile \
@@ -2915,6 +2915,13 @@ xray-vision-parity:
 		--image "$${IMAGE:-build/xray/public_form_1152x896.ppm}" \
 		--threads "$${CK_NUM_THREADS:-20}" \
 		--output-dir "$${XRAY_OUTPUT_DIR:-build/xray/qwen3vl_bf16}"
+
+test-v8-dsl-policy:
+	@echo "Running v8 zero-hardcoding DSL policy tests..."
+	@$(PYTHON) version/v8/scripts/audit_dsl_policy_v8.py --json-out build/v8/dsl_policy_report.json
+	@$(PYTHON) -m unittest tests.test_v8_dsl_policy -v
+
+test-v8-dsl: test-v8-dsl-policy test-numerical-contracts test-v8-template-circuit-audit
 
 v8-model-kernel-inspect:
 	@target="$${MODEL:-$${CONFIG:-}}"; \
@@ -5014,7 +5021,7 @@ v7-regression-fast:
 	@echo "Running v7 regression fast suite..."
 	@$(PYTHON) version/v7/scripts/run_regression_v7.py --mode fast --force-rebuild $(REGRESSION_ARGS)
 
-v8-regression-fast:
+v8-regression-fast: test-v8-dsl-policy
 	@echo "Running v8 regression fast suite..."
 	@$(PYTHON) version/v8/scripts/run_regression_v8.py --mode fast --force-rebuild $(REGRESSION_ARGS)
 

--- a/docs/notes/V8_DSL_ZERO_HARDCODING_2026-07-11.md
+++ b/docs/notes/V8_DSL_ZERO_HARDCODING_2026-07-11.md
@@ -1,0 +1,64 @@
+# v8 DSL Zero-Hardcoding Refactor
+
+## Target
+
+The generic v8 compiler consumes weights/configuration, circuits, kernel maps,
+and numerical contracts. It must not select model mathematics from model-family
+names. Circuits own topology and required semantics; kernel maps own supported
+functions and execution capabilities; code generation emits the resolved call
+IR without reselecting it.
+
+## First Inventory
+
+The initial AST inventory found 44 explicit family predicates in generic
+compiler modules:
+
+- `build_ir_v8.py`: 21
+- `codegen_core_v8.py`: 6
+- `codegen_prefill_v8.py`: 13
+- `codegen_v8.py`: 4
+
+The first migration removed three runtime numerical-policy branches for
+Qwen3.5, Qwen3-VL vision, and Gemma3. Their defaults now live in validated
+`contract.runtime_defaults` sections of the corresponding circuits. The
+remaining 41 sites are tracked as cleanup work, not accepted exceptions.
+
+No legacy allowlist is used. `version/v8/dsl_policy.json` lists only compiler
+functions already cleaned and covered by the zero-hardcoding gate. Each
+migration expands that enforced set. Removing a named function from the policy
+or naming a nonexistent function is a test failure.
+
+## Gates
+
+```bash
+make test-v8-dsl-policy
+make test-v8-dsl
+```
+
+The lightweight policy gate runs in `v8-regression-fast` and as a dedicated
+nightly row. It currently checks:
+
+- AST rejection of model-family literals in cleaned generic functions.
+- Circuit identity invariance.
+- JSON key-order determinism.
+- Explicit runtime override stability.
+- Unknown circuit runtime policy hard failures.
+- Policy-scope weakening hard failures.
+
+The aggregate gate also runs numerical contract resolution and template
+dataflow audits, including zero-provider, ambiguous-provider, incompatible
+threading/reduction, and invalid M-RoPE cases.
+
+## Migration Order
+
+1. Replace family-based runtime/config defaults with validated circuit fields.
+2. Replace family-based kernel selection with exact kernel-map resolution.
+3. Replace multimodal family checks with declared runtime capabilities and
+   explicit circuit operations.
+4. Replace model-specific diagnostic modes with semantic checkpoint metadata.
+5. Remove model-specific LoweredIR and codegen branches.
+6. Expand the AST policy to the complete generic compiler modules.
+
+Every group is characterized before removal, then validated with stage-level
+negative tests, generated-IR checks, compilation, family regression, and the
+applicable llama.cpp or PyTorch parity gate.

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -502,6 +502,12 @@ MAKE_TARGETS = {
         "target": "test-bf16-xray",
         "timeout_sec": 300,
     },
+    "v8_dsl_policy": {
+        "name": "v8 DSL Zero-Hardcoding Policy",
+        "category": "inference",
+        "target": "test-v8-dsl-policy",
+        "timeout_sec": 300,
+    },
     "v8_template_circuit_audit": {
         "name": "v8 Template Circuit/Dataflow Audit",
         "category": "inference",

--- a/tests/test_v8_dsl_policy.py
+++ b/tests/test_v8_dsl_policy.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str((ROOT / "version" / "v8" / "scripts").resolve()))
+
+
+def _load(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+audit = _load("audit_dsl_policy_v8", ROOT / "version" / "v8" / "scripts" / "audit_dsl_policy_v8.py")
+build_ir = _load("build_ir_v8_dsl_policy", ROOT / "version" / "v8" / "scripts" / "build_ir_v8.py")
+
+
+class V8DSLPolicyTests(unittest.TestCase):
+    def test_cleaned_compiler_functions_have_no_model_literals(self) -> None:
+        report = audit.audit()
+        self.assertEqual(report["status"], "pass", report["findings"])
+        self.assertGreaterEqual(report["checked_functions"], 3)
+
+    def test_ast_policy_rejects_model_specific_branch(self) -> None:
+        source = """
+def lower(config):
+    if config.get('model') == 'qwen_new':
+        return 'special_kernel'
+    return 'generic_kernel'
+"""
+        findings = audit.scan_source(source, ["lower"], ["qwen", "gemma"], path="synthetic.py")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["function"], "lower")
+
+    def test_runtime_defaults_are_key_order_deterministic(self) -> None:
+        first = {
+            "contract": {
+                "runtime_defaults": {
+                    "prefer_q8_0_contract": True,
+                    "activation_preference_by_op": {"mlp_down": "fp32", "out_proj": "q8_0"},
+                }
+            }
+        }
+        second = json.loads(json.dumps(first, sort_keys=True))
+        self.assertEqual(
+            build_ir._apply_circuit_runtime_defaults({}, first, source="first"),
+            build_ir._apply_circuit_runtime_defaults({}, second, source="second"),
+        )
+
+    def test_runtime_default_override_is_explicit_and_stable(self) -> None:
+        circuit = {
+            "contract": {
+                "runtime_defaults": {
+                    "prefer_q8_0_contract": True,
+                    "activation_preference_by_op": {"mlp_down": "fp32", "out_proj": "q8_0"},
+                }
+            }
+        }
+        actual = build_ir._apply_circuit_runtime_defaults(
+            {"prefer_q8_0_contract": False, "activation_preference_by_op": {"mlp_down": "q8_0"}},
+            circuit,
+            source="override",
+        )
+        self.assertFalse(actual["prefer_q8_0_contract"])
+        self.assertEqual(actual["activation_preference_by_op"]["mlp_down"], "q8_0")
+        self.assertEqual(actual["activation_preference_by_op"]["out_proj"], "q8_0")
+
+    def test_policy_rejects_missing_function_instead_of_weakening_scope(self) -> None:
+        policy = {
+            "schema": "cke.v8_dsl_policy",
+            "schema_version": 1,
+            "forbidden_model_literals": ["qwen"],
+            "compiler_functions": {"version/v8/scripts/build_ir_v8.py": ["function_does_not_exist"]},
+        }
+        with tempfile.TemporaryDirectory() as temp:
+            path = pathlib.Path(temp) / "policy.json"
+            path.write_text(json.dumps(policy), encoding="utf-8")
+            with self.assertRaisesRegex(audit.DSLPolicyError, "policy function not found"):
+                audit.audit(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v8_gemma4_scaffold.py
+++ b/tests/test_v8_gemma4_scaffold.py
@@ -16,8 +16,8 @@ from convert_gguf_to_bump_v8 import (  # type: ignore
     build_gemma4_attention_plan,
     classify_layer_contract,
     describe_layer_contract,
-    _inject_runtime_config_defaults,
 )
+from build_ir_v8 import _apply_circuit_runtime_defaults, _load_builtin_template_doc  # type: ignore
 
 
 def _write_tiny_bpe_tokenizer(checkpoint: Path, vocab_size: int) -> None:
@@ -89,10 +89,13 @@ class V8Gemma4ScaffoldTests(unittest.TestCase):
         self.assertEqual(contract["token_stop_markers"], ["<turn|>"])
 
     def test_gemma4_uses_q8_activation_logits_by_default(self) -> None:
-        gemma4 = _inject_runtime_config_defaults({}, "gemma4")
-        gemma3 = _inject_runtime_config_defaults({}, "gemma3")
-        self.assertFalse(gemma4["prefer_fp32_logits"])
-        self.assertTrue(gemma4["prefer_q8_0_contract"])
+        gemma4 = _apply_circuit_runtime_defaults(
+            {}, _load_builtin_template_doc("gemma4"), source="gemma4"
+        )
+        gemma3 = _apply_circuit_runtime_defaults(
+            {}, _load_builtin_template_doc("gemma3"), source="gemma3"
+        )
+        self.assertNotIn("prefer_fp32_logits", gemma4)
         self.assertTrue(gemma3["prefer_fp32_logits"])
 
     def test_build_chat_contract_detects_gemma4_markers(self) -> None:

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -414,15 +414,21 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "flags.prefer_fp32_mlp_matmuls"):
             build_ir_v8._hydrate_manifest_template(manifest)
 
-    def test_runtime_config_defaults_own_quant_policy(self) -> None:
-        qwen2_cfg = build_ir_v8._inject_runtime_config_defaults({}, "qwen2")
+    def test_circuit_runtime_defaults_own_quant_policy(self) -> None:
+        qwen2_cfg = build_ir_v8._apply_circuit_runtime_defaults(
+            {}, build_ir_v8._load_builtin_template_doc("qwen2"), source="qwen2"
+        )
         self.assertNotIn("prefer_fp32_mlp_matmuls", qwen2_cfg)
 
-        gemma_cfg = build_ir_v8._inject_runtime_config_defaults({}, "gemma3")
+        gemma_cfg = build_ir_v8._apply_circuit_runtime_defaults(
+            {}, build_ir_v8._load_builtin_template_doc("gemma3"), source="gemma3"
+        )
         self.assertTrue(gemma_cfg["prefer_q8_0_contract"])
         self.assertTrue(gemma_cfg["prefer_fp32_logits"])
 
-        vision_cfg = build_ir_v8._inject_runtime_config_defaults({}, "qwen3_vl_vision")
+        vision_cfg = build_ir_v8._apply_circuit_runtime_defaults(
+            {}, build_ir_v8._load_builtin_template_doc("qwen3_vl_vision"), source="vision"
+        )
         self.assertTrue(vision_cfg["prefer_q8_0_contract"])
         self.assertEqual(
             vision_cfg["q8_0_contract_ops"],
@@ -437,6 +443,20 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
                 "branch_fc2": "fp32",
             },
         )
+
+    def test_circuit_runtime_defaults_are_identity_invariant(self) -> None:
+        defaults = {"prefer_q8_0_contract": True, "activation_preference_by_op": {"mlp_down": "fp32"}}
+        alpha = {"name": "model_alpha", "contract": {"runtime_defaults": defaults}}
+        beta = {"name": "model_beta", "contract": {"runtime_defaults": defaults}}
+        self.assertEqual(
+            build_ir_v8._apply_circuit_runtime_defaults({}, alpha, source="alpha"),
+            build_ir_v8._apply_circuit_runtime_defaults({}, beta, source="beta"),
+        )
+
+    def test_circuit_runtime_defaults_reject_unknown_policy(self) -> None:
+        circuit = {"contract": {"runtime_defaults": {"model_specific_fast_path": True}}}
+        with self.assertRaisesRegex(RuntimeError, "HARD CIRCUIT DEFAULT FAULT"):
+            build_ir_v8._apply_circuit_runtime_defaults({}, circuit, source="invalid")
 
     def test_qwen3vl_branch_plan_reads_template_declared_layers(self) -> None:
         manifest = _make_qwen3vl_manifest()

--- a/version/v8/circuits/gemma3.json
+++ b/version/v8/circuits/gemma3.json
@@ -14,6 +14,10 @@
     "post_ffn_norm": true
   },
   "contract": {
+    "runtime_defaults": {
+      "prefer_q8_0_contract": true,
+      "prefer_fp32_logits": true
+    },
     "tokenizer_contract": {
       "tokenizer_type": "sentencepiece",
       "bos_policy": "model_defined",

--- a/version/v8/circuits/qwen35.json
+++ b/version/v8/circuits/qwen35.json
@@ -12,6 +12,15 @@
     "hybrid_block_pattern": "3x_recurrent_then_1x_full_attention"
   },
   "contract": {
+    "runtime_defaults": {
+      "prefer_q8_0_contract": true,
+      "mlp_gate_up_fp32_layers": [0],
+      "activation_preference_by_op": {
+        "recurrent_gate_proj": "q8_k",
+        "recurrent_alpha_proj": "q8_0",
+        "recurrent_beta_proj": "q8_0"
+      }
+    },
     "tokenizer_contract": {
       "tokenizer_type": "bpe",
       "bos_policy": "model_defined",

--- a/version/v8/circuits/qwen3_vl_vision.json
+++ b/version/v8/circuits/qwen3_vl_vision.json
@@ -8,6 +8,16 @@
     "normalization": "layernorm"
   },
   "contract": {
+    "runtime_defaults": {
+      "prefer_q8_0_contract": true,
+      "q8_0_contract_ops": ["projector_fc2", "branch_fc1", "branch_fc2"],
+      "activation_preference_by_op": {
+        "mlp_down": "fp32",
+        "out_proj": "q8_0",
+        "branch_fc1": "fp32",
+        "branch_fc2": "fp32"
+      }
+    },
     "vision_contract": {
       "input_modality": "image",
       "position_encoding": "absolute_2d",
@@ -62,17 +72,6 @@
       "cache_policy": "persistent_decoder_kv",
       "runtime_policy": "decode_staged"
     }
-  },
-  "activation_preference_by_op": {
-    "qkv_packed_proj": "q8_0",
-    "out_proj": "q8_0",
-    "attn_out_proj": "q8_0",
-    "mlp_up": "q8_0",
-    "mlp_down": "fp32",
-    "projector_fc1": "q8_0",
-    "projector_fc2": "fp32",
-    "branch_fc1": "fp32",
-    "branch_fc2": "fp32"
   },
   "kernels": {
     "patch_proj": "gemm_nt_fp32_exact",

--- a/version/v8/dsl_policy.json
+++ b/version/v8/dsl_policy.json
@@ -1,0 +1,22 @@
+{
+  "schema": "cke.v8_dsl_policy",
+  "schema_version": 1,
+  "forbidden_model_literals": [
+    "deepseek",
+    "gemma",
+    "glm",
+    "kimi",
+    "llama",
+    "nanbeige",
+    "qwen"
+  ],
+  "compiler_functions": {
+    "version/v8/scripts/build_ir_v8.py": [
+      "_apply_circuit_runtime_defaults",
+      "_hydrate_manifest_template"
+    ],
+    "version/v8/scripts/resolve_numerical_execution_contracts_v8.py": [
+      "resolve_contract"
+    ]
+  }
+}

--- a/version/v8/schemas/circuit_runtime_defaults.schema.json
+++ b/version/v8/schemas/circuit_runtime_defaults.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.circuit_runtime_defaults",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "prefer_q8_0_contract": {"type": "boolean"},
+    "prefer_fp32_logits": {"type": "boolean"},
+    "mlp_gate_up_fp32_layers": {
+      "type": "array",
+      "items": {"type": "integer", "minimum": 0},
+      "uniqueItems": true
+    },
+    "q8_0_contract_ops": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "activation_preference_by_op": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "enum": ["fp32", "q8_0", "q8_k"]
+      }
+    }
+  }
+}

--- a/version/v8/scripts/audit_dsl_policy_v8.py
+++ b/version/v8/scripts/audit_dsl_policy_v8.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Fail when cleaned generic DSL functions contain model-specific literals."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_POLICY = REPO_ROOT / "version" / "v8" / "dsl_policy.json"
+
+
+class DSLPolicyError(RuntimeError):
+    pass
+
+
+def _function_nodes(
+    tree: ast.AST, requested: set[str]
+) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    nodes: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name not in requested:
+                continue
+            if node.name in nodes:
+                raise DSLPolicyError(f"ambiguous compiler function name: {node.name}")
+            nodes[node.name] = node
+    return nodes
+
+
+def scan_source(source: str, functions: list[str], forbidden: list[str], *, path: str) -> list[dict[str, Any]]:
+    tree = ast.parse(source, filename=path)
+    available = _function_nodes(tree, set(functions))
+    findings: list[dict[str, Any]] = []
+    forbidden_lc = tuple(item.lower() for item in forbidden)
+    for function in functions:
+        node = available.get(function)
+        if node is None:
+            raise DSLPolicyError(f"policy function not found: {path}:{function}")
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Constant) or not isinstance(child.value, str):
+                continue
+            value = child.value.lower()
+            matched = sorted({item for item in forbidden_lc if item in value})
+            if matched:
+                findings.append(
+                    {
+                        "path": path,
+                        "function": function,
+                        "line": child.lineno,
+                        "literals": matched,
+                        "value": child.value,
+                    }
+                )
+    return findings
+
+
+def audit(policy_path: Path = DEFAULT_POLICY) -> dict[str, Any]:
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    if policy.get("schema") != "cke.v8_dsl_policy" or policy.get("schema_version") != 1:
+        raise DSLPolicyError("unsupported DSL policy schema")
+    forbidden = policy.get("forbidden_model_literals")
+    compiler_functions = policy.get("compiler_functions")
+    if not isinstance(forbidden, list) or not forbidden or not all(isinstance(item, str) and item for item in forbidden):
+        raise DSLPolicyError("forbidden_model_literals must be a non-empty string list")
+    if not isinstance(compiler_functions, dict) or not compiler_functions:
+        raise DSLPolicyError("compiler_functions must be a non-empty object")
+
+    findings: list[dict[str, Any]] = []
+    checked = 0
+    for relative_path, functions in compiler_functions.items():
+        if not isinstance(relative_path, str) or not isinstance(functions, list) or not functions:
+            raise DSLPolicyError("each compiler policy entry requires a path and non-empty function list")
+        path = REPO_ROOT / relative_path
+        if not path.is_file():
+            raise DSLPolicyError(f"compiler file not found: {relative_path}")
+        findings.extend(
+            scan_source(path.read_text(encoding="utf-8"), functions, forbidden, path=relative_path)
+        )
+        checked += len(functions)
+    return {"status": "fail" if findings else "pass", "checked_functions": checked, "findings": findings}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+    try:
+        report = audit(args.policy)
+    except (DSLPolicyError, OSError, ValueError, SyntaxError) as exc:
+        report = {"status": "error", "error": str(exc)}
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -488,50 +488,45 @@ _FORBIDDEN_TEMPLATE_KEY_NAMES: Dict[str, str] = {
 }
 
 
-def _inject_runtime_config_defaults(config: Dict[str, Any], arch: str) -> Dict[str, Any]:
-    arch_lc = str(arch or "").strip().lower()
+def _apply_circuit_runtime_defaults(
+    config: Dict[str, Any],
+    circuit: Optional[Dict[str, Any]],
+    *,
+    source: str,
+) -> Dict[str, Any]:
+    contract = circuit.get("contract") if isinstance(circuit, dict) else None
+    defaults = contract.get("runtime_defaults") if isinstance(contract, dict) else None
+    if defaults is None:
+        return dict(config)
+    schema_path = V8_ROOT / "schemas" / "circuit_runtime_defaults.schema.json"
+    with schema_path.open("r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(defaults),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    if errors:
+        error = errors[0]
+        location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        raise RuntimeError(
+            f"HARD CIRCUIT DEFAULT FAULT: {source} runtime_defaults invalid at "
+            f"{location}: {error.message}"
+        )
 
-    def _merge_activation_defaults(defaults: Dict[str, str]) -> None:
-        prefs = config.get("activation_preference_by_op")
-        if not isinstance(prefs, dict):
-            prefs = {}
+    merged = copy.deepcopy(config)
+    for key, value in defaults.items():
+        if isinstance(value, dict):
+            current = merged.get(key)
+            current = dict(current) if isinstance(current, dict) else {}
+            for item_key, item_value in value.items():
+                current.setdefault(item_key, copy.deepcopy(item_value))
+            merged.setdefault(key, current)
+            if isinstance(merged.get(key), dict):
+                for item_key, item_value in current.items():
+                    merged[key].setdefault(item_key, item_value)
         else:
-            prefs = dict(prefs)
-        for key, value in defaults.items():
-            prefs.setdefault(str(key), str(value))
-        config["activation_preference_by_op"] = prefs
-
-    if arch_lc == "qwen35":
-        config.setdefault("prefer_q8_0_contract", True)
-        # Empirical CK-vs-llama parity guard for Qwen3.5 decode:
-        # layer-0 recurrent gate is closer with the Q8_K activation contract,
-        # while layer-0 MLP gate/up stays on the FP32 adapter. Keep both as
-        # config defaults so other model families and later layers are not
-        # silently moved onto a broad fallback path.
-        config.setdefault("mlp_gate_up_fp32_layers", [0])
-        _merge_activation_defaults(
-            {
-                "recurrent_gate_proj": "q8_k",
-                "recurrent_alpha_proj": "q8_0",
-                "recurrent_beta_proj": "q8_0",
-            }
-        )
-    elif arch_lc == "qwen3_vl_vision":
-        config.setdefault("prefer_q8_0_contract", True)
-        config.setdefault(
-            "q8_0_contract_ops",
-            ["projector_fc2", "branch_fc1", "branch_fc2"],
-        )
-        _merge_activation_defaults({
-            "mlp_down": "fp32",
-            "out_proj": "q8_0",
-            "branch_fc1": "fp32",
-            "branch_fc2": "fp32",
-        })
-    elif arch_lc == "gemma3":
-        config.setdefault("prefer_q8_0_contract", True)
-        config.setdefault("prefer_fp32_logits", True)
-    return config
+            merged.setdefault(key, copy.deepcopy(value))
+    return merged
 
 
 def _collect_forbidden_template_metadata(
@@ -579,14 +574,17 @@ def _hydrate_manifest_template(manifest: Dict[str, Any]) -> Dict[str, Any]:
         template_name = str(template_doc.get("name", "") or "").strip().lower()
     if not template_name:
         template_name = str(cfg.get("model", "") or "").strip().lower()
-    cfg = _inject_runtime_config_defaults(dict(cfg), template_name or str(cfg.get("arch", "") or ""))
-    manifest["config"] = cfg
     built_in = _load_builtin_template_doc(template_name)
     if built_in and isinstance(template_doc, dict):
         manifest["template"] = _merge_template_defaults(built_in, template_doc)
     elif built_in:
         manifest["template"] = copy.deepcopy(built_in)
     _raise_on_forbidden_template_metadata(
+        manifest.get("template") if isinstance(manifest.get("template"), dict) else None,
+        source=f"manifest:{template_name or '<embedded>'}",
+    )
+    manifest["config"] = _apply_circuit_runtime_defaults(
+        dict(cfg),
         manifest.get("template") if isinstance(manifest.get("template"), dict) else None,
         source=f"manifest:{template_name or '<embedded>'}",
     )


### PR DESCRIPTION
## Why

Generic IR construction still selected activation/logits behavior from model-family names. That makes it too easy to encode a parity diagnosis as another hidden DSL branch instead of fixing the owning circuit, kernel map, kernel, or adapter.

## What

- Remove family branches for Qwen3.5, Qwen3-VL vision, and Gemma3 runtime numerical defaults.
- Move those requirements into schema-validated `contract.runtime_defaults` in their circuits.
- Add a zero-exception AST hardcoding policy for cleaned generic compiler functions.
- Add model-identity invariance, key-order determinism, explicit-override, malformed-contract, synthetic-hardcoding, and policy-scope tests.
- Add `make test-v8-dsl-policy` and aggregate `make test-v8-dsl`.
- Make `v8-regression-fast` depend on the lightweight policy.
- Register a dedicated nightly DSL policy row.
- Document the initial 44-family-predicate inventory and first reduction to 41.

No legacy hardcoding allowlist is introduced. The policy names only functions already cleaned; each subsequent migration expands enforced coverage.

## Validation

- DSL policy: 5/5 PASS
- Aggregate DSL contracts: PASS
- Pinned llama.cpp FP16 split-KV oracle: 14/14 PASS
- Qwen3-VL circuit/codegen: 20/20 PASS
- Numerical/X-ray/template audits: PASS
- v8 five-family regression: PASS
- Python compilation and `git diff --check`: PASS

Known Nanbeige bounded-response coherence heuristic remains reported separately while its release contract classification passes. Existing v7 first-token baseline failures are unchanged; no tolerance or status was relaxed.

## Dependency

This PR targets the #136 branch intentionally. Merge #136 first, then retarget this PR to `main` and rerun CI.
