### PR TITLE
docs(readme): connect ShivasNotes to CKE implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@
 
 C-Kernel-Engine (CKE) is a C-first compiler, kernel library, and runtime for transformer inference and training on CPUs. It turns model weights, explicit circuits, and kernel capability maps into inspectable generated C rather than hiding execution behind a general-purpose framework.
 
+New to the project? Start with [What Is the C Kernel Engine?](https://www.shivasnotes.com/blog/5889/What-Is-the-C-Kernel-Engine), then use this README as the map from the ideas to the [documentation](https://c-kernel-engine.github.io/C-Kernel-Engine/) and [source code](https://github.com/C-Kernel-Engine/C-Kernel-Engine).
+
 The project is built around a practical thesis:
 
 > A CPU AI system becomes competitive by making the complete model circuit explicit, proving its numerical behavior, and methodically moving every important stage toward the hardware roofline.
 
 CKE is not only a collection of fast GEMMs. It is an attempt to connect model architecture, numerical semantics, code generation, memory planning, threading, parity testing, and profiler evidence into one reproducible system.
+
+The longer argument behind that direction is documented in [the CPU and smaller-model strategic bet](https://www.shivasnotes.com/blog/5878/Why-I-Stopped-Getting-High-on-the-Newer-AI-Models-And-Why-My-Strategic-Bet-Is-Still-Consistent-CPUs-Smaller-Models-and-Less-Compute-Will-Win) and the project origin story, [Unimporting PyTorch](https://www.shivasnotes.com/blog/5872/Unimporting-PyTorch-How-Constraint-and-Curiosity-Built-a-C-Kernel-Engine).
 
 ## Why CKE Exists
 
@@ -26,6 +30,8 @@ CKE addresses that problem at several levels:
 - **Numerical evidence:** Leaf kernels, stitched layers, mixed prefill, teacher-forced decode, and end-to-end outputs are compared with independent references such as llama.cpp and PyTorch.
 - **Performance evidence:** Linux perf, Intel VTune, Intel Advisor roofline analysis, assembly inspection, and focused microbenchmarks identify where cycles and bandwidth are actually spent.
 - **One CPU path from kernels to systems:** The long-term direction is efficient single-node execution followed by distributed CPU inference and training without surrendering observability.
+
+For deeper context, read [v8 IR Pipeline Codegen](https://www.shivasnotes.com/blog/5917/v8-IR-Pipeline-Codegen-How-CKE-Hardens-Pure-C-Inference), [Templates Are Circuit Maps](https://www.shivasnotes.com/blog/5934/Templates-Are-Circuit-Maps-How-CKE-Describes-A-Model-Family), and the [architecture documentation](https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html).
 
 ## How It Works
 
@@ -59,6 +65,15 @@ The ownership boundary is deliberate:
 
 This separation is enforced by tests that reject new model-family dispatch in protected compiler paths and reject unsupported or ambiguous numerical contracts.
 
+Inspect the implementation directly:
+
+- [v8 circuits](version/v8/circuits/) define supported model-family graphs and requirements.
+- [v8 kernel maps](version/v8/kernel_maps/) bind exact operations to executable capabilities.
+- [v8 compiler scripts](version/v8/scripts/) parse, validate, lower, and generate C.
+- [C kernels](src/kernels/) implement the numerical and performance primitives.
+- [v7 training](version/v7/) owns the current FP32 forward/backward path.
+- [Tests](tests/) and [kernel unit tests](unittest/) preserve compiler, circuit, and numerical behavior.
+
 ## Current Scope
 
 | Area | Current state |
@@ -71,6 +86,23 @@ This separation is enforced by tests that reject new model-family dispatch in pr
 | Distributed CPU | Architectural direction and research target; not yet a completed production runtime |
 
 For the detailed support surface, see the [model and kernel matrix](https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html), [test report](https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html), and [roadmap](https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html).
+
+## Read the Work
+
+The articles explain the motivation and math; the documentation records the supported method; the source shows the current implementation.
+
+| Topic | ShivasNotes | Technical reference | Source |
+|---|---|---|---|
+| Project overview | [What Is the C Kernel Engine?](https://www.shivasnotes.com/blog/5889/What-Is-the-C-Kernel-Engine) | [Concepts](https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html) | [Repository](https://github.com/C-Kernel-Engine/C-Kernel-Engine) |
+| Compiler and generated C | [v8 IR Pipeline Codegen](https://www.shivasnotes.com/blog/5917/v8-IR-Pipeline-Codegen-How-CKE-Hardens-Pure-C-Inference) | [IR pipeline](https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html) | [v8 compiler](version/v8/scripts/) |
+| Model circuits | [Templates Are Circuit Maps](https://www.shivasnotes.com/blog/5934/Templates-Are-Circuit-Maps-How-CKE-Describes-A-Model-Family) | [Numerical contracts](https://c-kernel-engine.github.io/C-Kernel-Engine/v8-numerical-contracts.html) | [Circuits](version/v8/circuits/) and [kernel maps](version/v8/kernel_maps/) |
+| GGUF and model materialization | [GGUF: The File Format That Made Local LLMs Practical](https://www.shivasnotes.com/blog/5933/GGUF-The-File-Format-That-Made-Local-LLMs-Practical) | [GGUF to BUMP](https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html) | [Conversion scripts](version/v8/scripts/) |
+| Quantized kernels | [K-Quants Deep Dive](https://www.shivasnotes.com/blog/5925/K-Quants-Deep-Dive-Q4-K-Q5-K-Q6-K-Q8-K-And-Mixed-Dot-Products) | [Quant formats](https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html) | [Quantized kernels](src/kernels/) |
+| Runtime ownership | [Threadpools and Memory Pools](https://www.shivasnotes.com/blog/5924/Threadpools-And-Memory-Pools-Why-CKE-Needs-Runtime-Ownership-For-CPU-AI-Kernels) | [Thread-pool design](https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html) | [Thread pool](src/ck_threadpool.c) and [allocator](src/ckernel_alloc.c) |
+| Performance engineering | [CPU Rooflines, Flamegraphs, VTune, and Perf Gates](https://www.shivasnotes.com/blog/5915/CPU-Performance-Engineering-for-AI-Rooflines-Flamegraphs-VTune-and-Perf-Gates) | [Kernel tuning methodology](https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html) | [Benchmarks](benchmarks/) and [profiling scripts](scripts/) |
+| Distributed CPU AI | [MPI, RDMA, NUMA, and CKE](https://www.shivasnotes.com/blog/5922/Distributed-CPU-AI-MPI-RDMA-NUMA-and-C-Kernel-Engine) and [Pipeline vs Tensor Parallelism](https://www.shivasnotes.com/blog/5923/Pipeline-vs-Tensor-Parallelism-How-CKE-Splits-AI-Across-CPU-Nodes) | [Scaling architecture](https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html) | [Scaling roadmap](docs/site/_pages/scaling.html) |
+| Gemma4 architecture | [Four Attention Paths, Shared KV, and Sliding Windows](https://www.shivasnotes.com/blog/5935/Gemma4-In-CKE-Four-Attention-Paths-Shared-KV-And-Sliding-Windows) | [Gemma4 speculative pair](https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html) | [Gemma4 circuit](version/v8/circuits/gemma4.json) |
+| Audio roadmap | [How Audio Transformers Work](https://www.shivasnotes.com/blog/5928/How-Audio-Transformers-Work-The-Encoder-Path-Whisper-Timestamps-And-Why-Audio-Is-Not-A-VLM-Patch) | [Execution roadmap](https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html) | Audio circuit and kernels are planned after the v8 hardening gate |
 
 ## Correctness Before Speed
 
@@ -101,6 +133,8 @@ CKE optimization separates kernel throughput from model throughput. The workflow
 7. Preserve the gain with numerical and performance evidence.
 
 The goal is not to publish a theoretical peak as an achieved result. The goal is to explain the gap and close it stage by stage. See the [kernel tuning methodology](https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html), [profiling guide](https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html), and [prefill roadmap](https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html).
+
+The optimization strategy also follows [Amdahl's Law and the Theory of Constraints](https://www.shivasnotes.com/blog/5932/Amdahl-s-Law-Theory-Of-Constraints-And-C-Kernel-Engine-Optimization): improve the measured system constraint, then profile again instead of assuming the previous hotspot still dominates.
 
 ## Quick Start
 


### PR DESCRIPTION
## Why

The strengthened README explains CKE, but readers also need a direct path from the ShivasNotes articles to the corresponding technical documentation and source code.

## What

- Link the CKE overview, origin story, and CPU strategy from the README introduction.
- Add a curated Read the Work map covering IR/codegen, circuit maps, GGUF, K-quants, runtime ownership, profiling, distributed scaling, Gemma4, and Whisper.
- Pair each article with its relevant docs page and implementation directory or source file.
- Link the Amdahl's Law and Theory of Constraints article from the performance method.

## Validation

- All 14 linked ShivasNotes articles return HTTP 200.
- Referenced local source paths exist.
- git diff --check passes.
- Pre-push build, Gemma3 v8 E2E, inference contracts, v7 training smoke, and v7 training-kernel parity passed.