### PR TITLE
feat(v8/xray): unify llama and PyTorch vision parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2944,26 +2944,41 @@ test-numerical-contracts: $(LIB)
 test-bf16-xray:
 	@echo "Running bounded numerical X-ray architecture tests..."
 	@$(PYTHON) -m py_compile \
+		version/v8/scripts/xray_vision_parity_v8.py \
 		version/v8/scripts/xray_numerical_parity_v8.py \
 		version/v8/scripts/build_xray_checkpoint_manifest_v8.py \
 		version/v8/scripts/xray_qwen3vl_bf16_v8.py \
+		version/v8/scripts/xray_qwen3vl_llamacpp_v8.py \
 		version/v8/scripts/normalize_xray_ranking_report_v8.py
 	@$(PYTHON) tests/test_v8_numerical_execution_contracts.py
 	@$(PYTHON) tests/test_v8_xray_numerical_parity.py
+	@$(PYTHON) tests/test_v8_xray_vision_interface.py
 	@$(PYTHON) version/v8/test_assets/generate_xray_form_fixture_v8.py \
 		--output build/xray/public_form_1152x896.ppm
 
 xray-vision-parity:
-	@if [ -z "$(CHECKPOINT)" ] || [ -z "$(RUNTIME_DIR)" ] || [ -z "$(WEIGHTS_BUMP)" ] || [ -z "$(CALL_IR)" ]; then \
-		echo "Usage: make xray-vision-parity CHECKPOINT=/safetensors RUNTIME_DIR=/runtime WEIGHTS_BUMP=/weights.bump CALL_IR=/call.json [IMAGE=/form.ppm]"; \
-		exit 2; \
+	@if [ "$(BACKEND)" = "llamacpp" ]; then \
+		if [ -z "$(GGUF)" ]; then \
+			echo "Usage: make xray-vision-parity BACKEND=llamacpp GGUF=/mmproj.gguf [IMAGE=/form.ppm] [LAYER=0]"; \
+			exit 2; \
+		fi; \
+		$(PYTHON) version/v8/scripts/xray_vision_parity_v8.py --backend llamacpp \
+			--gguf "$(GGUF)" $(if $(IMAGE),--image "$(IMAGE)",) \
+			--layer "$(if $(LAYER),$(LAYER),0)" --image-max-tokens "$(if $(IMAGE_MAX_TOKENS),$(IMAGE_MAX_TOKENS),1024)" \
+			--threads "$${CK_NUM_THREADS:-20}" \
+			--output-dir "$${XRAY_OUTPUT_DIR:-build/xray/qwen3vl_llamacpp}"; \
+	else \
+		if [ -z "$(CHECKPOINT)" ] || [ -z "$(RUNTIME_DIR)" ] || [ -z "$(WEIGHTS_BUMP)" ] || [ -z "$(CALL_IR)" ]; then \
+			echo "Usage: make xray-vision-parity BACKEND=pytorch CHECKPOINT=/safetensors RUNTIME_DIR=/runtime WEIGHTS_BUMP=/weights.bump CALL_IR=/call.json [IMAGE=/form.ppm]"; \
+			exit 2; \
+		fi; \
+		$(PYTHON) version/v8/scripts/xray_vision_parity_v8.py --backend pytorch \
+			--checkpoint "$(CHECKPOINT)" --runtime-dir "$(RUNTIME_DIR)" \
+			--weights-bump "$(WEIGHTS_BUMP)" --call-ir "$(CALL_IR)" \
+			--image "$${IMAGE:-build/xray/public_form_1152x896.ppm}" \
+			--threads "$${CK_NUM_THREADS:-20}" \
+			--output-dir "$${XRAY_OUTPUT_DIR:-build/xray/qwen3vl_bf16}"; \
 	fi
-	@$(PYTHON) version/v8/scripts/xray_qwen3vl_bf16_v8.py \
-		--checkpoint "$(CHECKPOINT)" --runtime-dir "$(RUNTIME_DIR)" \
-		--weights-bump "$(WEIGHTS_BUMP)" --call-ir "$(CALL_IR)" \
-		--image "$${IMAGE:-build/xray/public_form_1152x896.ppm}" \
-		--threads "$${CK_NUM_THREADS:-20}" \
-		--output-dir "$${XRAY_OUTPUT_DIR:-build/xray/qwen3vl_bf16}"
 
 test-v8-dsl-policy:
 	@echo "Running v8 zero-hardcoding DSL policy tests..."

--- a/tests/test_v8_xray_vision_interface.py
+++ b/tests/test_v8_xray_vision_interface.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "version" / "v8" / "scripts"
+PROFILE = ROOT / "version" / "v8" / "parity_profiles" / "qwen3vl_llamacpp_q8_v1.json"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+import sys
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+frontend = load_module("xray_vision_parity_v8_test", SCRIPTS / "xray_vision_parity_v8.py")
+llama = load_module("xray_qwen3vl_llamacpp_v8_test", SCRIPTS / "xray_qwen3vl_llamacpp_v8.py")
+xray = load_module("xray_numerical_parity_v8_test_interface", SCRIPTS / "xray_numerical_parity_v8.py")
+
+
+class XRayVisionInterfaceTests(unittest.TestCase):
+    def test_frontend_dispatches_llamacpp_without_owning_backend_arguments(self) -> None:
+        with mock.patch.object(frontend.llamacpp_adapter, "main", return_value=7) as adapter:
+            result = frontend.dispatch(["--backend", "llamacpp", "--gguf", "model.gguf"])
+        self.assertEqual(result, 7)
+        adapter.assert_called_once_with(["--gguf", "model.gguf"])
+
+    def test_frontend_dispatches_pytorch_without_owning_backend_arguments(self) -> None:
+        with mock.patch.object(frontend.pytorch_adapter, "main", return_value=0) as adapter:
+            result = frontend.dispatch(["--backend", "pytorch", "--checkpoint", "model"])
+        self.assertEqual(result, 0)
+        adapter.assert_called_once_with(["--checkpoint", "model"])
+
+    def test_llama_profile_is_schema_valid(self) -> None:
+        profile = xray.load_json(PROFILE)
+        xray.validate(profile, xray.PROFILE_SCHEMA, "llama profile")
+        self.assertEqual(profile["backend"], "llamacpp")
+
+    def test_legacy_results_are_reordered_by_semantic_circuit_position(self) -> None:
+        profile = xray.load_json(PROFILE)
+        report = {
+            "results": [
+                {"layer": 0, "op": "Kcur_rope", "status": "FAIL", "max_abs_diff": 0.2},
+                {"layer": 0, "op": "q_proj", "status": "FAIL", "max_abs_diff": 0.1},
+                {"layer": 0, "op": "ln1", "status": "PASS", "max_abs_diff": 0.0},
+                {"layer": -1, "op": "inp_pos_emb", "status": "PASS", "max_abs_diff": 0.0},
+            ]
+        }
+        result = llama.normalize_capture_report(report, profile, layer=0)
+        self.assertEqual(result["last_passing_checkpoint"], "vision.layer.0.norm1.output")
+        self.assertEqual(result["first_divergence"]["checkpoint_id"], "vision.layer.0.q.pre_rope")
+        self.assertEqual(
+            result["first_divergence"]["classification"],
+            "KERNEL_IMPLEMENTATION_DIVERGENCE",
+        )
+
+    def test_capture_adapter_is_documented_as_internal_to_xray(self) -> None:
+        source = (SCRIPTS / "activation_parity_qwen3vl_mmproj_v8.py").read_text(encoding="utf-8")
+        self.assertIn("must invoke ``xray_vision_parity_v8.py --backend", source)
+        self.assertIn("Do not add model-family branches here", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/version/v8/parity_profiles/qwen3vl_llamacpp_q8_v1.json
+++ b/version/v8/parity_profiles/qwen3vl_llamacpp_q8_v1.json
@@ -1,0 +1,147 @@
+{
+  "schema": "cke.parity_profile",
+  "schema_version": 1,
+  "name": "qwen3vl_llamacpp_q8_v1",
+  "backend": "llamacpp",
+  "contract_schema_version": 1,
+  "required_match_fields": [
+    "checkpoint_id",
+    "producer",
+    "logical_layout",
+    "axis_names",
+    "resolved_contract_id",
+    "kernel_id",
+    "function"
+  ],
+  "observed_storage": {
+    "default": "fp32",
+    "checkpoints": {}
+  },
+  "dtype_thresholds": {
+    "fp32": {
+      "cosine_min": 0.99999,
+      "rmse_max": 0.0001,
+      "relative_rmse_max": 0.0001,
+      "max_abs_max": 0.001,
+      "finite_required": true
+    }
+  },
+  "checkpoint_order": [
+    "vision.frontend.position.output",
+    "vision.layer.{layer}.norm1.output",
+    "vision.layer.{layer}.q.pre_rope",
+    "vision.layer.{layer}.k.pre_rope",
+    "vision.layer.{layer}.v.output",
+    "vision.layer.{layer}.q.post_rope",
+    "vision.layer.{layer}.k.post_rope",
+    "vision.layer.{layer}.attention.output",
+    "vision.layer.{layer}.out_proj.output",
+    "vision.layer.{layer}.residual1.output",
+    "vision.layer.{layer}.norm2.output",
+    "vision.layer.{layer}.mlp.up",
+    "vision.layer.{layer}.mlp.down",
+    "vision.layer.{layer}.output"
+  ],
+  "interval_expansions": {},
+  "backend_mappings": {
+    "vision.frontend.position.output": {
+      "producer": "position_embeddings",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "inp_pos_emb",
+      "result_tensor": "inp_pos_emb",
+      "result_layer": -1
+    },
+    "vision.layer.{layer}.norm1.output": {
+      "producer": "attn_norm",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "ln1",
+      "result_tensor": "ln1"
+    },
+    "vision.layer.{layer}.q.pre_rope": {
+      "producer": "split_qkv",
+      "logical_layout": "head_major",
+      "axis_names": ["head", "token", "channel"],
+      "capture_tensor": "Qcur",
+      "result_tensor": "q_proj"
+    },
+    "vision.layer.{layer}.k.pre_rope": {
+      "producer": "split_qkv",
+      "logical_layout": "head_major",
+      "axis_names": ["head", "token", "channel"],
+      "capture_tensor": "Kcur",
+      "result_tensor": "k_proj"
+    },
+    "vision.layer.{layer}.v.output": {
+      "producer": "split_qkv",
+      "logical_layout": "head_major",
+      "axis_names": ["head", "token", "channel"],
+      "capture_tensor": "Vcur",
+      "result_tensor": "v_proj"
+    },
+    "vision.layer.{layer}.q.post_rope": {
+      "producer": "vision_mrope",
+      "logical_layout": "head_major",
+      "axis_names": ["head", "token", "channel"],
+      "capture_tensor": "Qcur_rope",
+      "result_tensor": "Qcur_rope"
+    },
+    "vision.layer.{layer}.k.post_rope": {
+      "producer": "vision_mrope",
+      "logical_layout": "head_major",
+      "axis_names": ["head", "token", "channel"],
+      "capture_tensor": "Kcur_rope",
+      "result_tensor": "Kcur_rope"
+    },
+    "vision.layer.{layer}.attention.output": {
+      "producer": "attn",
+      "logical_layout": "head_major",
+      "axis_names": ["head", "token", "channel"],
+      "capture_tensor": "kqv_out",
+      "result_tensor": "kqv_out"
+    },
+    "vision.layer.{layer}.out_proj.output": {
+      "producer": "attn_out_proj",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "attn_out",
+      "result_tensor": "attn_output"
+    },
+    "vision.layer.{layer}.residual1.output": {
+      "producer": "attn_residual",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "ffn_inp",
+      "result_tensor": "ffn_inp"
+    },
+    "vision.layer.{layer}.norm2.output": {
+      "producer": "ffn_norm",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "ffn_inp_normed",
+      "result_tensor": "ffn_inp_normed"
+    },
+    "vision.layer.{layer}.mlp.up": {
+      "producer": "mlp_up",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "ffn_up_b",
+      "result_tensor": "ffn_up_b"
+    },
+    "vision.layer.{layer}.mlp.down": {
+      "producer": "mlp_down",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "ffn_out",
+      "result_tensor": "ffn_out"
+    },
+    "vision.layer.{layer}.output": {
+      "producer": "mlp_residual",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "layer_out",
+      "result_tensor": "layer_out"
+    }
+  }
+}

--- a/version/v8/schemas/parity_profile.schema.json
+++ b/version/v8/schemas/parity_profile.schema.json
@@ -43,7 +43,10 @@
         "properties": {
           "producer": {"type": "string", "minLength": 1},
           "logical_layout": {"type": "string", "minLength": 1},
-          "axis_names": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+          "axis_names": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+          "capture_tensor": {"type": "string", "minLength": 1},
+          "result_tensor": {"type": "string", "minLength": 1},
+          "result_layer": {"type": "integer", "minimum": -1}
         }
       }
     }

--- a/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
+++ b/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+"""Qwen3-VL GGUF/llama.cpp checkpoint capture adapter.
+
+Ownership boundary:
+  * This module is backend-specific capture plumbing, not the public parity
+    orchestration surface.
+  * New checkpoint selection, bisection, canonicalization, comparison,
+    classification, or reporting belongs in the v8 X-ray tooling.
+  * Do not add model-family branches here. Add a separate backend adapter that
+    emits the canonical X-ray checkpoint ABI.
+
+Direct CLI use is retained for compatibility and adapter development only.
+Agents and automation must invoke ``xray_vision_parity_v8.py --backend
+llamacpp`` so checkpoint ordering and reports use the standard X-ray surface.
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/version/v8/scripts/xray_qwen3vl_bf16_v8.py
+++ b/version/v8/scripts/xray_qwen3vl_bf16_v8.py
@@ -173,7 +173,7 @@ def run(args: argparse.Namespace) -> Dict[str, Any]:
     return result
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--checkpoint", type=Path, required=True, help="Qwen3-VL safetensors checkpoint directory")
     parser.add_argument("--runtime-dir", type=Path, required=True)
@@ -187,7 +187,7 @@ def main() -> int:
     parser.add_argument("--threads", type=int, default=int(os.environ.get("CK_NUM_THREADS", "20")))
     parser.add_argument("--attn-implementation", choices=("auto", "eager", "sdpa"), default="eager")
     parser.add_argument("--max-rounds", type=int, default=3)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     result = run(args)
     divergence = (result.get("final_report") or {}).get("first_divergence") or {}
     print(f"status={result['status']} rounds={len(result['rounds'])}")

--- a/version/v8/scripts/xray_qwen3vl_llamacpp_v8.py
+++ b/version/v8/scripts/xray_qwen3vl_llamacpp_v8.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Qwen3-VL GGUF adapter for the unified vision X-ray surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+import activation_parity_qwen3vl_mmproj_v8 as capture_adapter
+import xray_numerical_parity_v8 as xray
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_PROFILE = SCRIPT_DIR.parent / "parity_profiles" / "qwen3vl_llamacpp_q8_v1.json"
+
+
+def _format_layer(value: str, layer: int) -> str:
+    return value.replace("{layer}", str(layer))
+
+
+def _active_checkpoints(profile: dict[str, Any], layer: int) -> list[tuple[str, dict[str, Any]]]:
+    active: list[tuple[str, dict[str, Any]]] = []
+    mappings = profile["backend_mappings"]
+    for template_id in profile["checkpoint_order"]:
+        mapping = mappings.get(template_id)
+        if not isinstance(mapping, dict):
+            raise RuntimeError(f"llama.cpp profile has no mapping for {template_id}")
+        active.append((_format_layer(template_id, layer), mapping))
+    return active
+
+
+def _legacy_result_index(report: dict[str, Any]) -> dict[tuple[int, str], dict[str, Any]]:
+    indexed: dict[tuple[int, str], dict[str, Any]] = {}
+    for row in report.get("results", []):
+        key = (int(row.get("layer", -1)), str(row.get("op", "")))
+        if key in indexed:
+            raise RuntimeError(f"ambiguous legacy parity result for layer={key[0]} op={key[1]}")
+        indexed[key] = row
+    return indexed
+
+
+def normalize_capture_report(
+    report: dict[str, Any], profile: dict[str, Any], layer: int
+) -> dict[str, Any]:
+    indexed = _legacy_result_index(report)
+    comparisons: list[dict[str, Any]] = []
+    first_divergence: dict[str, Any] | None = None
+    last_passing: str | None = None
+    for checkpoint_id, mapping in _active_checkpoints(profile, layer):
+        result_layer = int(mapping.get("result_layer", layer))
+        result_name = str(mapping["result_tensor"])
+        row = indexed.get((result_layer, result_name))
+        if row is None:
+            comparison = {
+                "checkpoint_id": checkpoint_id,
+                "status": "fail",
+                "classification": "MISSING_CHECKPOINT",
+                "subject_present": False,
+                "oracle_present": False,
+            }
+        else:
+            legacy_status = str(row.get("status", "ERROR")).upper()
+            status = "pass" if legacy_status == "PASS" else "fail"
+            if status == "pass":
+                classification = "MATCH"
+            elif bool(row.get("has_nan")) or bool(row.get("has_inf")):
+                classification = "NONFINITE_OUTPUT"
+            else:
+                classification = "KERNEL_IMPLEMENTATION_DIVERGENCE"
+            comparison = {
+                "checkpoint_id": checkpoint_id,
+                "status": status,
+                "classification": classification,
+                "legacy_tensor": result_name,
+                "metrics": {
+                    key: row[key]
+                    for key in (
+                        "max_abs_diff",
+                        "mean_abs_diff",
+                        "max_rel_err",
+                        "mean_rel_err",
+                        "diverge_idx",
+                    )
+                    if key in row
+                },
+            }
+        comparisons.append(comparison)
+        if comparison["status"] == "pass":
+            last_passing = checkpoint_id
+            continue
+        first_divergence = comparison
+        break
+
+    if first_divergence is not None:
+        classification = str(first_divergence["classification"])
+        first_divergence["fix_owner"] = xray.FIX_OWNERS.get(
+            classification, "first_divergent_edge"
+        )
+        first_divergence["recommended_action"] = xray.REMEDIATIONS.get(
+            classification, "Inspect the first failing semantic edge."
+        )
+    return {
+        "schema": "cke.xray_numerical_report",
+        "schema_version": 1,
+        "subject_backend": "ck",
+        "oracle_backend": "llamacpp",
+        "status": "fail" if first_divergence is not None else "pass",
+        "comparisons": comparisons,
+        "first_divergence": first_divergence,
+        "last_passing_checkpoint": last_passing,
+        "unresolved_contract_checkpoints": [],
+        "ranking_divergence": None,
+        "next_plan": {
+            "status": "first_divergence_attributed" if first_divergence else "complete",
+            "first_failure": first_divergence["checkpoint_id"] if first_divergence else None,
+            "passing_lower_bound": last_passing,
+            "next_checkpoints": [],
+        },
+        "architecture_policy": xray.ARCHITECTURE_POLICY,
+        "fix_progression": xray.XRAY_FIX_PROGRESSION,
+    }
+
+
+def _capture_args(args: argparse.Namespace, profile: dict[str, Any], report_path: Path) -> list[str]:
+    active = _active_checkpoints(profile, args.layer)
+    names = list(dict.fromkeys(str(mapping["capture_tensor"]) for _, mapping in active))
+    command = [
+        "--gguf", str(args.gguf),
+        "--output-dir", str(args.output_dir / "capture"),
+        "--threads", str(args.threads),
+        "--ck-threads", str(args.ck_threads or args.threads),
+        "--llama-dump-names", ",".join(names),
+        "--llama-dump-layer", str(args.layer),
+        "--ck-stop-layer", str(args.layer),
+        "--strict-parity",
+        "--quiet",
+        "--report", str(report_path),
+    ]
+    if args.image is not None:
+        command.extend(["--image-path", str(args.image)])
+    else:
+        command.extend(["--image-mode", args.image_mode])
+    if args.image_min_tokens is not None:
+        command.extend(["--image-min-tokens", str(args.image_min_tokens)])
+    if args.image_max_tokens is not None:
+        command.extend(["--image-max-tokens", str(args.image_max_tokens)])
+    return command
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    profile = xray.load_json(args.profile)
+    xray.validate(profile, xray.PROFILE_SCHEMA, "llama.cpp parity profile")
+    if profile["backend"] != "llamacpp":
+        raise RuntimeError(f"expected a llama.cpp profile, got {profile['backend']!r}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    capture_report_path = args.output_dir / "capture_report.json"
+    capture_rc = capture_adapter.main(_capture_args(args, profile, capture_report_path))
+    if not capture_report_path.is_file():
+        raise RuntimeError(
+            f"llama.cpp capture adapter returned rc={capture_rc} without {capture_report_path}"
+        )
+    report = normalize_capture_report(
+        xray.load_json(capture_report_path), profile, args.layer
+    )
+    result = {
+        "schema": "cke.xray_orchestration_report",
+        "schema_version": 1,
+        "backend": "llamacpp",
+        "status": report["status"],
+        "rounds": [{
+            "round": 0,
+            "layer": args.layer,
+            "capture_report": str(capture_report_path),
+            "status": report["status"],
+        }],
+        "preflight": None,
+        "final_report": report,
+    }
+    (args.output_dir / "xray_summary.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gguf", type=Path, required=True)
+    parser.add_argument("--image", type=Path)
+    parser.add_argument("--image-mode", choices=("gradient", "gray", "checker"), default="gradient")
+    parser.add_argument("--image-min-tokens", type=int)
+    parser.add_argument("--image-max-tokens", type=int)
+    parser.add_argument("--layer", type=int, default=0)
+    parser.add_argument("--profile", type=Path, default=DEFAULT_PROFILE)
+    parser.add_argument("--threads", type=int, default=20)
+    parser.add_argument("--ck-threads", type=int)
+    parser.add_argument("--output-dir", type=Path, default=Path("build/xray/qwen3vl_llamacpp"))
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    result = run(args)
+    divergence = (result.get("final_report") or {}).get("first_divergence") or {}
+    print(f"status={result['status']} backend=llamacpp")
+    if divergence:
+        print(f"fail_at={divergence.get('checkpoint_id')}")
+        print(f"class={divergence.get('classification')}")
+    print(f"report={args.output_dir / 'xray_summary.json'}")
+    return 1 if result["status"] != "pass" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/scripts/xray_vision_parity_v8.py
+++ b/version/v8/scripts/xray_vision_parity_v8.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Unified v8 numerical X-ray surface for vision reference backends."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+import xray_qwen3vl_bf16_v8 as pytorch_adapter
+import xray_qwen3vl_llamacpp_v8 as llamacpp_adapter
+
+
+BACKENDS = {
+    "llamacpp": llamacpp_adapter,
+    "pytorch": pytorch_adapter,
+}
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=(
+            "Backend options are parsed by the selected adapter. Use "
+            "--backend BACKEND --help for backend-specific arguments."
+        ),
+        add_help=False,
+    )
+    parser.add_argument("--backend", choices=tuple(BACKENDS), required=True)
+    parser.add_argument("-h", "--help", action="store_true")
+    return parser
+
+
+def dispatch(argv: Sequence[str] | None = None) -> int:
+    args, remaining = _parser().parse_known_args(list(argv) if argv is not None else None)
+    adapter = BACKENDS[args.backend]
+    if args.help:
+        remaining = ["--help", *remaining]
+    return int(adapter.main(remaining))
+
+
+def main() -> int:
+    return dispatch(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Qwen3-VL llama.cpp activation parity was invoked directly, bypassing X-ray semantic ordering and creating a second public diagnostic workflow. The legacy report could name an alphabetically earlier dump such as Kcur_rope even when the circuit diverged earlier at Q projection.

## What changed

- Add xray_vision_parity_v8.py as the single vision parity entry point.
- Dispatch backend-specific arguments to PyTorch and llama.cpp adapters.
- Wrap the existing Qwen3-VL activation harness as llama.cpp capture plumbing.
- Add a schema-validated Qwen3-VL GGUF semantic mapping profile.
- Normalize legacy dump results into the standard X-ray orchestration report in circuit order.
- Preserve direct activation-script use for compatibility only and document its ownership boundary.
- Extend make xray-vision-parity with BACKEND=pytorch and BACKEND=llamacpp.
- Add interface and ordering regression tests.

## Evidence

A real canonical 4032-token Qwen3-VL run through the public interface completed and wrote xray_summary.json.

- Last passing checkpoint: vision.layer.0.norm1.output
- First divergent checkpoint: vision.layer.0.q.pre_rope
- Classification: KERNEL_IMPLEMENTATION_DIVERGENCE
- Maximum absolute difference: 0.0018476248

This corrects the legacy alphabetic Kcur_rope attribution.

## Validation

- Numerical execution contracts: 16/16 PASS
- Canonical X-ray comparator: 8/8 PASS
- Unified interface tests: 5/5 PASS
- make test-bf16-xray: PASS
- make test-v8-dsl-policy: PASS
- PyTorch and llama.cpp backend help: PASS
- Makefile llama.cpp dry-run: PASS
- Real canonical llama.cpp X-ray capture: expected parity FAIL with valid standard report
- Pre-commit v7/v8 fast regressions: PASS
- Complete pre-push gate: PASS
- git diff --check: PASS

## Regression coverage

The tests enforce backend-neutral dispatch, profile schema validity, semantic circuit ordering, internal capture-adapter ownership, and preservation of the PyTorch path.

## Documentation

The capture adapter now directs agents and automation to xray_vision_parity_v8.py --backend llamacpp and prohibits adding model-family orchestration branches to the adapter.

## Content handoff

- Audience: Runtime, compiler, and numerical-parity engineers
- Angle: One X-ray diagnostic surface can preserve backend-specific capture while standardizing semantic attribution.
- Claims: PyTorch and llama.cpp share public entry-point ownership; llama results are ordered by circuit semantics.
- Caveats: The llama adapter still normalizes legacy aggregate dump metrics rather than emitting canonical per-tensor manifests, and it currently targets Qwen3-VL GGUF.
- Sources: Commit diff, interface tests, profile, and the local xray_summary.json evidence artifact.