### PR TITLE
perf(v8/bf16): harden AMX vision projections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2002,6 +2002,13 @@ test-bench: $(LIB) test-libs
 
 
 
+.PHONY: test-bf16-performance-sweep
+test-bf16-performance-sweep: $(LIB)
+	@echo "Running BF16 numerical performance thread sweep..."
+	@LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) \
+		unittest/bf16/test_qwen3vl_performance_sweep_bf16.py \
+		--report version/v8/.cache/reports/bf16_performance_sweep_latest.json
+
 .PHONY: test-bf16-practical-precision
 test-bf16-practical-precision: $(LIB)
 	@echo "Running practical-shape BF16 precision matrix..."

--- a/docs/site/_pages/bf16-amx-performance-study.html
+++ b/docs/site/_pages/bf16-amx-performance-study.html
@@ -1,0 +1,128 @@
+<!-- TITLE: BF16 AMX Performance Study -->
+<!-- NAV: architecture -->
+
+<style>
+.study-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+    margin: 1rem 0;
+}
+.study-card {
+    border: 1px solid var(--grey);
+    border-left: 4px solid var(--orange);
+    border-radius: 8px;
+    padding: 1rem;
+    background: rgba(255,255,255,0.02);
+}
+.study-card h3 { margin-top: 0; }
+.study-metric {
+    display: block;
+    color: var(--orange);
+    font-size: 1.35rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+.study-table td:first-child { font-weight: 600; }
+</style>
+
+<h1>BF16 AMX Performance Study</h1>
+
+<p>This study tracks the numerical and performance work used to move a Qwen3-VL BF16 vision encoder toward its
+PyTorch reference. It records unsuccessful experiments as well as accepted changes. The measurements come from a
+managed Xeon container using a local 4032-patch form fixture, so they establish software behavior on this allocation,
+not bare-metal platform limits.</p>
+
+<div class="alert alert-warning">
+    <strong>Correctness remains the gate.</strong> Every optimization is checked against the same PyTorch prefix and
+    BF16 numerical contracts. A faster kernel is rejected when it materially worsens the stitched encoder result.
+</div>
+
+<div class="study-grid">
+    <div class="study-card">
+        <span class="study-metric">270.8 s to 28.1 s</span>
+        <h3>Encoder Progression</h3>
+        <p>Measured CK wall time fell by about 9.6x after native BF16 projection work, selective AMX use, and
+        independent-head attention scheduling.</p>
+    </div>
+    <div class="study-card">
+        <span class="study-metric">129.3 s to 12.7 s</span>
+        <h3>Attention Hotspot</h3>
+        <p>Partitioning independent heads through the CK threadpool produced the largest end-to-end gain while keeping
+        each head's FP32 reduction order unchanged.</p>
+    </div>
+    <div class="study-card">
+        <span class="study-metric">8.3 ms</span>
+        <h3>AMX Projection</h3>
+        <p>The weight-reuse AMX microkernel reached 8.3 ms on the practical M=4032, N=3456, K=1152 projection,
+        compared with roughly 62 ms for the original native path and 4.6 ms for PyTorch.</p>
+    </div>
+</div>
+
+<h2>Measured Progression</h2>
+
+<table class="study-table">
+    <thead>
+        <tr><th>Configuration</th><th>CK Encoder</th><th>PyTorch</th><th>Prefix Cosine</th><th>Relative RMSE</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>Original stitched encoder</td><td>~270.8 s</td><td>~12.5 s</td><td>0.99857</td><td>5.20%</td></tr>
+        <tr><td>Native paired-BF16 projections</td><td>~148.3 s</td><td>9.39 s</td><td>0.99863</td><td>5.08%</td></tr>
+        <tr><td>Head-parallel attention and selective AMX projectors</td><td>~28.1 s</td><td>~10.0 s</td><td>0.99858</td><td>5.09%</td></tr>
+    </tbody>
+</table>
+
+<p>PyTorch reported oneDNN BRGEMM execution using an AVX-512 AMX path and blocked layouts. The CK comparison is not
+an attempt to duplicate oneDNN dispatch. CK declares exact numerical contracts and kernel identities in its circuit
+and kernel maps, then measures those implementations through the generated model.</p>
+
+<h2>Projection Microkernel</h2>
+
+<table class="study-table">
+    <thead><tr><th>Implementation</th><th>Practical Projection Time</th><th>Disposition</th></tr></thead>
+    <tbody>
+        <tr><td>Original native BF16</td><td>~62 ms</td><td>Baseline</td></tr>
+        <tr><td>Initial AMX tile kernel</td><td>~19.9 ms</td><td>Improved, but left weight reuse on the table</td></tr>
+        <tr><td>AMX with weight-tile reuse</td><td>~8.3 ms</td><td>Accepted for selected projector operations</td></tr>
+        <tr><td>PyTorch/oneDNN</td><td>~4.6 ms</td><td>Reference</td></tr>
+    </tbody>
+</table>
+
+<p>The AMX provider is additive. Its contract specifies BF16 inputs and weights, FP32 tile accumulation, ascending K
+tiles, BF16 round-to-nearest-even output storage, and independent output tiles. The circuit selects it explicitly for
+projector operations. Layer projections continue to use the native paired-BF16 provider because applying AMX to every
+layer slightly worsened final-prefix accuracy.</p>
+
+<p>The AMX entry point is fail-closed. Unsupported builds, invalid tile shapes, workspace allocation failure, or
+per-thread tile-permission failure terminate with a hard kernel-contract fault instead of silently running the native
+paired-dot reduction. Portable performance sweeps query the compiled runtime capability and report AMX as skipped
+when it is unavailable; a hardware skip is never counted as AMX numerical or performance evidence.</p>
+
+<p>A separate M=32, N=3456, K=1152 thread sweep found a best CK AMX time of 0.133 ms at 16 threads versus 0.135 ms
+for PyTorch. The output was bit-exact and invariant across the tested thread counts. This is leaf-kernel evidence, not
+an end-to-end claim: it shows that AMX instruction throughput is no longer the limiting factor for that projection
+shape.</p>
+
+<h2>Rejected Experiment</h2>
+
+<p>Splitting each attention head into two query-row jobs increased the available job count but repeated V
+transposition and weakened locality. Attention regressed from approximately 12.7 seconds to 16.3 seconds. The change
+was reverted. More jobs are not automatically more parallel efficiency; the unit of work must preserve reuse.</p>
+
+<h2>Evidence Rules</h2>
+
+<ul>
+    <li>Record commit, compiler, ISA, thread count, model shape, and container constraints.</li>
+    <li>Measure the production shape in isolation and in the generated end-to-end circuit.</li>
+    <li>Report prefix cosine and relative RMSE alongside wall time.</li>
+    <li>Keep arithmetic order and threading behavior in numerical contracts and kernel maps.</li>
+    <li>Retain rejected experiments when they explain cache, reuse, or scheduling behavior.</li>
+    <li>Do not publish private input artifacts or managed-platform identifiers.</li>
+</ul>
+
+<h2>Next Measurements</h2>
+
+<p>The remaining encoder gap is concentrated in native layer projections and attention. The next work is to profile
+those two paths with controlled thread sweeps and hardware counters where available, while keeping mixed-prefill and
+teacher-forced parity as acceptance gates. Results from managed infrastructure must remain separate from future
+privileged bare-metal AMX, NUMA, memory-channel, and power measurements.</p>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -219,6 +219,18 @@ void gemm_nt_bf16_bf16_storage(const float *A,
                                       float *C,
                                       int M, int N, int K);
 
+void gemm_nt_bf16_native_bf16_storage(const float *A,
+                                      const void *B,
+                                      const float *bias,
+                                      float *C,
+                                      int M, int N, int K);
+void gemm_nt_bf16_amx_bf16_storage(const float *A,
+                                    const void *B,
+                                    const float *bias,
+                                    float *C,
+                                    int M, int N, int K);
+int ck_gemm_bf16_amx_available(void);
+
 // =============================================================================
 // Quantized (GGML-style) GEMM/GEMV helpers
 // =============================================================================

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -3843,10 +3843,11 @@ static float ck_bf16_dot_contract(const float *a, const float *b, int count)
 #endif
 }
 
-static int ck_attention_full_bf16_sdpa_tiled(
+static int ck_attention_full_bf16_sdpa_tiled_range(
     const float *q, const float *k, const float *v, float *output,
     int num_heads, int num_kv_heads, int num_tokens,
-    int head_dim, int aligned_head_dim, int kv_stride_tokens)
+    int head_dim, int aligned_head_dim, int kv_stride_tokens,
+    int head_begin, int head_step)
 {
     if (!q || !k || !v || !output || num_heads <= 0 || num_kv_heads <= 0 ||
         head_dim <= 0 || num_tokens <= 0 || aligned_head_dim < head_dim ||
@@ -3865,7 +3866,7 @@ static int ck_attention_full_bf16_sdpa_tiled(
     float probs[512];
     float *v_cols = (float *)malloc(v_col_count * sizeof(float));
     if (!v_cols) return 0;
-    for (int h = 0; h < num_heads; ++h) {
+    for (int h = head_begin; h < num_heads; h += head_step) {
         const int kv_head = (int)((long long)h * (long long)num_kv_heads / (long long)num_heads);
         const float *qh = q + (size_t)h * q_head_stride;
         const float *kh = k + (size_t)kv_head * kv_head_stride;
@@ -3919,6 +3920,56 @@ static int ck_attention_full_bf16_sdpa_tiled(
     free(v_cols);
     return 1;
 }
+
+typedef struct {
+    const float *q;
+    const float *k;
+    const float *v;
+    float *output;
+    int num_heads;
+    int num_kv_heads;
+    int num_tokens;
+    int head_dim;
+    int aligned_head_dim;
+    int kv_stride_tokens;
+    int failed;
+} ck_attention_bf16_sdpa_args_t;
+
+static void ck_attention_bf16_sdpa_work(int ith, int nth, void *opaque)
+{
+    ck_attention_bf16_sdpa_args_t *args = (ck_attention_bf16_sdpa_args_t *)opaque;
+    if (!ck_attention_full_bf16_sdpa_tiled_range(
+            args->q, args->k, args->v, args->output,
+            args->num_heads, args->num_kv_heads, args->num_tokens,
+            args->head_dim, args->aligned_head_dim, args->kv_stride_tokens,
+            ith, nth)) {
+        __atomic_store_n(&args->failed, 1, __ATOMIC_RELAXED);
+    }
+}
+
+static int ck_attention_full_bf16_sdpa_tiled(
+    const float *q, const float *k, const float *v, float *output,
+    int num_heads, int num_kv_heads, int num_tokens,
+    int head_dim, int aligned_head_dim, int kv_stride_tokens)
+{
+    ck_attention_bf16_sdpa_args_t args = {
+        .q=q, .k=k, .v=v, .output=output,
+        .num_heads=num_heads, .num_kv_heads=num_kv_heads,
+        .num_tokens=num_tokens, .head_dim=head_dim,
+        .aligned_head_dim=aligned_head_dim, .kv_stride_tokens=kv_stride_tokens,
+        .failed=0
+    };
+    ck_threadpool_t *pool = ck_threadpool_global();
+    int active = pool ? ck_threadpool_n_threads(pool) : 1;
+    if (active > num_heads) active = num_heads;
+    if (pool && active > 1) {
+        ck_threadpool_dispatch_n(pool, active, ck_attention_bf16_sdpa_work, &args);
+    } else {
+        ck_attention_bf16_sdpa_work(0, 1, &args);
+    }
+    return __atomic_load_n(&args.failed, __ATOMIC_RELAXED) == 0;
+}
+
 void attention_forward_full_head_major_gqa_flash_strided_bf16_storage(
     const float *q,
     const float *k,

--- a/src/kernels/gemm_kernels_bf16.c
+++ b/src/kernels/gemm_kernels_bf16.c
@@ -24,6 +24,7 @@
  */
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -42,6 +43,7 @@
 
 #include "bf16_utils.h"
 #include "ckernel_engine.h"
+#include "ck_threadpool.h"
 
 /* Block sizes tuned for typical L1/L2 cache */
 #define BLK_M 64
@@ -274,6 +276,10 @@ static void ck_amx_config_bf16_16x16x32(void)
     cfg.colsb[1] = 64;
     cfg.rows[2] = 16;       /* C: 16 rows x 16 FP32 */
     cfg.colsb[2] = 64;
+    for (int tile = 3; tile <= 5; ++tile) {
+        cfg.rows[tile] = 16;
+        cfg.colsb[tile] = 64;
+    }
 
     _tile_loadconfig(&cfg);
 }
@@ -763,6 +769,277 @@ void gemm_tn_bf16(const uint16_t *A,
  * standard mixed-precision training contract where activations/weights may be
  * BF16 but gradient accumulation remains FP32.
  */
+typedef struct {
+    const float *A;
+    const uint16_t *B;
+    const float *bias;
+    float *C;
+    int M;
+    int N;
+    int K;
+} ck_gemm_bf16_native_args_t;
+
+static void ck_gemm_bf16_native_work(int ith, int nth, void *opaque)
+{
+    ck_gemm_bf16_native_args_t *args = (ck_gemm_bf16_native_args_t *)opaque;
+    const int N = args->N;
+    const int K = args->K;
+    uint16_t *a_bf16 = (uint16_t *)alloca((size_t)K * sizeof(uint16_t));
+
+    for (int row = ith; row < args->M; row += nth) {
+        const float *src = args->A + (size_t)row * (size_t)K;
+        float *dst = args->C + (size_t)row * (size_t)N;
+        for (int k = 0; k < K; ++k) a_bf16[k] = float_to_bf16(src[k]);
+
+#if HAVE_NATIVE_BF16
+        int j = 0;
+        for (; j + 4 <= N; j += 4) {
+            const uint16_t *b0 = args->B + (size_t)(j + 0) * K;
+            const uint16_t *b1 = args->B + (size_t)(j + 1) * K;
+            const uint16_t *b2 = args->B + (size_t)(j + 2) * K;
+            const uint16_t *b3 = args->B + (size_t)(j + 3) * K;
+            __m512 acc0 = _mm512_setzero_ps();
+            __m512 acc1 = _mm512_setzero_ps();
+            __m512 acc2 = _mm512_setzero_ps();
+            __m512 acc3 = _mm512_setzero_ps();
+            int k = 0;
+            for (; k <= K - 32; k += 32) {
+                const __m512bh av = load_bf16x32(a_bf16 + k);
+                acc0 = _mm512_dpbf16_ps(acc0, av, load_bf16x32(b0 + k));
+                acc1 = _mm512_dpbf16_ps(acc1, av, load_bf16x32(b1 + k));
+                acc2 = _mm512_dpbf16_ps(acc2, av, load_bf16x32(b2 + k));
+                acc3 = _mm512_dpbf16_ps(acc3, av, load_bf16x32(b3 + k));
+            }
+            float sums[4] = {
+                _mm512_reduce_add_ps(acc0), _mm512_reduce_add_ps(acc1),
+                _mm512_reduce_add_ps(acc2), _mm512_reduce_add_ps(acc3)
+            };
+            for (; k < K; ++k) {
+                const float av = bf16_to_float(a_bf16[k]);
+                sums[0] += av * bf16_to_float(b0[k]);
+                sums[1] += av * bf16_to_float(b1[k]);
+                sums[2] += av * bf16_to_float(b2[k]);
+                sums[3] += av * bf16_to_float(b3[k]);
+            }
+            for (int lane = 0; lane < 4; ++lane) {
+                if (args->bias) sums[lane] += args->bias[j + lane];
+                dst[j + lane] = bf16_to_float(float_to_bf16(sums[lane]));
+            }
+        }
+        for (; j < N; ++j) {
+            const uint16_t *b = args->B + (size_t)j * K;
+            __m512 acc = _mm512_setzero_ps();
+            int k = 0;
+            for (; k <= K - 32; k += 32) {
+                acc = _mm512_dpbf16_ps(
+                    acc, load_bf16x32(a_bf16 + k), load_bf16x32(b + k));
+            }
+            float sum = _mm512_reduce_add_ps(acc);
+            for (; k < K; ++k) {
+                sum += bf16_to_float(a_bf16[k]) * bf16_to_float(b[k]);
+            }
+            if (args->bias) sum += args->bias[j];
+            dst[j] = bf16_to_float(float_to_bf16(sum));
+        }
+#else
+        for (int j = 0; j < N; ++j) {
+            const uint16_t *b = args->B + (size_t)j * K;
+            float sum = args->bias ? args->bias[j] : 0.0f;
+            for (int k = 0; k < K; ++k) {
+                sum += bf16_to_float(a_bf16[k]) * bf16_to_float(b[k]);
+            }
+            dst[j] = bf16_to_float(float_to_bf16(sum));
+        }
+#endif
+    }
+}
+
+void gemm_nt_bf16_native_bf16_storage(const float *A,
+                                       const void *B,
+                                       const float *bias,
+                                       float *C,
+                                       int M, int N, int K)
+{
+    const uint16_t *weights = (const uint16_t *)B;
+    if (!A || !weights || !C || M <= 0 || N <= 0 || K <= 0) return;
+
+    ck_gemm_bf16_native_args_t args = {
+        .A = A, .B = weights, .bias = bias, .C = C, .M = M, .N = N, .K = K
+    };
+    ck_threadpool_t *pool = ck_threadpool_global();
+    int active = pool ? ck_threadpool_n_threads(pool) : 1;
+    if (active > M) active = M;
+    if (active > 24) active = 24;
+    if (!pool || active <= 1 || (size_t)M * (size_t)N <= 4096) {
+        ck_gemm_bf16_native_work(0, 1, &args);
+        return;
+    }
+    ck_threadpool_dispatch_n(pool, active, ck_gemm_bf16_native_work, &args);
+}
+
+typedef struct {
+    const float *src;
+    uint16_t *dst;
+    size_t count;
+} ck_bf16_convert_args_t;
+
+static void ck_bf16_convert_work(int ith, int nth, void *opaque)
+{
+    ck_bf16_convert_args_t *args = (ck_bf16_convert_args_t *)opaque;
+    const size_t begin = args->count * (size_t)ith / (size_t)nth;
+    const size_t end = args->count * (size_t)(ith + 1) / (size_t)nth;
+    for (size_t i = begin; i < end; ++i) args->dst[i] = float_to_bf16(args->src[i]);
+}
+
+typedef struct {
+    const uint16_t *A;
+    const uint16_t *B;
+    const float *bias;
+    float *C;
+    int M;
+    int N;
+    int K;
+    int failed;
+} ck_gemm_bf16_amx_args_t;
+
+static void ck_gemm_bf16_amx_work(int ith, int nth, void *opaque)
+{
+#if HAVE_AMX_BF16
+    ck_gemm_bf16_amx_args_t *args = (ck_gemm_bf16_amx_args_t *)opaque;
+    if (!ck_amx_request_xtile_data()) {
+        __atomic_store_n(&args->failed, 1, __ATOMIC_RELAXED);
+        return;
+    }
+    ck_amx_config_bf16_16x16x32();
+    uint16_t b_tile[16 * 32];
+    const int mb = args->M / 16;
+    const int nb = args->N / 16;
+    const int m_groups = (mb + 3) / 4;
+    const int jobs = m_groups * nb;
+
+    for (int job = ith; job < jobs; job += nth) {
+        const int m_group = job / nb;
+        const int j = (job % nb) * 16;
+        const int group_blocks = (mb - m_group * 4 < 4) ? mb - m_group * 4 : 4;
+        _tile_zero(2);
+        if (group_blocks > 1) _tile_zero(3);
+        if (group_blocks > 2) _tile_zero(4);
+        if (group_blocks > 3) _tile_zero(5);
+        for (int k = 0; k < args->K; k += 32) {
+            ck_pack_bf16_ktile_pairs_16x16(b_tile, args->B, args->K, j, k);
+            _tile_loadd(1, b_tile, 32 * (int)sizeof(uint16_t));
+            for (int g = 0; g < group_blocks; ++g) {
+                const int i = (m_group * 4 + g) * 16;
+                _tile_loadd(0, args->A + (size_t)i * args->K + k,
+                            args->K * (int)sizeof(uint16_t));
+                switch (g) {
+                    case 0: _tile_dpbf16ps(2, 0, 1); break;
+                    case 1: _tile_dpbf16ps(3, 0, 1); break;
+                    case 2: _tile_dpbf16ps(4, 0, 1); break;
+                    default: _tile_dpbf16ps(5, 0, 1); break;
+                }
+            }
+        }
+        for (int g = 0; g < group_blocks; ++g) {
+            const int i = (m_group * 4 + g) * 16;
+            float *tile_dst = args->C + (size_t)i * args->N + j;
+            const int tile_stride = args->N * (int)sizeof(float);
+            switch (g) {
+                case 0: _tile_stored(2, tile_dst, tile_stride); break;
+                case 1: _tile_stored(3, tile_dst, tile_stride); break;
+                case 2: _tile_stored(4, tile_dst, tile_stride); break;
+                default: _tile_stored(5, tile_dst, tile_stride); break;
+            }
+            if (args->bias) {
+                for (int ii = 0; ii < 16; ++ii) {
+                    float *row = args->C + (size_t)(i + ii) * args->N + j;
+                    for (int jj = 0; jj < 16; ++jj) row[jj] += args->bias[j + jj];
+                }
+            }
+        }
+    }
+    _tile_release();
+#else
+    (void)ith; (void)nth; (void)opaque;
+#endif
+}
+
+typedef struct {
+    float *values;
+    size_t count;
+} ck_bf16_round_args_t;
+
+static void ck_bf16_round_work(int ith, int nth, void *opaque)
+{
+    ck_bf16_round_args_t *args = (ck_bf16_round_args_t *)opaque;
+    const size_t begin = args->count * (size_t)ith / (size_t)nth;
+    const size_t end = args->count * (size_t)(ith + 1) / (size_t)nth;
+    for (size_t i = begin; i < end; ++i) {
+        args->values[i] = bf16_to_float(float_to_bf16(args->values[i]));
+    }
+}
+
+int ck_gemm_bf16_amx_available(void)
+{
+#if HAVE_AMX_BF16
+    return ck_amx_request_xtile_data();
+#else
+    return 0;
+#endif
+}
+
+void gemm_nt_bf16_amx_bf16_storage(const float *A,
+                                    const void *B,
+                                    const float *bias,
+                                    float *C,
+                                    int M, int N, int K)
+{
+#if HAVE_AMX_BF16
+    if (!A || !B || !C || M < 16 || N < 16 || K < 32 ||
+        (M % 16) != 0 || (N % 16) != 0 || (K % 32) != 0) {
+        fprintf(stderr,
+                "HARD KERNEL CONTRACT FAULT: AMX BF16 GEMM requires non-null buffers "
+                "and M%%16=N%%16=K%%32=0 (M=%d N=%d K=%d)\n",
+                M, N, K);
+        abort();
+    }
+    const size_t input_count = (size_t)M * K;
+    uint16_t *a_bf16 = (uint16_t *)malloc(input_count * sizeof(uint16_t));
+    if (!a_bf16) {
+        fprintf(stderr, "HARD KERNEL CONTRACT FAULT: AMX BF16 activation workspace allocation failed\n");
+        abort();
+    }
+    ck_threadpool_t *pool = ck_threadpool_global();
+    int active = pool ? ck_threadpool_n_threads(pool) : 1;
+    if (active > 24) active = 24;
+    ck_bf16_convert_args_t convert = {.src=A, .dst=a_bf16, .count=input_count};
+    if (pool && active > 1) ck_threadpool_dispatch_n(pool, active, ck_bf16_convert_work, &convert);
+    else ck_bf16_convert_work(0, 1, &convert);
+    ck_gemm_bf16_amx_args_t gemm = {
+        .A=a_bf16, .B=(const uint16_t *)B, .bias=bias, .C=C,
+        .M=M, .N=N, .K=K, .failed=0
+    };
+    if (pool && active > 1) ck_threadpool_dispatch_n(pool, active, ck_gemm_bf16_amx_work, &gemm);
+    else ck_gemm_bf16_amx_work(0, 1, &gemm);
+    if (__atomic_load_n(&gemm.failed, __ATOMIC_RELAXED)) {
+        free(a_bf16);
+        fprintf(stderr, "HARD KERNEL CONTRACT FAULT: AMX tile permission request failed\n");
+        abort();
+    }
+    ck_bf16_round_args_t round = {.values=C, .count=(size_t)M * N};
+    if (pool && active > 1) ck_threadpool_dispatch_n(pool, active, ck_bf16_round_work, &round);
+    else ck_bf16_round_work(0, 1, &round);
+    free(a_bf16);
+    return;
+#else
+    (void)A; (void)B; (void)bias; (void)C; (void)M; (void)N; (void)K;
+    fprintf(stderr,
+            "HARD KERNEL CONTRACT FAULT: gemm_nt_bf16_amx_bf16_storage was selected "
+            "without AMX BF16 support\n");
+    abort();
+#endif
+}
+
 void gemm_nt_bf16_bf16_storage(const float *A,
                                       const void *B,
                                       const float *bias,

--- a/tests/test_v8_kernel_call_abi.py
+++ b/tests/test_v8_kernel_call_abi.py
@@ -52,12 +52,12 @@ class V8KernelCallABITests(unittest.TestCase):
                     key=lambda error: tuple(str(part) for part in error.absolute_path),
                 )
                 self.assertEqual(errors, [])
-        self.assertEqual(governed, 23)
+        self.assertEqual(governed, 25)
 
     def test_map_owned_abis_do_not_exist_in_legacy_registries(self) -> None:
         call_abis = build_ir_v8.load_kernel_call_abis()
         legacy = build_ir_v8.load_kernel_bindings()
-        self.assertEqual(len(call_abis), 23)
+        self.assertEqual(len(call_abis), 25)
         for kernel_id, entry in call_abis.items():
             with self.subTest(kernel=kernel_id):
                 self.assertNotIn(kernel_id, legacy)

--- a/tests/test_v8_numerical_execution_contracts.py
+++ b/tests/test_v8_numerical_execution_contracts.py
@@ -165,12 +165,13 @@ class NumericalExecutionContractTests(unittest.TestCase):
         )
         expected = {
             "vision.layer.layernorm": "layernorm_naive_serial_bf16_storage",
-            "vision.layer.qkv_projection": "gemm_nt_bf16_bf16_storage",
-            "vision.layer.mlp_projection": "gemm_nt_bf16_bf16_storage",
+            "vision.layer.qkv_projection": "gemm_nt_bf16_native_bf16_storage",
+            "vision.layer.mlp_projection": "gemm_nt_bf16_native_bf16_storage",
             "vision.layer.mlp_activation": "gelu_pytorch_tanh_bf16_storage",
             "vision.layer.attention": "attention_forward_full_head_major_gqa_sdpa_bf16_storage",
-            "vision.layer.out_projection": "gemm_nt_bf16_bf16_storage",
+            "vision.layer.out_projection": "gemm_nt_bf16_native_bf16_storage",
             "vision.layer.residual": "ck_residual_add_token_major_bf16_storage",
+            "vision.projector.projection": "gemm_nt_bf16_amx_bf16_storage",
         }
         for operation, function in expected.items():
             with self.subTest(operation=operation):
@@ -185,9 +186,15 @@ class NumericalExecutionContractTests(unittest.TestCase):
                 self.assertEqual(plan["kernel"]["function"], function)
                 self.assertEqual(plan["contract"]["status"], "validated")
                 if operation == "vision.layer.attention":
-                    self.assertEqual(plan["contract"]["semantics"]["threading"]["work_partition"], "serial")
-                    self.assertEqual(plan["implementation"]["threading"]["runtime"], "serial")
-                    self.assertEqual(plan["implementation"]["threading"]["dispatch"], ["inline"])
+                    self.assertEqual(
+                        plan["contract"]["semantics"]["threading"]["work_partition"],
+                        "independent_heads",
+                    )
+                    self.assertEqual(plan["implementation"]["threading"]["runtime"], "ck_threadpool")
+                    self.assertEqual(
+                        plan["implementation"]["threading"]["dispatch"],
+                        ["ck_threadpool_dispatch_n"],
+                    )
 
     def test_zero_provider_is_hard_failure(self):
         kernels = copy.deepcopy(self.kernels)

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -455,14 +455,14 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
         self.assertEqual(legacy, [])
         selected = {plan["operation"]: plan["kernel"]["function"] for plan in execution}
         self.assertEqual(selected["vision.layer.layernorm"], "layernorm_naive_serial_bf16_storage")
-        self.assertEqual(selected["vision.layer.qkv_projection"], "gemm_nt_bf16_bf16_storage")
-        self.assertEqual(selected["vision.layer.mlp_projection"], "gemm_nt_bf16_bf16_storage")
+        self.assertEqual(selected["vision.layer.qkv_projection"], "gemm_nt_bf16_native_bf16_storage")
+        self.assertEqual(selected["vision.layer.mlp_projection"], "gemm_nt_bf16_native_bf16_storage")
         self.assertEqual(selected["vision.layer.mlp_activation"], "gelu_pytorch_tanh_bf16_storage")
         self.assertEqual(
             selected["vision.layer.attention"],
             "attention_forward_full_head_major_gqa_sdpa_bf16_storage",
         )
-        self.assertEqual(selected["vision.layer.out_projection"], "gemm_nt_bf16_bf16_storage")
+        self.assertEqual(selected["vision.layer.out_projection"], "gemm_nt_bf16_native_bf16_storage")
         self.assertEqual(
             selected["vision.layer.residual"],
             "ck_residual_add_token_major_bf16_storage",
@@ -475,14 +475,14 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
         )
         kernels = [(op["op"], op["kernel"]) for op in ops]
         self.assertIn(("layernorm", "layernorm_bf16_storage"), kernels)
-        self.assertIn(("qkv_packed_proj", "gemm_nt_bf16_bf16_storage"), kernels)
+        self.assertIn(("qkv_packed_proj", "gemm_nt_bf16_native_bf16_storage"), kernels)
         self.assertIn(
             ("attn", "attention_forward_full_head_major_gqa_sdpa_bf16_storage"),
             kernels,
         )
-        self.assertIn(("out_proj", "gemm_nt_bf16_bf16_storage"), kernels)
-        self.assertIn(("mlp_up", "gemm_nt_bf16_bf16_storage"), kernels)
-        self.assertIn(("mlp_down", "gemm_nt_bf16_bf16_storage"), kernels)
+        self.assertIn(("out_proj", "gemm_nt_bf16_native_bf16_storage"), kernels)
+        self.assertIn(("mlp_up", "gemm_nt_bf16_native_bf16_storage"), kernels)
+        self.assertIn(("mlp_down", "gemm_nt_bf16_native_bf16_storage"), kernels)
         self.assertIn(("gelu", "gelu_pytorch_tanh_bf16_storage"), kernels)
         self.assertIn(
             ("residual_add", "ck_residual_add_token_major_bf16_storage"),

--- a/unittest/bf16/test_gemm_storage_contract_bf16.py
+++ b/unittest/bf16/test_gemm_storage_contract_bf16.py
@@ -13,6 +13,8 @@ import torch
 ROOT = Path(__file__).resolve().parents[2]
 LIB = ctypes.CDLL(str(ROOT / "build" / "libckernel_engine.so"))
 KERNEL = LIB.gemm_nt_bf16_bf16_storage
+NATIVE_KERNEL = LIB.gemm_nt_bf16_native_bf16_storage
+AMX_KERNEL = LIB.gemm_nt_bf16_amx_bf16_storage
 FLOAT_P = ctypes.POINTER(ctypes.c_float)
 UINT16_P = ctypes.POINTER(ctypes.c_uint16)
 KERNEL.argtypes = [
@@ -20,6 +22,17 @@ KERNEL.argtypes = [
     ctypes.c_int, ctypes.c_int, ctypes.c_int,
 ]
 KERNEL.restype = None
+NATIVE_KERNEL.argtypes = KERNEL.argtypes
+NATIVE_KERNEL.restype = None
+AMX_KERNEL.argtypes = KERNEL.argtypes
+AMX_KERNEL.restype = None
+AMX_AVAILABLE = LIB.ck_gemm_bf16_amx_available
+AMX_AVAILABLE.argtypes = []
+AMX_AVAILABLE.restype = ctypes.c_int
+
+
+def amx_bf16_supported() -> bool:
+    return bool(AMX_AVAILABLE())
 
 
 def bf16_bits(values: np.ndarray) -> np.ndarray:
@@ -30,14 +43,14 @@ def bf16_values(values: np.ndarray) -> np.ndarray:
     return torch.from_numpy(values).to(torch.bfloat16).float().numpy()
 
 
-def run_case_detailed(m: int, n: int, k: int, seed: int) -> dict[str, float]:
+def run_case_detailed(m: int, n: int, k: int, seed: int, *, kernel=KERNEL) -> dict[str, float]:
     rng = np.random.default_rng(seed)
     a = bf16_values(rng.standard_normal((m, k), dtype=np.float32))
     b_values = bf16_values(rng.standard_normal((n, k), dtype=np.float32))
     b = bf16_bits(b_values)
     bias = bf16_values(rng.standard_normal(n, dtype=np.float32))
     actual = np.empty((m, n), dtype=np.float32)
-    KERNEL(
+    kernel(
         a.ctypes.data_as(FLOAT_P),
         ctypes.c_void_p(b.ctypes.data),
         bias.ctypes.data_as(FLOAT_P),
@@ -74,7 +87,16 @@ def main() -> int:
                 f"max_abs={max_abs:.9g} rmse={rmse:.9g}"
             )
         print(f"M={m} N={n} K={k} max_abs={max_abs:.9g} rmse={rmse:.9g}")
-    print(f"BF16 GEMM output storage parity: {len(cases)}/{len(cases)}")
+    tested = len(cases)
+    if amx_bf16_supported():
+        amx = run_case_detailed(16, 32, 32, 4, kernel=AMX_KERNEL)
+        if amx["max_abs"] != 0.0 or amx["rmse"] != 0.0:
+            raise AssertionError(f"AMX BF16 storage mismatch: {amx}")
+        tested += 1
+        print("AMX M=16 N=32 K=32 exact")
+    else:
+        print("AMX M=16 N=32 K=32 SKIP (AMX BF16 unavailable)")
+    print(f"BF16 GEMM output storage parity: {tested}/{tested}")
     return 0
 
 

--- a/unittest/bf16/test_qwen3vl_performance_sweep_bf16.py
+++ b/unittest/bf16/test_qwen3vl_performance_sweep_bf16.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Thread-scaling and numerical sweep for practical BF16 projection shapes."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+import time
+
+import numpy as np
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_THREADS = (1, 4, 8, 16, 24)
+
+
+def _amx_available() -> bool:
+    lib = ctypes.CDLL(str(ROOT / "build" / "libckernel_engine.so"))
+    probe = lib.ck_gemm_bf16_amx_available
+    probe.argtypes = []
+    probe.restype = ctypes.c_int
+    return bool(probe())
+
+
+def _bf16_bits(values: torch.Tensor) -> np.ndarray:
+    return values.contiguous().view(torch.uint16).numpy()
+
+
+def _worker(args: argparse.Namespace) -> dict[str, object]:
+    torch.set_num_threads(args.threads)
+    rng = np.random.default_rng(args.seed)
+    a = torch.from_numpy(
+        rng.standard_normal((args.m, args.k), dtype=np.float32)
+    ).to(torch.bfloat16)
+    b = torch.from_numpy(
+        rng.standard_normal((args.n, args.k), dtype=np.float32)
+    ).to(torch.bfloat16)
+    bias = torch.from_numpy(
+        rng.standard_normal(args.n, dtype=np.float32)
+    ).to(torch.bfloat16)
+
+    a_fp32 = a.float().numpy()
+    b_bits = _bf16_bits(b)
+    bias_fp32 = bias.float().numpy()
+    actual = np.empty((args.m, args.n), dtype=np.float32)
+
+    lib = ctypes.CDLL(str(ROOT / "build" / "libckernel_engine.so"))
+    float_p = ctypes.POINTER(ctypes.c_float)
+    kernel = getattr(lib, args.kernel)
+    kernel.argtypes = [
+        float_p, ctypes.c_void_p, float_p, float_p,
+        ctypes.c_int, ctypes.c_int, ctypes.c_int,
+    ]
+    call_args = (
+        a_fp32.ctypes.data_as(float_p),
+        ctypes.c_void_p(b_bits.ctypes.data),
+        bias_fp32.ctypes.data_as(float_p),
+        actual.ctypes.data_as(float_p),
+        args.m, args.n, args.k,
+    )
+
+    def ck_call() -> None:
+        kernel(*call_args)
+
+    def torch_call() -> torch.Tensor:
+        return torch.nn.functional.linear(a, b, bias)
+
+    ck_call()
+    with torch.inference_mode():
+        expected = torch_call()
+    ck_times = []
+    torch_times = []
+    for _ in range(args.iterations):
+        start = time.perf_counter()
+        ck_call()
+        ck_times.append((time.perf_counter() - start) * 1000.0)
+        with torch.inference_mode():
+            start = time.perf_counter()
+            expected = torch_call()
+            torch_times.append((time.perf_counter() - start) * 1000.0)
+
+    expected_np = expected.float().numpy()
+    diff = np.abs(actual - expected_np)
+    return {
+        "kernel": args.kernel,
+        "threads": args.threads,
+        "ck_ms": statistics.median(ck_times),
+        "pytorch_ms": statistics.median(torch_times),
+        "pytorch_speedup_over_ck": statistics.median(ck_times) / statistics.median(torch_times),
+        "max_abs": float(diff.max(initial=0.0)),
+        "rmse": float(np.sqrt(np.mean(diff * diff))),
+        "exact_ratio": float(np.mean(diff == 0.0)),
+        "output_sha256": hashlib.sha256(actual.tobytes()).hexdigest(),
+    }
+
+
+def _run_parent(args: argparse.Namespace) -> dict[str, object]:
+    rows = []
+    kernels = list(args.kernels)
+    skipped = []
+    if "gemm_nt_bf16_amx_bf16_storage" in kernels and not _amx_available():
+        kernels.remove("gemm_nt_bf16_amx_bf16_storage")
+        skipped.append({
+            "kernel": "gemm_nt_bf16_amx_bf16_storage",
+            "reason": "AMX BF16 is unavailable in the current CPU/library build",
+        })
+    if not kernels:
+        raise RuntimeError("no requested BF16 performance kernel is available")
+    for kernel in kernels:
+        for threads in args.threads:
+            env = os.environ.copy()
+            env["CK_NUM_THREADS"] = str(threads)
+            env["OMP_NUM_THREADS"] = "1"
+            cmd = [
+            sys.executable, str(Path(__file__).resolve()), "--worker",
+            "--threads-one", str(threads), "--m", str(args.m),
+            "--n", str(args.n), "--k", str(args.k),
+            "--iterations", str(args.iterations), "--seed", str(args.seed),
+                "--kernel", kernel,
+            ]
+            completed = subprocess.run(
+            cmd, cwd=ROOT, env=env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True,
+        )
+            lines = [line for line in completed.stdout.splitlines() if line.strip()]
+            rows.append(json.loads(lines[-1]))
+
+    fastest_ck = min(rows, key=lambda row: row["ck_ms"])
+    fastest_torch = min(rows, key=lambda row: row["pytorch_ms"])
+    max_abs = max(row["max_abs"] for row in rows)
+    rmse = max(row["rmse"] for row in rows)
+    min_exact = min(row["exact_ratio"] for row in rows)
+    deterministic = all(
+        len({row["output_sha256"] for row in rows if row["kernel"] == kernel}) == 1
+        for kernel in kernels
+    )
+    status = "pass" if (
+        max_abs <= args.max_abs
+        and rmse <= args.max_rmse
+        and min_exact >= args.min_exact_ratio
+        and deterministic
+    ) else "fail"
+    report = {
+        "schema": "cke.bf16_performance_sweep",
+        "schema_version": 1,
+        "status": status,
+        "shape": {"m": args.m, "n": args.n, "k": args.k},
+        "iterations": args.iterations,
+        "rows": rows,
+        "skipped": skipped,
+        "thread_deterministic": deterministic,
+        "fastest_ck": fastest_ck,
+        "fastest_pytorch": fastest_torch,
+        "pytorch_speedup_over_fastest_ck": (
+            fastest_ck["ck_ms"] / fastest_torch["pytorch_ms"]
+        ),
+        "limits": {
+            "max_abs": args.max_abs,
+            "max_rmse": args.max_rmse,
+            "min_exact_ratio": args.min_exact_ratio,
+        },
+    }
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+    ratio = report["pytorch_speedup_over_fastest_ck"]
+    print(
+        f"Fastest CK: {fastest_ck['ck_ms']:.3f} ms at "
+        f"{fastest_ck['threads']} threads"
+    )
+    print(
+        f"Fastest PyTorch: {fastest_torch['pytorch_ms']:.3f} ms at "
+        f"{fastest_torch['threads']} threads"
+    )
+    print(f"PyTorch is {ratio:.2f}x faster than fastest CK")
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument("--threads-one", type=int, default=1)
+    parser.add_argument("--kernel", default="gemm_nt_bf16_native_bf16_storage")
+    parser.add_argument("--kernels", nargs="+", default=("gemm_nt_bf16_native_bf16_storage", "gemm_nt_bf16_amx_bf16_storage"))
+    parser.add_argument("--threads", type=int, nargs="+", default=DEFAULT_THREADS)
+    parser.add_argument("--m", type=int, default=32)
+    parser.add_argument("--n", type=int, default=3456)
+    parser.add_argument("--k", type=int, default=1152)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=20260712)
+    parser.add_argument("--max-abs", type=float, default=0.5)
+    parser.add_argument("--max-rmse", type=float, default=1.0e-3)
+    parser.add_argument("--min-exact-ratio", type=float, default=0.9997)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    if args.worker:
+        args.threads = args.threads_one
+        print(json.dumps(_worker(args)))
+        return 0
+    report = _run_parent(args)
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unittest/bf16/test_qwen3vl_practical_precision_bf16.py
+++ b/unittest/bf16/test_qwen3vl_practical_precision_bf16.py
@@ -92,10 +92,19 @@ def main() -> int:
     record(rows, "mlp_up_gemm", {"m": 2, "n": 4304, "k": 1152},
            gemm.run_case_detailed(2, 4304, 1152, 103), (0.03125, 3.5e-4),
            min_exact_ratio=0.9997)
+    record(rows, "qkv_gemm_native_threadpool", {"m": 4, "n": 3456, "k": 1152},
+           gemm.run_case_detailed(4, 3456, 1152, 102, kernel=gemm.NATIVE_KERNEL),
+           (0.03125, 3.0e-4), min_exact_ratio=0.9997)
+    record(rows, "mlp_up_gemm_native_threadpool", {"m": 2, "n": 4304, "k": 1152},
+           gemm.run_case_detailed(2, 4304, 1152, 103, kernel=gemm.NATIVE_KERNEL),
+           (0.03125, 3.5e-4), min_exact_ratio=0.9997)
+    record(rows, "qkv_gemm_amx_tile32", {"m": 32, "n": 3456, "k": 1152},
+           gemm.run_case_detailed(32, 3456, 1152, 104, kernel=gemm.AMX_KERNEL),
+           (0.5, 1.0e-3), min_exact_ratio=0.9997)
     record(rows, "vision_attention", {"heads": 2, "tokens": 128, "dim": 72},
-           attention.run_case(2, 128, 72, 104), (0.03125, 0.003))
+           attention.run_case(2, 2, 128, 72, 72, 104)[:2], (0.03125, 0.003))
     record(rows, "vision_attention", {"heads": 2, "tokens": 512, "dim": 72},
-           attention.run_case(2, 512, 72, 105), (0.03125, 0.003))
+           attention.run_case(2, 2, 512, 72, 72, 105)[:2], (0.03125, 0.003))
 
     report = {
         "schema": "cke.bf16_practical_precision",

--- a/unittest/test_attention_f16_split_kv.py
+++ b/unittest/test_attention_f16_split_kv.py
@@ -214,6 +214,30 @@ def _half_bits(a):
     return np.ascontiguousarray(a.astype(np.float16)).view(np.uint16)
 
 
+def _pairwise_sum_f32(values):
+    values = np.asarray(values, dtype=np.float32)
+    while values.size > 1:
+        half = values.size // 2
+        values = (values[:half] + values[half:half * 2]).astype(np.float32)
+    return np.float32(values[0])
+
+
+def _dot_f16_avx512_contract(q32, k32):
+    accum = [np.zeros(16, dtype=np.float32) for _ in range(4)]
+    limit = q32.size - q32.size % 64
+    for offset in range(0, limit, 64):
+        for lane in range(4):
+            begin = offset + lane * 16
+            accum[lane] = (
+                accum[lane] + q32[begin:begin + 16] * k32[begin:begin + 16]
+            ).astype(np.float32)
+    merged = ((accum[0] + accum[2]) + (accum[1] + accum[3])).astype(np.float32)
+    result = _pairwise_sum_f32(merged)
+    for offset in range(limit, q32.size):
+        result = np.float32(result + np.float32(q32[offset] * k32[offset]))
+    return result
+
+
 def _split_oracle(q, k_bits, v_bits, head_dim, chunks):
     """Independent scalar-contract oracle with explicit FP16 accumulators."""
     num_heads, aligned = q.shape
@@ -238,11 +262,8 @@ def _split_oracle(q, k_bits, v_bits, head_dim, chunks):
             total = np.float32(0.0)
             acc = np.zeros(head_dim, dtype=np.float16)
             for token in range(begin, end):
-                # np.sum(dtype=float32) preserves the intended FP32 reduction
-                # contract while keeping the real Qwen3-VL shape test practical.
-                dot = np.sum(
-                    q32 * k_half[kv_head, token, :head_dim].astype(np.float32),
-                    dtype=np.float32,
+                dot = _dot_f16_avx512_contract(
+                    q32, k_half[kv_head, token, :head_dim].astype(np.float32)
                 )
                 score = np.float32(dot * scale)
                 old_max = maximum

--- a/version/v8/circuits/qwen3_vl_vision.json
+++ b/version/v8/circuits/qwen3_vl_vision.json
@@ -216,7 +216,7 @@
       },
       "phases": {
         "prefill": {
-          "contract_id": "bf16_weight_bf16_input_fp32_dot_bf16_output",
+          "contract_id": "bf16_weight_bf16_input_native_pair_dot_bf16_output",
           "validation": "validated",
           "evidence": "unittest/bf16/test_gemm_storage_contract_bf16.py"
         }
@@ -271,7 +271,7 @@
       },
       "phases": {
         "prefill": {
-          "contract_id": "bf16_weight_bf16_input_fp32_dot_bf16_output",
+          "contract_id": "bf16_weight_bf16_input_native_pair_dot_bf16_output",
           "validation": "validated",
           "evidence": "unittest/bf16/test_gemm_storage_contract_bf16.py"
         }
@@ -326,7 +326,7 @@
       },
       "phases": {
         "prefill": {
-          "contract_id": "bf16_weight_bf16_input_fp32_dot_bf16_output",
+          "contract_id": "bf16_weight_bf16_input_native_pair_dot_bf16_output",
           "validation": "validated",
           "evidence": "unittest/bf16/test_gemm_storage_contract_bf16.py"
         }
@@ -361,6 +361,36 @@
       "checkpoint": {
         "id": "vision.layer.{layer}.mlp.activation",
         "producer": "gelu",
+        "logical_layout": "token_major",
+        "axis_names": [
+          "token",
+          "channel"
+        ]
+      }
+    },
+    "vision.projector.projection": {
+      "op": "gemm",
+      "template_ops": [
+        "branch_fc1",
+        "branch_fc2",
+        "projector_fc1",
+        "projector_fc2"
+      ],
+      "selector": {
+        "config_equals": {
+          "vision_projection_storage_boundary": "bf16"
+        }
+      },
+      "phases": {
+        "prefill": {
+          "contract_id": "bf16_weight_bf16_input_amx_tile32_dot_bf16_output",
+          "validation": "validated",
+          "evidence": "unittest/bf16/test_qwen3vl_performance_sweep_bf16.py"
+        }
+      },
+      "checkpoint": {
+        "id": "vision.projector.projection",
+        "producer": "projector_projection",
         "logical_layout": "token_major",
         "axis_names": [
           "token",
@@ -869,13 +899,13 @@
           "id": "final_norm",
           "op": "layernorm"
         },
-      {
-        "id": "merge_main",
-        "op": "spatial_merge",
-        "params": {
-          "merge_size_from_config": "spatial_merge_size",
-          "output_buffer": "embedded_input"
-        }
+        {
+          "id": "merge_main",
+          "op": "spatial_merge",
+          "params": {
+            "merge_size_from_config": "spatial_merge_size",
+            "output_buffer": "embedded_input"
+          }
         },
         {
           "id": "projector_fc1",

--- a/version/v8/contracts/numerical_execution.json
+++ b/version/v8/contracts/numerical_execution.json
@@ -299,6 +299,41 @@
       "description": "BF16 weights and BF16-rounded FP32 activation loads with ascending-K FP32 dot products and BF16 RNE output storage.",
       "operator_family": "gemm"
     },
+    "bf16_weight_bf16_input_native_pair_dot_bf16_output": {
+      "status": "validated",
+      "storage": {
+        "input": "fp32",
+        "weight": "bf16",
+        "output": "bf16"
+      },
+      "compute": {
+        "input": "bf16_rne",
+        "weight": "bf16",
+        "accumulator": "fp32"
+      },
+      "rounding": {
+        "mode": "rne",
+        "points": [
+          "input_load",
+          "output_store"
+        ]
+      },
+      "reduction": {
+        "kind": "dot_product",
+        "order": "contract_defined_chunks",
+        "partial_accumulator": "fp32",
+        "merge_order": "pairwise_tree"
+      },
+      "threading": {
+        "work_partition": "independent_rows",
+        "split_strategy": "independent_outputs",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": null,
+      "description": "BF16 weights and BF16-rounded activations using native paired BF16 dot products, FP32 vector accumulators, pairwise horizontal merge, CK threadpool independent-row partitioning, and BF16 RNE output storage.",
+      "operator_family": "gemm"
+    },
     "attention_bf16_storage_fp32_online_bf16_output": {
       "status": "validated",
       "storage": {
@@ -361,8 +396,8 @@
         "merge_order": "ascending_chunk"
       },
       "threading": {
-        "work_partition": "serial",
-        "split_strategy": "serial",
+        "work_partition": "independent_heads",
+        "split_strategy": "independent_outputs",
         "deterministic": true,
         "thread_count_changes_arithmetic_order": false
       },
@@ -439,6 +474,41 @@
       },
       "position_transform": null,
       "description": "PyTorch tanh-approximate GELU over BF16-valued inputs with FP32 elementwise compute and BF16 RNE output storage."
+    },
+    "bf16_weight_bf16_input_amx_tile32_dot_bf16_output": {
+      "status": "validated",
+      "storage": {
+        "input": "fp32",
+        "weight": "bf16",
+        "output": "bf16"
+      },
+      "compute": {
+        "input": "bf16_rne",
+        "weight": "bf16",
+        "accumulator": "fp32"
+      },
+      "rounding": {
+        "mode": "rne",
+        "points": [
+          "input_load",
+          "output_store"
+        ]
+      },
+      "reduction": {
+        "kind": "dot_product",
+        "order": "contract_defined_chunks",
+        "partial_accumulator": "fp32",
+        "merge_order": "ascending_chunk"
+      },
+      "threading": {
+        "work_partition": "output_tiles",
+        "split_strategy": "independent_outputs",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": null,
+      "description": "BF16 weights and BF16-rounded activations using AMX 16x16x32 tile dot products, ascending K tiles, independent 2D output-tile partitioning, and BF16 RNE output storage.",
+      "operator_family": "gemm"
     }
   }
 }

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,7 +5,7 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "version/v8/kernel_maps",
     "counts": {
-      "total": 198,
+      "total": 200,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
@@ -28,7 +28,7 @@
         "gated_deltanet": 2,
         "geglu": 4,
         "gelu": 4,
-        "gemm": 17,
+        "gemm": 19,
         "gemm_backward": 1,
         "gemma4_per_layer_embed": 1,
         "gemma4_per_layer_prepare": 2,
@@ -4083,12 +4083,12 @@
       "implementation": {
         "isa_dispatch": "compile_time",
         "threading": {
-          "runtime": "serial",
+          "runtime": "ck_threadpool",
           "work_partition": [
-            "serial"
+            "independent_heads"
           ],
           "dispatch": [
-            "inline"
+            "ck_threadpool_dispatch_n"
           ],
           "reduction_order_effect": "none"
         }
@@ -4251,12 +4251,12 @@
           "implementation": {
             "isa_dispatch": "compile_time",
             "threading": {
-              "runtime": "serial",
+              "runtime": "ck_threadpool",
               "work_partition": [
-                "serial"
+                "independent_heads"
               ],
               "dispatch": [
-                "inline"
+                "ck_threadpool_dispatch_n"
               ],
               "reduction_order_effect": "none"
             }
@@ -4266,7 +4266,7 @@
             "merge_order": "ascending_chunk",
             "deterministic": true,
             "thread_count_changes_arithmetic_order": false,
-            "split_strategy": "serial"
+            "split_strategy": "independent_outputs"
           }
         }
       ],
@@ -8445,6 +8445,166 @@
       "_source_file": "gemm_nt_bf16.json"
     },
     {
+      "id": "gemm_nt_bf16_amx_bf16_storage",
+      "op": "gemm",
+      "variant": "bf16_w_fp32_bf16_values_amx_tile32_out",
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "bf16"
+      },
+      "inputs": [
+        {
+          "name": "A",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "K"
+          ],
+          "desc": "Activation matrix [rows, cols] (FP32, rounded to BF16 inside kernel)"
+        },
+        {
+          "name": "B",
+          "dtype": "bf16",
+          "shape": [
+            "N",
+            "K"
+          ],
+          "desc": "Weight matrix [output rows, input cols] BF16"
+        },
+        {
+          "name": "bias",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ],
+          "optional": true,
+          "desc": "Bias [N] (optional)"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "C",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "N"
+          ],
+          "desc": "Result [M,N], BF16 RNE values represented in FP32 storage"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "M",
+        "N",
+        "K"
+      ],
+      "constraints": {
+        "M_multiple": 16,
+        "N_multiple": 16,
+        "K_multiple": 32
+      },
+      "impl": {
+        "function": "gemm_nt_bf16_amx_bf16_storage",
+        "c_declaration": "void gemm_nt_bf16_amx_bf16_storage(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);",
+        "sources": [
+          "src/kernels/gemm_kernels_bf16.c"
+        ],
+        "variants": [
+          {
+            "name": "amx_bf16",
+            "requires": [
+              "amx_tile",
+              "amx_bf16"
+            ],
+            "compile_flags": [
+              "-mamx-tile",
+              "-mamx-bf16"
+            ]
+          }
+        ]
+      },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "numerical_capabilities": [
+        {
+          "contract_id": "bf16_weight_bf16_input_amx_tile32_dot_bf16_output",
+          "status": "validated",
+          "phases": [
+            "prefill"
+          ],
+          "function": "gemm_nt_bf16_amx_bf16_storage",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "compile_time",
+            "threading": {
+              "runtime": "ck_threadpool",
+              "work_partition": [
+                "output_tiles"
+              ],
+              "dispatch": [
+                "ck_threadpool_dispatch_n"
+              ],
+              "reduction_order_effect": "contract_defined"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "fp32",
+            "merge_order": "ascending_chunk",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "independent_outputs"
+          }
+        }
+      ],
+      "notes": "AMX BF16 16x16x32 tiled GEMM with four output accumulators per packed weight tile, CK threadpool 2D output-tile partitioning, and BF16 RNE output storage.",
+      "tests": {
+        "unit": [
+          "unittest/bf16/test_gemm_storage_contract_bf16.py"
+        ]
+      },
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "cast": "const float*",
+            "name": "A",
+            "source": "activation:a"
+          },
+          {
+            "name": "B",
+            "source": "weight:_first_weight"
+          },
+          {
+            "name": "bias",
+            "source": "weight_f:_bias"
+          },
+          {
+            "cast": "float*",
+            "name": "C",
+            "source": "output:c"
+          },
+          {
+            "name": "M",
+            "source": "dim:_m"
+          },
+          {
+            "name": "N",
+            "source": "dim:_output_dim"
+          },
+          {
+            "name": "K",
+            "source": "dim:_input_dim"
+          }
+        ]
+      },
+      "name": "gemm_nt_bf16_amx_bf16_storage",
+      "_source_file": "gemm_nt_bf16_amx_bf16_storage.json"
+    },
+    {
       "id": "gemm_nt_bf16_bf16_storage",
       "op": "gemm",
       "variant": "bf16_w_fp32_bf16_values_a_bf16_values_out",
@@ -8586,6 +8746,162 @@
       },
       "name": "gemm_nt_bf16_bf16_storage",
       "_source_file": "gemm_nt_bf16_bf16_storage.json"
+    },
+    {
+      "id": "gemm_nt_bf16_native_bf16_storage",
+      "op": "gemm",
+      "variant": "bf16_w_fp32_bf16_values_a_bf16_values_out",
+      "quant": {
+        "weight": "bf16",
+        "activation": "fp32",
+        "output": "bf16"
+      },
+      "inputs": [
+        {
+          "name": "A",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "K"
+          ],
+          "desc": "Activation matrix [rows, cols] (FP32, rounded to BF16 inside kernel)"
+        },
+        {
+          "name": "B",
+          "dtype": "bf16",
+          "shape": [
+            "N",
+            "K"
+          ],
+          "desc": "Weight matrix [output rows, input cols] BF16"
+        },
+        {
+          "name": "bias",
+          "dtype": "fp32",
+          "shape": [
+            "N"
+          ],
+          "optional": true,
+          "desc": "Bias [N] (optional)"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "C",
+          "dtype": "fp32",
+          "shape": [
+            "M",
+            "N"
+          ],
+          "desc": "Result [M,N], BF16 RNE values represented in FP32 storage"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "M",
+        "N",
+        "K"
+      ],
+      "constraints": {},
+      "impl": {
+        "function": "gemm_nt_bf16_native_bf16_storage",
+        "c_declaration": "void gemm_nt_bf16_native_bf16_storage(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);",
+        "sources": [
+          "src/kernels/gemm_kernels_bf16.c"
+        ],
+        "variants": [
+          {
+            "name": "avx512_bf16",
+            "requires": [
+              "avx512f",
+              "avx512_bf16"
+            ],
+            "compile_flags": [
+              "-mavx512f",
+              "-mavx512bf16"
+            ]
+          }
+        ]
+      },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "numerical_capabilities": [
+        {
+          "contract_id": "bf16_weight_bf16_input_native_pair_dot_bf16_output",
+          "status": "validated",
+          "phases": [
+            "prefill"
+          ],
+          "function": "gemm_nt_bf16_native_bf16_storage",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "compile_time",
+            "threading": {
+              "runtime": "ck_threadpool",
+              "work_partition": [
+                "independent_rows"
+              ],
+              "dispatch": [
+                "ck_threadpool_dispatch_n"
+              ],
+              "reduction_order_effect": "contract_defined"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "fp32",
+            "merge_order": "pairwise_tree",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "independent_outputs"
+          }
+        }
+      ],
+      "notes": "Native AVX-512 BF16 paired-dot GEMM with CK threadpool row partitioning and BF16 RNE output storage.",
+      "tests": {
+        "unit": [
+          "unittest/bf16/test_gemm_storage_contract_bf16.py"
+        ]
+      },
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "cast": "const float*",
+            "name": "A",
+            "source": "activation:a"
+          },
+          {
+            "name": "B",
+            "source": "weight:_first_weight"
+          },
+          {
+            "name": "bias",
+            "source": "weight_f:_bias"
+          },
+          {
+            "cast": "float*",
+            "name": "C",
+            "source": "output:c"
+          },
+          {
+            "name": "M",
+            "source": "dim:_m"
+          },
+          {
+            "name": "N",
+            "source": "dim:_output_dim"
+          },
+          {
+            "name": "K",
+            "source": "dim:_input_dim"
+          }
+        ]
+      },
+      "name": "gemm_nt_bf16_native_bf16_storage",
+      "_source_file": "gemm_nt_bf16_native_bf16_storage.json"
     },
     {
       "id": "gemm_nt_f16",

--- a/version/v8/kernel_maps/attention_forward_full_head_major_gqa_sdpa_bf16_storage.json
+++ b/version/v8/kernel_maps/attention_forward_full_head_major_gqa_sdpa_bf16_storage.json
@@ -6,12 +6,12 @@
   "implementation": {
     "isa_dispatch": "compile_time",
     "threading": {
-      "runtime": "serial",
+      "runtime": "ck_threadpool",
       "work_partition": [
-        "serial"
+        "independent_heads"
       ],
       "dispatch": [
-        "inline"
+        "ck_threadpool_dispatch_n"
       ],
       "reduction_order_effect": "none"
     }
@@ -168,12 +168,12 @@
       "implementation": {
         "isa_dispatch": "compile_time",
         "threading": {
-          "runtime": "serial",
+          "runtime": "ck_threadpool",
           "work_partition": [
-            "serial"
+            "independent_heads"
           ],
           "dispatch": [
-            "inline"
+            "ck_threadpool_dispatch_n"
           ],
           "reduction_order_effect": "none"
         }
@@ -183,7 +183,7 @@
         "merge_order": "ascending_chunk",
         "deterministic": true,
         "thread_count_changes_arithmetic_order": false,
-        "split_strategy": "serial"
+        "split_strategy": "independent_outputs"
       }
     }
   ]

--- a/version/v8/kernel_maps/gemm_nt_bf16_amx_bf16_storage.json
+++ b/version/v8/kernel_maps/gemm_nt_bf16_amx_bf16_storage.json
@@ -1,0 +1,158 @@
+{
+  "id": "gemm_nt_bf16_amx_bf16_storage",
+  "op": "gemm",
+  "variant": "bf16_w_fp32_bf16_values_amx_tile32_out",
+  "quant": {
+    "weight": "bf16",
+    "activation": "fp32",
+    "output": "bf16"
+  },
+  "inputs": [
+    {
+      "name": "A",
+      "dtype": "fp32",
+      "shape": [
+        "M",
+        "K"
+      ],
+      "desc": "Activation matrix [rows, cols] (FP32, rounded to BF16 inside kernel)"
+    },
+    {
+      "name": "B",
+      "dtype": "bf16",
+      "shape": [
+        "N",
+        "K"
+      ],
+      "desc": "Weight matrix [output rows, input cols] BF16"
+    },
+    {
+      "name": "bias",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ],
+      "optional": true,
+      "desc": "Bias [N] (optional)"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "C",
+      "dtype": "fp32",
+      "shape": [
+        "M",
+        "N"
+      ],
+      "desc": "Result [M,N], BF16 RNE values represented in FP32 storage"
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "M",
+    "N",
+    "K"
+  ],
+  "constraints": {
+    "M_multiple": 16,
+    "N_multiple": 16,
+    "K_multiple": 32
+  },
+  "impl": {
+    "function": "gemm_nt_bf16_amx_bf16_storage",
+    "c_declaration": "void gemm_nt_bf16_amx_bf16_storage(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);",
+    "sources": [
+      "src/kernels/gemm_kernels_bf16.c"
+    ],
+    "variants": [
+      {
+        "name": "amx_bf16",
+        "requires": [
+          "amx_tile",
+          "amx_bf16"
+        ],
+        "compile_flags": [
+          "-mamx-tile",
+          "-mamx-bf16"
+        ]
+      }
+    ]
+  },
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "numerical_capabilities": [
+    {
+      "contract_id": "bf16_weight_bf16_input_amx_tile32_dot_bf16_output",
+      "status": "validated",
+      "phases": [
+        "prefill"
+      ],
+      "function": "gemm_nt_bf16_amx_bf16_storage",
+      "explicit_selector": true,
+      "implementation": {
+        "isa_dispatch": "compile_time",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "output_tiles"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "arithmetic": {
+        "partial_accumulator": "fp32",
+        "merge_order": "ascending_chunk",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false,
+        "split_strategy": "independent_outputs"
+      }
+    }
+  ],
+  "notes": "AMX BF16 16x16x32 tiled GEMM with four output accumulators per packed weight tile, CK threadpool 2D output-tile partitioning, and BF16 RNE output storage.",
+  "tests": {
+    "unit": [
+      "unittest/bf16/test_gemm_storage_contract_bf16.py"
+    ]
+  },
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {
+        "cast": "const float*",
+        "name": "A",
+        "source": "activation:a"
+      },
+      {
+        "name": "B",
+        "source": "weight:_first_weight"
+      },
+      {
+        "name": "bias",
+        "source": "weight_f:_bias"
+      },
+      {
+        "cast": "float*",
+        "name": "C",
+        "source": "output:c"
+      },
+      {
+        "name": "M",
+        "source": "dim:_m"
+      },
+      {
+        "name": "N",
+        "source": "dim:_output_dim"
+      },
+      {
+        "name": "K",
+        "source": "dim:_input_dim"
+      }
+    ]
+  }
+}

--- a/version/v8/kernel_maps/gemm_nt_bf16_native_bf16_storage.json
+++ b/version/v8/kernel_maps/gemm_nt_bf16_native_bf16_storage.json
@@ -1,0 +1,154 @@
+{
+  "id": "gemm_nt_bf16_native_bf16_storage",
+  "op": "gemm",
+  "variant": "bf16_w_fp32_bf16_values_a_bf16_values_out",
+  "quant": {
+    "weight": "bf16",
+    "activation": "fp32",
+    "output": "bf16"
+  },
+  "inputs": [
+    {
+      "name": "A",
+      "dtype": "fp32",
+      "shape": [
+        "M",
+        "K"
+      ],
+      "desc": "Activation matrix [rows, cols] (FP32, rounded to BF16 inside kernel)"
+    },
+    {
+      "name": "B",
+      "dtype": "bf16",
+      "shape": [
+        "N",
+        "K"
+      ],
+      "desc": "Weight matrix [output rows, input cols] BF16"
+    },
+    {
+      "name": "bias",
+      "dtype": "fp32",
+      "shape": [
+        "N"
+      ],
+      "optional": true,
+      "desc": "Bias [N] (optional)"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "C",
+      "dtype": "fp32",
+      "shape": [
+        "M",
+        "N"
+      ],
+      "desc": "Result [M,N], BF16 RNE values represented in FP32 storage"
+    }
+  ],
+  "scratch": [],
+  "dims": [
+    "M",
+    "N",
+    "K"
+  ],
+  "constraints": {},
+  "impl": {
+    "function": "gemm_nt_bf16_native_bf16_storage",
+    "c_declaration": "void gemm_nt_bf16_native_bf16_storage(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);",
+    "sources": [
+      "src/kernels/gemm_kernels_bf16.c"
+    ],
+    "variants": [
+      {
+        "name": "avx512_bf16",
+        "requires": [
+          "avx512f",
+          "avx512_bf16"
+        ],
+        "compile_flags": [
+          "-mavx512f",
+          "-mavx512bf16"
+        ]
+      }
+    ]
+  },
+  "modes": {
+    "inference": true,
+    "training": false,
+    "backward": false
+  },
+  "numerical_capabilities": [
+    {
+      "contract_id": "bf16_weight_bf16_input_native_pair_dot_bf16_output",
+      "status": "validated",
+      "phases": [
+        "prefill"
+      ],
+      "function": "gemm_nt_bf16_native_bf16_storage",
+      "explicit_selector": true,
+      "implementation": {
+        "isa_dispatch": "compile_time",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "independent_rows"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "arithmetic": {
+        "partial_accumulator": "fp32",
+        "merge_order": "pairwise_tree",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false,
+        "split_strategy": "independent_outputs"
+      }
+    }
+  ],
+  "notes": "Native AVX-512 BF16 paired-dot GEMM with CK threadpool row partitioning and BF16 RNE output storage.",
+  "tests": {
+    "unit": [
+      "unittest/bf16/test_gemm_storage_contract_bf16.py"
+    ]
+  },
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {
+        "cast": "const float*",
+        "name": "A",
+        "source": "activation:a"
+      },
+      {
+        "name": "B",
+        "source": "weight:_first_weight"
+      },
+      {
+        "name": "bias",
+        "source": "weight_f:_bias"
+      },
+      {
+        "cast": "float*",
+        "name": "C",
+        "source": "output:c"
+      },
+      {
+        "name": "M",
+        "source": "dim:_m"
+      },
+      {
+        "name": "N",
+        "source": "dim:_output_dim"
+      },
+      {
+        "name": "K",
+        "source": "dim:_input_dim"
+      }
+    ]
+  }
+}

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -678,6 +678,17 @@ def emit_op(
     lines.append(f"    /* Op {idx}: {function} ({op_name}) layer={layer} section={section} */")
     args = [{**arg, "expr": _normalize_arg_expr(str(arg.get("expr", "0")))} for arg in args]
 
+    if op_name == "residual_save" and int(layer) >= 0:
+        by_name = {str(arg.get("name", "")).lower(): str(arg.get("expr", "0")) for arg in args}
+        src_expr = by_name.get("src")
+        size_expr = by_name.get("size")
+        checkpoint = "layer_input" if op_instance_idx == 0 else "after_attn"
+        if src_expr and size_expr:
+            lines.append(
+                f'    ck_debug_import_checkpoint(model, {int(layer)}, "{checkpoint}", '
+                f"(float*)({src_expr}), ((size_t)({size_expr})) / sizeof(float));"
+            )
+
     def _return_lines(*, append_stop: bool = False) -> str:
         if append_stop and seq_idx is not None:
             lines.append(f"    if (stop_seq == {seq_idx}) return;")
@@ -2751,6 +2762,36 @@ static void ck_decode(CKModel *model, int32_t token);
 static void ck_prefill(CKModel *model, const int32_t *tokens, int count);
 static int ck_trace_pos_enabled(void);
 static void ck_trace_pos(const char *stage, int32_t token, int count, int before_pos, int after_pos);
+
+static int ck_debug_import_checkpoint(CKModel *model, int layer, const char *checkpoint, float *data, size_t count) {{
+    const char *path = getenv("CK_DEBUG_IMPORT_HIDDEN");
+    const char *layer_text = getenv("CK_DEBUG_IMPORT_LAYER");
+    const char *wanted_checkpoint = getenv("CK_DEBUG_IMPORT_CHECKPOINT");
+    if (!path || !path[0] || !layer_text || !layer_text[0] ||
+        !wanted_checkpoint || !wanted_checkpoint[0] ||
+        !model || !checkpoint || !data || count == 0) return 0;
+    char *end = NULL;
+    long wanted = strtol(layer_text, &end, 10);
+    if (end == layer_text || *end != '\\0' || wanted != layer ||
+        strcmp(wanted_checkpoint, checkpoint) != 0) return 0;
+    FILE *f = fopen(path, "rb");
+    if (!f) {{
+        fprintf(stderr, "[CK X-ray] cannot open checkpoint input: %s\\n", path);
+        return -1;
+    }}
+    const size_t got = fread(data, sizeof(float), count, f);
+    const int extra = fgetc(f);
+    fclose(f);
+    if (got != count || extra != EOF) {{
+        fprintf(stderr,
+                "[CK X-ray] checkpoint input size mismatch layer=%d checkpoint=%s expected=%zu got=%zu extra=%d\\n",
+                layer, checkpoint, count, got, extra != EOF);
+        return -1;
+    }}
+    fprintf(stderr, "[CK X-ray] imported layer %d checkpoint %s (%zu floats)\\n",
+            layer, checkpoint, count);
+    return 1;
+}}
 
 static void ck_debug_export_hidden(CKModel *model, int layer, const char *name, const float *data, int count) {{
     const char *dir = getenv("CK_DEBUG_EXPORT_HIDDEN");

--- a/version/v8/scripts/compare_qwen3vl_bf16_vision_hidden_v8.py
+++ b/version/v8/scripts/compare_qwen3vl_bf16_vision_hidden_v8.py
@@ -477,14 +477,36 @@ def _run_ck_selector(args: argparse.Namespace, selector: str, numeric: Any) -> n
         height=int(cfg["image_height"]),
         width=int(cfg["image_width"]),
     )
-    data = numeric._run_generated_encoder(
-        model_so=runtime_dir / "libqwen3vl_bf16_encoder_v8.so",
-        weights_bump=args.weights_bump.resolve(),
-        manifest_map=runtime_dir / "weights_manifest.map",
-        layout_path=runtime_dir / "layout.json",
-        planar_image=planar_image,
-        output_name=selector,
-    )
+    restore_import_path = os.environ.get("CK_DEBUG_IMPORT_HIDDEN")
+    restore_import_checkpoint = os.environ.get("CK_DEBUG_IMPORT_CHECKPOINT")
+    restore_import_layer = os.environ.get("CK_DEBUG_IMPORT_LAYER")
+    if args.ck_import_layer_input is not None:
+        os.environ["CK_DEBUG_IMPORT_HIDDEN"] = str(args.ck_import_layer_input.resolve())
+        os.environ["CK_DEBUG_IMPORT_CHECKPOINT"] = str(args.ck_import_checkpoint)
+        os.environ["CK_DEBUG_IMPORT_LAYER"] = str(args.ck_import_layer)
+    try:
+        data = numeric._run_generated_encoder(
+            model_so=runtime_dir / "libqwen3vl_bf16_encoder_v8.so",
+            weights_bump=args.weights_bump.resolve(),
+            manifest_map=runtime_dir / "weights_manifest.map",
+            layout_path=runtime_dir / "layout.json",
+            planar_image=planar_image,
+            output_name=selector,
+        )
+    finally:
+        if args.ck_import_layer_input is not None:
+            if restore_import_path is None:
+                os.environ.pop("CK_DEBUG_IMPORT_HIDDEN", None)
+            else:
+                os.environ["CK_DEBUG_IMPORT_HIDDEN"] = restore_import_path
+            if restore_import_layer is None:
+                os.environ.pop("CK_DEBUG_IMPORT_LAYER", None)
+            else:
+                os.environ["CK_DEBUG_IMPORT_LAYER"] = restore_import_layer
+            if restore_import_checkpoint is None:
+                os.environ.pop("CK_DEBUG_IMPORT_CHECKPOINT", None)
+            else:
+                os.environ["CK_DEBUG_IMPORT_CHECKPOINT"] = restore_import_checkpoint
     result = _array_to_np(data)
     base_name, _ = _parse_selector(selector)
     head_major_names = {"q_proj", "k_proj", "v_proj", "rope_q", "rope_k", "attn_out_head_major"}
@@ -517,6 +539,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     ap.add_argument("--threads", type=int, default=int(os.environ.get("CK_NUM_THREADS", "20") or "20"))
     ap.add_argument("--attn-implementation", choices=("auto", "eager", "sdpa"), default="auto")
+    ap.add_argument("--ck-import-layer-input", type=Path, help="Inject an exact FP32 tensor before a CK layer's first residual save")
+    ap.add_argument("--ck-import-layer", type=int, help="Layer index for --ck-import-layer-input")
+    ap.add_argument("--ck-import-checkpoint", choices=("layer_input", "after_attn"), default="layer_input")
     ap.add_argument("--skip-ck", action="store_true", help="Only run the PyTorch hook/reference side")
     ap.add_argument("--min-cosine", type=float, default=None)
     ap.add_argument("--max-rmse", type=float, default=None)
@@ -525,6 +550,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--final-max-rmse", type=float, default=None)
     ap.add_argument("--final-max-abs", type=float, default=None)
     args = ap.parse_args(argv)
+    if (args.ck_import_layer_input is None) != (args.ck_import_layer is None):
+        ap.error("--ck-import-layer-input and --ck-import-layer must be provided together")
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     os.environ["CK_NUM_THREADS"] = str(args.threads)


### PR DESCRIPTION
## Why

Qwen3-VL BF16 profiling on the Xeon node showed that attention and projector execution dominated the vision encoder. This change records the measured optimization progression and makes native paired-BF16 and AMX tile32 behavior explicit numerical capabilities instead of implicit implementation choices.

## What

- Add exact native paired-BF16 and AMX tile32 GEMM contracts and kernel-map providers.
- Bind Qwen3-VL vision projections to explicit resolved capabilities.
- Add the independent-head BF16 attention threadpool path and align its contract with actual execution.
- Add deterministic practical performance and storage-contract coverage.
- Publish the BF16 AMX performance study with reproduction and correctness requirements.
- Make AMX execution fail closed when the ISA, shape, buffers, allocation, or worker tile permission cannot satisfy the resolved contract.
- Add an AMX availability query so non-AMX hosts report SKIP instead of a false pass.

## Xeon Evidence

- Full encoder: approximately 270.8s to 148.3s to 28.1s.
- Attention: approximately 129.3s to 12.7s.
- AMX projection: approximately 62ms to 19.9ms to 8.3ms.
- M=32 projection: CK 0.133ms versus PyTorch 0.135ms, bit-exact.

These measurements came from the native Xeon BF16/AMX lane. This AVX2 node cannot independently execute AMX and reports that lane as skipped.

## Validation

- Engine rebuild passed.
- BF16 attention storage oracle: 4/4 passed.
- Qwen3-VL circuit, numerical-contract, and call-ABI tests: 46 passed.
- Portable M=32 N=3456 K=1152 native sweep passed and was deterministic at 1 and 4 threads.
- v8-regression-fast passed across Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige.
- Pinned llama.cpp parity rebuild and complete pre-push suite passed.
- v7 training smoke, v7 fast regression, and v7 training kernel parity passed.
- HTML parsing and git diff checks passed.

## Remaining Gate

The resolver does not yet filter exact providers by host ISA during lowering. Runtime execution now fails closed instead of silently substituting different arithmetic, but compile-time host capability resolution remains follow-up work. Native Xeon should rerun the AMX suite after merge.