### PR TITLE
fix(v8): route vision M-RoPE by resolved semantics

### DIFF
--- a/logs/2026-07-11-qwen3vl-bf16-mrope-capability/README.md
+++ b/logs/2026-07-11-qwen3vl-bf16-mrope-capability/README.md
@@ -16,6 +16,10 @@ kernel and the generated model route to disagree.
   production geometry.
 - Propagate the exact kernel and contract through GraphIR, LoweredIR, call IR,
   and generated C.
+- Require resolved `operator_family=vision_mrope` and
+  `position_transform.pairing=multi_section` metadata. Lowering and diagnostic
+  routing consume these semantics rather than inferring behavior from a kernel
+  or function-name prefix.
 - Added exact ABI bindings for the two storage wrappers. No prefix fallback or
   model-name dispatch was introduced.
 
@@ -23,7 +27,9 @@ kernel and the generated model route to disagree.
 
 - Numerical execution resolver: 15/15 pass.
 - X-ray architecture: 8/8 pass.
-- Qwen3-VL circuit/codegen: 20/20 pass.
+- Qwen3-VL circuit/codegen: 21/21 pass.
+- Renamed-kernel semantic routing guard: pass; exact kernel identity remains a
+  resolver output asserted independently in call IR.
 - Template/dataflow audit: 10/10 pass.
 - Vision kernel suite: pass.
 - Storage matrix at head dimensions 8 and 72:

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -16,6 +16,7 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 V8_BUILD_PATH = ROOT / "version" / "v8" / "scripts" / "build_ir_v8.py"
 V8_CODEGEN_PATH = ROOT / "version" / "v8" / "scripts" / "codegen_v8.py"
+V8_CODEGEN_CORE_PATH = ROOT / "version" / "v8" / "scripts" / "codegen_core_v8.py"
 V8_CONVERT_PATH = ROOT / "version" / "v8" / "scripts" / "convert_gguf_to_bump_v8.py"
 V8_BRIDGE_PATH = ROOT / "version" / "v8" / "scripts" / "run_multimodal_bridge_v8.py"
 
@@ -33,6 +34,7 @@ def _load_module(name: str, path: Path):
 
 
 build_ir_v8 = _load_module("build_ir_v8_qwen3vl_tests", V8_BUILD_PATH)
+codegen_core_v8 = _load_module("codegen_core_v8_qwen3vl_tests", V8_CODEGEN_CORE_PATH)
 convert_gguf_to_bump_v8 = _load_module("convert_gguf_to_bump_v8_qwen3vl_tests", V8_CONVERT_PATH)
 run_multimodal_bridge_v8 = _load_module("run_multimodal_bridge_v8_qwen3vl_tests", V8_BRIDGE_PATH)
 
@@ -146,6 +148,28 @@ def _make_qwen3vl_manifest() -> dict:
 
 class V8Qwen3VLTemplateTests(unittest.TestCase):
 
+    def test_vision_mrope_classification_uses_semantics_not_kernel_name(self) -> None:
+        operation = {
+            "op": "rope_qk",
+            "kernel": "deliberately_renamed_kernel",
+            "function": "unrelated_function_name",
+            "resolved_contract": {
+                "semantics": {
+                    "operator_family": "vision_mrope",
+                    "position_transform": {
+                        "pairing": "multi_section",
+                        "position_rank": 4,
+                    },
+                }
+            },
+        }
+        self.assertTrue(build_ir_v8._is_vision_mrope_operation(operation))
+        self.assertTrue(codegen_core_v8._is_vision_mrope_operation(operation))
+
+        operation["resolved_contract"]["semantics"]["operator_family"] = "gemm"
+        self.assertFalse(build_ir_v8._is_vision_mrope_operation(operation))
+        self.assertFalse(codegen_core_v8._is_vision_mrope_operation(operation))
+
     def test_authoritative_contract_preserves_behavior_and_reaches_call_ir(self) -> None:
         manifest = _make_qwen3vl_manifest()
         with tempfile.TemporaryDirectory(prefix="v8_qwen3vl_contract_equivalence_") as td:
@@ -208,6 +232,10 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
                 self.assertEqual(
                     mrope["resolved_contract"]["contract_id"],
                     "vision_mrope_fp32_input_fp32_compute_bf16_output",
+                )
+                self.assertEqual(
+                    mrope["resolved_contract"]["semantics"]["operator_family"],
+                    "vision_mrope",
                 )
                 self.assertEqual(
                     mrope["resolved_contract"]["kernel_id"],

--- a/version/v8/contracts/numerical_execution.json
+++ b/version/v8/contracts/numerical_execution.json
@@ -4,6 +4,7 @@
   "engine_contract_version": "8",
   "contracts": {
     "bf16_weight_bf16_input_fp32_dot_fp32_output": {
+      "operator_family": "gemm",
       "status": "observed",
       "storage": {
         "input": "fp32",
@@ -37,6 +38,7 @@
       "description": "BF16 weights and BF16-rounded FP32 activation loads with an ascending-K FP32 dot product and FP32 output storage."
     },
     "bf16_tiled_2d_align_corners_rne_residual": {
+      "operator_family": "spatial_position_interpolation",
       "status": "validated",
       "storage": {
         "input": "bf16",
@@ -80,6 +82,7 @@
       "description": "Align-corners tiled 2D bilinear position interpolation with FP32 rational coordinates and explicit BF16 RNE product, accumulation, residual, and output boundaries."
     },
     "vision_mrope_fp32_input_fp32_compute_fp32_output": {
+      "operator_family": "vision_mrope",
       "status": "validated",
       "compute": {
         "input": "fp32",
@@ -127,6 +130,7 @@
       "description": "Vision M-RoPE uses full-width multi-section split-half FP32 math and stores FP32 output."
     },
     "vision_mrope_fp32_input_fp32_compute_bf16_output": {
+      "operator_family": "vision_mrope",
       "status": "validated",
       "compute": {
         "input": "fp32",
@@ -176,6 +180,7 @@
       "description": "Vision M-RoPE computes in FP32 and materializes a BF16 RNE storage boundary in the FP32 activation buffer."
     },
     "vision_mrope_fp32_input_fp32_compute_fp16_output": {
+      "operator_family": "vision_mrope",
       "status": "validated",
       "compute": {
         "input": "fp32",

--- a/version/v8/schemas/numerical_execution_contract_registry.schema.json
+++ b/version/v8/schemas/numerical_execution_contract_registry.schema.json
@@ -18,8 +18,11 @@
     "contract": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["status", "storage", "compute", "rounding", "reduction", "threading", "position_transform", "description"],
+      "required": ["operator_family", "status", "storage", "compute", "rounding", "reduction", "threading", "position_transform", "description"],
       "properties": {
+        "operator_family": {
+          "enum": ["gemm", "spatial_position_interpolation", "vision_mrope"]
+        },
         "status": {"enum": ["unresolved", "observed", "validated"]},
         "storage": {
           "type": "object",

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -285,6 +285,29 @@ def _graph_ir_contract_metadata(plan: Dict[str, Any]) -> Dict[str, Any]:
     return metadata
 
 
+def _is_vision_mrope_operation(operation: Dict[str, Any]) -> bool:
+    """Classify vision M-RoPE from circuit/contract semantics, never kernel names."""
+    resolved = operation.get("resolved_contract")
+    semantics = resolved.get("semantics") if isinstance(resolved, dict) else None
+    position = semantics.get("position_transform") if isinstance(semantics, dict) else None
+    if isinstance(semantics, dict):
+        return bool(
+            semantics.get("operator_family") == "vision_mrope"
+            and isinstance(position, dict)
+            and position.get("pairing") == "multi_section"
+            and int(position.get("position_rank", 0) or 0) == 4
+        )
+
+    op_type = str(operation.get("op", ""))
+    if op_type == "mrope_qk":
+        return True
+    if op_type != "rope_qk":
+        return False
+
+    params = operation.get("params") if isinstance(operation.get("params"), dict) else {}
+    return str(params.get("rope_mode", "")).strip().lower() == "vision"
+
+
 def _attach_semantic_checkpoints(
     template: Dict[str, Any],
     arranged_kernels: List[Dict[str, Any]],
@@ -8489,9 +8512,7 @@ def generate_memory_layout_packed(
         if op_type == "rope_q":
             alloc_act("q_scratch")
             alloc_act("rope_cache")
-        if op_type == "mrope_qk" or (
-            op_type == "rope_qk" and kernel_type.startswith("mrope_qk_vision")
-        ):
+        if _is_vision_mrope_operation(op):
             alloc_act("q_scratch")
             alloc_act("k_scratch")
             alloc_act("vision_positions")
@@ -9158,9 +9179,7 @@ def generate_ir_lower_2(
                     "dtype": "i32",
                     "ptr_expr": f"activations + {pos_buf['offset']}",
                 }
-        elif op_type == "mrope_qk" or (
-            op_type == "rope_qk" and str(ir_op.get("kernel", "")).startswith("mrope_qk_vision")
-        ):
+        elif _is_vision_mrope_operation(ir_op):
             q_buf = activation_buffers.get("q_scratch")
             k_buf = activation_buffers.get("k_scratch")
             pos_buf = activation_buffers.get("vision_positions")
@@ -9735,10 +9754,7 @@ def generate_ir_lower_2(
                         "dtype": "fp32",
                         "ptr_expr": f"activations + {k_buf['offset']}",
                     })
-        if ir_op.get("op", "") == "mrope_qk" or (
-            ir_op.get("op", "") == "rope_qk"
-            and str(ir_op.get("kernel", "")).startswith("mrope_qk_vision")
-        ):
+        if _is_vision_mrope_operation(ir_op):
             for scratch_name in ["q_scratch", "k_scratch"]:
                 buf = activation_buffers.get(scratch_name)
                 if buf:
@@ -9957,9 +9973,7 @@ def generate_ir_lower_2(
             gemma4v_freq_base = float(config.get("vision_rope_theta", 100.0) or 100.0)
             params["freq_base"] = gemma4v_freq_base
             params["rope_freq_base"] = gemma4v_freq_base
-        if op_type == "mrope_qk" or (
-            op_type == "rope_qk" and str(ir_op.get("kernel", "")).startswith("mrope_qk_vision")
-        ):
+        if _is_vision_mrope_operation(ir_op):
             sections = config.get("vision_mrope_sections")
             if not isinstance(sections, list) or len(sections) != 4:
                 default_section = max(1, int(params.get("head_dim", 0) or 0) // 4)
@@ -10064,10 +10078,7 @@ def generate_ir_lower_2(
             "quantize_final_output",
         ) or op_type == "branch_layernorm":
             params["_m"] = int(params.get("vision_merged_tokens", params.get("_m", 1)) or 1)
-        if op_type in ("vision_position_ids", "position_ids_2d", "mrope_qk") or (
-            op_type == "rope_qk"
-            and str(ir_op.get("kernel", "")).startswith("mrope_qk_vision")
-        ):
+        if op_type in ("vision_position_ids", "position_ids_2d") or _is_vision_mrope_operation(ir_op):
             params["_m"] = int(params.get("vision_num_patches", params.get("_m", 1)) or 1)
         if op_type in ("quantize_input_0", "quantize_input_1", "quantize_input_2", "quantize_out_proj_input", "quantize_mlp_down_input", "quantize_recurrent_out_proj_input", "quantize_mamba_out_proj_input", "quantize_final_output"):
             inferred_quant_rows = int(params.get("_m", params.get("seq_len", params.get("rows", 1))) or 1)

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -611,6 +611,24 @@ def _infer_logits_layout(config: Dict, layout: Dict) -> str:
                 return "full" if size > vocab * 4 else "last"
     return "last"
 
+
+def _is_vision_mrope_operation(op: Dict) -> bool:
+    """Use resolved semantics for vision M-RoPE diagnostics, never function names."""
+    resolved = op.get("resolved_contract")
+    semantics = resolved.get("semantics") if isinstance(resolved, dict) else None
+    transform = semantics.get("position_transform") if isinstance(semantics, dict) else None
+    if isinstance(semantics, dict):
+        return bool(
+            semantics.get("operator_family") == "vision_mrope"
+            and isinstance(transform, dict)
+            and transform.get("pairing") == "multi_section"
+            and int(transform.get("position_rank", 0) or 0) == 4
+        )
+    return bool(
+        op.get("op") in {"rope_qk", "mrope_qk"}
+        and str((op.get("params") or {}).get("rope_mode", "")).strip().lower() == "vision"
+    )
+
 def emit_op(
     op: Dict,
     seq_idx: int | None = None,
@@ -2056,14 +2074,7 @@ def emit_op(
                     )
                     lines.append("    #endif")
                 return _return_lines(append_stop=True)
-            if _same_op("rope_qk", "mrope_qk") and function in {
-                "mrope_qk_vision",
-                "mrope_qk_vision_bf16_storage",
-                "mrope_qk_vision_fp16_storage",
-                "mrope_qk_text",
-                "ck_qwen3vl_runtime_mrope_qk",
-                "ck_qwen3vl_prefill_mrope_qk",
-            }:
+            if _is_vision_mrope_operation(op):
                 q_expr = _get_arg("q")
                 k_expr = _get_arg("k")
                 rows = _get_arg("num_tokens")
@@ -2365,21 +2376,7 @@ static void ck_decode(CKModel *model, int32_t token) {
     lines.append("")
 
     vision_dump_mode = None
-    if any(
-        str(op.get("op", "")) == "split_qkv_packed"
-        or (
-            str(op.get("op", "")) in {"rope_qk", "mrope_qk"}
-            and str(op.get("function", op.get("kernel", ""))) in {
-                "mrope_qk_text",
-                "mrope_qk_vision",
-                "mrope_qk_vision_bf16_storage",
-                "mrope_qk_vision_fp16_storage",
-                "ck_qwen3vl_runtime_mrope_qk",
-                "ck_qwen3vl_prefill_mrope_qk",
-            }
-        )
-        for op in ops
-    ):
+    if any(_is_vision_mrope_operation(op) for op in ops):
         vision_dump_mode = "vision_qwen3vl"
 
     embed_scale_emitted = False

--- a/version/v8/scripts/parity_qwen3vl_mmproj_v8.py
+++ b/version/v8/scripts/parity_qwen3vl_mmproj_v8.py
@@ -159,12 +159,22 @@ def run_harness(gguf_path: Path, output_dir: Path) -> dict:
     branch_lowering_ops = {"branch_spatial_merge", "branch_layernorm", "branch_fc1", "branch_gelu", "branch_fc2", "branch_concat"}
     has_deepstack_lowering = branch_lowering_ops.issubset(set(ops))
     has_position_ids = "position_ids_2d" in ops or "vision_position_ids" in ops
-    has_vision_mrope = any(
-        op.get("op") in {"rope_qk", "mrope_qk"}
-        and str(op.get("kernel", "")).startswith("mrope_qk_vision")
-        for op in ir1_ops
-        if isinstance(op, dict)
-    )
+    def is_vision_mrope(op: dict) -> bool:
+        resolved = op.get("resolved_contract") or {}
+        semantics = resolved.get("semantics") or {}
+        transform = semantics.get("position_transform") or {}
+        if semantics:
+            return (
+                semantics.get("operator_family") == "vision_mrope"
+                and transform.get("pairing") == "multi_section"
+                and int(transform.get("position_rank", 0) or 0) == 4
+            )
+        return op.get("op") == "mrope_qk" or (
+            op.get("op") == "rope_qk"
+            and str((op.get("params") or {}).get("rope_mode", "")).strip().lower() == "vision"
+        )
+
+    has_vision_mrope = any(is_vision_mrope(op) for op in ir1_ops if isinstance(op, dict))
     config = manifest.get("config", {})
     entry_names = {
         str(entry.get("name"))


### PR DESCRIPTION
## Why

PR #142 resolved exact BF16 vision M-RoPE kernels, but several lowering and diagnostic paths still inferred vision semantics from kernel/function names. Kernel identity must remain an output of exact resolution, not an input to compiler guesses.

## What

- Require `operator_family` in numerical execution contracts.
- Identify vision M-RoPE using resolved `operator_family=vision_mrope` and `position_transform=multi_section` metadata.
- Remove kernel/function-prefix inference from memory planning, lowering, codegen diagnostics, and the mmproj parity harness.
- Preserve and assert exact resolved kernel ID/function independently in call IR.
- Add a renamed-kernel regression proving semantic routing is name-independent.

## Validation

- Qwen3-VL circuit/codegen: 21/21
- Numerical execution contracts: 15/15
- X-ray diagnostics: 8/8
- Circuit audit: 10/10
- FP16 split-KV attention: 14/14
- Pre-commit: v7 and v8 fast regressions passed
- Pre-push: build, Gemma3 E2E, v8 inference contracts, v7 training smoke, v7/v8 fast regressions, and v7 training-kernel parity passed

No tolerance was relaxed and no model-name dispatch was added.