### PR TITLE
refactor(v8/dsl): preserve resolved decode attention providers

### DIFF
--- a/docs/site/_pages/v8-numerical-contracts.html
+++ b/docs/site/_pages/v8-numerical-contracts.html
@@ -117,16 +117,18 @@ make v7-regression-fast</code></pre>
 <table>
   <thead><tr><th>Measured category</th><th>Before this PR</th><th>Current</th><th>Meaning</th></tr></thead>
   <tbody>
-    <tr><td>Direct family-gated predicates/assignments removed by this diff</td><td>37 identified lines</td><td>0 remain from that set</td><td>Qwen3.5, Nemotron-H, Gemma4, and Qwen3-VL decisions moved to circuits/configuration.</td></tr>
-    <tr><td>Forbidden family-dispatch findings in protected generic paths</td><td>Not enforced repository-wide</td><td>0</td><td>The AST policy now fails direct and aliased model/family dispatch.</td></tr>
-    <tr><td>Exact-function codegen predicates</td><td>Not separately tracked</td><td>39</td><td>Mostly ABI, debug, and optimized emission forms; semantic selection must continue moving upstream.</td></tr>
-    <tr><td>Generated M-RoPE call rewrites</td><td>2</td><td>2</td><td>The bridge shell still performs two semantic C-string rewrites.</td></tr>
-    <tr><td>Contract-governed map-owned call ABIs</td><td>0</td><td>23</td><td>Attention, BF16, vision M-RoPE, and Q4/Q6 providers own their ordered arguments.</td></tr>
-    <tr><td>Governed ABI definitions duplicated in legacy registries</td><td>23</td><td>0</td><td>Split ownership is rejected before Lower 3 emits call-ready IR.</td></tr>
+    <tr><td>Executable model-literal AST sites</td><td>71</td><td>69</td><td>A checked-in per-file ceiling now fails on any increase. Reductions must lower the ceiling.</td></tr>
+    <tr><td>Build and IR model-literal sites</td><td>32</td><td>30</td><td>Lower 1 no longer reselects decode attention from model-specific defaults or function-name patterns.</td></tr>
+    <tr><td>Code-generation model-literal sites</td><td>39</td><td>39</td><td>Bridge, tokenizer, debug, and specialized emission remain the largest migration area.</td></tr>
+    <tr><td>Lower-1 decode-attention reselection branches</td><td>7</td><td>0</td><td>Lower 1 validates the exact IR1 kernel and resolved contract, then only wires KV-cache inputs.</td></tr>
+    <tr><td>Compiler functions governed by the no-family-dispatch policy</td><td>8</td><td>9</td><td>The authoritative decode-attention validator is now covered directly.</td></tr>
+    <tr><td>Forbidden family dispatch in governed generic paths</td><td>0</td><td>0</td><td>Direct and aliased model/family dispatch continues to hard-fail.</td></tr>
   </tbody>
 </table>
 
-<p>The policy gate therefore reports zero forbidden family-dispatch findings in its protected generic paths, but codegen is not yet free of all specialized emission. The remaining inventory is 41 sites: 39 exact-function predicates plus two generated M-RoPE call rewrites. These routes are covered by regression tests, but they remain migration work: bridge position advancement and deepstack behavior should become call-IR operations, while specialized emission should consume resolved capability metadata.</p>
+<p>The 69-site inventory is deliberately broader than the previous 41-site estimate: it counts executable string literals containing model-family names across the four principal compiler and code-generation modules, while excluding comments and docstrings. Not every site selects mathematics, but every site is visible debt that cannot increase silently. The audit reports a per-function inventory so cleanup can proceed in bounded groups instead of relying on an informal grep count.</p>
+
+<p>The next priority is Qwen3-VL bridge generation: multimodal fallback injection, deepstack handling, M-RoPE calls, and position advancement should be explicit call-IR operations. Kimi/DeepSeek MLA decode and prefill selection follows after both phases have exact kernel-map providers. Tokenizer adapters may retain family knowledge only while hydrating external metadata into canonical configuration.</p>
 
 <p>This refactor prevents four concrete failure classes: model names silently changing tensor dimensions, undeclared weights being ignored by family branches, unavailable sliding attention falling back to ordinary attention, and generated runtimes enabling multimodal or quantized behavior from a family-name test instead of a hydrated capability.</p>
 

--- a/tests/test_v8_dsl_policy.py
+++ b/tests/test_v8_dsl_policy.py
@@ -28,7 +28,31 @@ class V8DSLPolicyTests(unittest.TestCase):
     def test_cleaned_compiler_functions_have_no_model_literals(self) -> None:
         report = audit.audit()
         self.assertEqual(report["status"], "pass", report["findings"])
-        self.assertGreaterEqual(report["checked_functions"], 3)
+        self.assertGreaterEqual(report["checked_functions"], 9)
+        self.assertEqual(report["model_literal_sites"], 69)
+
+    def test_model_literal_inventory_ignores_docs_and_counts_code(self) -> None:
+        source = '''
+def lower():
+    """Qwen in a function docstring is not executable specialization."""
+    # Gemma in a comment is also not executable specialization.
+    return "qwen_runtime_branch"
+'''
+        row = audit.count_model_literal_sites(source, ["qwen", "gemma"], path="synthetic.py")
+        self.assertEqual(row["sites"], 1)
+        self.assertEqual(row["functions"], {"lower": 1})
+
+    def test_model_literal_site_limit_is_fail_closed(self) -> None:
+        policy = json.loads(audit.DEFAULT_POLICY.read_text(encoding="utf-8"))
+        policy["model_literal_site_limits"]["version/v8/scripts/codegen_v8.py"] = 4
+        with tempfile.TemporaryDirectory() as temp:
+            path = pathlib.Path(temp) / "policy.json"
+            path.write_text(json.dumps(policy), encoding="utf-8")
+            report = audit.audit(path)
+        self.assertEqual(report["status"], "fail")
+        self.assertTrue(
+            any(finding.get("kind") == "model_literal_site_limit" for finding in report["findings"])
+        )
 
     def test_ast_policy_rejects_model_specific_branch(self) -> None:
         source = """
@@ -202,6 +226,49 @@ def lower(op):
             build_ir.compute_matmul_dims("quantize_final_output", config),
             (4096, 4096),
         )
+
+    def test_lowering_preserves_renamed_ir1_decode_attention_kernel(self) -> None:
+        op = {
+            "op": "attn_shared_kv",
+            "kernel": "renamed_exact_decode_provider_id",
+            "function": "renamed_exact_decode_provider_function",
+            "resolved_contract": {
+                "kernel_id": "renamed_exact_decode_provider_id",
+                "function": "renamed_exact_decode_provider_function",
+            },
+        }
+        self.assertEqual(
+            build_ir._require_resolved_decode_attention_kernel(op),
+            "renamed_exact_decode_provider_id",
+        )
+
+    def test_lowering_rejects_incomplete_or_ambiguous_attention_selection(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "without an exact IR1 kernel"):
+            build_ir._require_resolved_decode_attention_kernel({"op": "attn"})
+        with self.assertRaisesRegex(RuntimeError, "does not match resolved contract"):
+            build_ir._require_resolved_decode_attention_kernel(
+                {
+                    "op": "attn_sliding",
+                    "kernel": "provider_a",
+                    "function": "provider_function",
+                    "resolved_contract": {
+                        "kernel_id": "provider_b",
+                        "function": "provider_function",
+                    },
+                }
+            )
+        with self.assertRaisesRegex(RuntimeError, "does not match resolved contract function"):
+            build_ir._require_resolved_decode_attention_kernel(
+                {
+                    "op": "attn",
+                    "kernel": "provider_a",
+                    "function": "provider_function_a",
+                    "resolved_contract": {
+                        "kernel_id": "provider_a",
+                        "function": "provider_function_b",
+                    },
+                }
+            )
 
     def test_weight_policy_is_circuit_owned_and_conditional(self) -> None:
         circuit = {

--- a/version/v8/dsl_policy.json
+++ b/version/v8/dsl_policy.json
@@ -11,6 +11,12 @@
     "qwen"
   ],
   "forbidden_dispatch_keys": ["model", "model_type", "arch", "family"],
+  "model_literal_site_limits": {
+    "version/v8/scripts/build_ir_v8.py": 30,
+    "version/v8/scripts/codegen_core_v8.py": 12,
+    "version/v8/scripts/codegen_prefill_v8.py": 22,
+    "version/v8/scripts/codegen_v8.py": 5
+  },
   "compiler_files": {
     "version/v8/scripts/build_ir_v8.py": {
       "exclude_functions": [
@@ -32,7 +38,8 @@
       "_ignored_manifest_weights",
       "_circuit_op_weight_keys",
       "_config_layer_int",
-      "apply_layer_attention_dims"
+      "apply_layer_attention_dims",
+      "_require_resolved_decode_attention_kernel"
     ],
     "version/v8/scripts/resolve_numerical_execution_contracts_v8.py": [
       "resolve_contract"

--- a/version/v8/scripts/audit_dsl_policy_v8.py
+++ b/version/v8/scripts/audit_dsl_policy_v8.py
@@ -145,6 +145,39 @@ def scan_model_dispatch_source(
     return findings
 
 
+def count_model_literal_sites(source: str, forbidden: list[str], *, path: str) -> dict[str, Any]:
+    """Count existing specialization without treating comments/docstrings as code."""
+    tree = ast.parse(source, filename=path)
+    forbidden_lc = tuple(item.lower() for item in forbidden)
+    lines: set[int] = set()
+    by_function: dict[str, set[int]] = {}
+    for function in (
+        node for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ):
+        docstring = ast.get_docstring(function, clean=False)
+        function_lines: set[int] = set()
+        for child in ast.walk(function):
+            if not isinstance(child, ast.Constant) or not isinstance(child.value, str):
+                continue
+            if docstring is not None and child.value == docstring:
+                continue
+            value = child.value.lower()
+            if any(item in value for item in forbidden_lc):
+                function_lines.add(child.lineno)
+        if function_lines:
+            by_function[function.name] = function_lines
+            lines.update(function_lines)
+    return {
+        "path": path,
+        "sites": len(lines),
+        "functions": {
+            name: len(function_lines)
+            for name, function_lines in sorted(by_function.items())
+        },
+    }
+
+
 def audit(policy_path: Path = DEFAULT_POLICY) -> dict[str, Any]:
     policy = json.loads(policy_path.read_text(encoding="utf-8"))
     if policy.get("schema") != "cke.v8_dsl_policy" or policy.get("schema_version") != 1:
@@ -152,6 +185,7 @@ def audit(policy_path: Path = DEFAULT_POLICY) -> dict[str, Any]:
     forbidden = policy.get("forbidden_model_literals")
     compiler_functions = policy.get("compiler_functions")
     compiler_files = policy.get("compiler_files", {})
+    literal_site_limits = policy.get("model_literal_site_limits", {})
     dispatch_keys = policy.get("forbidden_dispatch_keys", [])
     if not isinstance(forbidden, list) or not forbidden or not all(isinstance(item, str) and item for item in forbidden):
         raise DSLPolicyError("forbidden_model_literals must be a non-empty string list")
@@ -191,7 +225,37 @@ def audit(policy_path: Path = DEFAULT_POLICY) -> dict[str, Any]:
                 exclude_functions=exclude,
             )
         )
-    return {"status": "fail" if findings else "pass", "checked_functions": checked, "findings": findings}
+    if not isinstance(literal_site_limits, dict):
+        raise DSLPolicyError("model_literal_site_limits must be an object")
+    inventory: dict[str, Any] = {}
+    total_sites = 0
+    for relative_path, limit in literal_site_limits.items():
+        if not isinstance(relative_path, str) or not isinstance(limit, int) or limit < 0:
+            raise DSLPolicyError("model literal site limits require paths and non-negative integers")
+        path = REPO_ROOT / relative_path
+        if not path.is_file():
+            raise DSLPolicyError(f"compiler file not found: {relative_path}")
+        row = count_model_literal_sites(
+            path.read_text(encoding="utf-8"), forbidden, path=relative_path
+        )
+        inventory[relative_path] = row
+        total_sites += int(row["sites"])
+        if row["sites"] > limit:
+            findings.append(
+                {
+                    "path": relative_path,
+                    "kind": "model_literal_site_limit",
+                    "sites": row["sites"],
+                    "limit": limit,
+                }
+            )
+    return {
+        "status": "fail" if findings else "pass",
+        "checked_functions": checked,
+        "model_literal_sites": total_sites,
+        "model_literal_inventory": inventory,
+        "findings": findings,
+    }
 
 
 def main() -> int:

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -6754,6 +6754,48 @@ def insert_bias_add_ops(
 # STAGE 3: IR LOWER 1 (Stitch kernel maps)
 # ═══════════════════════════════════════════════════════════════════════════
 
+_DECODE_ATTENTION_OPS = {
+    "attn",
+    "attn_sliding",
+    "attn_shared_kv",
+    "attn_sliding_shared_kv",
+}
+
+
+def _require_resolved_decode_attention_kernel(op: Dict[str, Any]) -> str:
+    """Validate the resolved decode provider without performing selection."""
+    op_name = str(op.get("op", "") or "")
+    if op_name not in _DECODE_ATTENTION_OPS:
+        raise RuntimeError(
+            f"HARD IR LOWERING FAULT: {op_name!r} is not a decode attention operation."
+        )
+    kernel_id = str(op.get("kernel", "") or "").strip()
+    function = str(op.get("function", "") or "").strip()
+    if not kernel_id or not function:
+        raise RuntimeError(
+            f"HARD IR LOWERING FAULT: {op_name} reached Lower 1 without an exact "
+            "IR1 kernel and function. Resolve it from circuit requirements and kernel maps."
+        )
+    resolved = op.get("resolved_contract")
+    if isinstance(resolved, dict):
+        resolved_kernel = str(resolved.get("kernel_id", "") or "").strip()
+        resolved_function = str(resolved.get("function", "") or "").strip()
+        if not resolved_kernel or not resolved_function:
+            raise RuntimeError(
+                f"HARD IR LOWERING FAULT: {op_name} has an incomplete resolved contract."
+            )
+        if resolved_kernel != kernel_id:
+            raise RuntimeError(
+                f"HARD IR LOWERING FAULT: {op_name} IR1 kernel {kernel_id!r} "
+                f"does not match resolved contract kernel {resolved_kernel!r}."
+            )
+        if resolved_function != function:
+            raise RuntimeError(
+                f"HARD IR LOWERING FAULT: {op_name} function {function!r} "
+                f"does not match resolved contract function {resolved_function!r}."
+            )
+    return kernel_id
+
 def generate_ir_lower_1(
     fused_ops: List[Dict],
     registry: Dict,
@@ -6786,7 +6828,6 @@ def generate_ir_lower_1(
     config = manifest.get("config", {})
     logits_layout = _resolve_logits_layout(config, mode)
     template = manifest.get("template", {}) if isinstance(manifest.get("template"), dict) else {}
-    template_kernels = template.get("kernels", {}) if isinstance(template.get("kernels"), dict) else {}
     template_contract = template.get("contract") if isinstance(template.get("contract"), dict) else {}
     attention_contract = template_contract.get("attention_contract") if isinstance(template_contract.get("attention_contract"), dict) else {}
     decode_cache_contract = attention_contract.get("decode_cache_contract") if isinstance(attention_contract.get("decode_cache_contract"), dict) else {}
@@ -6989,6 +7030,7 @@ def generate_ir_lower_1(
     print(f"\n  [{mode.capitalize()} mode] Inserting KV cache operations...")
     final_ops = []
     kv_store_count = 0
+    decode_attention_count = 0
 
     force_decode_attn_regular = str(os.environ.get("CK_V7_DECODE_ATTN_REGULAR", "")).strip().lower() in ("1", "true", "yes", "on")
     decode_kv_cache_dtype = str(config.get("decode_kv_cache_dtype", "fp32") or "fp32").strip().lower()
@@ -7131,29 +7173,15 @@ def generate_ir_lower_1(
                 op["inputs"]["v_cache"] = {"type": "kv_cache", "source": f"kv_cache_v_L{kv_read_layer}"}
                 op["inputs"].pop("k", None)
                 op["inputs"].pop("v", None)
-            elif op["op"] in ("attn", "attn_sliding") and "attention" in op["kernel"]:
-                resolved_contract = op.get("resolved_contract") if isinstance(op.get("resolved_contract"), dict) else None
-                if resolved_contract is not None:
-                    decode_kernel = str(resolved_contract["kernel_id"])
-                    if force_decode_attn_regular:
-                        raise RuntimeError(
-                            "HARD CONTRACT FAULT: CK_V7_DECODE_ATTN_REGULAR attempted to override "
-                            f"resolved kernel {decode_kernel!r}. Semantic runtime flags cannot override "
-                            "an authoritative GraphIR contract."
-                        )
-                # Legacy circuits without a declared contract retain their
-                # existing compatibility selection until they are migrated.
-                elif op["op"] == "attn_sliding":
-                    decode_kernel = template_kernels.get("attn_sliding_decode") or "attention_forward_decode_head_major_gqa_flash_sliding"
-                else:
-                    if force_decode_attn_regular:
-                        decode_kernel = "attention_forward_decode_head_major_gqa_regular"
-                    else:
-                        decode_kernel = template_kernels.get("attn_decode") or "attention_forward_decode_head_major_gqa_flash"
-                    if decode_uses_fp16_kv and decode_kernel == "attention_forward_decode_head_major_gqa_flash":
-                        decode_kernel = "attention_forward_decode_head_major_gqa_flash_f16cache"
-                op["kernel"] = decode_kernel
-                op["function"] = decode_kernel
+            elif op["op"] in _DECODE_ATTENTION_OPS:
+                decode_kernel = _require_resolved_decode_attention_kernel(op)
+                decode_attention_count += 1
+                if force_decode_attn_regular:
+                    raise RuntimeError(
+                        "HARD CONTRACT FAULT: CK_V7_DECODE_ATTN_REGULAR cannot override "
+                        f"authoritative IR1 kernel {decode_kernel!r}. Change the circuit or "
+                        "kernel-map contract instead."
+                    )
                 kv_read_layer = _kv_read_layer_for(int(op.get("layer", 0)))
                 op["_kv_cache_read_layer"] = kv_read_layer
                 # Update inputs to use KV cache instead of scratch
@@ -7163,18 +7191,6 @@ def generate_ir_lower_1(
                 # Remove scratch K/V references if present
                 op["inputs"].pop("k", None)
                 op["inputs"].pop("v", None)
-            elif op["op"] in ("attn_shared_kv", "attn_sliding_shared_kv") and "attention" in op["kernel"]:
-                if op["op"] == "attn_sliding_shared_kv":
-                    decode_kernel = template_kernels.get("attn_sliding_shared_kv_decode") or "attention_forward_decode_head_major_shared_kv_sliding_gemma4"
-                else:
-                    decode_kernel = template_kernels.get("attn_shared_kv_decode") or "attention_forward_decode_head_major_shared_kv_gemma4"
-                op["kernel"] = decode_kernel
-                op["function"] = decode_kernel
-                kv_read_layer = _kv_read_layer_for(int(op.get("layer", 0)))
-                op["_kv_cache_read_layer"] = kv_read_layer
-                op.setdefault("inputs", {})
-                op["inputs"]["k_cache"] = {"type": "kv_cache", "source": f"kv_cache_k_L{kv_read_layer}"}
-                op["inputs"]["v_cache"] = {"type": "kv_cache", "source": f"kv_cache_v_L{kv_read_layer}"}
 
         elif mode == "prefill":
             # Prefill layout bridges are a graph contract, not a decoder/KV-cache
@@ -7353,7 +7369,10 @@ def generate_ir_lower_1(
     if not uses_kv_cache:
         print("  KV cache insertion skipped: template declares no persistent KV cache")
     if mode == "decode" and uses_kv_cache:
-        print(f"  Updated {kv_store_count} attention ops to use decode kernel")
+        print(
+            f"  Validated {decode_attention_count} authoritative IR1 decode "
+            "attention kernels and wired KV-cache inputs"
+        )
 
     # Summary
     total_weight_refs = sum(len(op.get("weights", {})) for op in lowered_ops)


### PR DESCRIPTION
## Why

Lower 1 still reselected decode attention after IR1 had already chosen an exact provider. Template defaults, cache dtype, function-name checks, and Gemma4 fallback symbols could therefore override circuit and kernel-map ownership.

## What changed

- Preserve the exact IR1 decode-attention kernel ID and C function through Lower 1.
- Validate resolved kernel and function identity independently before wiring KV-cache inputs.
- Reject the legacy runtime override instead of changing numerical semantics.
- Remove seven regular, sliding, and shared-KV decode reselection branches.
- Add an AST-based per-file specialization inventory with fail-closed ceilings.
- Update the v8 numerical-contract page with the reproducible inventory and next migration targets.

## Evidence

| Measure | Before | After |
|---|---:|---:|
| Decode-attention reselection branches in Lower 1 | 7 | 0 |
| Executable model-literal AST sites | 71 | 69 |
| Build/IR sites | 32 | 30 |
| Codegen sites | 39 | 39 |
| Governed compiler functions | 8 | 9 |

The remaining 69 sites are now emitted as a per-function audit inventory. Any increase above a checked-in per-file ceiling fails.

## Validation

- DSL policy: 21/21
- Kernel call ABI: 7/7
- Codegen capabilities: 15/15
- Template circuit audit: 10/10
- Qwen2/Qwen3-VL/Gemma4 generated IR: 46/46
- `make v8-regression-fast`: PASS
- `make v7-regression-fast`: PASS after rebuilding the pinned llama.cpp oracle
- Pre-commit staged v7/v8 regressions: PASS
- Pre-push build, kernel parity, Gemma3 E2E, contracts, training smoke, and v7/v8 regressions: PASS

## Regression coverage

The v8 sweep passes configured Gemma3, Qwen2, Qwen3, Qwen3.5, and Nanbeige family gates. The v7 sweep passes the same configured families and first-token parity where enabled. Synthetic renamed-provider tests prove that stable kernel IDs and C functions may differ while both remain exact resolver outputs. Missing providers and identity drift hard-fail.

The aggregate `make test-v8-dsl` retains one pre-existing non-oracle FP16 split-KV case at KV=512 (`3.38e-5` versus `2e-5`). The pinned llama.cpp oracle at the same threshold passes (`7.00e-6`). No tolerance was changed.

## Documentation

Updated `docs/site/_pages/v8-numerical-contracts.html` with the 71-to-69 reduction, the per-file ratchet, decode provider ownership, and the next Qwen3-VL bridge and Kimi/DeepSeek MLA migrations.

## Content handoff

- Audience: CPU runtime, compiler, and numerical-parity engineers
- Angle: Make lowering consume resolved kernel decisions instead of guessing a second time
- Claims: Seven decode reselection branches were removed; measured specialization debt fell from 71 to 69; v7 and v8 family sweeps pass
- Caveats: Qwen3-VL bridge string surgery and Kimi MLA phase mapping remain; one pre-existing synthetic KV=512 split-KV tolerance case remains open
- Sources: commit b89dcc64, DSL audit output, v8 regression summary `20260712_172342`, v7 regression summary `20260712_173003`, and the v8 numerical-contract documentation page