### PR TITLE
fix(v8/dsl): audit module-level specialization debt

### DIFF
--- a/docs/site/_pages/v8-numerical-contracts.html
+++ b/docs/site/_pages/v8-numerical-contracts.html
@@ -117,8 +117,8 @@ make v7-regression-fast</code></pre>
 <table>
   <thead><tr><th>Measured category</th><th>Before this PR</th><th>Current</th><th>Meaning</th></tr></thead>
   <tbody>
-    <tr><td>Executable model-literal AST sites</td><td>71</td><td>69</td><td>A checked-in per-file ceiling now fails on any increase. Reductions must lower the ceiling.</td></tr>
-    <tr><td>Build and IR model-literal sites</td><td>32</td><td>30</td><td>Lower 1 no longer reselects decode attention from model-specific defaults or function-name patterns.</td></tr>
+    <tr><td>Executable model-literal AST sites</td><td>78</td><td>76</td><td>A checked-in per-file ceiling now fails on any increase. Reductions must lower the ceiling.</td></tr>
+    <tr><td>Build and IR model-literal sites</td><td>39</td><td>37</td><td>Lower 1 no longer reselects decode attention from model-specific defaults or function-name patterns.</td></tr>
     <tr><td>Code-generation model-literal sites</td><td>39</td><td>39</td><td>Bridge, tokenizer, debug, and specialized emission remain the largest migration area.</td></tr>
     <tr><td>Lower-1 decode-attention reselection branches</td><td>7</td><td>0</td><td>Lower 1 validates the exact IR1 kernel and resolved contract, then only wires KV-cache inputs.</td></tr>
     <tr><td>Compiler functions governed by the no-family-dispatch policy</td><td>8</td><td>9</td><td>The authoritative decode-attention validator is now covered directly.</td></tr>
@@ -126,7 +126,7 @@ make v7-regression-fast</code></pre>
   </tbody>
 </table>
 
-<p>The 69-site inventory is deliberately broader than the previous 41-site estimate: it counts executable string literals containing model-family names across the four principal compiler and code-generation modules, while excluding comments and docstrings. Not every site selects mathematics, but every site is visible debt that cannot increase silently. The audit reports a per-function inventory so cleanup can proceed in bounded groups instead of relying on an informal grep count.</p>
+<p>The 76-site inventory is deliberately broader than the previous 41-site estimate: it counts executable module-level and function-level string literals containing model-family names across the four principal compiler and code-generation modules, while excluding comments, docstrings, and standalone documentation strings. Not every site selects mathematics, but every site is visible debt that cannot increase silently. The audit reports a per-function inventory so cleanup can proceed in bounded groups instead of relying on an informal grep count.</p>
 
 <p>The next priority is Qwen3-VL bridge generation: multimodal fallback injection, deepstack handling, M-RoPE calls, and position advancement should be explicit call-IR operations. Kimi/DeepSeek MLA decode and prefill selection follows after both phases have exact kernel-map providers. Tokenizer adapters may retain family knowledge only while hydrating external metadata into canonical configuration.</p>
 

--- a/tests/test_v8_dsl_policy.py
+++ b/tests/test_v8_dsl_policy.py
@@ -29,18 +29,21 @@ class V8DSLPolicyTests(unittest.TestCase):
         report = audit.audit()
         self.assertEqual(report["status"], "pass", report["findings"])
         self.assertGreaterEqual(report["checked_functions"], 9)
-        self.assertEqual(report["model_literal_sites"], 69)
+        self.assertEqual(report["model_literal_sites"], 76)
 
     def test_model_literal_inventory_ignores_docs_and_counts_code(self) -> None:
         source = '''
+"""Qwen in a module docstring is not executable specialization."""
+GEMMA_PROVIDER = "gemma_runtime_provider"
+
 def lower():
     """Qwen in a function docstring is not executable specialization."""
     # Gemma in a comment is also not executable specialization.
     return "qwen_runtime_branch"
 '''
         row = audit.count_model_literal_sites(source, ["qwen", "gemma"], path="synthetic.py")
-        self.assertEqual(row["sites"], 1)
-        self.assertEqual(row["functions"], {"lower": 1})
+        self.assertEqual(row["sites"], 2)
+        self.assertEqual(row["functions"], {"<module>": 1, "lower": 1})
 
     def test_model_literal_site_limit_is_fail_closed(self) -> None:
         policy = json.loads(audit.DEFAULT_POLICY.read_text(encoding="utf-8"))

--- a/version/v8/dsl_policy.json
+++ b/version/v8/dsl_policy.json
@@ -12,7 +12,7 @@
   ],
   "forbidden_dispatch_keys": ["model", "model_type", "arch", "family"],
   "model_literal_site_limits": {
-    "version/v8/scripts/build_ir_v8.py": 30,
+    "version/v8/scripts/build_ir_v8.py": 37,
     "version/v8/scripts/codegen_core_v8.py": 12,
     "version/v8/scripts/codegen_prefill_v8.py": 22,
     "version/v8/scripts/codegen_v8.py": 5

--- a/version/v8/scripts/audit_dsl_policy_v8.py
+++ b/version/v8/scripts/audit_dsl_policy_v8.py
@@ -151,23 +151,36 @@ def count_model_literal_sites(source: str, forbidden: list[str], *, path: str) -
     forbidden_lc = tuple(item.lower() for item in forbidden)
     lines: set[int] = set()
     by_function: dict[str, set[int]] = {}
-    for function in (
-        node for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-    ):
-        docstring = ast.get_docstring(function, clean=False)
-        function_lines: set[int] = set()
-        for child in ast.walk(function):
-            if not isinstance(child, ast.Constant) or not isinstance(child.value, str):
-                continue
-            if docstring is not None and child.value == docstring:
-                continue
-            value = child.value.lower()
-            if any(item in value for item in forbidden_lc):
-                function_lines.add(child.lineno)
-        if function_lines:
-            by_function[function.name] = function_lines
-            lines.update(function_lines)
+    parents = {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    documentation_nodes = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    }
+    for node in ast.walk(tree):
+        if (
+            not isinstance(node, ast.Constant)
+            or not isinstance(node.value, str)
+            or node in documentation_nodes
+        ):
+            continue
+        if not any(item in node.value.lower() for item in forbidden_lc):
+            continue
+        owner = "<module>"
+        parent = parents.get(node)
+        while parent is not None:
+            if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                owner = parent.name
+                break
+            parent = parents.get(parent)
+        by_function.setdefault(owner, set()).add(node.lineno)
+        lines.add(node.lineno)
     return {
         "path": path,
         "sites": len(lines),


### PR DESCRIPTION
## Why

PR #161 made DSL specialization debt fail-closed inside functions, but its first inventory missed executable model literals at module scope. A future agent could move a family-specific value into a module constant and evade the ratchet.

## What changed

- Count executable model literals at module scope and attribute each literal to its nearest function or `<module>`.
- Exclude comments, docstrings, and standalone documentation strings.
- Add regression coverage proving module constants count while documentation does not.
- Correct the per-file ceilings and architecture documentation to the complete inventory.

## Evidence

The complete inventory is 76 sites: 37 in build/IR, 12 in core codegen, 22 in prefill codegen, and 5 in bridge codegen. Eight module-level build/IR sites that were invisible in the partial audit are now reported explicitly. Relative to the code before PR #161, decode-provider cleanup reduced the complete count from 78 to 76.

## Validation

- DSL policy: 21/21
- Kernel call ABI: 7/7
- Codegen capabilities: 15/15
- Nightly DSL registration: 2/2
- HTML parse: PASS
- `git diff --check`: PASS
- Pre-commit staged v7/v8 regressions: PASS
- Pre-push build, kernel parity, Gemma3 E2E, inference contracts, training smoke, and v7/v8 regressions: PASS

## Regression coverage

The synthetic audit fixture now contains a module doc string, module-level Gemma provider constant, function docstring, comment, and function-level Qwen literal. Only the two executable literals count. Lowering the checked-in ceiling still causes a hard failure.

## Documentation

Corrects `docs/site/_pages/v8-numerical-contracts.html` from the partial 69-site count to the complete 76-site module-and-function inventory.

## Content handoff

- Audience: Compiler, runtime, and numerical-parity engineers
- Angle: A no-hardcoding policy is incomplete if model-specific aliases can hide at module scope
- Claims: Eight previously invisible module-level sites are now audited; the complete 76-site baseline is fail-closed
- Caveats: This improves detection but does not remove the remaining Qwen3-VL bridge or Kimi MLA specialization
- Sources: PR #161, commit 3a50cb91, DSL audit JSON, `tests/test_v8_dsl_policy.py`, and the v8 numerical-contract documentation page