### PR TITLE
docs: strengthen project thesis and execution roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,190 @@
-# C Kernel Engine
+# C-Kernel-Engine
 
-![C Kernel Engine cover](assets/cover_image.png)
+![C-Kernel-Engine cover](assets/cover_image.png)
 
-A C-first kernel library for LLMs and deep-learning workloads.
+[![Nightly Tests](https://github.com/C-Kernel-Engine/C-Kernel-Engine/actions/workflows/nightly.yml/badge.svg)](https://github.com/C-Kernel-Engine/C-Kernel-Engine/actions/workflows/nightly.yml)
+[![llama.cpp Compatibility](https://github.com/C-Kernel-Engine/C-Kernel-Engine/actions/workflows/llamacpp-rolling-compat.yml/badge.svg)](https://github.com/C-Kernel-Engine/C-Kernel-Engine/actions/workflows/llamacpp-rolling-compat.yml)
+[![Documentation](https://github.com/C-Kernel-Engine/C-Kernel-Engine/actions/workflows/docs.yml/badge.svg)](https://github.com/C-Kernel-Engine/C-Kernel-Engine/actions/workflows/docs.yml)
 
-> Cover image generated with Google Gemini (banana-themed concept art).
+C-Kernel-Engine (CKE) is a C-first compiler, kernel library, and runtime for transformer inference and training on CPUs. It turns model weights, explicit circuits, and kernel capability maps into inspectable generated C rather than hiding execution behind a general-purpose framework.
 
-This project focuses on a **small, high-impact set of kernel shapes** that appear in transformer-style models, instead of trying to cover every BLAS case. The goal is to:
+The project is built around a practical thesis:
 
-- Implement a clean kernel DSL around a handful of GEMM and elementwise patterns.
-- Tune those kernels aggressively for CPU (x86/ARM/RISC-V, AVX2/AVX-512, etc.).
-- Keep the implementation understandable and hackable for systems and HPC engineers.
+> A CPU AI system becomes competitive by making the complete model circuit explicit, proving its numerical behavior, and methodically moving every important stage toward the hardware roofline.
 
-See `docs/01-llm-kernel-shapes.md` for the core math that drives the design.
+CKE is not only a collection of fast GEMMs. It is an attempt to connect model architecture, numerical semantics, code generation, memory planning, threading, parity testing, and profiler evidence into one reproducible system.
 
-**Start here:** `docs/00-quickstart.md` (build, tests, and codegen).
-**v7 SVG training plan:** `docs/v7-svg-training-ablation.md` (tokenizer/data/model ablation flow).
+## Why CKE Exists
 
-The code generator (`build/ck_ir_demo`) can emit a `libmodel.so` that supports:
-- Prompt **prefill** (full forward)
-- Autoregressive **decode** with KV cache (inference-only)
-- **Backward** / training (teacher forcing full forward+backward)
+Modern CPUs provide wide SIMD, large caches, high core counts, mature profiling tools, and inexpensive memory capacity. They are also widely available and straightforward to connect into distributed systems. Much of that capability is lost when a runtime uses the wrong kernel shape, silently changes reduction order, repeatedly materializes intermediates, or schedules heterogeneous cores poorly.
 
-## Git Hooks (Recommended)
+CKE addresses that problem at several levels:
 
-Bootstrap a development machine:
+- **Explicit circuits:** Model topology, dimensions, weight policy, position semantics, and required numerical behavior are data, not model-name branches hidden in code generation.
+- **Exact kernel resolution:** Kernel maps advertise concrete functions, layouts, dtypes, reductions, threading behavior, and ISA capabilities. Missing or ambiguous providers fail compilation.
+- **Generated C:** GraphIR, lowered IR, and call-ready IR preserve the resolved decisions before emitting a standalone model runtime.
+- **Numerical evidence:** Leaf kernels, stitched layers, mixed prefill, teacher-forced decode, and end-to-end outputs are compared with independent references such as llama.cpp and PyTorch.
+- **Performance evidence:** Linux perf, Intel VTune, Intel Advisor roofline analysis, assembly inspection, and focused microbenchmarks identify where cycles and bandwidth are actually spent.
+- **One CPU path from kernels to systems:** The long-term direction is efficient single-node execution followed by distributed CPU inference and training without surrendering observability.
 
-```bash
-./scripts/setup-dev-env.sh
+## How It Works
+
+```text
+GGUF / safetensors metadata and weights
+                 +
+       circuit JSON requirements
+                 +
+      kernel capability maps
+                 |
+                 v
+       fail-closed DSL resolver
+                 |
+                 v
+      GraphIR -> LoweredIR -> Call IR
+                 |
+                 v
+       generated C + weights.bump
+                 |
+                 v
+              libmodel.so
+        prefill / decode / backward
 ```
 
-Enable repo hooks:
+The ownership boundary is deliberate:
+
+- **Circuits** describe the mathematical graph and required semantics.
+- **Kernel maps** describe exact executable capabilities.
+- **Kernels** implement and test those capabilities.
+- **The DSL** validates, resolves, lowers, and emits. It must not guess model behavior.
+
+This separation is enforced by tests that reject new model-family dispatch in protected compiler paths and reject unsupported or ambiguous numerical contracts.
+
+## Current Scope
+
+| Area | Current state |
+|---|---|
+| v8 text inference | Active GGUF/safetensors conversion, generated runtimes, quantized prefill, KV-cached decode, and model-family regression lanes |
+| v8 vision inference | Qwen3-VL and related vision/compiler support under numerical-parity hardening with bounded first-divergence attribution |
+| v7 training | FP32 forward/backward, optimizer, gradient accumulation, and training-kernel parity are the authoritative training lane |
+| BF16 | Portable storage/rounding contracts are tested; native practical validation is resource-gated to AVX-512 BF16 or AMX-capable machines |
+| Audio | Whisper tiny/base inference is next after the v8 compiler and Qwen3-VL parity gates |
+| Distributed CPU | Architectural direction and research target; not yet a completed production runtime |
+
+For the detailed support surface, see the [model and kernel matrix](https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html), [test report](https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html), and [roadmap](https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html).
+
+## Correctness Before Speed
+
+A fast kernel is not eligible if it changes the required mathematics. CKE uses layered validation:
+
+1. Scalar or independent reference for the leaf operation.
+2. ISA and threaded implementations against the same numerical contract.
+3. Circuit and kernel-map resolution tests.
+4. Stitched layer and semantic checkpoint comparison.
+5. Mixed-prefill and teacher-forced token parity.
+6. Practical end-to-end prompts, images, or audio fixtures.
+7. Nightly and rolling llama.cpp compatibility gates.
+
+When a model diverges, the X-ray workflow moves from sparse checkpoints to the first failing layer and then to the first failing operation. Fixes belong in a circuit, kernel map, or tested kernel, not as a special case in the DSL.
+
+Read the [numerical contract architecture](https://c-kernel-engine.github.io/C-Kernel-Engine/v8-numerical-contracts.html) and [divergence harness guide](https://c-kernel-engine.github.io/C-Kernel-Engine/divergence-harness.html) for the method.
+
+## Performance Method
+
+CKE optimization separates kernel throughput from model throughput. The workflow is:
+
+1. Establish numerical parity and a repeatable baseline.
+2. Measure prefill and decode independently.
+3. Profile the real model path, not only a synthetic loop.
+4. Isolate the dominant kernel at a practical shape.
+5. Inspect SIMD width, instruction mix, reduction structure, cache behavior, and thread utilization.
+6. Change one implementation detail and remeasure both the kernel and end-to-end model.
+7. Preserve the gain with numerical and performance evidence.
+
+The goal is not to publish a theoretical peak as an achieved result. The goal is to explain the gap and close it stage by stage. See the [kernel tuning methodology](https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html), [profiling guide](https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html), and [prefill roadmap](https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html).
+
+## Quick Start
+
+Linux is the supported development and profiling environment.
+
+```bash
+git clone --recurse-submodules https://github.com/C-Kernel-Engine/C-Kernel-Engine.git
+cd C-Kernel-Engine
+
+./scripts/setup-dev-env.sh
+./scripts/setup-hooks.sh
+make
+```
+
+Run the compiler and contract gates:
+
+```bash
+make test-v8-dsl
+make v7-kernel-parity-train
+```
+
+Run a v8 model through conversion, compilation, and chat. This command downloads the model on first use:
+
+```bash
+version/v8/scripts/cks-v8-run run \
+  hf://unsloth/gemma-3-270m-it-GGUF/gemma-3-270m-it-Q5_K_M.gguf \
+  --context-len 1024 \
+  --generate-visualizer
+```
+
+Start with the [quickstart](https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html), [v8 runbook](https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html), or [v7 training runbook](https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html).
+
+## Generated Runtime Capabilities
+
+Depending on the circuit and model lane, generated `libmodel.so` runtimes can provide:
+
+- Prompt prefill over full token batches.
+- Autoregressive decode with per-layer KV cache.
+- Quantized and floating-point kernel paths selected by explicit capability.
+- FP32 teacher-forced forward/backward for supported v7 training circuits.
+- Bounded semantic tensor exports for parity attribution.
+- IR and memory visualizations for inspecting the generated program.
+
+## Contributing
+
+Useful contributions include:
+
+- A numerically justified kernel capability and independent oracle test.
+- A circuit definition that introduces no compiler model-name branch.
+- llama.cpp or PyTorch parity adapters at a canonical tensor boundary.
+- Reproducible VTune, Advisor, perf, assembly, or cache-analysis evidence.
+- Model fixtures and regression cases that expose a real failure mode.
+- Documentation that clearly separates measured support from planned work.
+
+Run the repository hooks before opening a pull request:
 
 ```bash
 ./scripts/setup-hooks.sh
 ```
 
-This enables:
-- `pre-commit`: runs `make regression-fast` when staged changes touch runtime/regression paths
-- `pre-push`: runs the heavier build/parity/e2e gate, plus scoped `regression-fast` and `v6.6` compatibility only when pushed files affect those paths
+The pre-commit hook runs scoped staged regressions. The pre-push hook runs the heavier build, parity, inference, and training gates when relevant.
+
+## Engineering and Consulting
+
+CKE is also a working laboratory for CPU AI systems engineering. If your team needs help with:
+
+- CPU inference or training architecture.
+- Quantized GEMM/GEMV, attention, or fusion kernels.
+- Numerical parity and first-divergence attribution.
+- Model conversion, generated runtimes, or deterministic memory planning.
+- Thread-pool, SIMD, cache, NUMA, or roofline optimization.
+- Intel VTune/Advisor or Linux perf investigation.
+- Building an evidence-backed CPU deployment or distributed-compute plan.
+
+open a focused [GitHub issue](https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues) for reproducible project work, or connect through [Antsand](https://antsand.com) for consulting and collaboration.
+
+## Project Principles
+
+- Evidence over benchmark theater.
+- Correctness before optimization.
+- Exact contracts instead of silent fallback.
+- Generated code that engineers can inspect.
+- Practical model shapes instead of toy-only claims.
+- Performance changes must survive end-to-end testing.
+- Planned work is labeled as planned.
+
+The cover image was generated with Google Gemini.

--- a/docs/site/_pages/version-history.html
+++ b/docs/site/_pages/version-history.html
@@ -247,7 +247,7 @@
       <div class="arch-node-dot"></div>
     </div>
     <div class="arch-arrow-right">→</div>
-    <div class="arch-node">
+    <div class="arch-node current">
       <div class="arch-node-badge arch-v8">v8-9</div>
       <div class="arch-node-label">Vision</div>
       <div class="arch-node-dot"></div>
@@ -811,6 +811,49 @@
     }
   </script>
 
+  <h2>Current Execution Order</h2>
+  <p style="color: var(--text-secondary);">
+    New model families are added only after their mathematical requirements can be expressed by circuits and
+    resolved exactly through kernel capabilities. The compiler emits the resolved decision; it does not infer a
+    model-specific fallback. This keeps correctness work reusable across text, vision, and audio.
+  </p>
+  <table class="roadmap-table">
+    <thead>
+      <tr>
+        <th>Order</th>
+        <th>Workstream</th>
+        <th>Exit Gate</th>
+        <th>State</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td><strong>v8 compiler and numerical hardening</strong><br>Circuits, kernel maps, exact resolution, bounded X-ray attribution, and zero model-family dispatch in protected compiler paths.</td>
+        <td>Supported text and vision circuits compile deterministically; incompatible or ambiguous capabilities hard-fail; stitched and end-to-end regressions remain clean.</td>
+        <td><span class="version-status status-building">Active</span></td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td><strong>Qwen3-VL parity closure</strong><br>Encoder checkpoints, mixed prefill, teacher-forced decode, and persistent decode against llama.cpp and PyTorch references.</td>
+        <td>First-divergence reports advance through every remaining boundary and each fix is retained by a numerical contract plus nightly coverage.</td>
+        <td><span class="version-status status-building">Active</span></td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td><strong>Whisper tiny/base inference</strong><br>PCM/WAV, resampling, STFT, log-Mel, Conv1D encoder stem, bidirectional encoder attention, decoder cross-attention, and audio token semantics.</td>
+        <td>Fixed public audio fixtures match PyTorch and whisper.cpp at frontend, encoder, mixed-prefill, and transcript boundaries before quantized optimization.</td>
+        <td><span class="version-status status-planned">Next</span></td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td><strong>Audio performance and FP32 training</strong><br>Encoder tiling/threading, cached cross-attention K/V, then Conv1D and cross-attention backward in v7.</td>
+        <td>Inference parity is stable; performance evidence separates frontend, encoder, and autoregressive decode; FP32 backward matches PyTorch.</td>
+        <td><span class="version-status status-planned">Gated</span></td>
+      </tr>
+    </tbody>
+  </table>
+
   <!-- Detailed Roadmap Table -->
   <h2>Detailed Roadmap</h2>
   <table class="roadmap-table">
@@ -854,30 +897,30 @@
       </tr>
       <tr>
         <td><strong>v8.0</strong></td>
-        <td>Vision Encoder</td>
-        <td>Patch embedding lowering, image positional encoding, ViT support, and block-local multimodal stitching groundwork</td>
+        <td>Inference Compiler + Vision Encoder</td>
+        <td>Circuit-owned topology and weight policy, fail-closed kernel capability resolution, explicit numerical and threading contracts, GraphIR-to-call-IR decision preservation, bounded X-ray attribution, patch embedding, resized position encoding, M-RoPE, deepstack, and multimodal stitching</td>
         <td>v7.x training</td>
         <td><span class="version-status status-building">Building</span></td>
       </tr>
       <tr>
         <td><strong>v9.0</strong></td>
-        <td>Vision Training</td>
-        <td>Backward through vision encoder, image classification fine-tuning</td>
+        <td>Vision Parity + Training</td>
+        <td>Qwen3-VL encoder, mixed-prefill, teacher-forced and persistent-decode parity; then FP32 backward through vision encoder and image fine-tuning</td>
         <td>v8.0</td>
         <td><span class="version-status status-planned">Planned</span></td>
       </tr>
       <tr>
         <td><strong>v10.0</strong></td>
-        <td>Audio Encoder</td>
-        <td>Conformer/Whisper-style encoder, spectrogram preprocessing</td>
-        <td>v7.x training</td>
+        <td>Audio Inference</td>
+        <td>Whisper tiny/base first: PCM/WAV ingestion, resampling, STFT and log-Mel preprocessing, Conv1D stem, bidirectional encoder, cached encoder-decoder cross-attention, and transcript parity</td>
+        <td>v8 exact resolution + X-ray gates</td>
         <td><span class="version-status status-planned">Planned</span></td>
       </tr>
       <tr>
         <td><strong>v11.0</strong></td>
         <td>Audio Training</td>
-        <td>Backward through audio encoder, speech recognition training</td>
-        <td>v10.0</td>
+        <td>FP32 Conv1D, encoder-attention and cross-attention backward; speech recognition training after inference parity. Log-Mel remains fixed preprocessing initially.</td>
+        <td>v10.0 inference parity</td>
         <td><span class="version-status status-planned">Planned</span></td>
       </tr>
       <tr>
@@ -1449,11 +1492,11 @@
     Version numbers follow this convention:
   </p>
   <ul style="color: var(--text-secondary);">
-    <li><strong>Current priority (2026):</strong> Complete v7.x training sign-off while actively bringing up v8.x vision inference foundations before opening v15 implementation</li>
+    <li><strong>Current priority (2026):</strong> Keep v7 FP32 training parity stable, finish v8 fail-closed compiler and Qwen3-VL numerical hardening, then bring up Whisper tiny/base inference through the same circuit and kernel-contract path</li>
     <li><strong>v6.x:</strong> Inference-only (forward pass)</li>
     <li><strong>v7.x:</strong> Training foundation (forward + backward)</li>
-    <li><strong>v8.x:</strong> Vision encoding and image training foundations, now in active bring-up</li>
-    <li><strong>v10.x:</strong> Audio encoding and audio training foundations</li>
+    <li><strong>v8.x:</strong> Deterministic inference compiler, numerical contracts, X-ray attribution, and vision encoding, now in active hardening</li>
+    <li><strong>v10.x:</strong> Whisper-style audio inference after v8 contract and parity gates; FP32 audio training follows in v11</li>
     <li><strong>v12.x:</strong> MoE architecture (efficient large models)</li>
     <li><strong>v14.x:</strong> Parameter-efficient fine-tuning (LoRA)</li>
     <li><strong>v15.x:</strong> Embedded AI inference on constrained hardware (enabled by v1-v14 groundwork)</li>


### PR DESCRIPTION
## Why\n\nThe repository entry point still described CKE as a small kernel experiment, while the public roadmap understated the v8 compiler, numerical-contract, X-ray, and Qwen3-VL hardening now in progress. The project needs one accurate explanation of its CPU-first thesis, current evidence, support boundaries, and path to audio.\n\n## What\n\n- Rewrite the README around the CPU AI thesis and generated-runtime architecture.\n- Explain circuits, exact kernel capabilities, fail-closed DSL resolution, IR lowering, and generated C.\n- Document layered numerical parity and profiler-driven performance methodology.\n- Add an honest current-scope table and practical quickstart.\n- Add contribution rules and an engineering/consulting contact path through Antsand.\n- Mark v8 vision/compiler work as active alongside v7 FP32 training.\n- Add an ordered roadmap with explicit exit gates.\n- Define Whisper tiny/base as the first audio inference target after v8 hardening.\n\n## Validation\n\n- docs/site/build.sh rendered the revised version-history page.\n- Referenced local documentation pages and Make targets exist.\n- git diff --check passed.\n- Pre-push build, Gemma3 v8 E2E, inference contracts, v7 training smoke, and v7 training-kernel parity passed.