### PR TITLE
refactor(v8/codegen): propagate quantization storage capability

### DIFF
--- a/tests/test_v8_codegen_bridge.py
+++ b/tests/test_v8_codegen_bridge.py
@@ -321,6 +321,7 @@ class V8CodegenBridgeTests(unittest.TestCase):
             rope_call = next(op for op in call_doc["operations"] if op["op"] == "rope_qk")
             attn_call = next(op for op in call_doc["operations"] if op["op"] == "attn")
             q_proj_call = next(op for op in call_doc["operations"] if op["op"] == "q_proj")
+            quantize_input_call = next(op for op in call_doc["operations"] if op["op"] == "quantize_input_0")
             mlp_down_call = next(op for op in call_doc["operations"] if op["op"] == "mlp_down")
             kv_store_call = next(op for op in call_doc["operations"] if op["op"] == "kv_cache_store")
             kv_buf = next(buf for buf in layout_doc["memory"]["activations"]["buffers"] if buf["name"] == "kv_cache")
@@ -329,6 +330,15 @@ class V8CodegenBridgeTests(unittest.TestCase):
             self.assertEqual(kv_store_call["function"], "kv_cache_store_f16")
             self.assertEqual(kv_buf["dtype"], "fp16")
             self.assertEqual(q_proj_call["resolved_execution"]["kernel_id"], "gemv_q4_k_q8_k")
+            self.assertEqual(
+                quantize_input_call["resolved_codegen_capability"]["output_storage"],
+                {
+                    "format": "q8_k",
+                    "block_elements": 256,
+                    "block_elements_symbol": "QK_K",
+                    "c_block_type": "block_q8_K",
+                },
+            )
             self.assertEqual(
                 q_proj_call["resolved_execution"]["implementation"]["threading"]["reduction_order_effect"],
                 "none",

--- a/tests/test_v8_codegen_capabilities.py
+++ b/tests/test_v8_codegen_capabilities.py
@@ -36,6 +36,8 @@ GOVERNED_SYMBOLS = {
     "gemv_q6_k_q8_k",
     "gemm_nt_q4_k_q8_k",
     "gemm_nt_q6_k_q8_k",
+    "quantize_row_q8_0",
+    "quantize_row_q8_k",
 }
 
 
@@ -97,6 +99,36 @@ def _prefill_op(op_name: str, weight: str) -> dict:
             {"name": "M", "expr": "M", "source": "dim:_m"},
             {"name": "N", "expr": "N"},
             {"name": "K", "expr": "K"},
+        ],
+    }
+
+
+def _quantize_op(op_name: str, storage: str, *, rows: str = "ROWS") -> dict:
+    is_q8_k = storage == "q8_k"
+    function = f"renamed_{storage}_quantizer"
+    return {
+        "idx": 2,
+        "op": op_name,
+        "function": function,
+        "layer": 0,
+        "section": "body",
+        "resolved_codegen_capability": {
+            "schema_version": 1,
+            "kernel_id": f"fake_{storage}_quantizer",
+            "operator_family": "activation_quantization",
+            "function": function,
+            "output_storage": {
+                "format": storage,
+                "block_elements": 256 if is_q8_k else 32,
+                "block_elements_symbol": "QK_K" if is_q8_k else "QK8_0",
+                "c_block_type": "block_q8_K" if is_q8_k else "block_q8_0",
+            },
+        },
+        "args": [
+            {"name": "x", "expr": "X"},
+            {"name": "y", "expr": "Y"},
+            {"name": "k", "expr": "K"},
+            {"name": "rows", "expr": rows},
         ],
     }
 
@@ -186,6 +218,86 @@ class V8CodegenCapabilityTests(unittest.TestCase):
                 debug_flag_name="debug",
                 debug_input_name="input",
             )
+
+    def test_quantization_maps_own_exact_output_storage_abi(self) -> None:
+        expected = {
+            "quantize_row_q8_0.json": ("q8_0", 32, "QK8_0", "block_q8_0"),
+            "quantize_row_q8_k.json": ("q8_k", 256, "QK_K", "block_q8_K"),
+        }
+        for filename, storage in expected.items():
+            with self.subTest(map=filename):
+                document = json.loads(
+                    (ROOT / "version" / "v8" / "kernel_maps" / filename).read_text(
+                        encoding="utf-8"
+                    )
+                )
+                capability = document["codegen_capability"]
+                self.assertEqual(capability["operator_family"], "activation_quantization")
+                self.assertEqual(
+                    (
+                        capability["output_storage"]["format"],
+                        capability["output_storage"]["block_elements"],
+                        capability["output_storage"]["block_elements_symbol"],
+                        capability["output_storage"]["c_block_type"],
+                    ),
+                    storage,
+                )
+
+    def test_quantization_codegen_capability_rejects_function_drift(self) -> None:
+        path = ROOT / "version" / "v8" / "kernel_maps" / "quantize_row_q8_k.json"
+        document = json.loads(path.read_text(encoding="utf-8"))
+        document["codegen_capability"]["function"] = "wrong_quantizer"
+        build_ir = _load("build_ir_v8_quant_drift_tests", SCRIPTS / "build_ir_v8.py")
+        with self.assertRaisesRegex(RuntimeError, "advertises function"):
+            build_ir._validated_kernel_codegen_capability(document["id"], document)
+
+    def test_decode_quantization_uses_storage_capability_not_symbol(self) -> None:
+        for storage, symbol, block_type in (
+            ("q8_0", "QK8_0", "block_q8_0"),
+            ("q8_k", "QK_K", "block_q8_K"),
+        ):
+            with self.subTest(storage=storage):
+                op = _quantize_op("quantize_input_1", storage)
+                code = core.emit_op(op)
+                self.assertIn(f"renamed_{storage}_quantizer(", code)
+                self.assertIn(f"/ {symbol}) * sizeof({block_type})", code)
+
+    def test_prefill_quantization_uses_storage_capability_not_symbol(self) -> None:
+        for storage, symbol, block_type in (
+            ("q8_0", "QK8_0", "block_q8_0"),
+            ("q8_k", "QK_K", "block_q8_K"),
+        ):
+            with self.subTest(storage=storage):
+                op = _quantize_op("quantize_input_0", storage)
+                code = prefill.emit_prefill_op(op, 2, {})
+                self.assertIn(f"renamed_{storage}_quantizer(", code)
+                self.assertIn(f"/ {symbol}) * sizeof({block_type})", code)
+
+    def test_quantization_without_resolved_capability_hard_fails(self) -> None:
+        op = _quantize_op("quantize_input_0", "q8_k")
+        del op["resolved_codegen_capability"]
+        with self.assertRaisesRegex(RuntimeError, "requires resolved map-owned"):
+            core.emit_op(op)
+        with self.assertRaisesRegex(RuntimeError, "requires resolved map-owned"):
+            prefill.emit_prefill_op(op, 2, {})
+
+    def test_quantize_provider_resolution_is_unique_and_map_driven(self) -> None:
+        registry = {
+            "kernels": [
+                {"id": "renamed_q8_0", "op": "quantize", "quant": {"output": "q8_0"}},
+                {"id": "renamed_q8_k", "op": "quantize", "quant": {"output": "q8_k"}},
+            ]
+        }
+        build_ir = _load("build_ir_v8_quant_capability_tests", SCRIPTS / "build_ir_v8.py")
+        self.assertEqual(
+            build_ir.get_quantize_kernel_for_activation(registry, "q8_k"),
+            "renamed_q8_k",
+        )
+        registry["kernels"].append(
+            {"id": "ambiguous_q8_k", "op": "quantize", "quant": {"output": "q8_k"}}
+        )
+        with self.assertRaisesRegex(RuntimeError, "resolved 2 quantization providers"):
+            build_ir.get_quantize_kernel_for_activation(registry, "q8_k")
 
     def test_codegen_conditions_do_not_name_governed_q4_q6_providers(self) -> None:
         for filename in ("codegen_core_v8.py", "codegen_prefill_v8.py"):

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -18389,6 +18389,17 @@
           }
         ]
       },
+      "codegen_capability": {
+        "schema_version": 1,
+        "operator_family": "activation_quantization",
+        "function": "quantize_row_q8_0",
+        "output_storage": {
+          "format": "q8_0",
+          "block_elements": 32,
+          "block_elements_symbol": "QK8_0",
+          "c_block_type": "block_q8_0"
+        }
+      },
       "tests": {
         "unit": [
           "unittest/test_quantize.py"
@@ -18481,6 +18492,17 @@
             "compile_flags": []
           }
         ]
+      },
+      "codegen_capability": {
+        "schema_version": 1,
+        "operator_family": "activation_quantization",
+        "function": "quantize_row_q8_k",
+        "output_storage": {
+          "format": "q8_k",
+          "block_elements": 256,
+          "block_elements_symbol": "QK_K",
+          "c_block_type": "block_q8_K"
+        }
       },
       "tests": {
         "unit": [

--- a/version/v8/kernel_maps/quantize_row_q8_0.json
+++ b/version/v8/kernel_maps/quantize_row_q8_0.json
@@ -40,6 +40,17 @@
       {"name": "default", "requires": [], "compile_flags": []}
     ]
   },
+  "codegen_capability": {
+    "schema_version": 1,
+    "operator_family": "activation_quantization",
+    "function": "quantize_row_q8_0",
+    "output_storage": {
+      "format": "q8_0",
+      "block_elements": 32,
+      "block_elements_symbol": "QK8_0",
+      "c_block_type": "block_q8_0"
+    }
+  },
   "tests": {
     "unit": ["unittest/test_quantize.py"],
     "bench": ["scripts/bench_quantize.py"],

--- a/version/v8/kernel_maps/quantize_row_q8_k.json
+++ b/version/v8/kernel_maps/quantize_row_q8_k.json
@@ -40,6 +40,17 @@
       {"name": "default", "requires": [], "compile_flags": []}
     ]
   },
+  "codegen_capability": {
+    "schema_version": 1,
+    "operator_family": "activation_quantization",
+    "function": "quantize_row_q8_k",
+    "output_storage": {
+      "format": "q8_k",
+      "block_elements": 256,
+      "block_elements_symbol": "QK_K",
+      "c_block_type": "block_q8_K"
+    }
+  },
   "tests": {
     "unit": ["unittest/test_quantize.py"],
     "bench": ["scripts/bench_quantize.py"],

--- a/version/v8/schemas/kernel_codegen_capability.schema.json
+++ b/version/v8/schemas/kernel_codegen_capability.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.kernel_codegen_capability",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "operator_family", "function", "output_storage"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "operator_family": {"enum": ["activation_quantization"]},
+    "function": {"type": "string", "minLength": 1},
+    "output_storage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["format", "block_elements", "block_elements_symbol", "c_block_type"],
+      "properties": {
+        "format": {"enum": ["q8_0", "q8_k"]},
+        "block_elements": {"type": "integer", "minimum": 1},
+        "block_elements_symbol": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"},
+        "c_block_type": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"}
+      }
+    }
+  }
+}

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -2460,6 +2460,34 @@ PROJECT_ROOT = SCRIPT_DIR.parent  # version/v8
 REPO_ROOT = PROJECT_ROOT.parent.parent  # repo root
 V8_ROOT = REPO_ROOT / "version" / "v8"
 
+
+def _validated_kernel_codegen_capability(kernel_id: str, kernel_map: Dict) -> Optional[Dict]:
+    capability = kernel_map.get("codegen_capability")
+    if capability is None:
+        return None
+    schema_path = V8_ROOT / "schemas" / "kernel_codegen_capability.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(capability),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    if errors:
+        error = errors[0]
+        location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        raise RuntimeError(
+            f"HARD CODEGEN CAPABILITY FAULT: kernel {kernel_id!r} capability is invalid "
+            f"at {location}: {error.message}"
+        )
+    function = str((kernel_map.get("impl") or {}).get("function", kernel_id))
+    if capability["function"] != function:
+        raise RuntimeError(
+            f"HARD CODEGEN CAPABILITY FAULT: kernel {kernel_id!r} advertises function "
+            f"{capability['function']!r}, but its implementation is {function!r}."
+        )
+    resolved = copy.deepcopy(capability)
+    resolved["kernel_id"] = kernel_id
+    return resolved
+
 # Template Op → Kernel Op Mapping
 # This is the single source of truth for how template ops map to kernel registry ops.
 # Keep this mapping semantic, not architecture-named: the builder should only see
@@ -4552,7 +4580,7 @@ def kernel_needs_q8_activation(registry: Dict, kernel_id: str) -> bool:
     return False
 
 
-def get_quantize_kernel_for_activation(activation_dtype: str) -> Optional[str]:
+def get_quantize_kernel_for_activation(registry: Dict, activation_dtype: str) -> Optional[str]:
     """
     Get the appropriate quantize kernel for the target activation dtype.
 
@@ -4562,11 +4590,22 @@ def get_quantize_kernel_for_activation(activation_dtype: str) -> Optional[str]:
     Returns:
         Quantize kernel ID or None if no quantization needed
     """
-    if activation_dtype == "q8_0":
-        return "quantize_row_q8_0"
-    elif activation_dtype == "q8_k":
-        return "quantize_row_q8_k"
-    return None
+    if activation_dtype not in {"q8_0", "q8_k"}:
+        return None
+    matches = [
+        str(kernel.get("id", ""))
+        for kernel in registry.get("kernels", [])
+        if isinstance(kernel, dict)
+        and kernel.get("op") == "quantize"
+        and (kernel.get("quant") or {}).get("output") == activation_dtype
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"HARD CODEGEN CAPABILITY FAULT: activation storage {activation_dtype!r} "
+            f"resolved {len(matches)} quantization providers: {matches}. "
+            "Kernel maps must provide exactly one quantize operator for the requested format."
+        )
+    return matches[0]
 
 
 # Quantization formats that require native kernels (no safe fallback)
@@ -5775,7 +5814,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                                 for kreg in registry.get("kernels", []):
                                     if kreg.get("id") == fk_id:
                                         act_dtype = kreg.get("quant", {}).get("activation", "fp32")
-                                        quantize_kernel = get_quantize_kernel_for_activation(act_dtype)
+                                        quantize_kernel = get_quantize_kernel_for_activation(registry, act_dtype)
                                         if quantize_kernel:
                                             quant_op_name = f"quantize_{op}_input"
                                             quant_op_info = get_op_info(quant_op_name, "body", layer_idx)
@@ -5858,7 +5897,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                                     for kreg in registry.get("kernels", []):
                                         if kreg.get("id") == nk_id:
                                             act_dtype = kreg.get("quant", {}).get("activation", "fp32")
-                                            quantize_kernel = get_quantize_kernel_for_activation(act_dtype)
+                                            quantize_kernel = get_quantize_kernel_for_activation(registry, act_dtype)
                                             if quantize_kernel:
                                                 quant_op_name = f"quantize_input_{norm_instance}"
                                                 quant_op_info = get_op_info(quant_op_name, "body", layer_idx)
@@ -5924,7 +5963,7 @@ def build_ir1_direct(manifest: Dict, manifest_path: Path, mode: str = "decode",
                                 for kreg in registry.get("kernels", []):
                                     if kreg.get("id") == k_id:
                                         act_dtype = kreg.get("quant", {}).get("activation", "fp32")
-                                        quantize_kernel = get_quantize_kernel_for_activation(act_dtype)
+                                        quantize_kernel = get_quantize_kernel_for_activation(registry, act_dtype)
                                         if quantize_kernel:
                                             quant_op_name = "quantize_final_output"
                                             quant_op_info = get_op_info(quant_op_name, section_name, -1)
@@ -6824,6 +6863,9 @@ def generate_ir_lower_1(
             "bias_for": ir_op.get("bias_for"),
             "dataflow": ir_op.get("dataflow", {}),  # Preserve dataflow for memory planner
         }
+        codegen_capability = _validated_kernel_codegen_capability(kernel_id, kernel_map)
+        if codegen_capability is not None:
+            lowered_op["resolved_codegen_capability"] = codegen_capability
         if ir_op.get("required_contract") is not None:
             lowered_op["required_contract"] = copy.deepcopy(ir_op["required_contract"])
         if ir_op.get("resolved_contract") is not None:
@@ -8732,6 +8774,16 @@ def generate_ir_lower_2(
                 raise RuntimeError(
                     f"HARD CONTRACT FAULT: memory lowering received kernel {ir_op['kernel']!r}, "
                     f"but execution metadata names {lowered_op['resolved_execution'].get('kernel_id')!r}."
+                )
+        if ir_op.get("resolved_codegen_capability") is not None:
+            lowered_op["resolved_codegen_capability"] = copy.deepcopy(
+                ir_op["resolved_codegen_capability"]
+            )
+            if lowered_op["resolved_codegen_capability"].get("kernel_id") != ir_op["kernel"]:
+                raise RuntimeError(
+                    f"HARD CODEGEN CAPABILITY FAULT: memory lowering received kernel "
+                    f"{ir_op['kernel']!r}, but codegen metadata names "
+                    f"{lowered_op['resolved_codegen_capability'].get('kernel_id')!r}."
                 )
         if ir_op.get("semantic_checkpoints") is not None:
             lowered_op["semantic_checkpoints"] = copy.deepcopy(ir_op["semantic_checkpoints"])
@@ -11082,6 +11134,19 @@ def generate_ir_lower_3(lowered_ir: Dict, mode: str) -> Dict:
                     f"execution metadata {resolved_execution.get('kernel_id')!r}."
                 )
             call_op["resolved_execution"] = resolved_execution
+        resolved_codegen = copy.deepcopy(op.get("resolved_codegen_capability")) if op.get("resolved_codegen_capability") else None
+        if resolved_codegen is not None:
+            if resolved_codegen.get("kernel_id") != op.get("kernel"):
+                raise RuntimeError(
+                    f"HARD CODEGEN CAPABILITY FAULT: call-ready IR kernel {op.get('kernel')!r} "
+                    f"differs from codegen metadata {resolved_codegen.get('kernel_id')!r}."
+                )
+            if resolved_codegen.get("function") != func:
+                raise RuntimeError(
+                    f"HARD CODEGEN CAPABILITY FAULT: call-ready IR function {func!r} differs "
+                    f"from codegen metadata {resolved_codegen.get('function')!r}."
+                )
+            call_op["resolved_codegen_capability"] = resolved_codegen
         if op.get("semantic_checkpoints") is not None:
             call_op["semantic_checkpoints"] = copy.deepcopy(op["semantic_checkpoints"])
         call_ops.append(call_op)

--- a/version/v8/scripts/codegen_capabilities_v8.py
+++ b/version/v8/scripts/codegen_capabilities_v8.py
@@ -39,3 +39,39 @@ def is_q4_q6_q8_linear(capability: Dict[str, Any] | None) -> bool:
         and capability["weight_format"] in {"q4_k", "q6_k"}
         and capability["activation_format"] == "q8_k"
     )
+
+
+def resolved_activation_quantization_emission(op: Dict[str, Any]) -> Dict[str, Any] | None:
+    capability = op.get("resolved_codegen_capability")
+    if not isinstance(capability, dict):
+        return None
+    if capability.get("operator_family") != "activation_quantization":
+        return None
+    function = str(op.get("function", "") or "")
+    if capability.get("function") != function:
+        raise RuntimeError(
+            "resolved activation quantization capability does not match the call-ready function"
+        )
+    storage = capability.get("output_storage")
+    if not isinstance(storage, dict):
+        raise RuntimeError("resolved activation quantization capability has no output storage")
+    required = {"format", "block_elements", "block_elements_symbol", "c_block_type"}
+    if set(storage) != required:
+        raise RuntimeError(
+            "resolved activation quantization storage must define exact format and block ABI"
+        )
+    return {
+        "format": str(storage["format"]),
+        "block_elements": int(storage["block_elements"]),
+        "block_elements_symbol": str(storage["block_elements_symbol"]),
+        "c_block_type": str(storage["c_block_type"]),
+    }
+
+
+def activation_quantized_row_bytes_expr(
+    capability: Dict[str, Any], dimension_expr: str
+) -> str:
+    return (
+        f"(size_t)(({dimension_expr}) / {capability['block_elements_symbol']}) * "
+        f"sizeof({capability['c_block_type']})"
+    )

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -165,7 +165,9 @@ from pathlib import Path
 from typing import Dict, List
 
 from codegen_capabilities_v8 import (
+    activation_quantized_row_bytes_expr,
     is_q4_q6_q8_linear,
+    resolved_activation_quantization_emission,
     resolved_quantized_linear_emission,
 )
 
@@ -662,6 +664,11 @@ def emit_op(
     op_name = op.get("op", "unknown")
     args = op.get("args", [])
     linear_emission = resolved_quantized_linear_emission(op)
+    quantization_emission = resolved_activation_quantization_emission(op)
+    if op_name.startswith("quantize_") and quantization_emission is None:
+        raise RuntimeError(
+            f"quantization op {op_name!r} requires resolved map-owned codegen capability"
+        )
     force_outproj_fp32 = int(layer) in (force_outproj_fp32_layers or set())
     force_attn_proj_fp32 = int(layer) in (force_attn_proj_fp32_layers or set())
     force_mlp_gate_up_fp32 = int(layer) in (force_mlp_gate_up_fp32_layers or set())
@@ -751,7 +758,7 @@ def emit_op(
             lines.append(f"    if (stop_seq == {seq_idx}) return;")
         return "\n".join(lines)
 
-    if op_name == "quantize_input_0" and function == "quantize_row_q8_k":
+    if op_name == "quantize_input_0" and quantization_emission and quantization_emission["format"] == "q8_k":
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -767,7 +774,7 @@ def emit_op(
             lines.append(f"    ck_debug_recurrent_proj_fp32_input = {x_expr};")
             if profile:
                 lines.append("    CK_PROFILE_BEGIN();")
-            lines.append("    quantize_row_q8_k(")
+            lines.append(f"    {function}(")
             lines.append(f"        {x_expr},")
             lines.append(f"        {y_expr},")
             lines.append(f"        {k_expr}")
@@ -953,7 +960,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name == "quantize_out_proj_input" and function == "quantize_row_q8_k":
+    if op_name == "quantize_out_proj_input" and quantization_emission and quantization_emission["format"] == "q8_k":
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -985,7 +992,7 @@ def emit_op(
             lines.append(f"    if (!{active_name}) {{")
             if profile:
                 lines.append("        CK_PROFILE_BEGIN();")
-            lines.append("        quantize_row_q8_k(")
+            lines.append(f"        {function}(")
             lines.append(f"            {x_expr},")
             lines.append(f"            {y_expr},")
             lines.append(f"            {k_expr}")
@@ -997,7 +1004,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name == "quantize_final_output" and function == "quantize_row_q8_k":
+    if op_name == "quantize_final_output" and quantization_emission and quantization_emission["format"] == "q8_k":
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -1010,6 +1017,9 @@ def emit_op(
         k_expr = arg_expr_by_name.get("k")
         rows_expr = arg_expr_by_name.get("rows")
         if x_expr and y_expr and k_expr and rows_expr:
+            row_bytes_expr = activation_quantized_row_bytes_expr(
+                quantization_emission, "_k"
+            )
             lines.append(f"    ck_debug_lm_head_fp32_input = {x_expr};")
             lines.append("    if (!g_ck_skip_decode_logits && !debug_lm_head_fp32) {")
             if profile:
@@ -1020,9 +1030,9 @@ def emit_op(
                 f"            uint8_t *_y_base = (uint8_t*)({y_expr});",
                 f"            const int _k = (int)({k_expr});",
                 f"            const int _rows = (int)({rows_expr});",
-                "            const size_t _row_bytes = (size_t)(_k / QK_K) * sizeof(block_q8_K);",
+                f"            const size_t _row_bytes = {row_bytes_expr};",
                 "            for (int _t = 0; _t < _rows; ++_t) {",
-                "                quantize_row_q8_k(_x_base + (size_t)_t * (size_t)_k, (void*)(_y_base + (size_t)_t * _row_bytes), _k);",
+                f"                {function}(_x_base + (size_t)_t * (size_t)_k, (void*)(_y_base + (size_t)_t * _row_bytes), _k);",
                 "            }",
                 "        }",
             ])
@@ -1187,7 +1197,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if op_name == "quantize_mlp_down_input" and function in {"quantize_row_q8_k", "quantize_row_q8_0"}:
+    if op_name == "quantize_mlp_down_input" and quantization_emission:
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -1417,7 +1427,7 @@ def emit_op(
                 lines.append(f"    if (stop_seq == {seq_idx}) return;")
             return "\n".join(lines)
 
-    if function in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+    if quantization_emission:
         arg_expr_by_name = {}
         for arg in args:
             nm = str(arg.get("name", "")).lower()
@@ -1429,7 +1439,7 @@ def emit_op(
         y_expr = arg_expr_by_name.get("y")
         k_expr = arg_expr_by_name.get("k")
         rows_expr = arg_expr_by_name.get("rows")
-        row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)" if function == "quantize_row_q8_k" else "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+        row_bytes_expr = activation_quantized_row_bytes_expr(quantization_emission, "_k")
 
         if x_expr and y_expr and k_expr and rows_expr:
             active_name = None

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -49,7 +49,9 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from codegen_capabilities_v8 import (
+    activation_quantized_row_bytes_expr,
     is_q4_q6_q8_linear,
+    resolved_activation_quantization_emission,
     resolved_quantized_linear_emission,
 )
 
@@ -175,6 +177,11 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     op_instance_idx = int(op.get("op_instance_idx", op.get("instance", 0)) or 0)
     args_list = op.get("args", [])
     linear_emission = resolved_quantized_linear_emission(op)
+    quantization_emission = resolved_activation_quantization_emission(op)
+    if op_type.startswith("quantize_") and quantization_emission is None:
+        raise RuntimeError(
+            f"quantization op {op_type!r} requires resolved map-owned codegen capability"
+        )
 
     # Handle special auto-inserted ops
     if op_type == "final_logit_softcap" and str(config.get("logits_layout", "auto")).lower() == "last":
@@ -500,16 +507,14 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
     # Prefill quantization must preserve token-major row layout exactly for
     # downstream GEMM kernels. Emit explicit per-token row quantization loops
     # instead of batch helper calls to avoid ABI/dispatch ambiguity.
-    batch_quant_kind = None
-    if func in ("quantize_row_q8_0", "quantize_row_q8_k"):
-        batch_quant_kind = func
+    batch_quant_kind = quantization_emission
 
     if batch_quant_kind:
         x_expr = arg_expr_by_name.get("x") or arg_expr_by_name.get("input")
         y_expr = arg_expr_by_name.get("y") or arg_expr_by_name.get("output")
         k_expr = arg_expr_by_name.get("k") or str(config.get("embed_dim", "EMBED_DIM"))
         if x_expr and y_expr and k_expr:
-            row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)" if batch_quant_kind == "quantize_row_q8_k" else "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+            row_bytes_expr = activation_quantized_row_bytes_expr(batch_quant_kind, "_k")
             if op_type == "quantize_out_proj_input":
                 lines.append(f"    ck_debug_outproj_fp32_input = (const float*)({x_expr});")
                 lines.append(
@@ -526,11 +531,11 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
                 f"        const int _k = (int)({k_expr});",
                 f"        const size_t _row_bytes = {row_bytes_expr};",
                 "        for (int _t = 0; _t < num_tokens; ++_t) {",
-                f"            {batch_quant_kind}(_x_base + (size_t)_t * (size_t)_k, (void*)(_y_base + (size_t)_t * _row_bytes), _k);",
+                f"            {func}(_x_base + (size_t)_t * (size_t)_k, (void*)(_y_base + (size_t)_t * _row_bytes), _k);",
                 "        }",
             ])
             if profile:
-                lines.append(f'        CK_PROFILE_END("prefill", "{batch_quant_kind}", "{op_type}", {layer});')
+                lines.append(f'        CK_PROFILE_END("prefill", "{func}", "{op_type}", {layer});')
             lines.append("    }")
             return "\n".join(lines)
 
@@ -732,10 +737,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         x_expr = args[0]
         y_expr = args[1]
         k_expr = args[2]
-        if batch_quant_kind == "quantize_row_q8_k":
-            row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)"
-        else:
-            row_bytes_expr = "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+        row_bytes_expr = activation_quantized_row_bytes_expr(batch_quant_kind, "_k")
         if op_type == "quantize_input_2":
             lines.append(f"    ck_debug_mlp_gate_up_fp32_input = (const float*)({x_expr});")
         if op_type == "quantize_out_proj_input":
@@ -752,7 +754,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             lines.append(f"        const size_t _row_bytes = {row_bytes_expr};")
             lines.append("        for (int _t = 0; _t < num_tokens; ++_t) {")
             lines.append(
-                f"            {batch_quant_kind}("
+                f"            {func}("
                 "_x_base + (size_t)_t * (size_t)_k, "
                 "(void*)(_y_base + (size_t)_t * _row_bytes), "
                 "_k);"
@@ -767,7 +769,7 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             lines.append(f"        const size_t _row_bytes = {row_bytes_expr};")
             lines.append("        for (int _t = 0; _t < num_tokens; ++_t) {")
             lines.append(
-                f"            {batch_quant_kind}("
+                f"            {func}("
                 "_x_base + (size_t)_t * (size_t)_k, "
                 "(void*)(_y_base + (size_t)_t * _row_bytes), "
                 "_k);"
@@ -1147,6 +1149,7 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
 
     for seq_idx, op in enumerate(ops):
         op_type_for_instance = str(op.get("op", ""))
+        quantization_emission = resolved_activation_quantization_emission(op)
         if swiglu_q8k_fusion_guard and op_type_for_instance != "quantize_mlp_down_input":
             swiglu_q8k_fusion_guard = None
             swiglu_q8k_fusion_call = None
@@ -1161,7 +1164,8 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
             swiglu_q8k_fusion_guard
             and swiglu_q8k_fusion_call
             and op_type_for_instance == "quantize_mlp_down_input"
-            and str(op.get("function", "")) == "quantize_row_q8_k"
+            and quantization_emission is not None
+            and quantization_emission["format"] == "q8_k"
         ):
             op_code = (
                 f"    if ({swiglu_q8k_fusion_guard}) {{\n"
@@ -1174,11 +1178,17 @@ static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
             swiglu_q8k_fusion_call = None
         elif op_type_for_instance in {"silu_mul", "swiglu"}:
             next_op = ops[seq_idx + 1] if seq_idx + 1 < len(ops) else None
+            next_quantization = (
+                resolved_activation_quantization_emission(next_op)
+                if isinstance(next_op, dict)
+                else None
+            )
             if (
                 isinstance(next_op, dict)
                 and str(op.get("function", "")) == "swiglu_forward"
                 and str(next_op.get("op", "")) == "quantize_mlp_down_input"
-                and str(next_op.get("function", "")) == "quantize_row_q8_k"
+                and next_quantization is not None
+                and next_quantization["format"] == "q8_k"
             ):
                 swiglu_args = op.get("args", [])
                 quant_args = next_op.get("args", [])
@@ -1429,15 +1439,16 @@ static void ck_qwen3vl_prefill_deepstack_add(CKModel *model, int layer, int num_
 
 def _emit_prefill_quant_rows(op: Dict, seq_idx: int, *, debug_inputs: list[str] | None = None, profile: bool = False) -> str:
     func = str(op.get("function", "") or "")
-    if func not in {"quantize_row_q8_0", "quantize_row_q8_k"}:
-        raise RuntimeError(f"unsupported prefill quant func={func}")
+    quantization_emission = resolved_activation_quantization_emission(op)
+    if quantization_emission is None:
+        raise RuntimeError("prefill quant rows require a resolved activation quantization capability")
     args_list = op.get("args", [])
     x_expr = _find_arg_expr(args_list, arg_name="x") or _find_arg_expr(args_list, arg_name="input")
     y_expr = _find_arg_expr(args_list, arg_name="y") or _find_arg_expr(args_list, arg_name="output")
     k_expr = _find_arg_expr(args_list, arg_name="k")
     if not x_expr or not y_expr or not k_expr:
         raise RuntimeError(f"prefill quant rows missing x/y/k args for op={op.get('op')}")
-    row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)" if func == "quantize_row_q8_k" else "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+    row_bytes_expr = activation_quantized_row_bytes_expr(quantization_emission, "_k")
     lines = [
         f"    /* Op {seq_idx}: {func} ({op.get('op', 'unknown')}) layer={op.get('layer', -1)} section={op.get('section', 'body')} */",
     ]
@@ -1463,8 +1474,9 @@ def _emit_prefill_quant_rows(op: Dict, seq_idx: int, *, debug_inputs: list[str] 
 
 def _emit_prefill_quant_debug_override(op: Dict, seq_idx: int, config: Dict, *, debug_flag_name: str, debug_input_name: str, profile: bool = False) -> str:
     func = str(op.get("function", "") or "")
-    if func not in {"quantize_row_q8_0", "quantize_row_q8_k"}:
-        raise RuntimeError(f"unsupported prefill quant override func={func}")
+    quantization_emission = resolved_activation_quantization_emission(op)
+    if quantization_emission is None:
+        raise RuntimeError("prefill quant override requires a resolved activation quantization capability")
 
     args_list = op.get("args", [])
     x_expr = _find_arg_expr(args_list, arg_name="x") or _find_arg_expr(args_list, arg_name="x_q8")
@@ -1473,7 +1485,7 @@ def _emit_prefill_quant_debug_override(op: Dict, seq_idx: int, config: Dict, *, 
     if not x_expr or not y_expr or not k_expr:
         raise RuntimeError("prefill quant override missing x/y/k args")
 
-    row_bytes_expr = "(size_t)(_k / QK_K) * sizeof(block_q8_K)" if func == "quantize_row_q8_k" else "(size_t)(_k / QK8_0) * sizeof(block_q8_0)"
+    row_bytes_expr = activation_quantized_row_bytes_expr(quantization_emission, "_k")
     lines = [
         f"    /* Op {seq_idx}: {func} ({op.get('op', 'unknown')}) layer={op.get('layer', -1)} */",
         f"    {debug_input_name} = (const float*)({x_expr});",
@@ -1814,6 +1826,7 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
             op["op_instance_idx"] = inst
             rmsnorm_counts_by_layer[layer_for_instance] = inst + 1
         linear_emission = resolved_quantized_linear_emission(op)
+        quantization_emission = resolved_activation_quantization_emission(op)
         if op_type == "dense_embedding_lookup":
             lines.append(f"    if (stop_seq == {seq_idx}) return;")
             if (
@@ -1826,13 +1839,13 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                 lines.append("")
             continue
 
-        if op_type == "quantize_input_0" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+        if op_type == "quantize_input_0" and quantization_emission:
             op_code = _emit_prefill_quant_rows(
                 op,
                 seq_idx,
                 profile=profile,
             )
-        elif op_type == "quantize_input_2" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
+        elif op_type == "quantize_input_2" and quantization_emission:
             op_code = _emit_prefill_quant_debug_override(
                 op,
                 seq_idx,
@@ -1868,8 +1881,8 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                     profile=profile,
                     dump=dump,
                 )
-        elif op_type == "quantize_mlp_down_input" and str(op.get("function", "")) in {"quantize_row_q8_0", "quantize_row_q8_k"}:
-            if swiglu_q8k_fusion_guard and swiglu_q8k_fusion_call and str(op.get("function", "")) == "quantize_row_q8_k":
+        elif op_type == "quantize_mlp_down_input" and quantization_emission:
+            if swiglu_q8k_fusion_guard and swiglu_q8k_fusion_call and quantization_emission["format"] == "q8_k":
                 base_code = _emit_prefill_quant_debug_override(
                     op,
                     seq_idx,
@@ -1915,11 +1928,17 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
             skip_swiglu_guard = None
         if op_type in {"silu_mul", "swiglu"}:
             next_op = ops[seq_idx + 1] if seq_idx + 1 < len(ops) else None
+            next_quantization = (
+                resolved_activation_quantization_emission(next_op)
+                if isinstance(next_op, dict)
+                else None
+            )
             if (
                 isinstance(next_op, dict)
                 and str(op.get("function", "")) == "swiglu_forward"
                 and str(next_op.get("op", "")) == "quantize_mlp_down_input"
-                and str(next_op.get("function", "")) == "quantize_row_q8_k"
+                and next_quantization is not None
+                and next_quantization["format"] == "q8_k"
             ):
                 swiglu_args = op.get("args", [])
                 quant_args = next_op.get("args", [])


### PR DESCRIPTION
## What

- Move Q8_0/Q8_K output block ABI ownership into quantization kernel maps.
- Resolve exactly one quantization provider from registry metadata.
- Validate capability schemas and preserve exact kernel/function/storage identity through LoweredIR and call IR.
- Make decode, prefill, embedded multimodal prefill, and SwiGLU fusion checks consume resolved storage capability.
- Hard-fail missing, ambiguous, malformed, or identity-drifted capabilities.

## Ad-hoc reduction

| Area | Before | After | Owner |
|---|---:|---:|---|
| Q8 quantizer symbol predicates | 11 | 0 | Quantization kernel map |
| Protected DSL violations | 0 / 8 functions | 0 / 8 functions | AST policy gate |
| Conservative broad family predicates | 15 | 15 | Remaining cleanup inventory |

The broad score is intentionally conservative and includes some legitimate exact operation dispatch that must be classified before removal.

## Validation

- make test-v8-dsl
- make v8-regression-fast PYTHON=.venv/bin/python
- make llamacpp-parity-nightly
- Pre-commit: v7 and v8 fast regressions
- Pre-push: build, kernel parity, Gemma E2E, v8 inference contracts, v7 training smoke, v7/v8 fast regressions, v7 training-kernel parity
- git diff --check
