### PR TITLE
fix(v8): restore ISA-exact nightly contracts

### DIFF
--- a/scripts/nightly_runner.py
+++ b/scripts/nightly_runner.py
@@ -569,6 +569,7 @@ MAKE_TARGETS = {
         "target": "vision-encoder-full",
         "timeout_sec": 21600,
         "status_artifact": "build/vision_encoder_accuracy/summary.json",
+        "status_phase": "bf16_pytorch",
     },
     "v8_gemma4_vision_smoke": {
         "name": "v8 Gemma4 Vision Smoke",
@@ -919,12 +920,21 @@ def run_make_target(target_info: dict, verbose: bool = False) -> TestResult:
         status = "pass" if result.returncode == 0 else "fail"
         status_artifact = target_info.get("status_artifact")
         artifact_payload = None
+        artifact_reason = ""
         if status_artifact:
             artifact_payload = _load_json_if_fresh(ROOT / status_artifact, start_ts=start)
-            artifact_status = str((artifact_payload or {}).get("status") or "").lower()
+            status_phase = target_info.get("status_phase")
+            if status_phase:
+                phase = ((artifact_payload or {}).get("phases") or {}).get(status_phase) or {}
+                artifact_status = str(phase.get("status") or "").lower()
+                artifact_reason = str(phase.get("reason") or "")
+            else:
+                artifact_status = str((artifact_payload or {}).get("status") or "").lower()
             if artifact_status in {"pass", "fail", "skip"}:
                 status = artifact_status
         error_msg = ""
+        if status == "skip" and artifact_reason:
+            error_msg = artifact_reason
         if status == "fail":
             # Look for error indicators in both stdout and stderr
             # Match: [ERROR], [FAIL], error, Error, failed, FAILED

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -4862,7 +4862,7 @@ static void ck_attention_f16_split_work(int ith, int nth, void *opaque)
     const int total_jobs = args->num_heads * args->split_chunks;
     const int chunk_size = (args->kv_tokens + args->split_chunks - 1) / args->split_chunks;
     const size_t head_stride = (size_t) args->cache_capacity * (size_t) args->aligned_head_dim;
-    const float scale = 1.0f / sqrtf((float) args->head_dim);
+    const float scale = ck_attention_strict_scale_f32(args->head_dim);
     uint16_t *q_half = (uint16_t *) alloca((size_t) args->aligned_head_dim * sizeof(uint16_t));
     uint16_t *acc_half = (uint16_t *) alloca((size_t) args->aligned_head_dim * sizeof(uint16_t));
 

--- a/src/kernels/gemm_kernels_q8_0.c
+++ b/src/kernels/gemm_kernels_q8_0.c
@@ -1211,35 +1211,27 @@ void vec_dot_q8_0_q8_0_avx512(int n, float *s, const void *vx, const void *vy)
     const block_q8_0 *x = (const block_q8_0 *)vx;
     const block_q8_0 *y = (const block_q8_0 *)vy;
 
-    float sumf = 0.0f;
-
-    for (int ib = 0; ib < nb; ib++) {
-        const float d = CK_FP16_TO_FP32(x[ib].d) * CK_FP16_TO_FP32(y[ib].d);
-
-        /* Load 32 int8 weights in two batches of 16 */
-        __m128i x8_lo = _mm_loadu_si128((const __m128i *)&x[ib].qs[0]);
-        __m128i x8_hi = _mm_loadu_si128((const __m128i *)&x[ib].qs[16]);
-        __m128i y8_lo = _mm_loadu_si128((const __m128i *)&y[ib].qs[0]);
-        __m128i y8_hi = _mm_loadu_si128((const __m128i *)&y[ib].qs[16]);
-
-        /* Sign-extend to 32-bit */
-        __m512i x32_lo = _mm512_cvtepi8_epi32(x8_lo);
-        __m512i x32_hi = _mm512_cvtepi8_epi32(x8_hi);
-        __m512i y32_lo = _mm512_cvtepi8_epi32(y8_lo);
-        __m512i y32_hi = _mm512_cvtepi8_epi32(y8_hi);
-
-        /* Integer multiply */
-        __m512i prod_lo = _mm512_mullo_epi32(x32_lo, y32_lo);
-        __m512i prod_hi = _mm512_mullo_epi32(x32_hi, y32_hi);
-
-        /* Sum all products */
-        int sumi = _mm512_reduce_add_epi32(_mm512_add_epi32(prod_lo, prod_hi));
-
-        /* Scale and accumulate - use scalar to avoid 16x broadcast bug */
-        sumf += d * (float)sumi;
+    /*
+     * ggml keeps the Q8_0 dot on its AVX2 eight-lane accumulation tree even
+     * in an AVX-512 build. Preserve that numerical contract here: reducing
+     * every block to a scalar first changes FP32 addition order and is not
+     * bit-exact at production vision widths.
+     */
+    __m256 acc = _mm256_setzero_ps();
+    for (int ib = 0; ib < nb; ++ib) {
+        const __m256 d = _mm256_set1_ps(
+            CK_FP16_TO_FP32(x[ib].d) * CK_FP16_TO_FP32(y[ib].d));
+        const __m256i qx = _mm256_loadu_si256((const __m256i *)x[ib].qs);
+        const __m256i qy = _mm256_loadu_si256((const __m256i *)y[ib].qs);
+        const __m256 q = mul_sum_i8_pairs_float_q8_0_avx2(qx, qy);
+#if defined(__FMA__)
+        acc = _mm256_fmadd_ps(d, q, acc);
+#else
+        acc = _mm256_add_ps(_mm256_mul_ps(d, q), acc);
+#endif
     }
 
-    *s = sumf;
+    *s = hsum_float_8_q8_0(acc);
 }
 #endif
 

--- a/tests/test_nightly_runner_artifact_status.py
+++ b/tests/test_nightly_runner_artifact_status.py
@@ -60,6 +60,37 @@ class NightlyArtifactStatusTests(unittest.TestCase):
         self.assertEqual([row.name for row in parsed], names)
         self.assertTrue(all(row.status == "pass" for row in parsed))
 
+    def test_phase_status_prevents_q8_pass_from_masking_bf16_skip(self) -> None:
+        runner = _load_runner()
+        target = {
+            "name": "BF16 artifact gate",
+            "category": "bf16",
+            "target": "fake-gate",
+            "timeout_sec": 10,
+            "status_artifact": "build/fake/summary.json",
+            "status_phase": "bf16_pytorch",
+        }
+        artifact = {
+            "status": "pass",
+            "phases": {
+                "q8_mmproj_llamacpp": {"status": "pass"},
+                "bf16_pytorch": {
+                    "status": "skip",
+                    "reason": "missing BF16 checkpoint",
+                },
+            },
+        }
+        completed = subprocess.CompletedProcess(
+            ["make", "fake-gate"], 0, stdout="", stderr=""
+        )
+        with mock.patch.object(runner.subprocess, "run", return_value=completed):
+            with mock.patch.object(
+                runner, "_load_json_if_fresh", return_value=artifact
+            ):
+                result = runner.run_make_target(target)
+        self.assertEqual(result.status, "skip")
+        self.assertEqual(result.error_msg, "missing BF16 checkpoint")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

The AVX-512 nightly exposed two real numerical-contract regressions and one reporting error. The Q8_0 AVX-512 implementation changed ggml arithmetic order, long split-KV attention bypassed the strict scale helper, and a passing Q8 encoder phase masked a skipped BF16/PyTorch phase.

## What changed

- Preserve ggml's eight-lane Q8_0 accumulation tree in the AVX-512 provider.
- Use `ck_attention_strict_scale_f32()` for split-KV attention.
- Derive the vision BF16 nightly row from the `bf16_pytorch` phase status and reason.
- Add a regression proving a Q8 pass cannot mask a BF16 skip.

## Evidence

- QKV, attention-out, and MLP-up Q8 composed projections changed from max error `4.291534e-06` to byte-exact.
- FP16 split-KV passes 17/17, including llama.cpp oracle cases at KV 1058 and 1609.
- AVX-512 objects compile; disassembly retains the required eight-lane reduction structure.

## Validation

- `make test-q8-composed-llama-parity`
- `make test-attention-f16-split-kv`
- `make test-numerical-contracts`
- `make test-qwen3vl-methodical-parity`
- `python -m unittest tests.test_nightly_runner_artifact_status`
- staged `v7-regression-fast` and `v8-regression-fast`
- full pre-push gate

## Regression coverage

The existing strict thresholds remain unchanged. The repaired numerical cases continue to execute in the FP16 attention, llama.cpp parity, Qwen3-VL methodical parity, and numerical-contract nightly lanes. BF16 phase status now has a focused unit test.

## Documentation

No static documentation change is needed. The generated nightly report now truthfully displays BF16 `PASS` or `SKIP` from the artifact-backed phase instead of inheriting the combined Q8/BF16 summary.

## Content handoff

- Audience: numerical-kernel and CPU inference engineers
- Angle: Wider ISA instructions cannot silently change a declared arithmetic contract.
- Claims: AVX-512 Q8 composed projections are byte-exact locally; long-KV attention contracts pass; BF16 artifact absence is reported as SKIP.
- Caveats: The hosted AVX-512 nightly remains the authoritative final gate.
- Sources: commit `416391d8`, scheduled artifact run `29226829578`, focused test logs, and AVX-512 disassembly.