### PR TITLE
ci(metadata): require structured content handoffs

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -12,11 +12,7 @@
 #   Why: explain intent and impact
 #   Test: list verification commands
 #
-# Knowledge trail (soft prompt for runtime/kernel/perf changes):
-#   Docs: updated docs path, or "not needed; <reason>"
-#   Nightly: added/updated test surface, or "not needed; <reason>"
-#   Research: added notes/analysis, or "not needed; <reason>"
-#   Blog: source material for blog agent, or "not needed; <reason>"
+# Substantive commits also require a durable evidence and content handoff.
 
 set -eu
 
@@ -136,39 +132,7 @@ MSG
   fi
 fi
 
-# Soft knowledge-trail prompts. These do not block commits; they make the
-# operator-facing/documentation impact explicit for humans and blog agents.
-STAGED_FILES="$(git diff --cached --name-only 2>/dev/null || true)"
-KNOWLEDGE_RELEVANT=0
-case "$TYPE" in
-  feat|fix|refactor|perf)
-    KNOWLEDGE_RELEVANT=1
-    ;;
-esac
-if printf '%s\n' "$STAGED_FILES" | grep -Eq '^(src/kernels/|version/v[0-9.]+/(scripts|templates|kernel_maps|model_maps)/|Makefile|scripts/nightly_runner.py|benchmarks/|research/)'; then
-  KNOWLEDGE_RELEVANT=1
-fi
-
-if [ "$KNOWLEDGE_RELEVANT" -eq 1 ] && [ -n "$BODY_NONEMPTY" ]; then
-  HAS_DOCS=0
-  HAS_NIGHTLY=0
-  HAS_RESEARCH=0
-  HAS_BLOG=0
-  printf '%s\n' "$BODY_NONEMPTY" | grep -Eq '^(Docs|Documentation): ' && HAS_DOCS=1 || true
-  printf '%s\n' "$BODY_NONEMPTY" | grep -Eq '^(Nightly|CI): ' && HAS_NIGHTLY=1 || true
-  printf '%s\n' "$BODY_NONEMPTY" | grep -Eq '^(Research|Analysis): ' && HAS_RESEARCH=1 || true
-  printf '%s\n' "$BODY_NONEMPTY" | grep -Eq '^(Blog|Blog-Agent|Blog Agent): ' && HAS_BLOG=1 || true
-
-  if [ "$HAS_DOCS" -eq 0 ] || [ "$HAS_NIGHTLY" -eq 0 ] || [ "$HAS_RESEARCH" -eq 0 ] || [ "$HAS_BLOG" -eq 0 ]; then
-    cat >&2 <<'MSG'
-Knowledge trail prompt (non-blocking):
-  For runtime/kernel/perf/command changes, consider adding:
-    Docs: <updated doc path> OR not needed; <reason>
-    Nightly: <new/updated CI or make target> OR not needed; <reason>
-    Research: <notes/analysis path> OR not needed; <reason>
-    Blog: <what a blog agent should read/extract> OR not needed; <reason>
-MSG
-  fi
-fi
+# Keep local commits and PR validation on the same fail-closed metadata rules.
+python3 scripts/validate_change_metadata.py commit --file "$MSG_FILE"
 
 exit 0

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## Why
+
+<!-- What problem or evidence gap required this change? -->
+
+## What changed
+
+<!-- Describe the implementation and ownership boundary. -->
+
+## Evidence
+
+<!-- Record measurements, numerical deltas, artifact paths, and the comparison baseline. -->
+
+## Validation
+
+<!-- Exact commands and results. Do not describe unavailable hardware as passing. -->
+
+## Regression coverage
+
+<!-- State the unit, stitched, nightly, and end-to-end guards added or exercised. -->
+
+## Documentation
+
+<!-- Link updated documentation, or explain why documentation is unnecessary. -->
+
+## Content handoff
+
+<!--
+This is a durable prompt for an Antsand/content agent scanning PRs and git history.
+Provide enough evidence to explain the progression methodically:
+problem -> diagnosis -> fix -> measured delta -> regression guard -> limitation -> next step.
+Link detailed documentation and machine-readable artifacts instead of duplicating them here.
+-->
+
+- Audience: <!-- Who benefits from this evidence? -->
+- Angle: <!-- What is the defensible engineering story? -->
+- Claims: <!-- Which measured claims may be published? -->
+- Caveats: <!-- Hardware, dataset, parity, or reproducibility limits. -->
+- Sources: <!-- Commit, code, docs, logs, JSON/CSV, and profiler artifacts. -->
+
+<!-- For non-publishable work, replace the five lines above with: -->
+<!-- Not publishable: concrete reason this change has no useful external story -->

--- a/.github/workflows/change-metadata.yml
+++ b/.github/workflows/change-metadata.yml
@@ -1,0 +1,33 @@
+name: Change Metadata
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preserve PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s\n' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+
+      - name: Validate PR and commit handoffs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 scripts/validate_change_metadata.py pr --body-file "$RUNNER_TEMP/pr-body.md"
+          python3 scripts/validate_change_metadata.py commits --base "$BASE_SHA" --head "$HEAD_SHA"
+
+      - name: Test metadata validator
+        run: python3 -m unittest tests.test_change_metadata

--- a/.gitmessage
+++ b/.gitmessage
@@ -10,4 +10,14 @@
 <type>(<scope>): <summary>
 
 Why: <what changed and why it matters>
-Test: <exact command(s) and result>
+What: <implementation and ownership boundary>
+Validation: <exact command(s) and result>
+Evidence: <metrics and artifact paths, or not measured; reason>
+Docs: <updated path, or not needed; reason>
+Nightly: <coverage added/exercised, or not needed; reason>
+# Content is a durable prompt for an Antsand/content agent scanning git logs.
+# Make it possible to explain: problem -> diagnosis -> fix -> measured delta ->
+# regression guard -> limitation -> next step. Link detailed docs/logs in Sources.
+Content: Angle=<story>; Claims=<publishable evidence>; Caveats=<limits and next step>; Sources=<code, docs, logs>
+# For changes with no useful external story:
+# Content: not publishable; <concrete reason>

--- a/scripts/validate_change_metadata.py
+++ b/scripts/validate_change_metadata.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Validate durable engineering and content handoff metadata."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+SUBSTANTIVE_TYPES = {"feat", "fix", "refactor", "perf", "revert"}
+COMMIT_FIELDS = {
+    "Why": ("Why", "Context", "Reason"),
+    "What": ("What",),
+    "Validation": ("Validation", "Test", "Tests"),
+    "Evidence": ("Evidence",),
+    "Docs": ("Docs", "Documentation"),
+    "Nightly": ("Nightly", "CI"),
+    "Content": ("Content", "Content-Handoff", "Content Handoff"),
+}
+PR_SECTIONS = (
+    "Why",
+    "What changed",
+    "Evidence",
+    "Validation",
+    "Regression coverage",
+    "Documentation",
+    "Content handoff",
+)
+PLACEHOLDER_RE = re.compile(r"^\s*(?:<[^>]+>|tbd|todo|n/?a)\s*$", re.IGNORECASE)
+
+
+def _clean_commit(message: str) -> str:
+    return "\n".join(line for line in message.splitlines() if not line.startswith("#"))
+
+
+def _field_values(message: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    aliases = {
+        alias.lower(): canonical
+        for canonical, names in COMMIT_FIELDS.items()
+        for alias in names
+    }
+    for line in message.splitlines()[2:]:
+        match = re.match(r"^([A-Za-z][A-Za-z -]*):\s*(.*)$", line)
+        if match and match.group(1).lower() in aliases:
+            values[aliases[match.group(1).lower()]] = match.group(2).strip()
+    return values
+
+
+def validate_commit(message: str) -> list[str]:
+    message = _clean_commit(message).strip()
+    if not message:
+        return []
+    header = message.splitlines()[0]
+    if header.startswith(("Merge ", "Revert \"", "fixup! ", "squash! ")):
+        return []
+    match = re.match(r"^([a-z]+)(?:\([^)]+\))?!?: ", header)
+    if not match or match.group(1) not in SUBSTANTIVE_TYPES:
+        return []
+
+    values = _field_values(message)
+    errors = []
+    for field in COMMIT_FIELDS:
+        value = values.get(field, "")
+        if not value or PLACEHOLDER_RE.match(value):
+            errors.append(f"missing or placeholder {field}: field")
+
+    content = values.get("Content", "")
+    if content and not PLACEHOLDER_RE.match(content):
+        if content.lower().startswith("not publishable;"):
+            if len(content.partition(";")[2].strip()) < 12:
+                errors.append("Content: not publishable requires a concrete reason")
+        else:
+            for key in ("Angle=", "Claims=", "Caveats=", "Sources="):
+                if key not in content:
+                    errors.append(f"Content: must include {key[:-1]}")
+    return errors
+
+
+def _sections(body: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^##\s+(.+?)\s*$", body))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[match.group(1).strip().lower()] = body[match.end():end].strip()
+    return sections
+
+
+def validate_pr(body: str) -> list[str]:
+    body = re.sub(r"<!--[\s\S]*?-->", "", body)
+    sections = _sections(body)
+    errors = []
+    for required in PR_SECTIONS:
+        value = sections.get(required.lower(), "")
+        if not value or PLACEHOLDER_RE.match(value):
+            errors.append(f"missing or empty PR section: {required}")
+
+    content = sections.get("content handoff", "")
+    if content and not PLACEHOLDER_RE.match(content):
+        if re.search(r"(?mi)^Not publishable:\s*.{12,}$", content):
+            return errors
+        for field in ("Audience", "Angle", "Claims", "Caveats", "Sources"):
+            if not re.search(rf"(?mi)^-?\s*{field}:\s*\S", content):
+                errors.append(f"Content handoff must include {field}:")
+    return errors
+
+
+def _git_messages(base: str, head: str) -> list[tuple[str, str]]:
+    hashes = subprocess.check_output(
+        ["git", "rev-list", "--no-merges", f"{base}..{head}"], text=True
+    ).splitlines()
+    return [
+        (commit, subprocess.check_output(["git", "show", "-s", "--format=%B", commit], text=True))
+        for commit in hashes
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    commit = subparsers.add_parser("commit")
+    commit.add_argument("--file", type=Path)
+    commit.add_argument("--message")
+    pr = subparsers.add_parser("pr")
+    pr.add_argument("--body-file", type=Path, required=True)
+    commits = subparsers.add_parser("commits")
+    commits.add_argument("--base", required=True)
+    commits.add_argument("--head", required=True)
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    if args.mode == "commit":
+        if bool(args.file) == bool(args.message):
+            parser.error("commit requires exactly one of --file or --message")
+        message = args.file.read_text() if args.file else args.message
+        failures = validate_commit(message)
+    elif args.mode == "pr":
+        failures = validate_pr(args.body_file.read_text())
+    else:
+        for commit_hash, message in _git_messages(args.base, args.head):
+            failures.extend(
+                f"{commit_hash[:12]}: {error}" for error in validate_commit(message)
+            )
+
+    if failures:
+        print("Change metadata validation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(
+            "Content metadata should let an agent explain: problem -> diagnosis -> "
+            "fix -> measured delta -> regression guard -> limitation -> next step.",
+            file=sys.stderr,
+        )
+        return 1
+    print("Change metadata validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_change_metadata.py
+++ b/tests/test_change_metadata.py
@@ -1,0 +1,69 @@
+import unittest
+
+from scripts.validate_change_metadata import validate_commit, validate_pr
+
+
+GOOD_COMMIT = """perf(v8/bf16): accelerate vision projections
+
+Why: Qwen3-VL projectors dominated encoder time.
+What: Add an AMX provider with fail-closed execution contracts.
+Validation: BF16 oracle 4/4; v8 regression passed.
+Evidence: Encoder 270.8s to 28.1s; report path build/report.json.
+Docs: docs/site/_pages/bf16-amx-performance-study.html
+Nightly: test-bf16-performance-sweep reports PASS or hardware SKIP.
+Content: Angle=AMX optimization under numerical contracts; Claims=9.6x encoder progression; Caveats=managed Xeon, not bare metal; Sources=study page, JSON report, commit diff
+"""
+
+GOOD_PR = """## Why
+Projectors dominated encoder time.
+## What changed
+Added an explicit AMX provider.
+## Evidence
+Encoder moved from 270.8s to 28.1s.
+## Validation
+BF16 oracle and v8 regression passed.
+## Regression coverage
+Nightly reports PASS or hardware SKIP.
+## Documentation
+docs/site/_pages/bf16-amx-performance-study.html
+## Content handoff
+- Audience: CPU AI engineers
+- Angle: AMX speed without relaxing numerical contracts
+- Claims: 9.6x measured encoder progression
+- Caveats: managed Xeon allocation, not bare-metal limits
+- Sources: study page, generated JSON report, commit diff
+"""
+
+
+class ChangeMetadataTests(unittest.TestCase):
+    def test_substantive_commit_requires_complete_handoff(self):
+        self.assertEqual(validate_commit(GOOD_COMMIT), [])
+        errors = validate_commit(GOOD_COMMIT.replace("Evidence: Encoder", "Evidence: <result>\nIgnored: Encoder"))
+        self.assertTrue(any("Evidence" in error for error in errors))
+
+    def test_non_publishable_commit_requires_reason(self):
+        message = GOOD_COMMIT.replace(
+            "Content: Angle=AMX optimization under numerical contracts; Claims=9.6x encoder progression; Caveats=managed Xeon, not bare metal; Sources=study page, JSON report, commit diff",
+            "Content: not publishable; internal path normalization with no user-visible behavior",
+        )
+        self.assertEqual(validate_commit(message), [])
+
+    def test_pr_requires_content_fields(self):
+        self.assertEqual(validate_pr(GOOD_PR), [])
+        errors = validate_pr(GOOD_PR.replace("- Caveats:", "- Limitations:"))
+        self.assertIn("Content handoff must include Caveats:", errors)
+
+    def test_pr_can_explain_why_not_publishable(self):
+        body = GOOD_PR.rsplit("## Content handoff", 1)[0] + (
+            "## Content handoff\nNot publishable: mechanical test fixture rename only\n"
+        )
+        self.assertEqual(validate_pr(body), [])
+
+    def test_template_comments_do_not_satisfy_sections(self):
+        body = "## Why\n<!-- fill this in -->\n## What changed\n<!-- fill this in -->"
+        errors = validate_pr(body)
+        self.assertIn("missing or empty PR section: Why", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
Engineering evidence was recorded inconsistently, making it difficult for Antsand and content agents to reconstruct what changed, why it mattered, and which claims were reproducible.

## What changed
Added one shared fail-closed metadata validator, wired it into the local commit-msg hook and PR CI, and added structured commit and pull-request templates.

## Evidence
The validator rejects omitted substantive-commit fields, empty PR sections, unchanged HTML-comment placeholders, incomplete content prompts, and vague non-publishable opt-outs.

## Validation
Python unit tests passed 5/5. Python compilation, commit-hook fixture, git diff checks, v7 fast regression, v8 fast regression, kernel parity, v8 E2E smoke, v8 inference contracts, v7 training smoke, and v7 training-kernel parity passed.

## Regression coverage
The Change Metadata workflow validates the PR body, every non-merge substantive commit, and the metadata validator test suite on open, edit, synchronize, and reopen events.

## Documentation
The tracked commit template and pull-request template explain the evidence and content handoff requirements. No separate progress Markdown file is introduced.

## Content handoff
- Audience: CKE contributors, engineering agents, and Antsand content agents
- Angle: Turn git history into a structured evidence stream for methodical technical publishing
- Claims: Substantive changes now require why, what, validation, evidence, docs, nightly coverage, and a content prompt
- Caveats: Repository administrators can override CI, and mechanical changes may opt out only with a concrete non-publishable reason
- Sources: .githooks/commit-msg, .gitmessage, .github/pull_request_template.md, .github/workflows/change-metadata.yml, scripts/validate_change_metadata.py, tests/test_change_metadata.py