### PR TITLE
docs(hardware): add CAD 30K funding milestones

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,6 @@
 # Funding supports reproducible CKE hardware validation and public evidence.
+github:
+  - antshiv
 custom:
   - https://c-kernel-engine.github.io/C-Kernel-Engine/support-hardware.html
+  - https://www.shivasnotes.com/work-with-us

--- a/docs/site/_pages/support-hardware.html
+++ b/docs/site/_pages/support-hardware.html
@@ -44,7 +44,15 @@ body { overflow-x: hidden; }
 .support-table th { color: var(--orange); background: rgba(255,180,0,.07); }
 .support-contract { padding: 1.4rem; border-left: 4px solid var(--blue); background: rgba(7,173,248,.07); }
 .support-callout { padding: 1.4rem; border: 1px solid rgba(255,180,0,.3); border-radius: 10px; background: rgba(255,180,0,.06); }
+.support-target { margin: 1.5rem 0 2rem; padding: 1.5rem; border: 1px solid rgba(71,180,117,.38); border-radius: 12px; background: linear-gradient(135deg, rgba(71,180,117,.1), rgba(7,173,248,.05)); }
+.support-target-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.support-target-value { color: var(--green); font: 800 1.7rem 'JetBrains Mono', monospace; }
+.support-milestones { display: grid; grid-template-columns: repeat(6, minmax(0,1fr)); gap: .45rem; margin-top: 1.2rem; }
+.support-milestone { padding: .7rem .45rem; border-top: 4px solid var(--grey-light); background: rgba(255,255,255,.025); text-align: center; }
+.support-milestone strong { display: block; color: var(--orange); font-family: 'JetBrains Mono', monospace; }
+.support-milestone span { color: var(--text-muted); font-size: .72rem; }
 @media (max-width: 850px) { .support-grid { grid-template-columns: minmax(0, 1fr); } .support-hero { padding: 2.2rem 1.25rem; } .support-actions, .support-button { box-sizing: border-box; width: 100%; } .support-table { display: block; max-width: 100%; overflow-x: auto; } }
+@media (max-width: 700px) { .support-milestones { grid-template-columns: repeat(2, minmax(0,1fr)); } }
 </style>
 
 <section class="support-hero">
@@ -52,10 +60,28 @@ body { overflow-x: hidden; }
   <h1>Help CKE prove CPU AI on hardware engineers can inspect and own.</h1>
   <p class="support-lead">C-Kernel-Engine needs more than benchmark claims. It needs repeatable measurements across SIMD generations, memory topologies, NUMA domains, and real network links. Support expands the laboratory while keeping the code, methods, limitations, and publishable results open.</p>
   <div class="support-actions">
-    <a class="support-button primary" href="mailto:anthony.shivakumar@antshiv.com?subject=CKE%20hardware%20lab%20support">Discuss hardware support</a>
+    <a class="support-button primary" href="https://github.com/sponsors/antshiv">Sponsor on GitHub</a>
+    <a class="support-button" href="mailto:anthony.shivakumar@antshiv.com?subject=CKE%20hardware%20lab%20support">Contribute hardware</a>
     <a class="support-button" href="https://www.shivasnotes.com/work-with-us">Fund a defined investigation</a>
     <a class="support-button" href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues">Propose a reproducible test</a>
   </div>
+</section>
+
+<section class="support-target">
+  <div class="support-target-head">
+    <div><div class="support-kicker">Public program target</div><h2 style="margin:.35rem 0 0">Build the full CPU AI evidence laboratory in stages</h2></div>
+    <div class="support-target-value">CAD $30,000</div>
+  </div>
+  <p>The target is a ceiling for the complete multi-year program, not a requirement to spend everything immediately. Each CAD $5,000 milestone releases a more capable evidence lane only after the previous stage produces inspectable results.</p>
+  <div class="support-milestones" aria-label="Six five-thousand-dollar funding milestones">
+    <div class="support-milestone"><strong>$5K</strong><span>first 636 node</span></div>
+    <div class="support-milestone"><strong>$10K</strong><span>matched 636 pair</span></div>
+    <div class="support-milestone"><strong>$15K</strong><span>memory + storage</span></div>
+    <div class="support-milestone"><strong>$20K</strong><span>network + metering</span></div>
+    <div class="support-milestone"><strong>$25K</strong><span>8-channel upgrade</span></div>
+    <div class="support-milestone"><strong>$30K</strong><span>full evidence program</span></div>
+  </div>
+  <p style="margin-top:1rem"><strong>Current funding must be reported manually.</strong> Until GitHub Sponsors and in-kind contributions are reconciled into a public ledger, these markers describe capability gates rather than claiming money raised.</p>
 </section>
 
 <h2>The Immediate Goal</h2>
@@ -122,6 +148,7 @@ body { overflow-x: hidden; }
   <li><strong>Funded investigation:</strong> sponsor a bounded model/hardware qualification, numerical investigation, kernel path, or benchmark lane.</li>
   <li><strong>Financial contribution:</strong> fund a published stage or a clearly identified component after the bill of materials is confirmed.</li>
 </ul>
+<p>Use <a href="https://github.com/sponsors/antshiv">GitHub Sponsors</a> for direct financial support. Use <a href="https://www.shivasnotes.com/work-with-us">ShivasNotes Work With Us</a> for a paid private investigation with bounded deliverables. Hardware vendors and laboratories can contact <a href="mailto:anthony.shivakumar@antshiv.com?subject=CKE%20hardware%20lab%20support">Anthony Shivakumar</a> about loaners, remote access, parts, or discounts.</p>
 
 <h2>Evidence and Disclosure Contract</h2>
 <div class="support-contract">

--- a/docs/site/support-hardware.html
+++ b/docs/site/support-hardware.html
@@ -991,7 +991,15 @@ body { overflow-x: hidden; }
 .support-table th { color: var(--orange); background: rgba(255,180,0,.07); }
 .support-contract { padding: 1.4rem; border-left: 4px solid var(--blue); background: rgba(7,173,248,.07); }
 .support-callout { padding: 1.4rem; border: 1px solid rgba(255,180,0,.3); border-radius: 10px; background: rgba(255,180,0,.06); }
+.support-target { margin: 1.5rem 0 2rem; padding: 1.5rem; border: 1px solid rgba(71,180,117,.38); border-radius: 12px; background: linear-gradient(135deg, rgba(71,180,117,.1), rgba(7,173,248,.05)); }
+.support-target-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.support-target-value { color: var(--green); font: 800 1.7rem 'JetBrains Mono', monospace; }
+.support-milestones { display: grid; grid-template-columns: repeat(6, minmax(0,1fr)); gap: .45rem; margin-top: 1.2rem; }
+.support-milestone { padding: .7rem .45rem; border-top: 4px solid var(--grey-light); background: rgba(255,255,255,.025); text-align: center; }
+.support-milestone strong { display: block; color: var(--orange); font-family: 'JetBrains Mono', monospace; }
+.support-milestone span { color: var(--text-muted); font-size: .72rem; }
 @media (max-width: 850px) { .support-grid { grid-template-columns: minmax(0, 1fr); } .support-hero { padding: 2.2rem 1.25rem; } .support-actions, .support-button { box-sizing: border-box; width: 100%; } .support-table { display: block; max-width: 100%; overflow-x: auto; } }
+@media (max-width: 700px) { .support-milestones { grid-template-columns: repeat(2, minmax(0,1fr)); } }
 </style>
 
 <section class="support-hero">
@@ -999,10 +1007,28 @@ body { overflow-x: hidden; }
   <h1>Help CKE prove CPU AI on hardware engineers can inspect and own.</h1>
   <p class="support-lead">C-Kernel-Engine needs more than benchmark claims. It needs repeatable measurements across SIMD generations, memory topologies, NUMA domains, and real network links. Support expands the laboratory while keeping the code, methods, limitations, and publishable results open.</p>
   <div class="support-actions">
-    <a class="support-button primary" href="mailto:anthony.shivakumar@antshiv.com?subject=CKE%20hardware%20lab%20support">Discuss hardware support</a>
+    <a class="support-button primary" href="https://github.com/sponsors/antshiv">Sponsor on GitHub</a>
+    <a class="support-button" href="mailto:anthony.shivakumar@antshiv.com?subject=CKE%20hardware%20lab%20support">Contribute hardware</a>
     <a class="support-button" href="https://www.shivasnotes.com/work-with-us">Fund a defined investigation</a>
     <a class="support-button" href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues">Propose a reproducible test</a>
   </div>
+</section>
+
+<section class="support-target">
+  <div class="support-target-head">
+    <div><div class="support-kicker">Public program target</div><h2 style="margin:.35rem 0 0">Build the full CPU AI evidence laboratory in stages</h2></div>
+    <div class="support-target-value">CAD $30,000</div>
+  </div>
+  <p>The target is a ceiling for the complete multi-year program, not a requirement to spend everything immediately. Each CAD $5,000 milestone releases a more capable evidence lane only after the previous stage produces inspectable results.</p>
+  <div class="support-milestones" aria-label="Six five-thousand-dollar funding milestones">
+    <div class="support-milestone"><strong>$5K</strong><span>first 636 node</span></div>
+    <div class="support-milestone"><strong>$10K</strong><span>matched 636 pair</span></div>
+    <div class="support-milestone"><strong>$15K</strong><span>memory + storage</span></div>
+    <div class="support-milestone"><strong>$20K</strong><span>network + metering</span></div>
+    <div class="support-milestone"><strong>$25K</strong><span>8-channel upgrade</span></div>
+    <div class="support-milestone"><strong>$30K</strong><span>full evidence program</span></div>
+  </div>
+  <p style="margin-top:1rem"><strong>Current funding must be reported manually.</strong> Until GitHub Sponsors and in-kind contributions are reconciled into a public ledger, these markers describe capability gates rather than claiming money raised.</p>
 </section>
 
 <h2>The Immediate Goal</h2>
@@ -1069,6 +1095,7 @@ body { overflow-x: hidden; }
   <li><strong>Funded investigation:</strong> sponsor a bounded model/hardware qualification, numerical investigation, kernel path, or benchmark lane.</li>
   <li><strong>Financial contribution:</strong> fund a published stage or a clearly identified component after the bill of materials is confirmed.</li>
 </ul>
+<p>Use <a href="https://github.com/sponsors/antshiv">GitHub Sponsors</a> for direct financial support. Use <a href="https://www.shivasnotes.com/work-with-us">ShivasNotes Work With Us</a> for a paid private investigation with bounded deliverables. Hardware vendors and laboratories can contact <a href="mailto:anthony.shivakumar@antshiv.com?subject=CKE%20hardware%20lab%20support">Anthony Shivakumar</a> about loaners, remote access, parts, or discounts.</p>
 
 <h2>Evidence and Disclosure Contract</h2>
 <div class="support-contract">


### PR DESCRIPTION
## Why
The hardware program needs a visible target and incremental evidence gates while the C-Kernel-Engine organization Sponsors profile remains under review.

## What changed
Route funding through the active antshiv Sponsors profile, retain the CKE hardware and ShivasNotes Work With Us routes, and publish CAD $5K through CAD $30K capability milestones.

## Evidence
The screenshot of the Sponsors dashboard confirms the antshiv profile is live and the C-Kernel-Engine organization profile is pending review.

## Validation
Documentation build completed; source and generated pages are synchronized; full local pre-push checks passed.

## Regression coverage
No runtime code changed. Build, kernel parity, v8 E2E, v8 contracts, v7 training smoke, and training-kernel parity passed.

## Documentation
Updates FUNDING.yml plus the source and generated support-hardware pages.

## Content handoff
Audience: potential hardware sponsors, engineering collaborators, and CKE readers.

Angle: CAD $30K is a staged program ceiling, not money already raised or permission to spend it immediately.

Claims: Six CAD $5K milestones unlock progressively stronger hardware evidence.

Caveats: The page is not a live funding ledger. The organization sponsor link changes only after GitHub approval.

Sources: GitHub Sponsors dashboard, CKE hardware evidence plan, and commit d993052d.

Problem: no visible funding target. Diagnosis: a broad budget range did not show what incremental support unlocks. Fix: six capability milestones and valid destination links. Measured delta: one CAD $30K target, six evidence gates, and three contribution routes. Regression guard: synchronized docs and full checks. Limitation: raised funds remain manually reported. Next step: publish the first-node BOM and evidence report.
