### PR TITLE
docs(perf): publish cross-hardware evidence matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ The goal is not to publish a theoretical peak as an achieved result. The goal is
 
 The optimization strategy also follows [Amdahl's Law and the Theory of Constraints](https://www.shivasnotes.com/blog/5932/Amdahl-s-Law-Theory-Of-Constraints-And-C-Kernel-Engine-Optimization): improve the measured system constraint, then profile again instead of assuming the previous hotspot still dominates.
 
+## Hardware Evidence Program
+
+CKE is hardened across different CPU classes because one workstation cannot establish portability, numerical stability, or scaling behavior. Current work spans multiple Intel Core i7 generations, a dedicated 14th Gen Core i7-14700T AVX2/AVX-VNNI profiling node, TI TDA4VM ARM/NEON hardware, and external 2nd, 3rd, and 5th Gen Intel Xeon systems. A Xeon 6 workstation is planned for AVX-512, AMX BF16, memory-channel, NUMA, and distributed experiments.
+
+| Hardware lane | ISA and dtype role | Evidence status |
+|---|---|---|
+| Intel Core i7, multiple generations | FP32 and quantized commodity x86 compatibility, practical model runs, compiler and regression testing | Active |
+| Intel Core i7-14700T | AVX2/FMA/AVX-VNNI FP32 and Q4/Q5/Q6/Q8 profiling with VTune, Advisor, perf, flamegraphs, assembly, thread-pool, and roofline evidence; no native BF16 claim | Active profiling node |
+| TI TDA4VM ARM | FP32 and quantized ARM NEON portability under embedded memory and power constraints | Active portability lane |
+| Intel Xeon, 2nd/3rd/5th Gen | FP32 and quantized AVX-512/VNNI where available; native BF16/AMX only on hosts that expose those ISA features; larger-memory parity and cross-generation behavior | External validation lanes |
+| Intel Xeon 6 | Planned native AMX BF16, AVX-512/VNNI, wider memory/NUMA studies, sustained power, and multi-node scaling | Planned; no results claimed yet |
+
+Hardware coverage does not mean every model, dtype, quantization, and gate has passed on every host. Every published result should identify the CPU, detected ISA flags, storage and compute dtype, memory topology, compiler, CKE commit, model and quantization, prompt or tensor shape, thread/affinity policy, warmup/repeats, and profiler mode. Intel systems use VTune and Advisor where available; Linux perf, flamegraphs, assembly inspection, parity tests, and end-to-end workloads provide the common evidence path across vendors and ISAs.
+
+Future performance articles and release notes should use this matrix, label active versus planned hardware, link raw profiler or benchmark artifacts, and avoid extrapolating one host's result to another CPU generation.
+
 ## Quick Start
 
 Linux is the supported development and profiling environment.

--- a/docs/site/_pages/index.html
+++ b/docs/site/_pages/index.html
@@ -431,6 +431,30 @@
 ═══════════════════════════════════════════════════════════════════════ -->
 <h2>Performance</h2>
 
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Measured Across CPU Classes</h3>
+    <p>CKE performance engineering combines numerical parity, practical end-to-end workloads, Linux <code>perf</code>, flamegraphs, assembly inspection, Intel VTune, and Intel Advisor roofline analysis. The objective is to explain the distance from each machine's useful hardware limits and close it kernel by kernel, not to infer efficiency from peak FLOPS or CPU utilization alone.</p>
+    <table class="pillar-evidence">
+        <tr>
+            <td>Intel Core i7</td>
+            <td>Multiple-generation FP32 and quantized compatibility work, including a dedicated 14th Gen Core i7-14700T AVX2/FMA/AVX-VNNI profiling node. Native BF16 is not claimed on this host.</td>
+        </tr>
+        <tr>
+            <td>TI TDA4VM ARM</td>
+            <td>FP32 and quantized ARM NEON portability under embedded memory and power constraints.</td>
+        </tr>
+        <tr>
+            <td>Intel Xeon</td>
+            <td>External 2nd, 3rd, and 5th Gen validation lanes for FP32/quantized AVX-512 and VNNI where available, plus native BF16/AMX only when the host exposes those features.</td>
+        </tr>
+        <tr>
+            <td>Xeon 6</td>
+            <td>Planned native AMX BF16, AVX-512/VNNI, memory-channel, NUMA, power, and distributed-node laboratory. No Xeon 6 result is claimed yet.</td>
+        </tr>
+    </table>
+    <p style="margin-bottom: 0;">Coverage is reported per host, detected ISA, dtype, and workload; it does not imply every model passes every gate on every CPU. <a href="kernel-tuning-methodology.html">Read the tuning methodology</a> or <a href="profiling.html">reproduce the profiling lanes</a>.</p>
+</div>
+
 <div class="grid grid-2" style="gap: 1rem;">
     <div class="card">
         <h3 style="margin-top: 0;">Profiling + SIMD</h3>
@@ -581,7 +605,7 @@
 cd C-Kernel-Engine
 make                  # builds build/libckernel_engine.so
 make test             # runs all kernel parity tests vs PyTorch</pre>
-    <p style="color: var(--text-muted); font-size: 0.88rem; margin-bottom: 0;">Requires Linux, GCC, Python 3 + PyTorch for parity tests. AVX2 minimum; AVX-512 recommended.</p>
+    <p style="color: var(--text-muted); font-size: 0.88rem; margin-bottom: 0;">Requires Linux, a supported C toolchain, and Python 3 + PyTorch for parity tests. AVX2 is the current x86 production baseline; ARM NEON is an active portability lane; AVX-512, VNNI, BF16, and AMX paths are enabled only where the host supports them.</p>
 </div>
 
 <div class="grid grid-2" style="gap: 1rem; margin-top: 1rem;">

--- a/docs/site/_pages/kernel-tuning-methodology.html
+++ b/docs/site/_pages/kernel-tuning-methodology.html
@@ -200,6 +200,70 @@ path, weight reuse, quantized GEMM dispatch, thread scheduling, and cache behavi
     </tbody>
 </table>
 
+<h2>Cross-Hardware Evidence Matrix</h2>
+
+<p>A kernel is not "CPU optimized" because it performed well on one host. CKE uses several hardware lanes to separate
+portable mathematics from ISA-specific implementation quality, heterogeneous scheduling, memory topology, and
+server-scale behavior.</p>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Hardware Lane</th>
+            <th>Primary Question</th>
+            <th>Tools and Evidence</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Intel Core i7, multiple generations</td>
+            <td>Do FP32 and quantized generated runtimes remain useful on commodity x86 systems?</td>
+            <td>Practical E2E, fixed-token throughput, parity, compiler and ISA inspection.</td>
+            <td>Active</td>
+        </tr>
+        <tr>
+            <td>Core i7-14700T</td>
+            <td>How close can AVX2/FMA/AVX-VNNI FP32 and Q4/Q5/Q6/Q8 kernels get to the useful roofline on a hybrid 8P + 12E CPU? Native BF16 is not claimed.</td>
+            <td>VTune hotspots/uarch/memory/threading, Advisor roofline, perf, flamegraphs, assembly, frequency and utilization.</td>
+            <td>Dedicated profiling node</td>
+        </tr>
+        <tr>
+            <td>TI TDA4VM ARM</td>
+            <td>Are FP32 and quantized contracts and kernels portable to ARM NEON and realistic embedded constraints?</td>
+            <td>Build and kernel parity, NEON path inspection, constrained-memory and practical runtime checks.</td>
+            <td>Active portability lane</td>
+        </tr>
+        <tr>
+            <td>Intel Xeon, 2nd/3rd/5th Gen</td>
+            <td>How do FP32/quantized AVX-512/VNNI and host-gated native BF16/AMX availability affect parity and throughput across generations?</td>
+            <td>ISA-appropriate kernel tests, model parity, larger artifacts, profiler summaries, and cross-generation comparisons.</td>
+            <td>External validation lanes</td>
+        </tr>
+        <tr>
+            <td>Intel Xeon 6</td>
+            <td>What do native AMX BF16, AVX-512/VNNI, wider memory systems, NUMA placement, sustained power, and multiple nodes enable?</td>
+            <td>Planned VTune/Advisor, native BF16, memory-channel roofline, NUMA, power, and distributed CKU experiments.</td>
+            <td>Planned; not measured</td>
+        </tr>
+    </tbody>
+</table>
+
+<div class="alert alert-warning">
+    <strong>Coverage is workload-specific.</strong> A platform row does not certify every model, dtype, quantization, or
+    context length. Publish the host, CPU and detected ISA flags, storage/compute dtype, memory topology, compiler, CKE commit, model hash, quantization,
+    prompt or tensor shape, thread/affinity policy, warmup/repeats, power/frequency state, raw command, and artifact path.
+</div>
+
+<h3>Publication Contract</h3>
+<ul class="check-list">
+    <li>Label the hardware lane as active, external, or planned; planned hardware has no benchmark result.</li>
+    <li>Separate portable numerical evidence from ISA-specific throughput evidence.</li>
+    <li>Compare before/after and reference runtimes on the same host with equivalent model and workload settings.</li>
+    <li>Link raw commands, logs, profiler output, and the CKE commit behind every published performance table.</li>
+    <li>Do not extrapolate one Core, Xeon, or ARM result to another generation without running that lane.</li>
+</ul>
+
 <h2>How To Read The Signals</h2>
 
 <table class="phase-table">


### PR DESCRIPTION
## Why

CKE uses rigorous Linux and Intel profiling across several CPU classes, but the homepage did not explain which hardware lanes exist, which dtype/ISA each lane validates, or how performance claims are promoted.

## What

- Add a visible hardware evidence program to the README.
- Add a cross-hardware section to the main documentation page.
- Add the canonical matrix and publication contract to the kernel tuning methodology.
- Document Intel Core i7 FP32/quantized AVX2/FMA/AVX-VNNI work.
- Document TI TDA4VM FP32/quantized ARM NEON portability.
- Document 2nd/3rd/5th Gen Xeon AVX-512/VNNI and host-gated BF16/AMX validation.
- Mark Xeon 6 AMX BF16, NUMA, power, and distributed work as planned with no result claimed.
- Require exact host, ISA, dtype, model, workload, threading, compiler, and profiler metadata for published results.

## Validation

- docs/site/build.sh rendered the updated pages; its existing optional local training-manifest warning remained non-fatal.
- git diff --check passed.
- Pre-push build, Gemma3 v8 E2E, inference contracts, v7 training smoke, and v7 training-kernel parity passed.