### PR TITLE
perf(v8/bf16): reuse weights across four vision rows

### DIFF
--- a/docs/site/_pages/bf16-amx-performance-study.html
+++ b/docs/site/_pages/bf16-amx-performance-study.html
@@ -40,10 +40,10 @@ not bare-metal platform limits.</p>
 
 <div class="study-grid">
     <div class="study-card">
-        <span class="study-metric">270.8 s to 28.1 s</span>
+        <span class="study-metric">270.8 s to 24.6 s</span>
         <h3>Encoder Progression</h3>
-        <p>Measured CK wall time fell by about 9.6x after native BF16 projection work, selective AMX use, and
-        independent-head attention scheduling.</p>
+        <p>Measured CK wall time fell by about 11.0x after native BF16 projection work, selective AMX use, and
+        independent-head attention scheduling, and four-row native projection tiling.</p>
     </div>
     <div class="study-card">
         <span class="study-metric">129.3 s to 12.7 s</span>
@@ -69,6 +69,7 @@ not bare-metal platform limits.</p>
         <tr><td>Original stitched encoder</td><td>~270.8 s</td><td>~12.5 s</td><td>0.99857</td><td>5.20%</td></tr>
         <tr><td>Native paired-BF16 projections</td><td>~148.3 s</td><td>9.39 s</td><td>0.99863</td><td>5.08%</td></tr>
         <tr><td>Head-parallel attention and selective AMX projectors</td><td>~28.1 s</td><td>~10.0 s</td><td>0.99858</td><td>5.09%</td></tr>
+        <tr><td>Four-row native projection reuse</td><td>~24.6 s</td><td>9.49 s</td><td>0.99858</td><td>5.09%</td></tr>
     </tbody>
 </table>
 
@@ -108,6 +109,10 @@ shape.</p>
 <p>Splitting each attention head into two query-row jobs increased the available job count but repeated V
 transposition and weakened locality. Attention regressed from approximately 12.7 seconds to 16.3 seconds. The change
 was reverted. More jobs are not automatically more parallel efficiency; the unit of work must preserve reuse.</p>
+
+<p>A shared-V query-block variant preserved the prefix exactly but regressed CK encoder time from approximately
+24.6 seconds to 25.8 seconds. A row-parallel LayerNorm variant was bit-exact in isolation but regressed encoder time
+to about 26.7 seconds. Both were rejected; the patch retains only changes that improved the full generated model.</p>
 
 <h2>Evidence Rules</h2>
 

--- a/src/kernels/gemm_kernels_bf16.c
+++ b/src/kernels/gemm_kernels_bf16.c
@@ -784,12 +784,17 @@ static void ck_gemm_bf16_native_work(int ith, int nth, void *opaque)
     ck_gemm_bf16_native_args_t *args = (ck_gemm_bf16_native_args_t *)opaque;
     const int N = args->N;
     const int K = args->K;
-    uint16_t *a_bf16 = (uint16_t *)alloca((size_t)K * sizeof(uint16_t));
+    enum { ROW_TILE = 4 };
+    uint16_t *a_bf16 = (uint16_t *)alloca(
+        (size_t)ROW_TILE * (size_t)K * sizeof(uint16_t));
 
-    for (int row = ith; row < args->M; row += nth) {
-        const float *src = args->A + (size_t)row * (size_t)K;
-        float *dst = args->C + (size_t)row * (size_t)N;
-        for (int k = 0; k < K; ++k) a_bf16[k] = float_to_bf16(src[k]);
+    for (int row0 = ith * ROW_TILE; row0 < args->M; row0 += nth * ROW_TILE) {
+        const int rows = args->M - row0 < ROW_TILE ? args->M - row0 : ROW_TILE;
+        for (int r = 0; r < rows; ++r) {
+            const float *src = args->A + (size_t)(row0 + r) * (size_t)K;
+            uint16_t *ar = a_bf16 + (size_t)r * (size_t)K;
+            for (int k = 0; k < K; ++k) ar[k] = float_to_bf16(src[k]);
+        }
 
 #if HAVE_NATIVE_BF16
         int j = 0;
@@ -798,57 +803,79 @@ static void ck_gemm_bf16_native_work(int ith, int nth, void *opaque)
             const uint16_t *b1 = args->B + (size_t)(j + 1) * K;
             const uint16_t *b2 = args->B + (size_t)(j + 2) * K;
             const uint16_t *b3 = args->B + (size_t)(j + 3) * K;
-            __m512 acc0 = _mm512_setzero_ps();
-            __m512 acc1 = _mm512_setzero_ps();
-            __m512 acc2 = _mm512_setzero_ps();
-            __m512 acc3 = _mm512_setzero_ps();
+            __m512 acc[ROW_TILE][4];
+            for (int r = 0; r < rows; ++r) {
+                for (int lane = 0; lane < 4; ++lane) acc[r][lane] = _mm512_setzero_ps();
+            }
             int k = 0;
             for (; k <= K - 32; k += 32) {
-                const __m512bh av = load_bf16x32(a_bf16 + k);
-                acc0 = _mm512_dpbf16_ps(acc0, av, load_bf16x32(b0 + k));
-                acc1 = _mm512_dpbf16_ps(acc1, av, load_bf16x32(b1 + k));
-                acc2 = _mm512_dpbf16_ps(acc2, av, load_bf16x32(b2 + k));
-                acc3 = _mm512_dpbf16_ps(acc3, av, load_bf16x32(b3 + k));
+                const __m512bh bv[4] = {
+                    load_bf16x32(b0 + k), load_bf16x32(b1 + k),
+                    load_bf16x32(b2 + k), load_bf16x32(b3 + k)
+                };
+                for (int r = 0; r < rows; ++r) {
+                    const __m512bh av =
+                        load_bf16x32(a_bf16 + (size_t)r * (size_t)K + k);
+                    for (int lane = 0; lane < 4; ++lane) {
+                        acc[r][lane] = _mm512_dpbf16_ps(acc[r][lane], av, bv[lane]);
+                    }
+                }
             }
-            float sums[4] = {
-                _mm512_reduce_add_ps(acc0), _mm512_reduce_add_ps(acc1),
-                _mm512_reduce_add_ps(acc2), _mm512_reduce_add_ps(acc3)
-            };
-            for (; k < K; ++k) {
-                const float av = bf16_to_float(a_bf16[k]);
-                sums[0] += av * bf16_to_float(b0[k]);
-                sums[1] += av * bf16_to_float(b1[k]);
-                sums[2] += av * bf16_to_float(b2[k]);
-                sums[3] += av * bf16_to_float(b3[k]);
-            }
-            for (int lane = 0; lane < 4; ++lane) {
-                if (args->bias) sums[lane] += args->bias[j + lane];
-                dst[j + lane] = bf16_to_float(float_to_bf16(sums[lane]));
+            for (int r = 0; r < rows; ++r) {
+                float sums[4];
+                for (int lane = 0; lane < 4; ++lane) {
+                    sums[lane] = _mm512_reduce_add_ps(acc[r][lane]);
+                }
+                const uint16_t *ar = a_bf16 + (size_t)r * (size_t)K;
+                for (int tail = k; tail < K; ++tail) {
+                    const float av = bf16_to_float(ar[tail]);
+                    sums[0] += av * bf16_to_float(b0[tail]);
+                    sums[1] += av * bf16_to_float(b1[tail]);
+                    sums[2] += av * bf16_to_float(b2[tail]);
+                    sums[3] += av * bf16_to_float(b3[tail]);
+                }
+                float *dst = args->C + (size_t)(row0 + r) * (size_t)N;
+                for (int lane = 0; lane < 4; ++lane) {
+                    if (args->bias) sums[lane] += args->bias[j + lane];
+                    dst[j + lane] = bf16_to_float(float_to_bf16(sums[lane]));
+                }
             }
         }
         for (; j < N; ++j) {
             const uint16_t *b = args->B + (size_t)j * K;
-            __m512 acc = _mm512_setzero_ps();
+            __m512 acc[ROW_TILE];
+            for (int r = 0; r < rows; ++r) acc[r] = _mm512_setzero_ps();
             int k = 0;
             for (; k <= K - 32; k += 32) {
-                acc = _mm512_dpbf16_ps(
-                    acc, load_bf16x32(a_bf16 + k), load_bf16x32(b + k));
+                const __m512bh bv = load_bf16x32(b + k);
+                for (int r = 0; r < rows; ++r) {
+                    acc[r] = _mm512_dpbf16_ps(
+                        acc[r], load_bf16x32(a_bf16 + (size_t)r * (size_t)K + k), bv);
+                }
             }
-            float sum = _mm512_reduce_add_ps(acc);
-            for (; k < K; ++k) {
-                sum += bf16_to_float(a_bf16[k]) * bf16_to_float(b[k]);
+            for (int r = 0; r < rows; ++r) {
+                const uint16_t *ar = a_bf16 + (size_t)r * (size_t)K;
+                float sum = _mm512_reduce_add_ps(acc[r]);
+                for (int tail = k; tail < K; ++tail) {
+                    sum += bf16_to_float(ar[tail]) * bf16_to_float(b[tail]);
+                }
+                if (args->bias) sum += args->bias[j];
+                args->C[(size_t)(row0 + r) * (size_t)N + j] =
+                    bf16_to_float(float_to_bf16(sum));
             }
-            if (args->bias) sum += args->bias[j];
-            dst[j] = bf16_to_float(float_to_bf16(sum));
         }
 #else
-        for (int j = 0; j < N; ++j) {
-            const uint16_t *b = args->B + (size_t)j * K;
-            float sum = args->bias ? args->bias[j] : 0.0f;
-            for (int k = 0; k < K; ++k) {
-                sum += bf16_to_float(a_bf16[k]) * bf16_to_float(b[k]);
+        for (int r = 0; r < rows; ++r) {
+            const uint16_t *ar = a_bf16 + (size_t)r * (size_t)K;
+            float *dst = args->C + (size_t)(row0 + r) * (size_t)N;
+            for (int j = 0; j < N; ++j) {
+                const uint16_t *b = args->B + (size_t)j * K;
+                float sum = args->bias ? args->bias[j] : 0.0f;
+                for (int k = 0; k < K; ++k) {
+                    sum += bf16_to_float(ar[k]) * bf16_to_float(b[k]);
+                }
+                dst[j] = bf16_to_float(float_to_bf16(sum));
             }
-            dst[j] = bf16_to_float(float_to_bf16(sum));
         }
 #endif
     }

--- a/unittest/bf16/test_gemm_storage_contract_bf16.py
+++ b/unittest/bf16/test_gemm_storage_contract_bf16.py
@@ -88,6 +88,18 @@ def main() -> int:
             )
         print(f"M={m} N={n} K={k} max_abs={max_abs:.9g} rmse={rmse:.9g}")
     tested = len(cases)
+    native_cases = [(4, 24, 16, 11), (5, 24, 16, 12), (7, 36, 32, 13)]
+    for m, n, k, seed in native_cases:
+        metrics = run_case_detailed(m, n, k, seed, kernel=NATIVE_KERNEL)
+        if metrics["max_abs"] > 0.5 or metrics["rmse"] > 0.03:
+            raise AssertionError(
+                f"native BF16 row-tile mismatch M={m} N={n} K={k}: {metrics}"
+            )
+        tested += 1
+        print(
+            f"native M={m} N={n} K={k} max_abs={metrics['max_abs']:.9g} "
+            f"rmse={metrics['rmse']:.9g}"
+        )
     if amx_bf16_supported():
         amx = run_case_detailed(16, 32, 32, 4, kernel=AMX_KERNEL)
         if amx["max_abs"] != 0.0 or amx["rmse"] != 0.0:

--- a/version/v8/scripts/bf16_safetensors_lowering_guard_v8.py
+++ b/version/v8/scripts/bf16_safetensors_lowering_guard_v8.py
@@ -334,12 +334,12 @@ def run_guard(workdir: Path) -> None:
     expected_kernels = {
         "patch_proj": "gemm_nt_bf16",
         "patch_proj_aux": "gemm_nt_bf16",
-        "qkv_packed_proj": "gemm_nt_bf16_bf16_storage",
-        "out_proj": "gemm_nt_bf16_bf16_storage",
-        "mlp_up": "gemm_nt_bf16_bf16_storage",
-        "mlp_down": "gemm_nt_bf16_bf16_storage",
-        "projector_fc1": "gemm_nt_bf16",
-        "projector_fc2": "gemm_nt_bf16",
+        "qkv_packed_proj": "gemm_nt_bf16_native_bf16_storage",
+        "out_proj": "gemm_nt_bf16_native_bf16_storage",
+        "mlp_up": "gemm_nt_bf16_native_bf16_storage",
+        "mlp_down": "gemm_nt_bf16_native_bf16_storage",
+        "projector_fc1": "gemm_nt_bf16_amx_bf16_storage",
+        "projector_fc2": "gemm_nt_bf16_amx_bf16_storage",
     }
     for op_name, expected in expected_kernels.items():
         got = kernels_by_op.get(op_name)
@@ -361,6 +361,12 @@ def run_guard(workdir: Path) -> None:
     generated = generated_c.read_text(encoding="utf-8")
     if "gemm_nt_bf16(" not in generated:
         raise AssertionError("generated C does not call gemm_nt_bf16")
+    for required in (
+        "gemm_nt_bf16_native_bf16_storage(",
+        "gemm_nt_bf16_amx_bf16_storage(",
+    ):
+        if required not in generated:
+            raise AssertionError(f"generated C does not call {required}")
     for forbidden in ("gemm_naive_parallel(", "gemm_blocked_serial("):
         if forbidden in generated:
             raise AssertionError(f"generated C still contains {forbidden}")


### PR DESCRIPTION
## Why
Native BF16 Qwen3-VL layer projections remained a material Xeon encoder bottleneck after attention parallelism and selective AMX optimization.

## What changed
Process four activation rows per worker tile so each BF16 weight vector is reused. Add direct row-tile and tail tests, update the stale lowering guard to exact native/AMX providers, and update the existing performance study.

## Evidence
On Xeon, the full M=4032 projection measured 32.6ms at 24 threads with 99.987% exact outputs and RMSE 0.000742. The full encoder previously measured about 24.6s with unchanged prefix accuracy, improving the documented progression from about 270.8s to 24.6s, or 11.0x.

## Validation
Engine build passed. Native row-tile GEMM parity passed 6/6. BF16 lowering/codegen guard passed. Forty-six circuit, numerical-contract, and call-ABI tests passed. Portable output was deterministic. Complete pre-commit and pre-push gates passed, including v7/v8 fast regressions and llama.cpp kernel parity.

## Regression coverage
Direct native-provider cases now cover M=4, M=5, and M=7 so full tiles and both tail forms are exercised. The lowering guard requires exact native layer and AMX projector identities in generated C.

## Documentation
Updated docs/site/_pages/bf16-amx-performance-study.html with the corrected 11.0x progression and rejected shared-V and row-parallel LayerNorm experiments.

## Content handoff
- Audience: CPU AI, Xeon, compiler, and numerical-kernel engineers
- Angle: Reuse BF16 weights across activation rows to reduce a real vision-encoder bottleneck without changing the arithmetic contract
- Claims: Managed-Xeon encoder progression moved from about 270.8s to 24.6s; the M4032 projection measured 32.6ms with 99.987% exact outputs
- Caveats: Native performance requires Xeon AVX-512 BF16; this AVX2 node validated portable behavior and guards but cannot reproduce the native timing; mixed-prefill and teacher-forced parity remain final gates
- Sources: docs/site/_pages/bf16-amx-performance-study.html, src/kernels/gemm_kernels_bf16.c, unittest/bf16/test_gemm_storage_contract_bf16.py, version/v8/scripts/bf16_safetensors_lowering_guard_v8.py, commit 7450be49, Xeon handoff measurements