### PR TITLE
fix(v8): resolve GGUF vision M-RoPE semantics

### DIFF
--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -1382,11 +1382,20 @@ static int explicit_mrope_apply_ggml_exact(
     int ggml_sections[GGML_MROPE_SECTIONS] = {
         sections[0], sections[1], sections[2], sections[3]
     };
+    /* CK's vision contract names the full rotary width. ggml's VISION mode
+     * names the split-half stride (the number of frequency pairs). Keep this
+     * unit conversion inside the oracle adapter so production kernels and IR
+     * continue to carry the canonical full-width value. */
+    const int ggml_n_dims = rope_type == GGML_ROPE_TYPE_VISION ? n_dims / 2 : n_dims;
+    if (ggml_n_dims <= 0 || (rope_type == GGML_ROPE_TYPE_VISION && (n_dims & 1) != 0)) {
+        ggml_free_fn(ctx);
+        return 0;
+    }
     struct ggml_tensor *rope = ggml_rope_multi_inplace_fn(ctx,
                                                           x_view,
                                                           pos_base,
                                                           NULL,
-                                                          n_dims,
+                                                          ggml_n_dims,
                                                           ggml_sections,
                                                           rope_type,
                                                           n_ctx_orig,

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -148,6 +148,51 @@ def _make_qwen3vl_manifest() -> dict:
 
 class V8Qwen3VLTemplateTests(unittest.TestCase):
 
+    def test_gguf_vision_mrope_resolves_fp32_contract(self) -> None:
+        manifest = _make_qwen3vl_manifest()
+        manifest["config"]["vision_mrope_storage_boundary"] = "fp32"
+        self.assertEqual(
+            convert_gguf_to_bump_v8._inject_runtime_config_defaults(
+                manifest["config"], "qwen3_vl_vision"
+            )["vision_mrope_storage_boundary"],
+            "fp32",
+        )
+        with tempfile.TemporaryDirectory(prefix="v8_qwen3vl_gguf_mrope_") as td:
+            root = Path(td)
+            manifest_path = root / "weights_manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            paths = {
+                name: root / f"{name}.json"
+                for name in ("ir1", "layout", "lowered", "call")
+            }
+            args = [
+                "--manifest", str(manifest_path),
+                "--mode", "prefill",
+                "--output", str(paths["ir1"]),
+                "--layout-output", str(paths["layout"]),
+                "--lowered-output", str(paths["lowered"]),
+                "--call-output", str(paths["call"]),
+            ]
+            with redirect_stdout(io.StringIO()):
+                self.assertEqual(build_ir_v8.main(args), 0)
+
+            for artifact in ("ir1", "lowered", "call"):
+                doc = json.loads(paths[artifact].read_text())
+                operations = doc if isinstance(doc, list) else doc.get("operations", doc.get("ops", []))
+                mrope = next(item for item in operations if item.get("op") == "rope_qk")
+                self.assertEqual(
+                    mrope["resolved_contract"]["contract_id"],
+                    "vision_mrope_fp32_input_fp32_compute_fp32_output",
+                )
+                self.assertEqual(
+                    mrope["resolved_contract"]["kernel_id"],
+                    "mrope_qk_vision",
+                )
+                if artifact == "call":
+                    self.assertEqual(mrope["function"], "mrope_qk_vision")
+                else:
+                    self.assertEqual(mrope["kernel"], "mrope_qk_vision")
+
     def test_vision_mrope_classification_uses_semantics_not_kernel_name(self) -> None:
         operation = {
             "op": "rope_qk",

--- a/version/v8/circuits/qwen3_vl_vision.json
+++ b/version/v8/circuits/qwen3_vl_vision.json
@@ -121,6 +121,34 @@
     }
   },
   "required_numerical_contracts": {
+    "vision.layer.mrope.fp32": {
+      "op": "rope",
+      "template_ops": [
+        "rope_qk"
+      ],
+      "selector": {
+        "config_equals": {
+          "vision_mrope_storage_boundary": "fp32"
+        }
+      },
+      "phases": {
+        "prefill": {
+          "contract_id": "vision_mrope_fp32_input_fp32_compute_fp32_output",
+          "validation": "validated",
+          "evidence": "unittest/test_vision.py::test_mrope_qk_vision_storage_matrix"
+        }
+      },
+      "checkpoint": {
+        "id": "vision.layer.{layer}.q.post_rope",
+        "producer": "vision_mrope",
+        "logical_layout": "head_major",
+        "axis_names": [
+          "head",
+          "token",
+          "channel"
+        ]
+      }
+    },
     "vision.frontend.position": {
       "op": "position_embeddings",
       "template_ops": [

--- a/version/v8/scripts/convert_gguf_to_bump_v8.py
+++ b/version/v8/scripts/convert_gguf_to_bump_v8.py
@@ -361,6 +361,10 @@ def _inject_runtime_config_defaults(config: dict, arch: str) -> dict:
         )
     elif arch_lc == "qwen3_vl_vision":
         config.setdefault("prefer_q8_0_contract", True)
+        # GGUF mmproj tensors enter vision M-RoPE as FP32 and retain FP32
+        # storage. The circuit resolves the exact provider from this boundary;
+        # lowering must not infer it from the model family or kernel spelling.
+        config.setdefault("vision_mrope_storage_boundary", "fp32")
         config.setdefault(
             "q8_0_contract_ops",
             ["projector_fc2", "branch_fc1", "branch_fc2"],


### PR DESCRIPTION
## Why

Current-head Qwen3-VL stitched parity could not reach a valid encoder comparison. GGUF mmproj conversion did not declare the FP32 M-RoPE storage boundary, and the strict llama.cpp oracle consumed a different rotary-width unit than CKE's canonical contract.

## What changed

- Declare the GGUF Qwen3-VL FP32 M-RoPE storage boundary.
- Add the exact circuit numerical contract for the existing FP32 provider.
- Assert that the provider survives IR1, LoweredIR, and call IR unchanged.
- Translate full rotary width to GGML VISION pair count only at the strict oracle ABI.

## Evidence

The canonical OCR image now completes both encoders with identical 1008 x 16384 output shapes. Current CKE versus llama.cpp prefix metrics are cosine 0.999555, RMSE 0.004839, and max absolute error 0.539022. Granular attribution shows exact patch bias, layer-0 ln1 max error 8.11e-6, and the first material amplification at Q8 Q/K/V projection.

CK strict encoding took 362.4s; llama.cpp encoding took 29.5s. Correctness and performance parity remain open.

## Validation

- make test-v8-qwen3vl: 24/24 PASS
- make test-v8-vision-kernels: PASS
- make test-v8-dsl-policy: PASS
- make test-qwen3vl-strict-attn-oracle-build: PASS
- Pre-commit v7/v8 fast regressions: PASS
- Pre-push build, kernel parity, E2E, inference contracts, v7 training, v7/v8 fast regressions, and training-kernel parity: PASS
- git diff --check: PASS

## Regression coverage

The new Qwen3-VL test verifies exact FP32 M-RoPE contract and provider identity through every IR stage. Existing vision-kernel tests cover FP32/BF16/FP16 M-RoPE storage semantics and production head width 72.

## Documentation

No user-facing documentation changed. This PR is narrowly scoped contract and oracle integration plumbing.

## Content handoff

- Audience: CPU inference, compiler, and numerical-parity engineers
- Angle: Fail-closed contracts exposed missing GGUF semantics, then the independent oracle exposed an API unit mismatch before numerical optimization.
- Claims: Two setup blockers are fixed; identical output geometry is established; encoder numerical parity is not complete.
- Caveats: This does not fix the remaining Q8 activation amplification, 64-token decode parity, or the strict encoder performance gap.
- Sources: Commit diff, encoder_numeric_after_oracle_fix.json, and layer0_granular.json in the local parity work directory.