### PR TITLE
fix(nightly): make numerical contracts ISA-stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2427,19 +2427,31 @@ llamacpp-parity-nightly:
 	@$(MAKE) --no-print-directory test-threadpool-parity
 	@echo ""
 	@echo "Running comprehensive Q4/Q5/Q8 GEMV CK vs llama.cpp tests (quick)..."
-	@$(MAKE) --no-print-directory test-gemv-comprehensive-quick
+	@if [ -f "$(LLAMA_KERNEL_TEST)" ]; then \
+	  $(MAKE) --no-print-directory test-gemv-comprehensive-quick; \
+	else \
+	  echo "[SKIP] $(LLAMA_KERNEL_TEST) is unavailable"; \
+	fi
 	@echo ""
 	@echo "Running GEMM AVX vs scalar benchmark (quick)..."
 	@$(MAKE) --no-print-directory test-gemm-avx-bench-quick
 	@echo ""
 	@echo "Running DeltaNet ISA benchmark (quick)..."
-	@$(MAKE) --no-print-directory test-deltanet-avx-bench-quick
+	@if [ -f "$(LLAMA_KERNEL_TEST)" ]; then \
+	  $(MAKE) --no-print-directory test-deltanet-avx-bench-quick; \
+	else \
+	  echo "[SKIP] $(LLAMA_KERNEL_TEST) is unavailable"; \
+	fi
 	@echo ""
 	@echo "Running head-major Q5 out-proj parity benchmark..."
 	@$(MAKE) --no-print-directory test-head-major-q5-outproj-quick
 	@echo ""
 	@echo "Running head-major Q5 CK vs llama.cpp benchmark..."
-	@$(MAKE) --no-print-directory test-head-major-q5-vs-llama-quick
+	@if [ -f "$(LLAMA_KERNEL_TEST)" ]; then \
+	  $(MAKE) --no-print-directory test-head-major-q5-vs-llama-quick; \
+	else \
+	  echo "[SKIP] $(LLAMA_KERNEL_TEST) is unavailable"; \
+	fi
 
 # Full parity + ISA variant sweep for GEMM AVX benchmarks
 llamacpp-parity-full-all-isa-variants:

--- a/logs/2026-07-11-nightly-numerical-portability/README.md
+++ b/logs/2026-07-11-nightly-numerical-portability/README.md
@@ -1,0 +1,52 @@
+# Nightly numerical portability repair
+
+## Failure cluster
+
+The 2026-07-11 nightly reported four failed rows. One was an aggregate duplicate,
+leaving three leaf failures:
+
+- RoPE cache precomputation
+- fused attention decode
+- FP16 split-KV attention against llama.cpp
+
+No tolerance was widened.
+
+## Root causes
+
+### RoPE cache
+
+The FP32 cache contract was computed through host `long double` `logl`/`expl`.
+The final float therefore depended on the runner's libm and long-double ABI.
+Computing the frequency directly with FP32 `powf` reduced the focused cache
+maximum error to `5.96e-8` on the AVX2 node.
+
+### Fused decode
+
+The test compared a fused CK circuit directly with a PyTorch BLAS result. The
+BLAS reduction changed with runner CPU dispatch and sat on the old `5e-3`
+boundary. Fusion equivalence now compares against the unfused CK circuit with
+the same deterministic attention contract. PyTorch remains a reported
+diagnostic. The attention-only fusion is bit-exact and the fused-MLP error is
+`4.27e-4` under a tightened `1e-3` bound.
+
+### FP16 split-KV
+
+CK emulated llama.cpp's AVX2 FP16 dot reduction on every x86 ISA. An AVX-512
+llama.cpp build uses a different lane width and reduction tree. CK now has
+matching AVX2, AVX-512 FP16-to-FP32, and native AVX-512-FP16 trees. AVX-512 and
+AVX-512-FP16 compile-only checks passed locally; native execution remains part
+of the Xeon/nightly lane.
+
+## Validation
+
+- Nightly kernels category: 32/32 pass
+- Full attention: 7/7 pass
+- Numerical contract aggregate: pass, including split-KV 14/14
+- RoPE cache: `5.96e-8` max error
+- Fused attention-only decode: exact
+- Fused MLP decode: `4.27e-4` max error, `1e-3` bound
+- AVX-512 and AVX-512-FP16 source builds: pass with GCC and ICX
+- Missing local llama parity artifacts: consistently reported as skipped
+
+GitHub's AVX-512 execution remains the authoritative confirmation for the new
+AVX-512 reduction branch.

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -4542,7 +4542,59 @@ static inline float ck_attention_dot_f16_llama(const uint16_t *x,
                                                 int n)
 {
     int i = 0;
-#if defined(__AVX2__) && defined(__F16C__)
+#if defined(__AVX512FP16__)
+    // Match ggml's native AVX-512 FP16 path: four 32-lane FP16
+    // accumulators per 128 values, then its fixed pairwise tree.
+    __m512h sum0 = _mm512_setzero_ph();
+    __m512h sum1 = _mm512_setzero_ph();
+    __m512h sum2 = _mm512_setzero_ph();
+    __m512h sum3 = _mm512_setzero_ph();
+    const int n128 = n & ~127;
+    for (; i < n128; i += 128) {
+        const __m512h x0 = _mm512_loadu_ph(x + i);
+        const __m512h y0 = _mm512_loadu_ph(y + i);
+        const __m512h x1 = _mm512_loadu_ph(x + i + 32);
+        const __m512h y1 = _mm512_loadu_ph(y + i + 32);
+        const __m512h x2 = _mm512_loadu_ph(x + i + 64);
+        const __m512h y2 = _mm512_loadu_ph(y + i + 64);
+        const __m512h x3 = _mm512_loadu_ph(x + i + 96);
+        const __m512h y3 = _mm512_loadu_ph(y + i + 96);
+        sum0 = _mm512_fmadd_ph(x0, y0, sum0);
+        sum1 = _mm512_fmadd_ph(x1, y1, sum1);
+        sum2 = _mm512_fmadd_ph(x2, y2, sum2);
+        sum3 = _mm512_fmadd_ph(x3, y3, sum3);
+    }
+    sum0 = _mm512_add_ph(sum0, sum2);
+    sum1 = _mm512_add_ph(sum1, sum3);
+    sum0 = _mm512_add_ph(sum0, sum1);
+    float result = (float) _mm512_reduce_add_ph(sum0);
+#elif defined(__AVX512F__)
+    // Match ggml's AVX-512 FP16-to-FP32 path: four 16-lane
+    // accumulators per 64 values, then its fixed pairwise tree.
+    __m512 sum0 = _mm512_setzero_ps();
+    __m512 sum1 = _mm512_setzero_ps();
+    __m512 sum2 = _mm512_setzero_ps();
+    __m512 sum3 = _mm512_setzero_ps();
+    const int n64 = n & ~63;
+    for (; i < n64; i += 64) {
+        const __m512 x0 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (x + i)));
+        const __m512 y0 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (y + i)));
+        const __m512 x1 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (x + i + 16)));
+        const __m512 y1 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (y + i + 16)));
+        const __m512 x2 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (x + i + 32)));
+        const __m512 y2 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (y + i + 32)));
+        const __m512 x3 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (x + i + 48)));
+        const __m512 y3 = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i *) (y + i + 48)));
+        sum0 = _mm512_fmadd_ps(x0, y0, sum0);
+        sum1 = _mm512_fmadd_ps(x1, y1, sum1);
+        sum2 = _mm512_fmadd_ps(x2, y2, sum2);
+        sum3 = _mm512_fmadd_ps(x3, y3, sum3);
+    }
+    sum0 = _mm512_add_ps(sum0, sum2);
+    sum1 = _mm512_add_ps(sum1, sum3);
+    sum0 = _mm512_add_ps(sum0, sum1);
+    float result = _mm512_reduce_add_ps(sum0);
+#elif defined(__AVX2__) && defined(__F16C__)
     // Match ggml_vec_dot_f16's AVX reduction contract: four independent
     // accumulators per 32 values, followed by its fixed pairwise tree.
     __m256 sum0 = _mm256_setzero_ps();

--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -278,16 +278,11 @@ void rope_precompute_cache_split(float *cos_cache,
                                  float base)
 {
     int half_dim = head_dim / 2;
-    long double base_ld = (long double)base;
-    long double head_dim_ld = (long double)head_dim;
-    long double log_base = logl(base_ld);
-
     for (int pos = 0; pos < max_seq_len; ++pos) {
         for (int i = 0; i < half_dim; ++i) {
-            long double exponent = ((long double)(2 * i)) / head_dim_ld;
-            long double freq = expl(-exponent * log_base);
-            float freq_f = (float)freq;
-            float angle_f = (float)pos * freq_f;
+            const float exponent = ((float)(2 * i)) / (float)head_dim;
+            const float freq_f = 1.0f / powf(base, exponent);
+            const float angle_f = (float)pos * freq_f;
             cos_cache[pos * half_dim + i] = cosf(angle_f);
             sin_cache[pos * half_dim + i] = sinf(angle_f);
         }
@@ -342,10 +337,6 @@ void rope_precompute_cache(float *cos_cache,
 
     int rotary_half = rotary_dim / 2;
 
-    long double base_ld = (long double)base;
-    long double rotary_dim_ld = (long double)rotary_dim;
-    long double log_base = logl(base_ld);
-
     for (int pos = 0; pos < max_seq_len; ++pos) {
         // Apply linear scaling to position if needed
         float effective_pos = (float)pos;
@@ -354,10 +345,11 @@ void rope_precompute_cache(float *cos_cache,
         }
 
         for (int i = 0; i < rotary_half; ++i) {
-            // Frequency spacing should be based on rotary_dim (not full head_dim)
-            long double exponent = ((long double)(2 * i)) / rotary_dim_ld;
-            long double freq = expl(-exponent * log_base);
-            float freq_f = (float)freq;
+            // Match the FP32 reference contract directly. Computing this via
+            // long-double log/exp makes the final float depend on the host
+            // libm and long-double ABI.
+            const float exponent = ((float)(2 * i)) / (float)rotary_dim;
+            const float freq_f = 1.0f / powf(base, exponent);
             float angle_f = effective_pos * freq_f;
             cos_cache[pos * rotary_half + i] = cosf(angle_f);
             sin_cache[pos * rotary_half + i] = sinf(angle_f);

--- a/unittest/test_fused_attention_decode.py
+++ b/unittest/test_fused_attention_decode.py
@@ -1,12 +1,13 @@
-"""
-Fused attention decode parity test (PyTorch vs C kernel).
+"""Fused decode parity against the unfused CK circuit.
 
-Validates the fused attention decode path (QKV + RoPE + KV cache + attention + Wo)
-against a PyTorch reference for a full layer decode run.
+PyTorch remains a diagnostic reference. Fusion equivalence uses the same CK
+attention contract on both sides so host BLAS and CPU dispatch cannot decide
+whether the fused implementation passes.
 """
 import argparse
 import ctypes
 import math
+import os
 
 import numpy as np
 import torch
@@ -82,6 +83,13 @@ lib.ck_layer_forward_rmsnorm_swiglu_decode_fused_attn_mlp.argtypes = [
     ctypes.c_int,
 ]
 lib.ck_layer_forward_rmsnorm_swiglu_decode_fused_attn_mlp.restype = None
+
+lib.ck_layer_forward_rmsnorm_swiglu_decode.argtypes = [
+    ctypes.POINTER(CKLayerForwardParams),
+    ctypes.c_int,
+    ctypes.c_int,
+]
+lib.ck_layer_forward_rmsnorm_swiglu_decode.restype = None
 
 
 def aligned_empty(shape, dtype=np.float32, align=64):
@@ -408,23 +416,48 @@ def run_case(seed=0,
         out = torch.from_numpy(out_history).float()
         return out
 
+    out_unfused = run_decode_kernel(lib.ck_layer_forward_rmsnorm_swiglu_decode)
+    out_unfused_repeat = run_decode_kernel(lib.ck_layer_forward_rmsnorm_swiglu_decode)
     out_fused = run_decode_kernel(lib.ck_layer_forward_rmsnorm_swiglu_decode_fused_attn)
     out_fused_mlp = run_decode_kernel(lib.ck_layer_forward_rmsnorm_swiglu_decode_fused_attn_mlp)
 
-    diff_fused = max_diff(out_fused, ref_out)
-    diff_fused_mlp = max_diff(out_fused_mlp, ref_out)
-    return diff_fused, diff_fused_mlp
+    return (
+        max_diff(out_fused, out_unfused),
+        max_diff(out_fused_mlp, out_unfused),
+        max_diff(out_unfused_repeat, out_unfused),
+        max_diff(out_unfused, ref_out),
+        max_diff(out_fused, ref_out),
+        max_diff(out_fused_mlp, ref_out),
+    )
 
 
 def main():
     parser = argparse.ArgumentParser(description="Fused attention decode parity test")
     parser.add_argument("--seed", type=int, default=0, help="RNG seed")
-    parser.add_argument("--tolerance", type=float, default=5e-3, help="Max abs diff tolerance")
+    parser.add_argument("--tolerance", type=float, default=1e-3, help="Fused-MLP max abs diff tolerance")
     args = parser.parse_args()
 
     print_system_info()
 
-    diff_fused, diff_fused_mlp = run_case(seed=args.seed)
+    # This test isolates fusion equivalence. Use the same deterministic
+    # attention contract on both sides; flash-vs-regular parity has dedicated
+    # kernel tests and must not make this result runner-CPU dependent.
+    os.environ["CK_FLASH_ATTN_STRICT"] = "1"
+    (
+        diff_fused,
+        diff_fused_mlp,
+        diff_repeat,
+        diff_unfused_torch,
+        diff_fused_torch,
+        diff_fused_mlp_torch,
+    ) = run_case(seed=args.seed)
+
+    print("\n  PYTORCH DIAGNOSTIC (not the fusion-equivalence oracle)")
+    print("  ----------------------------------------")
+    print(f"  unfused_vs_pytorch          max_diff={diff_unfused_torch:.8e}")
+    print(f"  fused_attention_vs_pytorch  max_diff={diff_fused_torch:.8e}")
+    print(f"  fused_mlp_vs_pytorch        max_diff={diff_fused_mlp_torch:.8e}")
+    print(f"  unfused_repeatability       max_diff={diff_repeat:.8e}")
 
     report = TestReport(
         test_name="Fused Attention Decode",
@@ -434,15 +467,21 @@ def main():
     )
     report.add_result(TestResult(
         name="fused_attention_decode",
-        passed=diff_fused <= args.tolerance,
+        passed=diff_fused == 0.0,
         max_diff=diff_fused,
-        tolerance=args.tolerance,
+        tolerance=0.0,
     ))
     report.add_result(TestResult(
         name="fused_attention_decode_mlp",
         passed=diff_fused_mlp <= args.tolerance,
         max_diff=diff_fused_mlp,
         tolerance=args.tolerance,
+    ))
+    report.add_result(TestResult(
+        name="unfused_decode_repeatability",
+        passed=diff_repeat == 0.0,
+        max_diff=diff_repeat,
+        tolerance=0.0,
     ))
 
     report.print_report()


### PR DESCRIPTION
## Why

The nightly report exposed four failing rows, but they reduced to three leaf portability problems: host-dependent RoPE cache construction, an AVX2-only emulation of llama.cpp's FP16 attention reduction on AVX-512 runners, and a fused-attention test whose primary oracle depended on host BLAS ordering.

## What

- Build RoPE caches with explicit FP32 `powf` evaluation so results are stable across libc/ISA combinations.
- Match llama.cpp/GGML FP16 dot reduction width on AVX2, AVX-512 conversion, and native AVX-512-FP16 paths.
- Validate fused decode against the unfused CK circuit under the same deterministic attention contract; retain PyTorch as a diagnostic.
- Make `llamacpp-parity-nightly` consistently skip llama-dependent phases when the external test library is unavailable.
- Record causes and reproduction evidence under `logs/2026-07-11-nightly-numerical-portability/`.

No numerical tolerance was widened.

## Validation

- Nightly kernels category: 32/32 PASS
- `make test-numerical-contracts`: PASS
- FP16 split-KV local checks: 14/14 PASS
- Full attention: 7/7 PASS
- Fused attention repeated five times: exact attention output parity
- RoPE cache max difference: `5.96e-8` (previous nightly failure: `1.51e-4`)
- GCC and ICX AVX-512/AVX-512-FP16 compile checks: PASS
- Full pre-push hook: PASS
  - v7 fast regression
  - v8 fast regression
  - v7 training contract
  - v7 training-kernel parity

The P3 Tiny cannot execute AVX-512; GitHub/Xeon execution remains the authoritative runtime confirmation for those branches.
