### PR TITLE
refactor(v8/codegen): consume resolved Q4 Q6 capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2963,6 +2963,7 @@ test-v8-dsl-policy:
 	@$(PYTHON) version/v8/scripts/audit_dsl_policy_v8.py --json-out build/v8/dsl_policy_report.json
 	@$(PYTHON) -m unittest tests.test_v8_dsl_policy -v
 	@$(PYTHON) -m unittest tests.test_v8_kernel_call_abi -v
+	@$(PYTHON) -m unittest tests.test_v8_codegen_capabilities -v
 
 test-v8-dsl: test-v8-dsl-policy test-numerical-contracts test-v8-template-circuit-audit
 

--- a/Makefile
+++ b/Makefile
@@ -2964,6 +2964,7 @@ test-v8-dsl-policy:
 	@$(PYTHON) -m unittest tests.test_v8_dsl_policy -v
 	@$(PYTHON) -m unittest tests.test_v8_kernel_call_abi -v
 	@$(PYTHON) -m unittest tests.test_v8_codegen_capabilities -v
+	@$(PYTHON) -m unittest tests.test_v8_dsl_nightly_registration -v
 
 test-v8-dsl: test-v8-dsl-policy test-numerical-contracts test-v8-template-circuit-audit
 

--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -751,6 +751,10 @@
       </ul>
     </li>
     <li><strong>Kernel Unit Tests</strong>: Individual kernel parity with PyTorch</li>
+    <li><strong>v8 DSL and Codegen Contracts</strong>: The aggregate <code>make test-v8-dsl</code> gate is reported as three
+      independently visible nightly rows so a failure identifies the responsible layer: <code>test-v8-dsl-policy</code> enforces
+      zero model/provider hardcoding and map-owned codegen capabilities, <code>test-numerical-contracts</code> validates resolved
+      numerical execution semantics, and <code>test-v8-template-circuit-audit</code> verifies circuit dataflow and lowered bindings.</li>
     <li><strong>v8 Vision Kernel Parity</strong>: Vision kernel parity for patch extraction/reconstruction, tiled position embeddings,
       Qwen3-VL resized position interpolation order, spatial merge/reorder, feature concat/slice, and vision M-RoPE
       (<code>make test-v8-vision-kernels</code>)</li>

--- a/docs/site/_pages/test-report.html
+++ b/docs/site/_pages/test-report.html
@@ -401,6 +401,27 @@
       </div>
     </div>
 
+    <div class="regression-section" id="v8-dsl-contract-dashboard">
+      <h2>v8 DSL &amp; Compiler Contracts</h2>
+      <p class="regression-meta" id="v8-dsl-contract-meta">
+        Waiting for the three nightly rows that compose <code>make test-v8-dsl</code>.
+      </p>
+
+      <div class="summary-cards" style="margin: 0 0 1rem 0;">
+        <div class="summary-card"><div class="value" id="v8-dsl-contract-status">-</div><div class="label">Overall</div></div>
+        <div class="summary-card"><div class="value" id="v8-dsl-policy-status">-</div><div class="label">Zero Hardcoding</div></div>
+        <div class="summary-card"><div class="value" id="v8-dsl-numerical-status">-</div><div class="label">Numerical</div></div>
+        <div class="summary-card"><div class="value" id="v8-dsl-circuit-status">-</div><div class="label">Circuit/Dataflow</div></div>
+      </div>
+
+      <table class="results-table">
+        <thead><tr><th>Status</th><th>Nightly Row</th><th>Local Target</th><th>Duration</th></tr></thead>
+        <tbody id="v8-dsl-contract-tbody">
+          <tr><td colspan="4" class="updated-time">No DSL contract rows published in this report.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
     <div class="regression-section">
       <h2>Visualizer Contract Matrix</h2>
       <p class="regression-meta">
@@ -1097,6 +1118,7 @@ function renderResults(data) {
   document.getElementById('sub-tests-failed').textContent = subFailed;
   renderRegressionFast(data.regression_fast || null);
   renderArchitectureContracts(data.architecture_contracts || null);
+  renderV8DSLContracts(data.results || []);
   renderVisionEncoderAccuracy(data.vision_encoder_accuracy || null);
   renderVisionVisualizer(data.vision_visualizer || null);
   renderKernelMapContracts(data.kernel_map_contracts || null);
@@ -1242,6 +1264,48 @@ function contractBadge(status) {
   const cls = s === 'pass' ? 'pass' : s === 'fail' ? 'fail' : 'skip';
   const text = s === 'pass' ? 'PASS' : s === 'fail' ? 'FAIL' : s === 'warn' ? 'WARN' : s === 'partial' ? 'PARTIAL' : 'N/R';
   return `<span class="regression-badge ${cls}">${text}</span>`;
+}
+
+function renderV8DSLContracts(results) {
+  const definitions = [
+    {name: 'v8 DSL Zero-Hardcoding Policy', target: 'test-v8-dsl-policy', statusId: 'v8-dsl-policy-status'},
+    {name: 'v8 Numerical Kernel Contracts', target: 'test-numerical-contracts', statusId: 'v8-dsl-numerical-status'},
+    {name: 'v8 Template Circuit/Dataflow Audit', target: 'test-v8-template-circuit-audit', statusId: 'v8-dsl-circuit-status'},
+  ];
+  const byName = new Map((Array.isArray(results) ? results : []).map(row => [row.name, row]));
+  const rows = definitions.map(definition => ({...definition, result: byName.get(definition.name)}));
+  const published = rows.filter(row => row.result);
+  const statuses = published.map(row => String(row.result.status || 'skip').toLowerCase());
+  const overall = published.length !== definitions.length
+    ? 'PARTIAL'
+    : statuses.some(status => status === 'fail' || status === 'timeout')
+      ? 'FAIL'
+      : statuses.every(status => status === 'pass') ? 'PASS' : 'PARTIAL';
+
+  const overallEl = document.getElementById('v8-dsl-contract-status');
+  overallEl.textContent = overall;
+  overallEl.className = overall === 'PASS' ? 'value test-pass' : overall === 'FAIL' ? 'value test-fail' : 'value test-skip';
+  document.getElementById('v8-dsl-contract-meta').textContent =
+    `${published.length}/3 component rows published. Monitor this panel for aggregate health; expand the same rows under Test Details for diagnostics.`;
+
+  rows.forEach(row => {
+    const status = row.result ? String(row.result.status || 'skip').toUpperCase() : 'N/R';
+    const element = document.getElementById(row.statusId);
+    element.textContent = status;
+    element.className = status === 'PASS' ? 'value test-pass' : status === 'FAIL' || status === 'TIMEOUT' ? 'value test-fail' : 'value test-skip';
+  });
+
+  document.getElementById('v8-dsl-contract-tbody').innerHTML = rows.map(row => {
+    const status = row.result ? String(row.result.status || 'skip').toUpperCase() : 'N/R';
+    const badgeClass = status === 'PASS' ? 'pass' : status === 'FAIL' || status === 'TIMEOUT' ? 'fail' : 'skip';
+    const duration = row.result && row.result.duration_sec ? `${Number(row.result.duration_sec).toFixed(2)}s` : '-';
+    return `<tr>
+      <td><span class="regression-badge ${badgeClass}">${escapeHtml(status)}</span></td>
+      <td><code>${escapeHtml(row.name)}</code></td>
+      <td><code>make ${escapeHtml(row.target)}</code></td>
+      <td>${duration}</td>
+    </tr>`;
+  }).join('');
 }
 
 function renderVisionEncoderAccuracy(data) {

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1698,6 +1698,10 @@
       </ul>
     </li>
     <li><strong>Kernel Unit Tests</strong>: Individual kernel parity with PyTorch</li>
+    <li><strong>v8 DSL and Codegen Contracts</strong>: The aggregate <code>make test-v8-dsl</code> gate is reported as three
+      independently visible nightly rows so a failure identifies the responsible layer: <code>test-v8-dsl-policy</code> enforces
+      zero model/provider hardcoding and map-owned codegen capabilities, <code>test-numerical-contracts</code> validates resolved
+      numerical execution semantics, and <code>test-v8-template-circuit-audit</code> verifies circuit dataflow and lowered bindings.</li>
     <li><strong>v8 Vision Kernel Parity</strong>: Vision kernel parity for patch extraction/reconstruction, tiled position embeddings,
       Qwen3-VL resized position interpolation order, spatial merge/reorder, feature concat/slice, and vision M-RoPE
       (<code>make test-v8-vision-kernels</code>)</li>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -1348,6 +1348,27 @@
       </div>
     </div>
 
+    <div class="regression-section" id="v8-dsl-contract-dashboard">
+      <h2>v8 DSL &amp; Compiler Contracts</h2>
+      <p class="regression-meta" id="v8-dsl-contract-meta">
+        Waiting for the three nightly rows that compose <code>make test-v8-dsl</code>.
+      </p>
+
+      <div class="summary-cards" style="margin: 0 0 1rem 0;">
+        <div class="summary-card"><div class="value" id="v8-dsl-contract-status">-</div><div class="label">Overall</div></div>
+        <div class="summary-card"><div class="value" id="v8-dsl-policy-status">-</div><div class="label">Zero Hardcoding</div></div>
+        <div class="summary-card"><div class="value" id="v8-dsl-numerical-status">-</div><div class="label">Numerical</div></div>
+        <div class="summary-card"><div class="value" id="v8-dsl-circuit-status">-</div><div class="label">Circuit/Dataflow</div></div>
+      </div>
+
+      <table class="results-table">
+        <thead><tr><th>Status</th><th>Nightly Row</th><th>Local Target</th><th>Duration</th></tr></thead>
+        <tbody id="v8-dsl-contract-tbody">
+          <tr><td colspan="4" class="updated-time">No DSL contract rows published in this report.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
     <div class="regression-section">
       <h2>Visualizer Contract Matrix</h2>
       <p class="regression-meta">
@@ -2044,6 +2065,7 @@ function renderResults(data) {
   document.getElementById('sub-tests-failed').textContent = subFailed;
   renderRegressionFast(data.regression_fast || null);
   renderArchitectureContracts(data.architecture_contracts || null);
+  renderV8DSLContracts(data.results || []);
   renderVisionEncoderAccuracy(data.vision_encoder_accuracy || null);
   renderVisionVisualizer(data.vision_visualizer || null);
   renderKernelMapContracts(data.kernel_map_contracts || null);
@@ -2189,6 +2211,48 @@ function contractBadge(status) {
   const cls = s === 'pass' ? 'pass' : s === 'fail' ? 'fail' : 'skip';
   const text = s === 'pass' ? 'PASS' : s === 'fail' ? 'FAIL' : s === 'warn' ? 'WARN' : s === 'partial' ? 'PARTIAL' : 'N/R';
   return `<span class="regression-badge ${cls}">${text}</span>`;
+}
+
+function renderV8DSLContracts(results) {
+  const definitions = [
+    {name: 'v8 DSL Zero-Hardcoding Policy', target: 'test-v8-dsl-policy', statusId: 'v8-dsl-policy-status'},
+    {name: 'v8 Numerical Kernel Contracts', target: 'test-numerical-contracts', statusId: 'v8-dsl-numerical-status'},
+    {name: 'v8 Template Circuit/Dataflow Audit', target: 'test-v8-template-circuit-audit', statusId: 'v8-dsl-circuit-status'},
+  ];
+  const byName = new Map((Array.isArray(results) ? results : []).map(row => [row.name, row]));
+  const rows = definitions.map(definition => ({...definition, result: byName.get(definition.name)}));
+  const published = rows.filter(row => row.result);
+  const statuses = published.map(row => String(row.result.status || 'skip').toLowerCase());
+  const overall = published.length !== definitions.length
+    ? 'PARTIAL'
+    : statuses.some(status => status === 'fail' || status === 'timeout')
+      ? 'FAIL'
+      : statuses.every(status => status === 'pass') ? 'PASS' : 'PARTIAL';
+
+  const overallEl = document.getElementById('v8-dsl-contract-status');
+  overallEl.textContent = overall;
+  overallEl.className = overall === 'PASS' ? 'value test-pass' : overall === 'FAIL' ? 'value test-fail' : 'value test-skip';
+  document.getElementById('v8-dsl-contract-meta').textContent =
+    `${published.length}/3 component rows published. Monitor this panel for aggregate health; expand the same rows under Test Details for diagnostics.`;
+
+  rows.forEach(row => {
+    const status = row.result ? String(row.result.status || 'skip').toUpperCase() : 'N/R';
+    const element = document.getElementById(row.statusId);
+    element.textContent = status;
+    element.className = status === 'PASS' ? 'value test-pass' : status === 'FAIL' || status === 'TIMEOUT' ? 'value test-fail' : 'value test-skip';
+  });
+
+  document.getElementById('v8-dsl-contract-tbody').innerHTML = rows.map(row => {
+    const status = row.result ? String(row.result.status || 'skip').toUpperCase() : 'N/R';
+    const badgeClass = status === 'PASS' ? 'pass' : status === 'FAIL' || status === 'TIMEOUT' ? 'fail' : 'skip';
+    const duration = row.result && row.result.duration_sec ? `${Number(row.result.duration_sec).toFixed(2)}s` : '-';
+    return `<tr>
+      <td><span class="regression-badge ${badgeClass}">${escapeHtml(status)}</span></td>
+      <td><code>${escapeHtml(row.name)}</code></td>
+      <td><code>make ${escapeHtml(row.target)}</code></td>
+      <td>${duration}</td>
+    </tr>`;
+  }).join('');
 }
 
 function renderVisionEncoderAccuracy(data) {

--- a/tests/test_v8_codegen_bridge.py
+++ b/tests/test_v8_codegen_bridge.py
@@ -277,6 +277,14 @@ class V8CodegenBridgeTests(unittest.TestCase):
             "gemv_q4_k_q8_k_ref",
         )
         self.assertEqual(
+            by_op["q_proj"][0]["resolved_execution"]["implementation"]["weight_storage"],
+            {"format": "q4_k", "block_elements": 256, "block_bytes": 144},
+        )
+        self.assertEqual(
+            by_op["mlp_down"][0]["resolved_execution"]["implementation"]["weight_storage"],
+            {"format": "q6_k", "block_elements": 256, "block_bytes": 210},
+        )
+        self.assertEqual(
             by_op["mlp_down"][0]["resolved_execution"]["numerical_contract"],
             "q6_k_x_q8_k_fp32_block_order",
         )
@@ -333,6 +341,14 @@ class V8CodegenBridgeTests(unittest.TestCase):
             self.assertEqual(
                 q_proj_call["resolved_execution"]["production"]["threaded_function"],
                 "gemv_q4_k_q8_k_parallel_dispatch",
+            )
+            self.assertEqual(
+                q_proj_call["resolved_execution"]["implementation"]["diagnostic_providers"],
+                {"fp32_activation": "gemv_q4_k"},
+            )
+            self.assertEqual(
+                mlp_down_call["resolved_execution"]["implementation"]["diagnostic_providers"],
+                {"fp32_activation": "gemv_q6_k"},
             )
             arg_map = {arg["name"]: arg["expr"] for arg in rope_call["args"]}
             self.assertEqual(arg_map["pos_offset"], "model->rope_pos")

--- a/tests/test_v8_codegen_capabilities.py
+++ b/tests/test_v8_codegen_capabilities.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "version" / "v8" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+core = _load("codegen_core_v8_capability_tests", SCRIPTS / "codegen_core_v8.py")
+prefill = _load("codegen_prefill_v8_capability_tests", SCRIPTS / "codegen_prefill_v8.py")
+resolver = _load(
+    "resolve_attention_contracts_v8_capability_tests",
+    SCRIPTS / "resolve_attention_contracts_v8.py",
+)
+
+GOVERNED_SYMBOLS = {
+    "gemv_q4_k_q8_k",
+    "gemv_q6_k_q8_k",
+    "gemm_nt_q4_k_q8_k",
+    "gemm_nt_q6_k_q8_k",
+}
+
+
+def _execution(weight: str, *, prefill_mode: bool = False) -> dict:
+    is_q4 = weight == "q4_k"
+    prefix = "gemm_nt" if prefill_mode else "gemv"
+    return {
+        "numerical_contract": f"{weight}_x_q8_k_fp32_block_order",
+        "implementation": {
+            "weight_storage": {
+                "format": weight,
+                "block_elements": 256,
+                "block_bytes": 144 if is_q4 else 210,
+            },
+            "activation_storage": {"format": "q8_k", "block_elements": 256},
+            "diagnostic_providers": {
+                "fp32_activation": f"{prefix}_{weight}",
+                **(
+                    {"row_quantized": f"renamed_{weight}_row_provider"}
+                    if prefill_mode
+                    else {}
+                ),
+            },
+        },
+    }
+
+
+def _decode_op(op_name: str, weight: str) -> dict:
+    return {
+        "idx": 1,
+        "op": op_name,
+        "function": f"renamed_{weight}_production",
+        "layer": 0,
+        "section": "body",
+        "resolved_execution": _execution(weight),
+        "args": [
+            {"name": "y", "expr": "Y"},
+            {"name": "W", "expr": "W"},
+            {"name": "x_q8", "expr": "XQ"},
+            {"name": "M", "expr": "M"},
+            {"name": "K", "expr": "K"},
+        ],
+    }
+
+
+def _prefill_op(op_name: str, weight: str) -> dict:
+    return {
+        "idx": 1,
+        "op": op_name,
+        "function": f"renamed_{weight}_production",
+        "layer": 0,
+        "section": "body",
+        "resolved_execution": _execution(weight, prefill_mode=True),
+        "args": [
+            {"name": "A", "expr": "A"},
+            {"name": "B", "expr": "B"},
+            {"name": "bias", "expr": "BIAS"},
+            {"name": "C", "expr": "C"},
+            {"name": "M", "expr": "M", "source": "dim:_m"},
+            {"name": "N", "expr": "N"},
+            {"name": "K", "expr": "K"},
+        ],
+    }
+
+
+class V8CodegenCapabilityTests(unittest.TestCase):
+    def test_kernel_maps_own_q4_q6_storage_and_diagnostic_providers(self) -> None:
+        kernels = resolver.load_kernel_execution_capabilities()["kernels"]
+        expected = {
+            "gemv_q4_k_q8_k": ("q4_k", 144, "gemv_q4_k", None),
+            "gemv_q6_k_q8_k": ("q6_k", 210, "gemv_q6_k", None),
+            "gemm_nt_q4_k_q8_k": ("q4_k", 144, "gemm_nt_q4_k", "gemv_q4_k_q8_k"),
+            "gemm_nt_q6_k_q8_k": ("q6_k", 210, "gemm_nt_q6_k", "gemv_q6_k_q8_k"),
+        }
+        for kernel_id, (weight, block_bytes, fp32, row) in expected.items():
+            with self.subTest(kernel=kernel_id):
+                implementation = kernels[kernel_id]["implementation"]
+                self.assertEqual(implementation["weight_storage"]["format"], weight)
+                self.assertEqual(implementation["weight_storage"]["block_bytes"], block_bytes)
+                self.assertEqual(implementation["activation_storage"]["format"], "q8_k")
+                self.assertEqual(implementation["diagnostic_providers"]["fp32_activation"], fp32)
+                self.assertEqual(implementation["diagnostic_providers"].get("row_quantized"), row)
+
+    def test_missing_storage_capability_is_a_hard_failure(self) -> None:
+        source = ROOT / "version" / "v8" / "kernel_maps" / "gemv_q4_k_q8_k.json"
+        document = json.loads(source.read_text(encoding="utf-8"))
+        del document["implementation"]["weight_storage"]
+        with tempfile.TemporaryDirectory(prefix="cke_missing_linear_storage_") as td:
+            path = Path(td) / source.name
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(resolver.ContractError, "no explicit storage capability"):
+                resolver.load_kernel_execution_capabilities(Path(td))
+
+    def test_storage_capability_must_match_numerical_contract(self) -> None:
+        source = ROOT / "version" / "v8" / "kernel_maps" / "gemv_q4_k_q8_k.json"
+        document = json.loads(source.read_text(encoding="utf-8"))
+        document["implementation"]["weight_storage"]["format"] = "q6_k"
+        with tempfile.TemporaryDirectory(prefix="cke_wrong_linear_storage_") as td:
+            path = Path(td) / source.name
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(resolver.ContractError, "disagrees with its contract"):
+                resolver.load_kernel_execution_capabilities(Path(td))
+
+    def test_missing_diagnostic_provider_is_a_hard_failure(self) -> None:
+        source = ROOT / "version" / "v8" / "kernel_maps" / "gemm_nt_q4_k_q8_k.json"
+        document = json.loads(source.read_text(encoding="utf-8"))
+        del document["implementation"]["diagnostic_providers"]["row_quantized"]
+        with tempfile.TemporaryDirectory(prefix="cke_missing_linear_diagnostic_") as td:
+            path = Path(td) / source.name
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(resolver.ContractError, "no row-quantized provider"):
+                resolver.load_kernel_execution_capabilities(Path(td))
+
+    def test_decode_projection_categories_ignore_production_symbol_spelling(self) -> None:
+        for weight in ("q4_k", "q6_k"):
+            for op_name in ("q_proj", "k_proj", "v_proj", "logits", "out_proj", "mlp_down"):
+                with self.subTest(weight=weight, op=op_name):
+                    code = core.emit_op(_decode_op(op_name, weight))
+                    self.assertIn(f"renamed_{weight}_production(", code)
+                    self.assertIn(f"gemv_{weight}(", code)
+
+    def test_decode_gate_up_uses_map_owned_row_layout(self) -> None:
+        for weight, block_bytes in (("q4_k", 144), ("q6_k", 210)):
+            with self.subTest(weight=weight):
+                code = core.emit_op(_decode_op("mlp_gate_up", weight))
+                self.assertIn(f"/ 256u) * {block_bytes}u", code)
+                self.assertIn(f"gemv_{weight}(", code)
+                self.assertIn(f"renamed_{weight}_production(", code)
+
+    def test_prefill_projection_categories_ignore_production_symbol_spelling(self) -> None:
+        for weight in ("q4_k", "q6_k"):
+            with self.subTest(weight=weight, op="out_proj"):
+                code = prefill.emit_prefill_op(_prefill_op("out_proj", weight), 1, {})
+                self.assertIn(f"renamed_{weight}_production(", code)
+                self.assertIn(f"gemm_nt_{weight}(", code)
+            with self.subTest(weight=weight, op="mlp_gate_up"):
+                code = prefill.emit_prefill_op(_prefill_op("mlp_gate_up", weight), 1, {})
+                self.assertIn(f"renamed_{weight}_row_provider(", code)
+                self.assertIn(f"gemm_nt_{weight}(", code)
+
+    def test_prefill_override_requires_resolved_capability(self) -> None:
+        op = _prefill_op("mlp_down", "q4_k")
+        del op["resolved_execution"]
+        with self.assertRaisesRegex(RuntimeError, "requires resolved Q4/Q6"):
+            prefill._emit_prefill_gemm_fp32_override(
+                op,
+                1,
+                debug_flag_name="debug",
+                debug_input_name="input",
+            )
+
+    def test_codegen_conditions_do_not_name_governed_q4_q6_providers(self) -> None:
+        for filename in ("codegen_core_v8.py", "codegen_prefill_v8.py"):
+            tree = ast.parse((SCRIPTS / filename).read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.If, ast.IfExp, ast.While)):
+                    continue
+                literals = {
+                    child.value
+                    for child in ast.walk(node.test)
+                    if isinstance(child, ast.Constant) and isinstance(child.value, str)
+                }
+                with self.subTest(file=filename, line=node.lineno):
+                    self.assertFalse(literals & GOVERNED_SYMBOLS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_v8_dsl_nightly_registration.py
+++ b/tests/test_v8_dsl_nightly_registration.py
@@ -53,6 +53,9 @@ class V8DSLNightlyRegistrationTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("v8 DSL and Codegen Contracts", source)
+        self.assertIn('id="v8-dsl-contract-dashboard"', source)
+        self.assertIn("function renderV8DSLContracts(results)", source)
+        self.assertIn("renderV8DSLContracts(data.results || [])", source)
         for target in self.EXPECTED_TARGETS:
             with self.subTest(target=target):
                 self.assertIn(f"<code>{target}</code>", source)

--- a/tests/test_v8_dsl_nightly_registration.py
+++ b/tests/test_v8_dsl_nightly_registration.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_nightly_runner():
+    path = ROOT / "scripts" / "nightly_runner.py"
+    spec = importlib.util.spec_from_file_location("nightly_runner_v8_dsl_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+nightly = _load_nightly_runner()
+
+
+class V8DSLNightlyRegistrationTests(unittest.TestCase):
+    EXPECTED_TARGETS = {
+        "test-v8-dsl-policy": "v8 DSL Zero-Hardcoding Policy",
+        "test-numerical-contracts": "v8 Numerical Kernel Contracts",
+        "test-v8-template-circuit-audit": "v8 Template Circuit/Dataflow Audit",
+    }
+
+    def test_full_dsl_gate_dependencies_are_explicit_nightly_rows(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        match = re.search(r"^test-v8-dsl:\s+([^\n]+)$", makefile, re.MULTILINE)
+        self.assertIsNotNone(match, "Makefile must define the aggregate test-v8-dsl gate")
+        dependencies = set(match.group(1).split())
+        self.assertEqual(dependencies, set(self.EXPECTED_TARGETS))
+
+        registered = {
+            entry["target"]: entry
+            for entry in nightly.MAKE_TARGETS.values()
+            if entry.get("target") in self.EXPECTED_TARGETS
+        }
+        self.assertEqual(set(registered), set(self.EXPECTED_TARGETS))
+        for target, expected_name in self.EXPECTED_TARGETS.items():
+            with self.subTest(target=target):
+                self.assertEqual(registered[target]["name"], expected_name)
+                self.assertIn(registered[target]["category"], {"inference", "parity"})
+
+    def test_report_documents_the_three_visible_rows(self) -> None:
+        source = (ROOT / "docs" / "site" / "_pages" / "test-report.html").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("v8 DSL and Codegen Contracts", source)
+        for target in self.EXPECTED_TARGETS:
+            with self.subTest(target=target):
+                self.assertIn(f"<code>{target}</code>", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -8953,6 +8953,19 @@
       },
       "implementation": {
         "isa_dispatch": "runtime",
+        "weight_storage": {
+          "format": "q4_k",
+          "block_elements": 256,
+          "block_bytes": 144
+        },
+        "activation_storage": {
+          "format": "q8_k",
+          "block_elements": 256
+        },
+        "diagnostic_providers": {
+          "fp32_activation": "gemm_nt_q4_k",
+          "row_quantized": "gemv_q4_k_q8_k"
+        },
         "threading": {
           "runtime": "ck_threadpool",
           "work_partition": [
@@ -9673,6 +9686,19 @@
       },
       "implementation": {
         "isa_dispatch": "runtime",
+        "weight_storage": {
+          "format": "q6_k",
+          "block_elements": 256,
+          "block_bytes": 210
+        },
+        "activation_storage": {
+          "format": "q8_k",
+          "block_elements": 256
+        },
+        "diagnostic_providers": {
+          "fp32_activation": "gemm_nt_q6_k",
+          "row_quantized": "gemv_q6_k_q8_k"
+        },
         "threading": {
           "runtime": "ck_threadpool",
           "work_partition": [
@@ -10969,6 +10995,18 @@
       },
       "implementation": {
         "isa_dispatch": "runtime",
+        "weight_storage": {
+          "format": "q4_k",
+          "block_elements": 256,
+          "block_bytes": 144
+        },
+        "activation_storage": {
+          "format": "q8_k",
+          "block_elements": 256
+        },
+        "diagnostic_providers": {
+          "fp32_activation": "gemv_q4_k"
+        },
         "threading": {
           "runtime": "ck_threadpool",
           "work_partition": [
@@ -11778,6 +11816,18 @@
       },
       "implementation": {
         "isa_dispatch": "runtime",
+        "weight_storage": {
+          "format": "q6_k",
+          "block_elements": 256,
+          "block_bytes": 210
+        },
+        "activation_storage": {
+          "format": "q8_k",
+          "block_elements": 256
+        },
+        "diagnostic_providers": {
+          "fp32_activation": "gemv_q6_k"
+        },
         "threading": {
           "runtime": "ck_threadpool",
           "work_partition": [

--- a/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
@@ -29,6 +29,9 @@
   },
   "implementation": {
     "isa_dispatch": "runtime",
+    "weight_storage": {"format": "q4_k", "block_elements": 256, "block_bytes": 144},
+    "activation_storage": {"format": "q8_k", "block_elements": 256},
+    "diagnostic_providers": {"fp32_activation": "gemm_nt_q4_k", "row_quantized": "gemv_q4_k_q8_k"},
     "threading": {
       "runtime": "ck_threadpool",
       "work_partition": ["serial", "independent_rows", "independent_columns", "output_tiles"],

--- a/version/v8/kernel_maps/gemm_nt_q6_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q6_k_q8_k.json
@@ -29,6 +29,9 @@
   },
   "implementation": {
     "isa_dispatch": "runtime",
+    "weight_storage": {"format": "q6_k", "block_elements": 256, "block_bytes": 210},
+    "activation_storage": {"format": "q8_k", "block_elements": 256},
+    "diagnostic_providers": {"fp32_activation": "gemm_nt_q6_k", "row_quantized": "gemv_q6_k_q8_k"},
     "threading": {
       "runtime": "ck_threadpool",
       "work_partition": ["serial", "independent_rows", "output_tiles"],

--- a/version/v8/kernel_maps/gemv_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q4_k_q8_k.json
@@ -29,6 +29,9 @@
   },
   "implementation": {
     "isa_dispatch": "runtime",
+    "weight_storage": {"format": "q4_k", "block_elements": 256, "block_bytes": 144},
+    "activation_storage": {"format": "q8_k", "block_elements": 256},
+    "diagnostic_providers": {"fp32_activation": "gemv_q4_k"},
     "threading": {
       "runtime": "ck_threadpool",
       "work_partition": ["serial", "independent_rows"],

--- a/version/v8/kernel_maps/gemv_q6_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q6_k_q8_k.json
@@ -29,6 +29,9 @@
   },
   "implementation": {
     "isa_dispatch": "runtime",
+    "weight_storage": {"format": "q6_k", "block_elements": 256, "block_bytes": 210},
+    "activation_storage": {"format": "q8_k", "block_elements": 256},
+    "diagnostic_providers": {"fp32_activation": "gemv_q6_k"},
     "threading": {
       "runtime": "ck_threadpool",
       "work_partition": ["serial", "independent_rows"],

--- a/version/v8/schemas/kernel_execution_capability.schema.json
+++ b/version/v8/schemas/kernel_execution_capability.schema.json
@@ -14,6 +14,34 @@
       "required": ["isa_dispatch", "threading"],
       "properties": {
         "isa_dispatch": {"enum": ["runtime", "compile_time", "scalar"]},
+        "weight_storage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["format", "block_elements", "block_bytes"],
+          "properties": {
+            "format": {"type": "string", "minLength": 1},
+            "block_elements": {"type": "integer", "minimum": 1},
+            "block_bytes": {"type": "integer", "minimum": 1}
+          }
+        },
+        "activation_storage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["format", "block_elements"],
+          "properties": {
+            "format": {"type": "string", "minLength": 1},
+            "block_elements": {"type": "integer", "minimum": 1}
+          }
+        },
+        "diagnostic_providers": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["fp32_activation"],
+          "properties": {
+            "fp32_activation": {"type": "string", "minLength": 1},
+            "row_quantized": {"type": "string", "minLength": 1}
+          }
+        },
         "threading": {
           "type": "object",
           "additionalProperties": false,

--- a/version/v8/scripts/codegen_capabilities_v8.py
+++ b/version/v8/scripts/codegen_capabilities_v8.py
@@ -1,0 +1,41 @@
+"""Read resolved code-generation capabilities without interpreting C symbols."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def resolved_quantized_linear_emission(op: Dict[str, Any]) -> Dict[str, Any] | None:
+    execution = op.get("resolved_execution")
+    if not isinstance(execution, dict) or not execution.get("numerical_contract"):
+        return None
+    implementation = execution.get("implementation")
+    if not isinstance(implementation, dict):
+        raise RuntimeError("resolved quantized linear operation has no implementation metadata")
+    weight = implementation.get("weight_storage")
+    activation = implementation.get("activation_storage")
+    diagnostics = implementation.get("diagnostic_providers")
+    if not all(isinstance(value, dict) for value in (weight, activation, diagnostics)):
+        raise RuntimeError(
+            "resolved quantized linear operation is missing map-owned storage or diagnostic providers"
+        )
+    result = {
+        "weight_format": str(weight["format"]),
+        "weight_block_elements": int(weight["block_elements"]),
+        "weight_block_bytes": int(weight["block_bytes"]),
+        "activation_format": str(activation["format"]),
+        "activation_block_elements": int(activation["block_elements"]),
+        "fp32_activation_function": str(diagnostics["fp32_activation"]),
+    }
+    row_provider = diagnostics.get("row_quantized")
+    if row_provider is not None:
+        result["row_quantized_function"] = str(row_provider)
+    return result
+
+
+def is_q4_q6_q8_linear(capability: Dict[str, Any] | None) -> bool:
+    return bool(
+        capability
+        and capability["weight_format"] in {"q4_k", "q6_k"}
+        and capability["activation_format"] == "q8_k"
+    )

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -164,6 +164,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List
 
+from codegen_capabilities_v8 import (
+    is_q4_q6_q8_linear,
+    resolved_quantized_linear_emission,
+)
+
 # =============================================================================
 # PART 1: MEMORY LAYOUT IN C
 # =============================================================================
@@ -656,6 +661,7 @@ def emit_op(
     section = op.get("section", "")
     op_name = op.get("op", "unknown")
     args = op.get("args", [])
+    linear_emission = resolved_quantized_linear_emission(op)
     force_outproj_fp32 = int(layer) in (force_outproj_fp32_layers or set())
     force_attn_proj_fp32 = int(layer) in (force_attn_proj_fp32_layers or set())
     force_mlp_gate_up_fp32 = int(layer) in (force_mlp_gate_up_fp32_layers or set())
@@ -772,7 +778,10 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name in {"recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj"} and function in {"gemv_q4_k_q8_k", "gemv_q8_0_q8_0_contract"}:
+    legacy_q8_recurrent = function == "gemv_q8_0_q8_0_contract"
+    if op_name in {"recurrent_gate_proj", "recurrent_alpha_proj", "recurrent_beta_proj"} and (
+        is_q4_q6_q8_linear(linear_emission) or legacy_q8_recurrent
+    ):
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -786,8 +795,10 @@ def emit_op(
         x_expr = arg_expr_by_name.get("x")
         m_expr = arg_expr_by_name.get("m")
         k_expr = arg_expr_by_name.get("k")
-        fp32_function = "gemv_q4_k" if function == "gemv_q4_k_q8_k" else "gemv_q8_0"
-        q8_call_input = x_q8_expr if function == "gemv_q4_k_q8_k" else x_expr
+        fp32_function = (
+            linear_emission["fp32_activation_function"] if linear_emission else "gemv_q8_0"
+        )
+        q8_call_input = x_q8_expr if linear_emission else x_expr
         if y_expr and w_expr and q8_call_input and m_expr and k_expr:
             active_name = f"ck_debug_recurrent_proj_fp32_active_{seq_idx if seq_idx is not None else idx}"
             lines.append(
@@ -842,7 +853,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name in {"q_proj", "q_gate_proj", "k_proj", "v_proj"} and function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}:
+    if op_name in {"q_proj", "q_gate_proj", "k_proj", "v_proj"} and is_q4_q6_q8_linear(linear_emission):
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -855,7 +866,7 @@ def emit_op(
         x_expr = arg_expr_by_name.get("x_q8")
         m_expr = arg_expr_by_name.get("m")
         k_expr = arg_expr_by_name.get("k")
-        fp32_function = "gemv_q4_k" if function == "gemv_q4_k_q8_k" else "gemv_q6_k"
+        fp32_function = linear_emission["fp32_activation_function"]
         if y_expr and w_expr and x_expr and m_expr and k_expr:
             active_name = f"ck_debug_attn_proj_fp32_active_{seq_idx if seq_idx is not None else idx}"
             lines.append(
@@ -1022,7 +1033,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name == "logits" and function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}:
+    if op_name == "logits" and is_q4_q6_q8_linear(linear_emission):
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -1035,7 +1046,7 @@ def emit_op(
         x_expr = arg_expr_by_name.get("x_q8")
         m_expr = arg_expr_by_name.get("m")
         k_expr = arg_expr_by_name.get("k")
-        fp32_function = "gemv_q4_k" if function == "gemv_q4_k_q8_k" else "gemv_q6_k"
+        fp32_function = linear_emission["fp32_activation_function"]
         if y_expr and w_expr and x_expr and m_expr and k_expr:
             lines.append("    if (!g_ck_skip_decode_logits) {")
             lines.append("        if (debug_lm_head_fp32 && ck_debug_lm_head_fp32_input != NULL) {")
@@ -1110,7 +1121,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name == "out_proj" and function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}:
+    if op_name == "out_proj" and is_q4_q6_q8_linear(linear_emission):
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -1123,7 +1134,7 @@ def emit_op(
         x_expr = arg_expr_by_name.get("x_q8")
         m_expr = arg_expr_by_name.get("m")
         k_expr = arg_expr_by_name.get("k")
-        fp32_function = "gemv_q4_k" if function == "gemv_q4_k_q8_k" else "gemv_q6_k"
+        fp32_function = linear_emission["fp32_activation_function"]
         if y_expr and w_expr and x_expr and m_expr and k_expr:
             active_name = f"ck_debug_outproj_fp32_active_{seq_idx if seq_idx is not None else idx}"
             lines.append(
@@ -1209,7 +1220,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name == "mlp_down" and function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}:
+    if op_name == "mlp_down" and is_q4_q6_q8_linear(linear_emission):
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -1222,7 +1233,7 @@ def emit_op(
         x_expr = arg_expr_by_name.get("x_q8")
         m_expr = arg_expr_by_name.get("m")
         k_expr = arg_expr_by_name.get("k")
-        fp32_function = "gemv_q4_k" if function == "gemv_q4_k_q8_k" else "gemv_q6_k"
+        fp32_function = linear_emission["fp32_activation_function"]
         if y_expr and w_expr and x_expr and m_expr and k_expr:
             active_name = f"ck_debug_mlp_down_fp32_active_{seq_idx if seq_idx is not None else idx}"
             lines.append(
@@ -1276,7 +1287,13 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name == "mlp_gate_up" and function in {"gemv_q4_k", "gemv_q4_k_q8_k", "gemv_q6_k", "gemv_q6_k_q8_k"}:
+    legacy_fp32_weight_format = {
+        "gemv_q4_k": "q4_k",
+        "gemv_q6_k": "q6_k",
+    }.get(function)
+    if op_name == "mlp_gate_up" and (
+        is_q4_q6_q8_linear(linear_emission) or legacy_fp32_weight_format is not None
+    ):
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -1290,11 +1307,17 @@ def emit_op(
         m_expr = arg_expr_by_name.get("m")
         k_expr = arg_expr_by_name.get("k")
 
-        row_bytes_expr = None
-        if function in {"gemv_q4_k", "gemv_q4_k_q8_k"}:
-            row_bytes_expr = f"(((size_t)({k_expr}) / 256u) * 144u)"
-        elif function in {"gemv_q6_k", "gemv_q6_k_q8_k"}:
-            row_bytes_expr = f"(((size_t)({k_expr}) / 256u) * 210u)"
+        if linear_emission is not None:
+            block_elements = linear_emission["weight_block_elements"]
+            block_bytes = linear_emission["weight_block_bytes"]
+            fp32_function = linear_emission["fp32_activation_function"]
+        elif legacy_fp32_weight_format == "q4_k":
+            block_elements, block_bytes, fp32_function = 256, 144, function
+        else:
+            block_elements, block_bytes, fp32_function = 256, 210, function
+        row_bytes_expr = (
+            f"(((size_t)({k_expr}) / {block_elements}u) * {block_bytes}u)"
+        )
 
         if y_expr and w_expr and x_expr and m_expr and k_expr and row_bytes_expr:
             half_expr = f"(({m_expr}) / 2)"
@@ -1302,10 +1325,9 @@ def emit_op(
             up_y_expr = f"((float*)({y_expr}) + {half_expr})"
             gate_w_expr = w_expr
             up_w_expr = f"((const void*)((const uint8_t*)({w_expr}) + ((size_t)({half_expr}) * {row_bytes_expr})))"
-            fp32_function = "gemv_q4_k" if function in {"gemv_q4_k", "gemv_q4_k_q8_k"} else "gemv_q6_k"
             active_name = f"ck_debug_mlp_gate_up_fp32_active_{seq_idx if seq_idx is not None else idx}"
             q8_contract_name = f"ck_debug_mlp_gate_up_q8_contract_active_{seq_idx if seq_idx is not None else idx}"
-            q8_contract_supported = function in {"gemv_q4_k_q8_k", "gemv_q6_k_q8_k"}
+            q8_contract_supported = linear_emission is not None
 
             if profile:
                 lines.append("    CK_PROFILE_BEGIN();")

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -48,6 +48,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from codegen_capabilities_v8 import (
+    is_q4_q6_q8_linear,
+    resolved_quantized_linear_emission,
+)
+
 
 def _annotate_kv_transpose_roles(ops: List[Dict]) -> None:
     """Mark synthetic transpose ops with K/V role and per-layer head geometry."""
@@ -169,6 +174,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     section = op.get("section", "")
     op_instance_idx = int(op.get("op_instance_idx", op.get("instance", 0)) or 0)
     args_list = op.get("args", [])
+    linear_emission = resolved_quantized_linear_emission(op)
 
     # Handle special auto-inserted ops
     if op_type == "final_logit_softcap" and str(config.get("logits_layout", "auto")).lower() == "last":
@@ -528,7 +534,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             lines.append("    }")
             return "\n".join(lines)
 
-    if op_type == "out_proj" and func in ("gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"):
+    if op_type == "out_proj" and is_q4_q6_q8_linear(linear_emission):
         a_expr = arg_expr_by_name.get("a")
         b_expr = arg_expr_by_name.get("b")
         bias_expr = arg_expr_by_name.get("bias", "NULL")
@@ -536,7 +542,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         m_expr = arg_expr_by_name.get("m", "num_tokens")
         n_expr = arg_expr_by_name.get("n")
         k_expr = arg_expr_by_name.get("k")
-        fp32_func = "gemm_nt_q4_k" if func == "gemm_nt_q4_k_q8_k" else "gemm_nt_q6_k"
+        fp32_func = linear_emission["fp32_activation_function"]
         if a_expr and b_expr and c_expr and n_expr and k_expr:
             lines.append("    if (debug_outproj_fp32 && ck_debug_outproj_fp32_input != NULL) {")
             lines.append(f"        {fp32_func}(")
@@ -577,7 +583,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
                 lines.append("    #endif")
             return "\n".join(lines)
 
-    if op_type == "mlp_gate_up" and func in ("gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"):
+    if op_type == "mlp_gate_up" and is_q4_q6_q8_linear(linear_emission):
         a_expr = arg_expr_by_name.get("a")
         b_expr = arg_expr_by_name.get("b")
         bias_expr = arg_expr_by_name.get("bias", "NULL")
@@ -585,8 +591,11 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         m_expr = arg_expr_by_name.get("m", "num_tokens")
         n_expr = arg_expr_by_name.get("n")
         k_expr = arg_expr_by_name.get("k")
-        row_gemv_func = "gemv_q4_k_q8_k" if func == "gemm_nt_q4_k_q8_k" else "gemv_q6_k_q8_k"
-        weight_row_bytes_expr = f"(((size_t)({k_expr}) / 256u) * 144u)" if func == "gemm_nt_q4_k_q8_k" else f"(((size_t)({k_expr}) / 256u) * 210u)"
+        row_gemv_func = linear_emission["row_quantized_function"]
+        weight_row_bytes_expr = (
+            f"(((size_t)({k_expr}) / {linear_emission['weight_block_elements']}u) * "
+            f"{linear_emission['weight_block_bytes']}u)"
+        )
         if a_expr and b_expr and c_expr and n_expr and k_expr:
             lines.append(f"    if (debug_prefill_mlp_gate_up_row_gemv || debug_prefill_mlp_gate_up_row_gemv_layer == {layer}) {{")
             if profile:
@@ -614,7 +623,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             ])
             if profile:
                 lines.append(f'        CK_PROFILE_END("prefill", "{row_gemv_func}", "{op_type}_row_gemv", {layer});')
-            fp32_func = "gemm_nt_q4_k" if func == "gemm_nt_q4_k_q8_k" else "gemm_nt_q6_k"
+            fp32_func = linear_emission["fp32_activation_function"]
             lines.append(f"    }} else if ((debug_mlp_gate_up_fp32 || debug_mlp_gate_up_fp32_layer == {layer}) && ck_debug_mlp_gate_up_fp32_input != NULL) {{")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
@@ -1491,8 +1500,9 @@ def _emit_prefill_quant_debug_override(op: Dict, seq_idx: int, config: Dict, *, 
 
 def _emit_prefill_gemm_fp32_override(op: Dict, seq_idx: int, *, debug_flag_name: str, debug_input_name: str, profile: bool = False, dump: bool = False) -> str:
     func = str(op.get("function", "") or "")
-    if func not in {"gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"}:
-        raise RuntimeError(f"unsupported prefill fp32 override func={func}")
+    linear_emission = resolved_quantized_linear_emission(op)
+    if not is_q4_q6_q8_linear(linear_emission):
+        raise RuntimeError("prefill fp32 override requires resolved Q4/Q6 x Q8 execution metadata")
 
     args_list = op.get("args", [])
     m_arg = next(
@@ -1517,11 +1527,14 @@ def _emit_prefill_gemm_fp32_override(op: Dict, seq_idx: int, *, debug_flag_name:
     if not a_expr or not b_expr or not c_expr or not n_expr or not k_expr:
         raise RuntimeError("prefill fp32 override missing GEMM args")
 
-    fp32_func = "gemm_nt_q4_k" if func == "gemm_nt_q4_k_q8_k" else "gemm_nt_q6_k"
+    fp32_func = linear_emission["fp32_activation_function"]
     layer_value = op.get("layer", -1)
     layer = int(layer_value) if layer_value is not None else -1
-    row_gemv_func = "gemv_q4_k_q8_k" if func == "gemm_nt_q4_k_q8_k" else "gemv_q6_k_q8_k"
-    weight_row_bytes_expr = f"(((size_t)({k_expr}) / 256u) * 144u)" if func == "gemm_nt_q4_k_q8_k" else f"(((size_t)({k_expr}) / 256u) * 210u)"
+    row_gemv_func = linear_emission["row_quantized_function"]
+    weight_row_bytes_expr = (
+        f"(((size_t)({k_expr}) / {linear_emission['weight_block_elements']}u) * "
+        f"{linear_emission['weight_block_bytes']}u)"
+    )
 
     row_gemv_allowed = 1 if str(op.get("op", "")) == "mlp_gate_up" else 0
     lines = [
@@ -1800,6 +1813,7 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
             op = dict(op)
             op["op_instance_idx"] = inst
             rmsnorm_counts_by_layer[layer_for_instance] = inst + 1
+        linear_emission = resolved_quantized_linear_emission(op)
         if op_type == "dense_embedding_lookup":
             lines.append(f"    if (stop_seq == {seq_idx}) return;")
             if (
@@ -1827,10 +1841,10 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                 debug_input_name="ck_debug_mlp_gate_up_fp32_input",
                 profile=profile,
             )
-        elif op_type == "mlp_gate_up" and str(op.get("function", "")) in {"gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"}:
+        elif op_type == "mlp_gate_up" and is_q4_q6_q8_linear(linear_emission):
             next_op = ops[seq_idx + 1] if seq_idx + 1 < len(ops) else None
             if (
-                str(op.get("function", "")) == "gemm_nt_q4_k_q8_k"
+                linear_emission["weight_format"] == "q4_k"
                 and isinstance(next_op, dict)
                 and str(next_op.get("op", "")) in {"silu_mul", "swiglu"}
             ):
@@ -1882,7 +1896,7 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                     debug_input_name="ck_debug_mlp_down_fp32_input",
                     profile=profile,
                 )
-        elif has_multimodal_bridge and op_type == "mlp_down" and str(op.get("function", "")) in {"gemm_nt_q4_k_q8_k", "gemm_nt_q6_k_q8_k"}:
+        elif has_multimodal_bridge and op_type == "mlp_down" and is_q4_q6_q8_linear(linear_emission):
             op_code = _emit_prefill_gemm_fp32_override(
                 op,
                 seq_idx,

--- a/version/v8/scripts/resolve_attention_contracts_v8.py
+++ b/version/v8/scripts/resolve_attention_contracts_v8.py
@@ -150,6 +150,40 @@ def load_kernel_execution_capabilities(root: Path = DEFAULT_KERNELS) -> Dict[str
                 reference=linear_capability["reference"],
                 production=linear_capability["production"],
             )
+            contract = linear_contracts["contracts"][linear_capability["numerical_contract"]]
+            implementation = capability["implementation"]
+            weight_storage = implementation.get("weight_storage")
+            activation_storage = implementation.get("activation_storage")
+            diagnostic_providers = implementation.get("diagnostic_providers")
+            if not isinstance(weight_storage, dict) or not isinstance(activation_storage, dict):
+                raise hard_contract_fault(
+                    f"quantized linear kernel {kernel_id!r} has no explicit storage capability",
+                    "Code generation must not recover weight or activation layout from a function name.",
+                    "declare implementation.weight_storage and implementation.activation_storage.",
+                )
+            if (
+                weight_storage["format"] != contract["weight"]["format"]
+                or weight_storage["block_elements"] != contract["weight"]["block_size"]
+                or activation_storage["format"] != contract["activation"]["format"]
+                or activation_storage["block_elements"] != contract["activation"]["block_size"]
+            ):
+                raise hard_contract_fault(
+                    f"quantized linear kernel {kernel_id!r} storage capability disagrees with its contract",
+                    f"implementation={implementation}, contract={contract}",
+                    "make the implementation storage metadata match the numerical contract.",
+                )
+            if not isinstance(diagnostic_providers, dict):
+                raise hard_contract_fault(
+                    f"quantized linear kernel {kernel_id!r} has no diagnostic providers",
+                    "Code generation must not derive an FP32 or row-quantized provider from a function name.",
+                    "declare implementation.diagnostic_providers in the kernel map.",
+                )
+            if capability["op"] == "gemm" and not diagnostic_providers.get("row_quantized"):
+                raise hard_contract_fault(
+                    f"quantized GEMM kernel {kernel_id!r} has no row-quantized provider",
+                    "The bounded prefill diagnostic path requires an exact map-owned row provider.",
+                    "declare implementation.diagnostic_providers.row_quantized in the kernel map.",
+                )
         kernels[kernel_id] = {**capability, "source": str(path)}
     if not kernels:
         raise ContractError(f"No versioned kernel execution capabilities found under: {root}")


### PR DESCRIPTION
## Why

Q4_K/Q6_K code generation still recognized four C provider names at 13 decode/prefill decision sites. That duplicated kernel-map ownership and allowed provider renames, storage layout changes, or diagnostic routing changes to silently alter generated code.

## Migration

| Category | Before | After | Owner | Stage |
| --- | ---: | ---: | --- | --- |
| Q4_K vs Q6_K projection decisions | 13 symbol-driven sites | 0 governed provider names in codegen predicates | circuit numerical requirement + kernel map | IR1 resolved execution -> LoweredIR -> call IR -> codegen |
| Q8_K activation ABI | inferred from C symbol | explicit q8_k/256 capability | kernel map | resolver + codegen |
| Q4_K row layout | hardcoded 256/144 | explicit block metadata | kernel map | resolver + codegen |
| Q6_K row layout | hardcoded 256/210 | explicit block metadata | kernel map | resolver + codegen |
| FP32/row diagnostics | derived from production symbol | exact map-owned providers | kernel map | fail-closed resolver + codegen |

## Coverage

- Renamed-provider tests cover decode Q/K/V, logits, out projection, MLP down, and gate/up for Q4_K and Q6_K.
- Prefill tests cover out projection, gate/up, row diagnostics, and FP32 overrides.
- Negative tests reject missing storage, contract/storage disagreement, missing row providers, and missing resolved capabilities.
- AST policy rejects reintroducing governed Q4/Q6 provider symbols into codegen conditions.
- Qwen3-VL bridge test verifies capability metadata survives IR1 through call-ready IR.
- `test-v8-dsl-policy` owns this gate, so v8 regression and nightly execute it.

## Validation

- `make test-v8-dsl`
- `make llamacpp-parity-nightly`
- `make v8-regression-fast`
- `make v7-kernel-parity-train`
- clean staged-snapshot pre-commit: v7 and v8 PASS
- pre-push 6/6: build, kernel parity, real Gemma3 E2E, v8 contracts, v7 training, v7/v8 regression PASS
- v8 model-family sweep: Gemma3, Qwen2, Qwen3, Qwen3.5, Nanbeige build/smoke/contracts PASS
- Q4/Q6 scalar, production, threadpool, and llama.cpp parity PASS

## Scope

This removes the governed Q4_K/Q6_K x Q8_K selection row. Fused Q4 gate-up identity and uncontracted plain-FP32 Q4/Q6 gate-up remain explicitly separate cleanup rows; this PR does not hide them in the zero count.