### PR TITLE
docs(hardware): define sponsored eight-channel upgrade

### DIFF
--- a/docs/site/_pages/support-hardware.html
+++ b/docs/site/_pages/support-hardware.html
@@ -59,7 +59,7 @@ body { overflow-x: hidden; }
 </section>
 
 <h2>The Immediate Goal</h2>
-<p>Build a matched two-node Xeon 6 laboratory for native AMX BF16, AVX-512/VNNI, fully populated memory channels, NUMA-aware execution, and direct 100GbE experiments. The existing Core i7-14700T node remains the AVX2/AVX-VNNI commodity reference; external Xeon systems and TI TDA4VM remain cross-generation and embedded validation lanes.</p>
+<p>Founder funding establishes matched Xeon 636 nodes for native AMX BF16, AVX-512/VNNI, four-channel memory, and direct-network experiments. Sponsor support then unlocks the Xeon 600 platform's full eight-channel path through compatible 650/670-class processor upgrades and four additional matched RDIMMs per node. The resulting four-channel-versus-eight-channel comparison becomes a published experiment rather than an assumed benefit.</p>
 
 <div class="support-grid">
   <article class="support-card">
@@ -69,17 +69,22 @@ body { overflow-x: hidden; }
     <p>Remote machine access, short-term loaners, cloud or lab credits, profiler access, and engineering contacts. This stage validates fixtures and reduces the risk of purchasing the wrong configuration.</p>
   </article>
   <article class="support-card">
-    <span class="support-status">Stage 1 · target</span>
-    <h3>One Xeon 6 Evidence Node</h3>
+    <span class="support-status">Stage 1 · founder funded</span>
+    <h3>One Xeon 636 Evidence Node</h3>
     <div class="support-price">CAD $5,500–$8,000</div>
-    <p>A balanced workstation with ECC memory across available channels, NVMe storage, sustained cooling, power measurement, and room for a high-speed NIC. It unlocks native AMX BF16 and controlled memory/NUMA work.</p>
+    <p>A balanced workstation with ECC memory across the four channels exposed by the 630-series CPU, NVMe storage, sustained cooling, power measurement, and room for a high-speed NIC. It unlocks native AMX BF16 and controlled memory work.</p>
   </article>
   <article class="support-card">
-    <span class="support-status">Stage 2 · target</span>
-    <h3>Matched Two-Node Lab</h3>
+    <span class="support-status">Stage 2 · founder target</span>
+    <h3>Matched Xeon 636 Lab</h3>
     <div class="support-price">CAD $12,500–$19,000 total</div>
     <p>A second matched node plus two 100GbE-capable NICs, a direct DAC link, storage, metering, and contingencies. A switch is deferred until a third node creates a measured need.</p>
   </article>
+</div>
+
+<div class="support-callout">
+  <h2 style="margin-top:0">Primary Sponsorship Target: The Eight-Channel Upgrade</h2>
+  <p>The W890 workstation platform has eight DIMM slots, but ASUS specifies that a Xeon 630-series processor enables only channels A, C, E, and G. The most valuable hardware sponsorship is therefore two compatible Xeon 650/670-class processors plus four additional matched RDIMMs per node. CKE will publish the controlled four-channel-versus-eight-channel result across memory bandwidth, prefill, decode, AMX BF16 kernels, power, NUMA behavior, and distributed workloads. Final CPU selection will also score cache per core, core count, topology, price, and availability; channel count alone will not decide the configuration.</p>
 </div>
 
 <p><strong>Budget discipline:</strong> these are planning ranges, not a final bill of materials. CPU availability, ECC-memory pricing, tax, cooling, chassis, PSU connectors, NIC provenance, and warranty must be quoted before purchase. Funds are released by stage; a second node is not purchased until the first-node evidence pipeline is working.</p>

--- a/docs/site/support-hardware.html
+++ b/docs/site/support-hardware.html
@@ -1006,7 +1006,7 @@ body { overflow-x: hidden; }
 </section>
 
 <h2>The Immediate Goal</h2>
-<p>Build a matched two-node Xeon 6 laboratory for native AMX BF16, AVX-512/VNNI, fully populated memory channels, NUMA-aware execution, and direct 100GbE experiments. The existing Core i7-14700T node remains the AVX2/AVX-VNNI commodity reference; external Xeon systems and TI TDA4VM remain cross-generation and embedded validation lanes.</p>
+<p>Founder funding establishes matched Xeon 636 nodes for native AMX BF16, AVX-512/VNNI, four-channel memory, and direct-network experiments. Sponsor support then unlocks the Xeon 600 platform's full eight-channel path through compatible 650/670-class processor upgrades and four additional matched RDIMMs per node. The resulting four-channel-versus-eight-channel comparison becomes a published experiment rather than an assumed benefit.</p>
 
 <div class="support-grid">
   <article class="support-card">
@@ -1016,17 +1016,22 @@ body { overflow-x: hidden; }
     <p>Remote machine access, short-term loaners, cloud or lab credits, profiler access, and engineering contacts. This stage validates fixtures and reduces the risk of purchasing the wrong configuration.</p>
   </article>
   <article class="support-card">
-    <span class="support-status">Stage 1 · target</span>
-    <h3>One Xeon 6 Evidence Node</h3>
+    <span class="support-status">Stage 1 · founder funded</span>
+    <h3>One Xeon 636 Evidence Node</h3>
     <div class="support-price">CAD $5,500–$8,000</div>
-    <p>A balanced workstation with ECC memory across available channels, NVMe storage, sustained cooling, power measurement, and room for a high-speed NIC. It unlocks native AMX BF16 and controlled memory/NUMA work.</p>
+    <p>A balanced workstation with ECC memory across the four channels exposed by the 630-series CPU, NVMe storage, sustained cooling, power measurement, and room for a high-speed NIC. It unlocks native AMX BF16 and controlled memory work.</p>
   </article>
   <article class="support-card">
-    <span class="support-status">Stage 2 · target</span>
-    <h3>Matched Two-Node Lab</h3>
+    <span class="support-status">Stage 2 · founder target</span>
+    <h3>Matched Xeon 636 Lab</h3>
     <div class="support-price">CAD $12,500–$19,000 total</div>
     <p>A second matched node plus two 100GbE-capable NICs, a direct DAC link, storage, metering, and contingencies. A switch is deferred until a third node creates a measured need.</p>
   </article>
+</div>
+
+<div class="support-callout">
+  <h2 style="margin-top:0">Primary Sponsorship Target: The Eight-Channel Upgrade</h2>
+  <p>The W890 workstation platform has eight DIMM slots, but ASUS specifies that a Xeon 630-series processor enables only channels A, C, E, and G. The most valuable hardware sponsorship is therefore two compatible Xeon 650/670-class processors plus four additional matched RDIMMs per node. CKE will publish the controlled four-channel-versus-eight-channel result across memory bandwidth, prefill, decode, AMX BF16 kernels, power, NUMA behavior, and distributed workloads. Final CPU selection will also score cache per core, core count, topology, price, and availability; channel count alone will not decide the configuration.</p>
 </div>
 
 <p><strong>Budget discipline:</strong> these are planning ranges, not a final bill of materials. CPU availability, ECC-memory pricing, tax, cooling, chassis, PSU connectors, NIC provenance, and warranty must be quoted before purchase. Funds are released by stage; a second node is not purchased until the first-node evidence pipeline is working.</p>


### PR DESCRIPTION
## Why
The merged support page described a generic Xeon 6 target. The affordable Xeon 636 baseline exposes four memory channels on the W890E-SAGE, while compatible 650/670-class processors unlock the platform's eight-channel path.

## What changed
Identify matched Xeon 636 nodes as founder-funded four-channel systems and define two compatible 650/670-class CPUs plus four additional RDIMMs per node as the primary sponsor target.

## Evidence
ASUS specifies that only channels A, C, E, and G function with a Xeon 630-series processor on this board.

## Validation
Documentation build completed; source and generated pages are synchronized; full local pre-push checks passed.

## Regression coverage
No runtime code changed. Build, kernel parity, v8 E2E, v8 contracts, v7 training smoke, and training-kernel parity passed.

## Documentation
Updates both docs/site/_pages/support-hardware.html and docs/site/support-hardware.html.

## Content handoff
Audience: CPU hardware sponsors, Intel platform engineers, memory vendors, and CKE readers.

Angle: Founder funding buys the practical four-channel baseline; sponsorship buys a precise eight-channel upgrade and publishable comparison.

Claims: Xeon 636 is the entry baseline; compatible 650/670-class processors are the planned full-channel upgrade.

Caveats: Final CPUs require dated quotes and must be scored by cache per core, cores, topology, and price as well as channel count.

Sources: ASUS W890E-SAGE technical specifications and the CKE hardware evidence page.

Problem: sponsor target was generic. Diagnosis: platform capability and 630-series enabled channels were conflated. Fix: separate founder baseline from sponsored upgrade. Measured delta: a controlled four-versus-eight-channel experiment is now specified. Regression guard: synchronized source/generated docs and full checks. Limitation: no performance result is claimed. Next step: quote exact CPUs and RDIMMs.