### PR TITLE
fix(v8/vision): match BF16 position storage contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -723,7 +723,8 @@ PY_TESTS_BF16 := unittest/bf16/test_sigmoid_bf16.py \
                 unittest/bf16/test_relu_bf16.py \
                 unittest/bf16/test_swiglu_bf16.py \
                 unittest/bf16/test_embedding_bf16.py \
-                unittest/bf16/test_cross_entropy_bf16.py
+                unittest/bf16/test_cross_entropy_bf16.py \
+                unittest/bf16/test_vision_position_storage_bf16.py
 PY_TESTS_BF16_V8 := version/v8/scripts/bf16_safetensors_lowering_guard_v8.py
 
 LITMUS_DEMO_ARGS ?= --vocab 100 --ctx 100 --embed 64 --intermediate 128 --heads 4 --kv-heads 2

--- a/docs/notes/QWEN3VL_BF16_LAYER0_XRAY_2026-07-11.md
+++ b/docs/notes/QWEN3VL_BF16_LAYER0_XRAY_2026-07-11.md
@@ -1,0 +1,54 @@
+# Qwen3-VL BF16 layer-0 X-ray results
+
+Validated against PyTorch BF16 on the canonical 1152x896 OCR geometry at origin/main a3829c1e.
+
+## Proven kernel fixes
+
+### Position interpolation
+
+The BF16-storage-matched align-corners kernel passes 3/3 focused cases exactly. On the isolated real frontend position input it matches all 4,644,864 values.
+
+### Vision M-RoPE
+
+The production runtime passed a full rotary width of 72. The kernel treated the value as a pair count and indexed the second split half using pair + n_dims. Decoder-style section values also caused the vision kernel to return without rotating.
+
+The corrected contract is:
+
+    rotary_width = n_dims
+    rope_pairs = rotary_width / 2
+    split-half partner = pair + rope_pairs
+    axis sections for head_dim 72 = [18, 18, 0, 0]
+
+Measured layer-0 post-RoPE Q:
+
+| State | Cosine | RMSE |
+| --- | ---: | ---: |
+| Before correction | 0.616694 | 1.473396 |
+| Corrected kernel/sections | 0.999972 | 0.002710 |
+| Plus BF16 post-RoPE storage | 0.9999998 | 0.000132 |
+
+Focused kernel tests pass at head dimensions 8 and 72; production-width max absolute error is 2.38e-7.
+
+## Measured numerical-contract requirements
+
+These generated-artifact experiments are evidence, not committed generated-C fixes:
+
+| Boundary | Before RMSE | Matched RMSE | Improvement |
+| --- | ---: | ---: | ---: |
+| layer-0 LayerNorm output | 5.44e-4 | 1.82e-5 | about 30x |
+| layer-0 Q projection | 2.80e-3 | 1.04e-4 | about 27x |
+| layer-0 post-RoPE Q | 2.71e-3 | 1.32e-4 | about 20x |
+
+Required generic edge contracts:
+
+1. Position interpolation output uses BF16 storage semantics.
+2. LayerNorm consumes BF16-valued input and materializes BF16 output.
+3. Packed QKV projection materializes BF16 before head splitting.
+4. Vision RoPE consumes full rotary width, uses split-half pairing, and materializes BF16 Q/K.
+5. Tolerances remain in the parity profile, not the circuit.
+
+## Remaining infrastructure findings
+
+- Latest strict call-IR generation still lacks generic bindings for use_rope_freq_factors and rope_freq_base.
+- The vision_patch_bias exporter emits rows instead of rows times channels, causing a shape mismatch in bounded frontend diagnosis.
+- Compiler/circuit fixes belong to the zero-hardcoding DSL work. No model-name branch is required.

--- a/docs/notes/QWEN3VL_BF16_XRAY_KERNEL_HANDOFF_2026-07-11.md
+++ b/docs/notes/QWEN3VL_BF16_XRAY_KERNEL_HANDOFF_2026-07-11.md
@@ -1,0 +1,83 @@
+# Qwen3-VL BF16 X-ray Kernel Handoff
+
+This note records the Xeon diagnosis and its AVX2 integration through the v8 numerical execution contract resolver. The position edge is now selected declaratively; no model-name branch was added.
+
+## Position Edge
+
+Checkpoint: `vision.frontend.position.output`
+
+The generic kernel `position_embeddings_add_tiled_2d_align_corners_bf16` now matches PyTorch's BF16 storage and arithmetic boundary:
+
+- interpolation coordinates: each rational coordinate evaluated before FP32 storage, matching `torch.linspace`
+- position table: BF16
+- interpolation weights: BF16 RNE
+- products: BF16 RNE
+- accumulation: `((v00 + v01) + v10) + v11`, BF16 after each addition
+- incoming hidden value: BF16 RNE
+- residual result: BF16 RNE
+- work partition: independent tokens
+- deterministic: yes
+- thread count changes arithmetic: no
+
+Validation:
+
+```text
+synthetic shapes: 3/3 bit-exact
+real grid: 56x72
+embedding dimension: 1152
+real values compared: 4,644,864
+mismatches: 0
+max_abs: 0
+RMSE: 0
+```
+
+The registered contract is `bf16_tiled_2d_align_corners_rne_residual`. The Qwen3-VL vision circuit requests it only when the manifest declares `vision_position_storage_boundary=bf16`. The resolver selects `position_embeddings_add_tiled_2d_align_corners_bf16`, and GraphIR, LoweredIR, and call IR retain the exact contract ID, kernel ID, and function. GGUF manifests do not satisfy that selector and retain their existing FP32 position path.
+
+Nightly coverage:
+
+```text
+Vision Position Storage BF16: 3/3 exact
+v8 BF16 safetensors lowering: resolved contract and function identity pass
+Qwen3-VL GGUF circuit tests: existing FP32 position path pass
+```
+
+## Next Edge: Layer-0 Norm1
+
+Using the exact PyTorch position output as input:
+
+```text
+existing FP32 matched LayerNorm:
+  cosine 0.9999986264
+  RMSE 0.0005443210
+  max_abs 0.01562357
+
+existing BF16 LayerNorm:
+  cosine 0.9999999999
+  RMSE 0.0000039821
+  max_abs 0.00390625
+  mismatches 210 / 4,644,864
+```
+
+The existing BF16 kernel already matches storage but not PyTorch CPU's reduction order exactly. This is a `REDUCTION_CONTRACT_MISMATCH`, not justification for a model-specific LayerNorm path.
+
+Public minimal reproduction:
+
+```bash
+LD_LIBRARY_PATH=build .venv/bin/python \
+  research/numerical_contracts/reproduce_qwen3vl_bf16_layernorm_seed21.py
+```
+
+Fixture: `research/numerical_contracts/qwen3vl_bf16_layernorm_seed21.json`
+
+Current seed-21 result:
+
+```text
+dimension: 1152
+mismatches: 1
+index: 332
+CK: 0.00022411346435546875
+PyTorch: 0.0002231597900390625
+max_abs: 9.5367431640625e-7
+```
+
+The missing generic capability must specify BF16 input/gamma/beta/output, FP32 accumulation, exact mean and variance reduction order/formula, reciprocal-square-root precision, BF16 output rounding, independent-row threading and thread-count arithmetic stability.

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -3308,6 +3308,13 @@ void embedding_forward_bf16_fp32(const int32_t *token_ids,
 	                                                    int embed_dim,
 	                                                    int merge_size,
 	                                                    int source_grid_size);
+	void position_embeddings_add_tiled_2d_align_corners_bf16(float *x,
+	                                                         const float *position_embd,
+	                                                         int grid_h,
+	                                                         int grid_w,
+	                                                         int embed_dim,
+	                                                         int merge_size,
+	                                                         int source_grid_size);
 	void position_embeddings_add_gemma4v_xy(float *x,
 	                                       const float *position_embd,
 	                                       int grid_h,

--- a/research/numerical_contracts/qwen3vl_bf16_layernorm_seed21.json
+++ b/research/numerical_contracts/qwen3vl_bf16_layernorm_seed21.json
@@ -1,0 +1,49 @@
+{
+  "schema": "cke.minimal_numerical_fixture",
+  "schema_version": 1,
+  "name": "qwen3vl_bf16_layernorm_seed21",
+  "operation": "layernorm",
+  "semantic_checkpoint": "vision.layer.0.norm1.output",
+  "public_generator": {
+    "framework": "torch",
+    "seed": 21,
+    "tokens": 1,
+    "dimension": 1152,
+    "input_dtype": "bf16",
+    "gamma_dtype": "bf16",
+    "beta_dtype": "bf16",
+    "epsilon": 0.000001
+  },
+  "subject": {
+    "kernel": "layernorm_forward_unrolled_slice_bf16",
+    "input_storage": "bf16",
+    "output_storage": "bf16",
+    "compute": "fp32",
+    "reduction": "avx512_four_accumulator_horizontal_reduce"
+  },
+  "oracle": {
+    "backend": "pytorch_cpu",
+    "operation": "torch.nn.functional.layer_norm",
+    "version_observed": "2.8.0+cpu"
+  },
+  "expected_current_divergence": {
+    "classification": "REDUCTION_CONTRACT_MISMATCH",
+    "mismatch_count": 1,
+    "index": 332,
+    "ck": 0.00022411346435546875,
+    "pytorch": 0.0002231597900390625,
+    "max_abs": 0.00000095367431640625
+  },
+  "required_generic_capability": {
+    "storage": {"input": "bf16", "gamma": "bf16", "beta": "bf16", "output": "bf16"},
+    "accumulator": "fp32",
+    "mean_reduction_order": "backend_matched_required",
+    "variance_reduction_order": "backend_matched_required",
+    "variance_formula": "backend_matched_required",
+    "rsqrt_precision": "backend_matched_required",
+    "output_rounding": "bf16_rne",
+    "threading": "independent_rows",
+    "thread_count_changes_arithmetic_order": false,
+    "status": "unresolved"
+  }
+}

--- a/research/numerical_contracts/reproduce_qwen3vl_bf16_layernorm_seed21.py
+++ b/research/numerical_contracts/reproduce_qwen3vl_bf16_layernorm_seed21.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Reproduce the public seed-21 BF16 LayerNorm reduction mismatch."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = json.loads((Path(__file__).with_name("qwen3vl_bf16_layernorm_seed21.json")).read_text())
+
+
+def to_bf16(values: np.ndarray) -> np.ndarray:
+    bits = values.astype(np.float32, copy=False).view(np.uint32)
+    return ((bits + 0x7FFF + ((bits >> 16) & 1)) >> 16).astype(np.uint16)
+
+
+def from_bf16(values: np.ndarray) -> np.ndarray:
+    return (values.astype(np.uint32) << 16).view(np.float32)
+
+
+def main() -> None:
+    config = FIXTURE["public_generator"]
+    dim = int(config["dimension"])
+    generator = torch.Generator().manual_seed(int(config["seed"]))
+    x = torch.randn(1, dim, generator=generator).to(torch.bfloat16)
+    gamma = torch.randn(dim, generator=generator).to(torch.bfloat16)
+    beta = torch.randn(dim, generator=generator).to(torch.bfloat16)
+    reference = torch.nn.functional.layer_norm(
+        x, (dim,), gamma, beta, float(config["epsilon"])
+    ).float().numpy()
+
+    x_bf16 = to_bf16(x.float().numpy())
+    output_bf16 = np.empty_like(x_bf16)
+    gamma_f32 = gamma.float().numpy()
+    beta_f32 = beta.float().numpy()
+    mean = np.empty(1, np.float32)
+    rstd = np.empty(1, np.float32)
+    scratch_input = np.empty(dim, np.float32)
+    scratch_output = np.empty(dim, np.float32)
+
+    library = ctypes.CDLL(str(ROOT / "build" / "libckernel_engine.so"))
+    function = library.layernorm_forward_unrolled_slice_bf16
+    float_p = ctypes.POINTER(ctypes.c_float)
+    bf16_p = ctypes.POINTER(ctypes.c_uint16)
+    function.argtypes = [bf16_p, float_p, float_p, bf16_p, float_p, float_p,
+                         ctypes.c_int, ctypes.c_int, ctypes.c_float, float_p, float_p]
+    function(
+        x_bf16.ctypes.data_as(bf16_p),
+        gamma_f32.ctypes.data_as(float_p),
+        beta_f32.ctypes.data_as(float_p),
+        output_bf16.ctypes.data_as(bf16_p),
+        mean.ctypes.data_as(float_p), rstd.ctypes.data_as(float_p),
+        1, dim, ctypes.c_float(float(config["epsilon"])),
+        scratch_input.ctypes.data_as(float_p), scratch_output.ctypes.data_as(float_p),
+    )
+    output = from_bf16(output_bf16)
+    mismatch = np.flatnonzero(output != reference)
+    if mismatch.size == 0:
+        raise RuntimeError("fixture no longer diverges; update its validated contract status")
+    diff = np.abs(output - reference)
+    worst = int(np.argmax(diff))
+    report = {
+        "classification": "REDUCTION_CONTRACT_MISMATCH",
+        "mismatch_count": int(mismatch.size),
+        "index": worst,
+        "ck": float(output.flat[worst]),
+        "pytorch": float(reference.flat[worst]),
+        "max_abs": float(diff.flat[worst]),
+    }
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -326,6 +326,11 @@ TEST_SUITES = {
     "attention_bf16": TestSuite("Attention BF16", "bf16", BF16_DIR / "test_attention_bf16.py"),
     "mlp_bf16": TestSuite("MLP BF16", "bf16", BF16_DIR / "test_mlp_bf16.py"),
     "cross_entropy_bf16": TestSuite("Cross Entropy BF16", "bf16", BF16_DIR / "test_cross_entropy_bf16.py"),
+    "vision_position_storage_bf16": TestSuite(
+        "Vision Position Storage BF16",
+        "bf16",
+        BF16_DIR / "test_vision_position_storage_bf16.py",
+    ),
     "v8_bf16_safetensors_lowering": TestSuite(
         "v8 BF16 safetensors lowering",
         "bf16",

--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -1240,13 +1240,14 @@ static void vision_mrope_apply_head(
         return;
     }
 
-    int rope_pairs = n_dims;
-    if (rope_pairs > head_dim / 2) {
-        rope_pairs = head_dim / 2;
+    int rotary_width = n_dims;
+    if (rotary_width > head_dim) {
+        rotary_width = head_dim;
     }
-    if (rope_pairs <= 0 || 2 * rope_pairs > aligned_head_dim) {
+    if (rotary_width <= 0 || (rotary_width & 1) != 0 || rotary_width > aligned_head_dim) {
         return;
     }
+    const int rope_pairs = rotary_width / 2;
 
     const int axis_y_pairs = sections[0];
     const int axis_x_pairs = sections[1];
@@ -1285,9 +1286,9 @@ static void vision_mrope_apply_head(
             );
 
             const float x0 = row[pair];
-            const float x1 = row[pair + n_dims];
+            const float x1 = row[pair + rope_pairs];
             row[pair] = x0 * cos_theta - x1 * sin_theta;
-            row[pair + n_dims] = x0 * sin_theta + x1 * cos_theta;
+            row[pair + rope_pairs] = x0 * sin_theta + x1 * cos_theta;
 
             theta_y *= theta_scale;
             theta_x *= theta_scale;

--- a/src/kernels/vision_kernels.c
+++ b/src/kernels/vision_kernels.c
@@ -17,6 +17,8 @@
 #include <stdint.h>
 #include <math.h>
 
+#include "bf16_utils.h"
+
 #if defined(__clang__)
 #define CK_VISION_NOINLINE __attribute__((noinline))
 #define CK_VISION_OPTNONE __attribute__((optnone))
@@ -334,6 +336,66 @@ void position_embeddings_add_tiled_2d_align_corners(float *x,
         for (int d = 0; d < embed_dim; ++d) {
             const float pos = p00[d] * w00 + p01[d] * w01 + p10[d] * w10 + p11[d] * w11;
             dst[d] += pos;
+        }
+    }
+}
+
+/*
+ * Match a backend that materializes this interpolation and residual-add edge
+ * in BF16. The ABI remains FP32 so generated runtimes can share activation
+ * storage, but every value is rounded at the BF16 boundary before the next
+ * arithmetic step. Selection belongs to the circuit/kernel-map contract.
+ */
+void position_embeddings_add_tiled_2d_align_corners_bf16(float *x,
+                                                          const float *position_embd,
+                                                          int grid_h,
+                                                          int grid_w,
+                                                          int embed_dim,
+                                                          int merge_size,
+                                                          int source_grid_size)
+{
+    if (x == NULL || position_embd == NULL || grid_h <= 0 || grid_w <= 0 ||
+        embed_dim <= 0 || merge_size <= 0 || source_grid_size <= 0) {
+        return;
+    }
+
+    for (int tok = 0; tok < grid_h * grid_w; ++tok) {
+        const int row_major = tile_order_index_2d(tok, grid_h, grid_w, merge_size);
+        const int dst_y = row_major / grid_w;
+        const int dst_x = row_major % grid_w;
+        /* torch.linspace computes each rational coordinate before FP32 storage. */
+        const float src_y = grid_h > 1
+            ? (float)((double)dst_y * (double)(source_grid_size - 1) / (double)(grid_h - 1))
+            : 0.0f;
+        const float src_x = grid_w > 1
+            ? (float)((double)dst_x * (double)(source_grid_size - 1) / (double)(grid_w - 1))
+            : 0.0f;
+        const int y0 = (int)src_y;
+        const int x0 = (int)src_x;
+        const int y1 = y0 + 1 < source_grid_size ? y0 + 1 : y0;
+        const int x1 = x0 + 1 < source_grid_size ? x0 + 1 : x0;
+        const float dy = src_y - (float)y0;
+        const float dx = src_x - (float)x0;
+        const float w00 = bf16_to_float(float_to_bf16((1.0f - dy) * (1.0f - dx)));
+        const float w01 = bf16_to_float(float_to_bf16((1.0f - dy) * dx));
+        const float w10 = bf16_to_float(float_to_bf16(dy * (1.0f - dx)));
+        const float w11 = bf16_to_float(float_to_bf16(dy * dx));
+        const float *p00 = position_embd + ((size_t)y0 * source_grid_size + x0) * embed_dim;
+        const float *p01 = position_embd + ((size_t)y0 * source_grid_size + x1) * embed_dim;
+        const float *p10 = position_embd + ((size_t)y1 * source_grid_size + x0) * embed_dim;
+        const float *p11 = position_embd + ((size_t)y1 * source_grid_size + x1) * embed_dim;
+        float *dst = x + (size_t)tok * embed_dim;
+
+        for (int d = 0; d < embed_dim; ++d) {
+            const float v00 = bf16_to_float(float_to_bf16(p00[d] * w00));
+            const float v01 = bf16_to_float(float_to_bf16(p01[d] * w01));
+            const float v10 = bf16_to_float(float_to_bf16(p10[d] * w10));
+            const float v11 = bf16_to_float(float_to_bf16(p11[d] * w11));
+            float pos = bf16_to_float(float_to_bf16(v00 + v01));
+            pos = bf16_to_float(float_to_bf16(pos + v10));
+            pos = bf16_to_float(float_to_bf16(pos + v11));
+            const float hidden = bf16_to_float(float_to_bf16(dst[d]));
+            dst[d] = bf16_to_float(float_to_bf16(hidden + pos));
         }
     }
 }

--- a/tests/test_v8_numerical_execution_contracts.py
+++ b/tests/test_v8_numerical_execution_contracts.py
@@ -71,6 +71,31 @@ class NumericalExecutionContractTests(unittest.TestCase):
         )
         self.assertEqual(plan["checkpoint"]["axis_names"], ["token", "channel"])
 
+    def test_bf16_position_contract_resolves_exact_kernel(self):
+        circuit_doc = resolver.load_json(
+            ROOT / "version" / "v8" / "circuits" / "qwen3_vl_vision.json"
+        )
+        plan = resolver.resolve_contract(
+            circuit_doc,
+            self.contracts,
+            self.kernels,
+            "vision.frontend.position",
+            "prefill",
+            mode="production",
+        )
+        self.assertEqual(
+            plan["contract"]["id"],
+            "bf16_tiled_2d_align_corners_rne_residual",
+        )
+        self.assertEqual(
+            plan["kernel"]["id"],
+            "position_embeddings_add_tiled_2d_align_corners_bf16",
+        )
+        self.assertEqual(
+            plan["kernel"]["function"],
+            "position_embeddings_add_tiled_2d_align_corners_bf16",
+        )
+
     def test_zero_provider_is_hard_failure(self):
         kernels = copy.deepcopy(self.kernels)
         kernels["kernels"] = {}

--- a/tests/test_v8_safetensors_to_bump.py
+++ b/tests/test_v8_safetensors_to_bump.py
@@ -1222,8 +1222,9 @@ def test_qwen3vl_safetensors_vision_maps_temporal_patch_split(tmp_path: Path) ->
     ]
     assert manifest["config"]["rope_layout"] == "multi_section_2d"
     assert manifest["config"]["vision_mrope_n_dims"] == 2
-    assert manifest["config"]["vision_mrope_sections"] == [1, 1, 1, 1]
+    assert manifest["config"]["vision_mrope_sections"] == [1, 1, 0, 0]
     assert manifest["config"]["position_interpolation_policy"] == "align_corners_bilinear"
+    assert manifest["config"]["vision_position_storage_boundary"] == "bf16"
     assert (out / "weights.bump").stat().st_size > 0
 
     build_ir = Path("version/v8/scripts/build_ir_v8.py")
@@ -1255,12 +1256,16 @@ def test_qwen3vl_safetensors_vision_maps_temporal_patch_split(tmp_path: Path) ->
     )
     lowered_ops = json.loads(lowered.read_text(encoding="utf-8"))["operations"]
     kernels_by_op = {op["op"]: op.get("kernel") for op in lowered_ops}
-    assert kernels_by_op["position_embeddings"] == "position_embeddings_add_tiled_2d_align_corners"
+    assert kernels_by_op["position_embeddings"] == "position_embeddings_add_tiled_2d_align_corners_bf16"
     call_ops = json.loads(call.read_text(encoding="utf-8"))["operations"]
+    position_call = next(op for op in call_ops if op["op"] == "position_embeddings")
+    assert position_call["function"] == "position_embeddings_add_tiled_2d_align_corners_bf16"
+    assert position_call["resolved_contract"]["resolved_contract_id"] == "bf16_tiled_2d_align_corners_rne_residual"
+    assert position_call["resolved_contract"]["kernel_id"] == "position_embeddings_add_tiled_2d_align_corners_bf16"
     rope_call = next(op for op in call_ops if op["op"] == "rope_qk")
     rope_args = {arg["name"]: arg["expr"] for arg in rope_call["args"]}
     assert rope_args["n_dims"] == "2"
-    assert [rope_args[f"section_{i}"] for i in range(4)] == ["1", "1", "1", "1"]
+    assert [rope_args[f"section_{i}"] for i in range(4)] == ["1", "1", "0", "0"]
     for op_name in (
         "patch_proj",
         "patch_proj_aux",

--- a/unittest/bf16/test_vision_position_storage_bf16.py
+++ b/unittest/bf16/test_vision_position_storage_bf16.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Exact BF16 storage-boundary parity for tiled 2D position interpolation."""
+
+from __future__ import annotations
+
+import ctypes
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ctypes.CDLL(str(ROOT / "build" / "libckernel_engine.so"))
+LIB.position_embeddings_add_tiled_2d_align_corners_bf16.argtypes = [
+    ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+]
+LIB.position_embeddings_add_tiled_2d_align_corners_bf16.restype = None
+
+
+def tile_order_indices(grid_h: int, grid_w: int, merge_size: int) -> torch.Tensor:
+    values = []
+    for tile_y in range(0, grid_h, merge_size):
+        for tile_x in range(0, grid_w, merge_size):
+            for dy in range(merge_size):
+                for dx in range(merge_size):
+                    values.append((tile_y + dy) * grid_w + tile_x + dx)
+    return torch.tensor(values, dtype=torch.long)
+
+
+def reference(x: torch.Tensor, table: torch.Tensor, grid_h: int, grid_w: int, merge_size: int) -> torch.Tensor:
+    source = int(round(table.shape[0] ** 0.5))
+    ys = torch.linspace(0, source - 1, grid_h, dtype=torch.float32)
+    xs = torch.linspace(0, source - 1, grid_w, dtype=torch.float32)
+    y0 = ys.to(torch.long); x0 = xs.to(torch.long)
+    y1 = (y0 + 1).clamp(max=source - 1); x1 = (x0 + 1).clamp(max=source - 1)
+    dy = ys - y0; dx = xs - x0
+    weights = [
+        ((1 - dy)[:, None] * (1 - dx)[None, :]).to(torch.bfloat16),
+        ((1 - dy)[:, None] * dx[None, :]).to(torch.bfloat16),
+        (dy[:, None] * (1 - dx)[None, :]).to(torch.bfloat16),
+        (dy[:, None] * dx[None, :]).to(torch.bfloat16),
+    ]
+    table = table.to(torch.bfloat16).view(source, source, -1)
+    terms = [
+        table[y0[:, None], x0[None, :]] * weights[0][..., None],
+        table[y0[:, None], x1[None, :]] * weights[1][..., None],
+        table[y1[:, None], x0[None, :]] * weights[2][..., None],
+        table[y1[:, None], x1[None, :]] * weights[3][..., None],
+    ]
+    interpolated = (terms[0] + terms[1] + terms[2] + terms[3]).reshape(grid_h * grid_w, -1)
+    ordered = interpolated.index_select(0, tile_order_indices(grid_h, grid_w, merge_size))
+    return (x.to(torch.bfloat16) + ordered).to(torch.float32)
+
+
+def run_case(grid_h: int, grid_w: int, source: int, dim: int, seed: int) -> None:
+    generator = torch.Generator().manual_seed(seed)
+    x = torch.randn(grid_h * grid_w, dim, generator=generator, dtype=torch.float32)
+    table = torch.randn(source * source, dim, generator=generator, dtype=torch.float32).to(torch.bfloat16).float()
+    expected = reference(x, table, grid_h, grid_w, 2).numpy()
+    actual = x.numpy().copy()
+    LIB.position_embeddings_add_tiled_2d_align_corners_bf16(
+        actual.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        table.numpy().ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        grid_h, grid_w, dim, 2, source,
+    )
+    if not np.array_equal(actual, expected):
+        diff = np.abs(actual - expected)
+        index = np.unravel_index(int(np.argmax(diff)), diff.shape)
+        raise AssertionError(
+            f"BF16 position storage mismatch shape={grid_h}x{grid_w} dim={dim} "
+            f"max_abs={float(diff[index])} index={index} got={actual[index]} ref={expected[index]}"
+        )
+
+
+if __name__ == "__main__":
+    run_case(6, 10, 4, 8, 4411)
+    run_case(28, 36, 32, 16, 4412)
+    run_case(36, 28, 32, 72, 4413)
+    print("BF16 tiled position storage parity: 3/3 exact")

--- a/unittest/test_vision.py
+++ b/unittest/test_vision.py
@@ -1015,7 +1015,8 @@ def _ref_qwen3vl_vision_mrope_qk(
     def apply(x: torch.Tensor) -> torch.Tensor:
         out = x.clone()
         head_dim = out.shape[-1]
-        rope_pairs = min(int(n_dims), int(head_dim) // 2)
+        rotary_width = min(int(n_dims), int(head_dim))
+        rope_pairs = rotary_width // 2
         axis_pairs = rope_pairs // 2
         if axis_pairs <= 0 or 2 * rope_pairs > head_dim:
             return out
@@ -1032,9 +1033,9 @@ def _ref_qwen3vl_vision_mrope_qk(
                     c = math.cos(theta)
                     s = math.sin(theta)
                     x0 = float(out[h, tok, pair].item())
-                    x1 = float(out[h, tok, pair + n_dims].item())
+                    x1 = float(out[h, tok, pair + rope_pairs].item())
                     out[h, tok, pair] = x0 * c - x1 * s
-                    out[h, tok, pair + n_dims] = x0 * s + x1 * c
+                    out[h, tok, pair + rope_pairs] = x0 * s + x1 * c
         return out
 
     return apply(q), apply(k)
@@ -1057,8 +1058,9 @@ def test_mrope_qk_vision(num_heads=2, num_kv_heads=2, num_tokens=4, head_dim=8):
     q = torch.randn(num_heads, num_tokens, head_dim, dtype=torch.float32)
     k = torch.randn(num_kv_heads, num_tokens, head_dim, dtype=torch.float32)
     positions = _ref_vision_position_ids(2, 2, 2)
-    sections = [max(1, head_dim // 4)] * 4
-    n_dims = head_dim // 2
+    axis_pairs = max(1, head_dim // 4)
+    sections = [axis_pairs, axis_pairs, 0, 0]
+    n_dims = head_dim
 
     ref_q, ref_k = _ref_qwen3vl_vision_mrope_qk(q, k, positions, n_dims)
     out_q, out_k = run_c_mrope_qk(q, k, positions, n_dims, sections)

--- a/version/v8/circuits/qwen3_vl_vision.json
+++ b/version/v8/circuits/qwen3_vl_vision.json
@@ -109,6 +109,30 @@
       }
     }
   },
+  "required_numerical_contracts": {
+    "vision.frontend.position": {
+      "op": "position_embeddings",
+      "template_ops": ["position_embeddings"],
+      "selector": {
+        "config_equals": {
+          "vision_position_storage_boundary": "bf16"
+        }
+      },
+      "phases": {
+        "prefill": {
+          "contract_id": "bf16_tiled_2d_align_corners_rne_residual",
+          "validation": "validated",
+          "evidence": "unittest/bf16/test_vision_position_storage_bf16.py: 3/3 exact synthetic geometries and 4,644,864/4,644,864 exact OCR-scale values on the native BF16 reference lane."
+        }
+      },
+      "checkpoint": {
+        "id": "vision.frontend.position.output",
+        "producer": "position_embeddings",
+        "logical_layout": "token_major",
+        "axis_names": ["token", "channel"]
+      }
+    }
+  },
   "semantic_checkpoints": {
     "schema": "cke.semantic_checkpoint_contract",
     "schema_version": 1,

--- a/version/v8/contracts/numerical_execution.json
+++ b/version/v8/contracts/numerical_execution.json
@@ -33,6 +33,44 @@
       },
       "position_transform": null,
       "description": "BF16 weights and BF16-rounded FP32 activation loads with an ascending-K FP32 dot product and FP32 output storage."
+    },
+    "bf16_tiled_2d_align_corners_rne_residual": {
+      "status": "validated",
+      "storage": {
+        "input": "bf16",
+        "weight": "bf16",
+        "output": "bf16"
+      },
+      "compute": {
+        "input": "bf16_rne",
+        "weight": "bf16",
+        "accumulator": "bf16"
+      },
+      "rounding": {
+        "mode": "rne",
+        "points": ["input_load", "weighted_product", "reduction_update", "output_store"]
+      },
+      "reduction": {
+        "kind": "sum",
+        "order": "left_to_right",
+        "partial_accumulator": "bf16",
+        "merge_order": "none"
+      },
+      "threading": {
+        "work_partition": "serial",
+        "split_strategy": "serial",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": null,
+      "spatial_transform": {
+        "interpolation": "bilinear",
+        "coordinate_transform": "align_corners",
+        "coordinate_compute": "fp32_from_rational",
+        "source_layout": "row_major",
+        "output_traversal": "merged_tile_order"
+      },
+      "description": "Align-corners tiled 2D bilinear position interpolation with FP32 rational coordinates and explicit BF16 RNE product, accumulation, residual, and output boundaries."
     }
   }
 }

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,7 +5,7 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "version/v8/kernel_maps",
     "counts": {
-      "total": 189,
+      "total": 190,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -51,7 +51,7 @@
         "moe_swiglu_expert_mlp": 2,
         "optimizer": 4,
         "partial_rope_concat": 2,
-        "position_embeddings": 4,
+        "position_embeddings": 5,
         "position_ids": 1,
         "projector_prep": 1,
         "q_norm": 1,
@@ -15235,6 +15235,102 @@
       "notes": "Add align-corners bilinearly interpolated learned position embeddings to a stream in merged-tile traversal.",
       "name": "position_embeddings_add_tiled_2d_align_corners",
       "_source_file": "position_embeddings_add_tiled_2d_align_corners.json"
+    },
+    {
+      "id": "position_embeddings_add_tiled_2d_align_corners_bf16",
+      "op": "position_embeddings",
+      "variant": "absolute_learned_inplace_tiled_2d_align_corners_bf16_storage",
+      "quant": {
+        "weight": "bf16",
+        "activation": "bf16",
+        "output": "bf16"
+      },
+      "inputs": [
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "FP32 ABI carrying BF16-rounded token-major values"
+        }
+      ],
+      "weights": [
+        {
+          "name": "pos_emb",
+          "dtype": "fp32",
+          "shape": [
+            "P",
+            "E"
+          ],
+          "desc": "FP32 ABI carrying BF16-rounded learned position values"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "x",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "E"
+          ],
+          "desc": "FP32 ABI carrying BF16-rounded residual output"
+        }
+      ],
+      "dims": [
+        "grid_h",
+        "grid_w",
+        "embed_dim",
+        "merge_size",
+        "source_grid_size"
+      ],
+      "impl": {
+        "function": "position_embeddings_add_tiled_2d_align_corners_bf16",
+        "c_declaration": "void position_embeddings_add_tiled_2d_align_corners_bf16(float *x, const float *position_embd, int grid_h, int grid_w, int embed_dim, int merge_size, int source_grid_size);",
+        "sources": [
+          "src/kernels/vision_kernels.c"
+        ]
+      },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "numerical_capabilities": [
+        {
+          "contract_id": "bf16_tiled_2d_align_corners_rne_residual",
+          "status": "validated",
+          "phases": [
+            "prefill"
+          ],
+          "function": "position_embeddings_add_tiled_2d_align_corners_bf16",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "scalar",
+            "threading": {
+              "runtime": "serial",
+              "work_partition": [
+                "serial"
+              ],
+              "dispatch": [
+                "inline"
+              ],
+              "reduction_order_effect": "contract_defined"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "bf16",
+            "merge_order": "none",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "serial"
+          }
+        }
+      ],
+      "notes": "Exact PyTorch BF16 storage-boundary contract for Qwen3-VL-style tiled position interpolation. Selection is contract-driven, not model-name-driven.",
+      "name": "position_embeddings_add_tiled_2d_align_corners_bf16",
+      "_source_file": "position_embeddings_add_tiled_2d_align_corners_bf16.json"
     },
     {
       "id": "q_norm_forward",

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -1664,6 +1664,41 @@
         }
       ]
     },
+    "position_embeddings_add_tiled_2d_align_corners_bf16": {
+      "note": "Add align-corners position embeddings with explicit BF16 storage and arithmetic boundaries.",
+      "params": [
+        {
+          "cast": "float*",
+          "name": "x",
+          "source": "output:x"
+        },
+        {
+          "cast": "const float*",
+          "name": "position_embd",
+          "source": "weight:pos_emb"
+        },
+        {
+          "name": "grid_h",
+          "source": "dim:vision_grid_h"
+        },
+        {
+          "name": "grid_w",
+          "source": "dim:vision_grid_w"
+        },
+        {
+          "name": "embed_dim",
+          "source": "dim:embed_dim"
+        },
+        {
+          "name": "merge_size",
+          "source": "dim:merge_size"
+        },
+        {
+          "name": "source_grid_size",
+          "source": "dim:source_grid_size"
+        }
+      ]
+    },
     "position_embeddings_add_tiled_2d": {
       "note": "Add position embeddings to an activation stream already laid out in merged-tile order.",
       "params": [

--- a/version/v8/kernel_maps/position_embeddings_add_tiled_2d_align_corners_bf16.json
+++ b/version/v8/kernel_maps/position_embeddings_add_tiled_2d_align_corners_bf16.json
@@ -1,0 +1,52 @@
+{
+  "id": "position_embeddings_add_tiled_2d_align_corners_bf16",
+  "op": "position_embeddings",
+  "variant": "absolute_learned_inplace_tiled_2d_align_corners_bf16_storage",
+  "quant": {
+    "weight": "bf16",
+    "activation": "bf16",
+    "output": "bf16"
+  },
+  "inputs": [
+    {"name": "x", "dtype": "fp32", "shape": ["T", "E"], "desc": "FP32 ABI carrying BF16-rounded token-major values"}
+  ],
+  "weights": [
+    {"name": "pos_emb", "dtype": "fp32", "shape": ["P", "E"], "desc": "FP32 ABI carrying BF16-rounded learned position values"}
+  ],
+  "outputs": [
+    {"name": "x", "dtype": "fp32", "shape": ["T", "E"], "desc": "FP32 ABI carrying BF16-rounded residual output"}
+  ],
+  "dims": ["grid_h", "grid_w", "embed_dim", "merge_size", "source_grid_size"],
+  "impl": {
+    "function": "position_embeddings_add_tiled_2d_align_corners_bf16",
+    "c_declaration": "void position_embeddings_add_tiled_2d_align_corners_bf16(float *x, const float *position_embd, int grid_h, int grid_w, int embed_dim, int merge_size, int source_grid_size);",
+    "sources": ["src/kernels/vision_kernels.c"]
+  },
+  "modes": {"inference": true, "training": false, "backward": false},
+  "numerical_capabilities": [
+    {
+      "contract_id": "bf16_tiled_2d_align_corners_rne_residual",
+      "status": "validated",
+      "phases": ["prefill"],
+      "function": "position_embeddings_add_tiled_2d_align_corners_bf16",
+      "explicit_selector": true,
+      "implementation": {
+        "isa_dispatch": "scalar",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": ["serial"],
+          "dispatch": ["inline"],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "arithmetic": {
+        "partial_accumulator": "bf16",
+        "merge_order": "none",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false,
+        "split_strategy": "serial"
+      }
+    }
+  ],
+  "notes": "Exact PyTorch BF16 storage-boundary contract for Qwen3-VL-style tiled position interpolation. Selection is contract-driven, not model-name-driven."
+}

--- a/version/v8/schemas/numerical_execution_contract_registry.schema.json
+++ b/version/v8/schemas/numerical_execution_contract_registry.schema.json
@@ -101,6 +101,23 @@
             }
           ]
         },
+        "spatial_transform": {
+          "oneOf": [
+            {"type": "null"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["interpolation", "coordinate_transform", "coordinate_compute", "source_layout", "output_traversal"],
+              "properties": {
+                "interpolation": {"enum": ["bilinear"]},
+                "coordinate_transform": {"enum": ["align_corners"]},
+                "coordinate_compute": {"enum": ["fp32_from_rational"]},
+                "source_layout": {"enum": ["row_major"]},
+                "output_traversal": {"enum": ["row_major", "merged_tile_order"]}
+              }
+            }
+          ]
+        },
         "description": {"type": "string", "minLength": 1}
       }
     }

--- a/version/v8/schemas/numerical_required_contracts.schema.json
+++ b/version/v8/schemas/numerical_required_contracts.schema.json
@@ -15,6 +15,18 @@
         "properties": {
           "op": {"type": "string", "minLength": 1},
           "template_ops": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+          "selector": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["config_equals"],
+            "properties": {
+              "config_equals": {
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": {"type": ["string", "number", "integer", "boolean"]}
+              }
+            }
+          },
           "phases": {
             "type": "object",
             "minProperties": 1,

--- a/version/v8/scripts/bf16_safetensors_lowering_guard_v8.py
+++ b/version/v8/scripts/bf16_safetensors_lowering_guard_v8.py
@@ -285,7 +285,7 @@ def run_guard(workdir: Path) -> None:
     manifest = json.loads((out / "weights_manifest.json").read_text(encoding="utf-8"))
     assert manifest["config"]["rope_layout"] == "multi_section_2d"
     assert manifest["config"]["vision_mrope_n_dims"] == 2
-    assert manifest["config"]["vision_mrope_sections"] == [1, 1, 1, 1]
+    assert manifest["config"]["vision_mrope_sections"] == [1, 1, 0, 0]
     assert manifest["config"]["position_interpolation_policy"] == "align_corners_bilinear"
 
     lowered = out / "lowered_vision.json"
@@ -314,12 +314,16 @@ def run_guard(workdir: Path) -> None:
     )
     lowered_ops = json.loads(lowered.read_text(encoding="utf-8"))["operations"]
     kernels_by_op = {op["op"]: op.get("kernel") for op in lowered_ops}
-    assert kernels_by_op["position_embeddings"] == "position_embeddings_add_tiled_2d_align_corners"
+    assert kernels_by_op["position_embeddings"] == "position_embeddings_add_tiled_2d_align_corners_bf16"
     call_ops = json.loads(call.read_text(encoding="utf-8"))["operations"]
+    position_call = next(op for op in call_ops if op["op"] == "position_embeddings")
+    assert position_call["function"] == "position_embeddings_add_tiled_2d_align_corners_bf16"
+    assert position_call["resolved_contract"]["resolved_contract_id"] == "bf16_tiled_2d_align_corners_rne_residual"
+    assert position_call["resolved_contract"]["kernel_id"] == "position_embeddings_add_tiled_2d_align_corners_bf16"
     rope_call = next(op for op in call_ops if op["op"] == "rope_qk")
     rope_args = {arg["name"]: arg["expr"] for arg in rope_call["args"]}
     assert rope_args["n_dims"] == "2"
-    assert [rope_args[f"section_{idx}"] for idx in range(4)] == ["1", "1", "1", "1"]
+    assert [rope_args[f"section_{idx}"] for idx in range(4)] == ["1", "1", "0", "0"]
     for op_name in (
         "patch_proj",
         "patch_proj_aux",

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -151,6 +151,28 @@ def _resolve_manifest_execution_contracts(
     resolution_mode = str((manifest.get("config") or {}).get("numerical_contract_mode", "bringup"))
     plans: List[Dict[str, Any]] = []
     for operation, operation_doc in required.items():
+        selector = operation_doc.get("selector") if isinstance(operation_doc, dict) else None
+        if selector is not None:
+            config_equals = selector.get("config_equals") if isinstance(selector, dict) else None
+            if not isinstance(config_equals, dict) or not config_equals:
+                raise RuntimeError(
+                    f"Numerical execution contract {operation!r} has an invalid selector. "
+                    "Declare a non-empty selector.config_equals map."
+                )
+            config = manifest.get("config") if isinstance(manifest.get("config"), dict) else {}
+            selected = True
+            for key, expected in config_equals.items():
+                current: Any = config
+                for part in str(key).split("."):
+                    if not isinstance(current, dict) or part not in current:
+                        selected = False
+                        break
+                    current = current[part]
+                if not selected or current != expected:
+                    selected = False
+                    break
+            if not selected:
+                continue
         phases = operation_doc.get("phases") if isinstance(operation_doc, dict) else None
         if not isinstance(phases, dict) or mode not in phases:
             continue

--- a/version/v8/scripts/convert_safetensors_to_bump_v8.py
+++ b/version/v8/scripts/convert_safetensors_to_bump_v8.py
@@ -1365,9 +1365,11 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
                 preproc = {}
         if head_dim > 0:
             axis_pairs = max(1, head_dim // 4)
-            vision_mrope_sections = [axis_pairs, axis_pairs, axis_pairs, axis_pairs]
+            # Vision M-RoPE has two spatial axes. Keep the four-slot ABI, but
+            # do not populate decoder-only time/extra sections.
+            vision_mrope_sections = [axis_pairs, axis_pairs, 0, 0]
         else:
-            vision_mrope_sections = [1, 1, 1, 1]
+            vision_mrope_sections = [1, 1, 0, 0]
         cfg.update({
             "model": "qwen3_vl_vision",
             "arch": "qwen3_vl_vision",
@@ -1402,6 +1404,7 @@ def _build_config(model_dir: Path, arch: str, config_template: Path | None) -> d
             "vision_grid_w": grid,
             "position_grid_size": grid,
             "position_interpolation_policy": "align_corners_bilinear",
+            "vision_position_storage_boundary": "bf16",
             "vision_num_patches": pos_rows,
             "spatial_merge_size": merge,
             "spatial_merge_factor": merge_factor,


### PR DESCRIPTION
## Why

Qwen3-VL BF16 position interpolation was numerically close but did not reproduce PyTorch's BF16 storage and arithmetic boundaries. That frontend error can amplify through the vision encoder and alter mixed-prefill logits and long generation.

## What

- Add `position_embeddings_add_tiled_2d_align_corners_bf16`.
- Match FP32 rational coordinates and explicit BF16 RNE at weights, products, left-to-right accumulation, residual add, and output.
- Register the exact validated numerical and spatial contract in the kernel map.
- Add a generic `selector.config_equals` contract selector.
- Have safetensors manifests declare `vision_position_storage_boundary=bf16`.
- Resolve the exact provider authoritatively through GraphIR, LoweredIR, and call IR.
- Keep GGUF on its existing FP32 position path.
- Add nightly-visible exact BF16 position coverage.
- Add the public seed-21 LayerNorm fixture that intentionally exposes the next reduction-contract mismatch.

No model-name compiler branch is added.

## Validation

- Synthetic BF16 position parity: 3/3 bit-exact.
- Xeon real OCR-scale tensor: 4,644,864/4,644,864 exact.
- BF16 safetensors lowering/codegen: exact contract, kernel, and function identity pass.
- Numerical execution contracts: 12/12.
- FP16 split-KV llama oracle: 14/14.
- Qwen3-VL GGUF/circuit gate: 20 template tests + 3 accuracy-gate tests + nightly status test.
- DSL zero-hardcoding and circuit audit: pass.
- BF16 nightly on AVX2: 5 pass, 0 fail, 11 truthful hardware skips.
- v7 and v8 staged regressions: pass.
- All pre-push gates: pass.

## Remaining Work

BF16 LayerNorm still differs at one seed-21 output by `9.536743e-07`. The fixture classifies it as `REDUCTION_CONTRACT_MISMATCH`; this PR does not claim full encoder or long-generation parity.

## Dependency

This branch is stacked on #139. Once #139 merges, this PR reduces to the single vision-contract commit.