### PR TITLE
fix(kernels): restore exact Q6_K x Q8_K parity

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -200,19 +200,39 @@ trap cleanup_snapshot EXIT
 build_staged_snapshot() {
     SNAPSHOT_PARENT="$(mktemp -d "${SNAPSHOT_PREFIX}.XXXXXX")"
     SNAPSHOT_DIR="${SNAPSHOT_PARENT}/worktree"
-    git clone --shared --quiet --no-hardlinks "$ROOT_DIR" "$SNAPSHOT_DIR" >/dev/null 2>&1
-    git -C "$SNAPSHOT_DIR" checkout --detach HEAD >/dev/null 2>&1
+    local staged_patch="${SNAPSHOT_PARENT}/staged.patch"
+    if git -C "$ROOT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+        git -C "$ROOT_DIR" diff --cached --binary --submodule=diff HEAD -- > "$staged_patch"
+    else
+        git -C "$ROOT_DIR" diff --cached --binary --submodule=diff > "$staged_patch"
+    fi
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+        git clone --shared --quiet --no-hardlinks "$ROOT_DIR" "$SNAPSHOT_DIR" >/dev/null 2>&1
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+        git -C "$SNAPSHOT_DIR" checkout --detach HEAD >/dev/null 2>&1
     if [ -d "$ROOT_DIR/.venv" ] && [ ! -e "$SNAPSHOT_DIR/.venv" ]; then
         ln -s "$ROOT_DIR/.venv" "$SNAPSHOT_DIR/.venv"
     fi
-    if [ -d "$ROOT_DIR/llama.cpp/include" ] && [ ! -d "$SNAPSHOT_DIR/llama.cpp/include" ]; then
-        rm -rf "$SNAPSHOT_DIR/llama.cpp"
-        ln -s "$ROOT_DIR/llama.cpp" "$SNAPSHOT_DIR/llama.cpp"
+    local llama_cpp_root="${CK_LLAMA_CPP_ROOT:-${LLAMA_CPP_ROOT:-}}"
+    if [ -z "$llama_cpp_root" ] || [ ! -d "$llama_cpp_root/include" ]; then
+        local worktree_path
+        while IFS= read -r worktree_path; do
+            if [ -d "$worktree_path/llama.cpp/include" ] && [ -d "$worktree_path/llama.cpp/build/bin" ]; then
+                llama_cpp_root="$worktree_path/llama.cpp"
+                break
+            fi
+        done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
     fi
-    if git -C "$ROOT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
-        git -C "$ROOT_DIR" diff --cached --binary --submodule=diff HEAD -- | env -u GIT_INDEX_FILE git -C "$SNAPSHOT_DIR" apply --index --whitespace=nowarn
+    if [ -d "$llama_cpp_root/include" ] && [ ! -d "$SNAPSHOT_DIR/llama.cpp/include" ]; then
+        rm -rf "$SNAPSHOT_DIR/llama.cpp"
+        ln -s "$llama_cpp_root" "$SNAPSHOT_DIR/llama.cpp"
+    fi
+    if [ -s "$staged_patch" ]; then
+        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+            git -C "$SNAPSHOT_DIR" apply --index --whitespace=nowarn "$staged_patch"
     else
-        git -C "$ROOT_DIR" diff --cached --binary --submodule=diff | env -u GIT_INDEX_FILE git -C "$SNAPSHOT_DIR" apply --index --whitespace=nowarn
+        echo -e "${RED}✗ Staged snapshot patch is unexpectedly empty${NC}" >&2
+        return 1
     fi
 }
 

--- a/src/kernels/gemm_kernels_q6k_q8k.c
+++ b/src/kernels/gemm_kernels_q6k_q8k.c
@@ -596,6 +596,18 @@ void gemv_q6_k_q8_k_avx(float *y,
 
 #if defined(__AVX2__)
 
+/* Match ggml's x86 hsum_float_8 reduction tree exactly. Replacing the final
+ * two additions with _mm_hadd_ps changes one FP32 ULP for realistic MLP-down
+ * rows and can cross the absolute parity gate on AVX2/AVX-512 runners. */
+static inline float ck_q6k_hsum_float_8(const __m256 x)
+{
+    __m128 res = _mm256_extractf128_ps(x, 1);
+    res = _mm_add_ps(res, _mm256_castps256_ps128(x));
+    res = _mm_add_ps(res, _mm_movehl_ps(res, res));
+    res = _mm_add_ss(res, _mm_movehdup_ps(res));
+    return _mm_cvtss_f32(res);
+}
+
 /* Q6_K optimization note:
  * ----------------------
  * llama.cpp's newer Q6_K AVX2 work inspired an experiment that separates the
@@ -603,15 +615,10 @@ void gemv_q6_k_q8_k_avx(float *y,
  * (bsums). That can reduce repeated subtract-32 work and improve some CPU
  * layouts, but it also changes reduction order and instruction balance.
  *
- * On the local AVX2 i7-1260P test box, a direct port kept correctness but made
- * focused single-core Q6_K GEMV slower. More importantly, Qwen3.5 long-decode
- * parity is sensitive to borderline logit movement from reduction order. CK
- * therefore keeps the public Q6_K path on the llama-compatible scalar reduction
- * by default, while v8 threadpool dispatch may use the SIMD row worker for
- * phase/shape-specific decode or prefill sweeps.
- *
- * Promotion rule: only make a Q6_K SIMD/packed path the default after the
- * dispatch matrix shows a stable speedup and model-family long parity passes.
+ * Current llama.cpp x86 kernels use the AVX2 reduction tree even in AVX-512
+ * builds. CK uses the same tree for its AVX2 and non-VBMI AVX-512 paths. Keep
+ * the final horizontal reduction in sync with ggml: an equivalent _mm_hadd_ps
+ * tree differs by one FP32 ULP on realistic MLP-down rows.
  */
 
 /* Scale shuffle for AVX2 - 32-byte version */
@@ -723,13 +730,7 @@ static float dot_q6_k_q8_k_avx2(const block_q6_K *w,
         acc = _mm256_fmadd_ps(_mm256_broadcast_ss(&d), _mm256_cvtepi32_ps(sumi), acc);
     }
 
-    /* Horizontal sum */
-    __m128 hi = _mm256_extractf128_ps(acc, 1);
-    __m128 lo = _mm256_castps256_ps128(acc);
-    __m128 sum128 = _mm_add_ps(hi, lo);
-    sum128 = _mm_hadd_ps(sum128, sum128);
-    sum128 = _mm_hadd_ps(sum128, sum128);
-    return _mm_cvtss_f32(sum128);
+    return ck_q6k_hsum_float_8(acc);
 }
 
 void gemv_q6_k_q8_k_avx2(float *y,
@@ -1030,13 +1031,7 @@ static float dot_q6_k_q8_k_avx512(const block_q6_K *w,
         acc = _mm256_fmadd_ps(_mm256_set1_ps(d), _mm256_cvtepi32_ps(sumi), acc);
     }
 
-    /* Horizontal sum - use AVX-512 reduce for efficiency */
-    __m128 hi = _mm256_extractf128_ps(acc, 1);
-    __m128 lo = _mm256_castps256_ps128(acc);
-    __m128 sum128 = _mm_add_ps(hi, lo);
-    sum128 = _mm_hadd_ps(sum128, sum128);
-    sum128 = _mm_hadd_ps(sum128, sum128);
-    return _mm_cvtss_f32(sum128);
+    return ck_q6k_hsum_float_8(acc);
 }
 
 void gemv_q6_k_q8_k_avx512(float *y,
@@ -1076,10 +1071,8 @@ void vec_dot_q6_k_q8_k(int n, float *s, const void *vx, const void *vy)
     const block_q6_K *x = (const block_q6_K *)vx;
     const block_q8_K *y = (const block_q8_K *)vy;
 
-    /* Keep the public dispatch on the llama-compatible reduction order.
-     * The SIMD variants are still exported for direct tests/benchmarks, but
-     * their horizontal reduction order can move borderline logits in Qwen3.5
-     * long-decode parity. */
+    /* This is the architecture-neutral scalar oracle. Production x86 dispatch
+     * uses the separately parity-tested SIMD reduction tree. */
     *s = dot_q6_k_q8_k_ref(x, y, n);
 }
 
@@ -1096,33 +1089,19 @@ void gemv_q6_k_q8_k(float *y,
         return;
     }
 
-    const char *simd_env = getenv("CK_Q6K_Q8K_SIMD");
-    if (!simd_env || !simd_env[0]) {
-        simd_env = getenv("CK_DEBUG_Q6K_Q8K_SIMD");
-    }
-    if (!(simd_env && simd_env[0] && simd_env[0] != '0')) {
-        /* Keep the public Q6_K dispatcher on the llama-compatible scalar
-         * reduction for now. The AVX/AVX2 path is faster, but it changes the
-         * reduction order enough to fail tight GEMM parity in some cases.
-         * Promote SIMD/packed Q6 only after the faster path is numerically
-         * reliable across model-family parity and long-decode tests. */
-        gemv_q6_k_q8_k_ref(y, W, x_q8, M, K);
-        return;
-    }
-
 #if defined(__AVX512F__) && defined(__AVX512BW__)
-        /* Avoid the Q6 VBMI implementation: it is not parity-safe on Xeon 6542Y. */
-        gemv_q6_k_q8_k_avx512(y, W, x_q8, M, K);
-        return;
+    /* Avoid the Q6 VBMI implementation: it is not parity-safe on Xeon 6542Y. */
+    gemv_q6_k_q8_k_avx512(y, W, x_q8, M, K);
+    return;
 #elif defined(__AVX2__)
-        gemv_q6_k_q8_k_avx2(y, W, x_q8, M, K);
-        return;
+    gemv_q6_k_q8_k_avx2(y, W, x_q8, M, K);
+    return;
 #elif defined(__AVX__)
-        gemv_q6_k_q8_k_avx(y, W, x_q8, M, K);
-        return;
+    gemv_q6_k_q8_k_avx(y, W, x_q8, M, K);
+    return;
 #elif defined(__SSE4_1__)
-        gemv_q6_k_q8_k_sse(y, W, x_q8, M, K);
-        return;
+    gemv_q6_k_q8_k_sse(y, W, x_q8, M, K);
+    return;
 #endif
     gemv_q6_k_q8_k_ref(y, W, x_q8, M, K);
 }

--- a/tests/test_build_ir_v8_scaffold.py
+++ b/tests/test_build_ir_v8_scaffold.py
@@ -31,6 +31,11 @@ build_ir_v8 = _load_module("build_ir_v8_for_tests", V8_BUILD_PATH)
 def _normalized_template_doc(doc: dict) -> dict:
     normalized = json.loads(json.dumps(doc))
     normalized.pop("required_contracts", None)
+    contract = normalized.get("contract")
+    if isinstance(contract, dict):
+        # Runtime preferences moved out of circuit flags in v8. They are not
+        # graph topology and therefore are excluded from the v7 seed check.
+        contract.pop("runtime_defaults", None)
     kernels = normalized.get("kernels")
     if isinstance(kernels, dict):
         for key in list(kernels):

--- a/tests/test_ck_chat_runtime_contract.py
+++ b/tests/test_ck_chat_runtime_contract.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import io
+import os
 import sys
 import tempfile
 import unittest
@@ -33,6 +34,20 @@ class _FakeCFunc:
 
 
 class TestCKChatRuntimeContract(unittest.TestCase):
+    def test_first_token_llama_root_honors_environment(self) -> None:
+        old = os.environ.get("CK_LLAMA_CPP_ROOT")
+        try:
+            os.environ["CK_LLAMA_CPP_ROOT"] = "/tmp/cke-test-llama-root"
+            self.assertEqual(
+                first_token._llama_cpp_root(),
+                Path("/tmp/cke-test-llama-root").resolve(),
+            )
+        finally:
+            if old is None:
+                os.environ.pop("CK_LLAMA_CPP_ROOT", None)
+            else:
+                os.environ["CK_LLAMA_CPP_ROOT"] = old
+
     def test_ck_model_reads_named_activation_f32_when_runtime_exports_api(self) -> None:
         data = np.array([1.25, -2.5, 3.75, 4.5], dtype=np.float32)
         data_ptr = data.ctypes.data

--- a/unittest/test_gemv_kernels_comprehensive.py
+++ b/unittest/test_gemv_kernels_comprehensive.py
@@ -421,13 +421,15 @@ def get_test_cases(quick: bool = False, large: bool = False) -> dict:
         ],
         "Q6_K": [
             # Q6_K parity harness currently exposes a decode-style single-row
-            # entry point. Keep M=1 so reported GFLOPS match actual work.
-            TestCase("tiny", M=1, K=256, description="Minimal Q6_K decode"),
-            TestCase("small", M=1, K=512, description="Small Q6_K decode"),
-            TestCase("qwen", M=1, K=768, description="Qwen 0.5B Q6_K decode"),
-            TestCase("medium", M=1, K=1024, description="Medium Q6_K decode"),
-            TestCase("wide", M=1, K=2048, description="Wide Q6_K decode"),
-            TestCase("mlp_down", M=1, K=4864, description="Qwen 0.5B MLP down decode"),
+            # entry point. Keep M=1 so reported GFLOPS match actual work. The
+            # x86 production reduction is expected to match llama.cpp exactly;
+            # 1e-7 catches a one-ULP regression at realistic output magnitudes.
+            TestCase("tiny", M=1, K=256, tol=1e-7, description="Minimal Q6_K decode"),
+            TestCase("small", M=1, K=512, tol=1e-7, description="Small Q6_K decode"),
+            TestCase("qwen", M=1, K=768, tol=1e-7, description="Qwen 0.5B Q6_K decode"),
+            TestCase("medium", M=1, K=1024, tol=1e-7, description="Medium Q6_K decode"),
+            TestCase("wide", M=1, K=2048, tol=1e-7, description="Wide Q6_K decode"),
+            TestCase("mlp_down", M=1, K=4864, tol=1e-7, description="Qwen 0.5B MLP down decode"),
         ],
         "Q4_K_Q8_K": [
             TestCase("tiny", M=1, K=256, tol=1e-5, rtol=1e-4, description="Minimal direct vec_dot"),

--- a/version/v7/scripts/parity/compare_first_token_logits.py
+++ b/version/v7/scripts/parity/compare_first_token_logits.py
@@ -25,9 +25,15 @@ import numpy as np
 
 ROOT = Path(__file__).resolve().parents[4]
 SCRIPT_DIR = Path(__file__).resolve().parent
-LLAMA_CPP = ROOT / "llama.cpp"
 HELPER_SRC = SCRIPT_DIR / "llama_token_replay.cpp"
 HELPER_BIN = Path("/tmp/ckv7_llama_token_replay")
+
+
+def _llama_cpp_root() -> Path:
+    configured = os.environ.get("CK_LLAMA_CPP_ROOT") or os.environ.get("LLAMA_CPP_ROOT")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return ROOT / "llama.cpp"
 
 
 def parse_tokens_csv(text: str) -> list[int]:
@@ -157,9 +163,10 @@ def ensure_llama_helper() -> Path:
     if not rebuild:
         return HELPER_BIN
 
-    include_dir = LLAMA_CPP / "include"
-    ggml_include_dir = LLAMA_CPP / "ggml" / "include"
-    lib_dir = LLAMA_CPP / "build" / "bin"
+    llama_cpp = _llama_cpp_root()
+    include_dir = llama_cpp / "include"
+    ggml_include_dir = llama_cpp / "ggml" / "include"
+    lib_dir = llama_cpp / "build" / "bin"
     if not include_dir.exists():
         raise FileNotFoundError(f"llama include dir missing: {include_dir}")
     if not ggml_include_dir.exists():
@@ -202,7 +209,7 @@ def ensure_llama_helper() -> Path:
 
 def run_llama_logits(gguf_path: Path, tokens: list[int], ctx_len: int, top_k: int, threads: int) -> dict[str, Any]:
     helper = ensure_llama_helper()
-    helper_env = _llama_runtime_env(LLAMA_CPP / "build" / "bin")
+    helper_env = _llama_runtime_env(_llama_cpp_root() / "build" / "bin")
     with tempfile.TemporaryDirectory(prefix="llama_token_replay_") as td:
         logits_path = Path(td) / "llama_logits.f32"
         cmd = [


### PR DESCRIPTION
## Why

The AVX-512 nightly runner reported `Q6_K_mlp_down max_diff=1.95e-03`. CK used two `_mm_hadd_ps` rounds for the final Q6_K reduction, while current ggml uses a different eight-lane reduction tree. The order difference moves realistic MLP-down outputs by up to two FP32 ULPs.

Commit-time staged snapshots also lost Git's temporary index and could misclassify a missing llama.cpp checkout as model parity divergence.

## What

- Match ggml's x86 `hsum_float_8` reduction order in AVX2 and non-VBMI AVX-512 Q6_K x Q8_K GEMV.
- Use the parity-tested SIMD Q6_K path by default on x86; strict/reference mode remains scalar.
- Tighten all six Q6_K comprehensive cases from `1e-3` to `1e-7`.
- Let the v7 first-token helper consume `CK_LLAMA_CPP_ROOT`.
- Make pre-commit snapshots reuse an initialized llama.cpp checkout from another worktree.
- Capture staged patches before cloning and clear hook-local Git repository variables for snapshot-side commands.
- Exclude extracted v8 runtime defaults from the v7/v8 circuit topology scaffold comparison.

## Validation

- Comprehensive GEMV: 51/51 pass.
- Q6_K shapes K=256, 512, 768, 1024, 2048, 4864: exact, max diff 0.
- FP16 split-KV attention: 14/14 pass.
- Numerical contracts, X-ray, full attention: pass.
- AVX-512 compile check: pass.
- v8 kernel-map contracts: pass.
- v7-regression-fast: pass.
- v8-regression-fast: pass.
- Pre-push: all gates pass.

## Nightly

This directly fixes the single current llama.cpp nightly parity failure without relaxing tolerance.