### PR TITLE
feat(v8): diagnose execution state before tensor math

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2984,7 +2984,7 @@ test-numerical-contracts: $(LIB)
 	@echo "Running v8 numerical contract validation..."
 	@$(PYTHON) -m py_compile version/v8/scripts/resolve_attention_contracts_v8.py
 	@$(PYTHON) -m py_compile version/v8/scripts/resolve_numerical_execution_contracts_v8.py
-	@$(PYTHON) -m py_compile version/v8/scripts/xray_numerical_parity_v8.py version/v8/scripts/build_xray_checkpoint_manifest_v8.py
+	@$(PYTHON) -m py_compile version/v8/scripts/xray_numerical_parity_v8.py version/v8/scripts/xray_execution_state_v8.py version/v8/scripts/build_xray_checkpoint_manifest_v8.py
 	@$(PYTHON) tests/test_v8_attention_contracts.py
 	@$(PYTHON) tests/test_v8_numerical_execution_contracts.py
 	@$(PYTHON) unittest/bf16/test_layernorm_storage_contract_bf16.py
@@ -2994,6 +2994,7 @@ test-numerical-contracts: $(LIB)
 	@$(PYTHON) unittest/bf16/test_gelu_pytorch_tanh_storage_bf16.py
 	@PYTHONPATH=unittest CK_NUMERICAL_CAPABILITY_REPORT=version/v8/.cache/reports/mrope_capabilities_latest.json $(PYTHON) -c "import test_vision; test_vision.test_mrope_qk_vision_storage_matrix()"
 	@$(PYTHON) tests/test_v8_xray_numerical_parity.py
+	@$(PYTHON) tests/test_v8_xray_execution_state.py
 	@$(PYTHON) unittest/test_attention_full.py
 	@$(PYTHON) unittest/test_attention_f16_split_kv.py
 	@mkdir -p build/v8/contracts
@@ -3007,12 +3008,14 @@ test-bf16-xray:
 	@$(PYTHON) -m py_compile \
 		version/v8/scripts/xray_vision_parity_v8.py \
 		version/v8/scripts/xray_numerical_parity_v8.py \
+		version/v8/scripts/xray_execution_state_v8.py \
 		version/v8/scripts/build_xray_checkpoint_manifest_v8.py \
 		version/v8/scripts/xray_qwen3vl_bf16_v8.py \
 		version/v8/scripts/xray_qwen3vl_llamacpp_v8.py \
 		version/v8/scripts/normalize_xray_ranking_report_v8.py
 	@$(PYTHON) tests/test_v8_numerical_execution_contracts.py
 	@$(PYTHON) tests/test_v8_xray_numerical_parity.py
+	@$(PYTHON) tests/test_v8_xray_execution_state.py
 	@$(PYTHON) tests/test_v8_xray_vision_interface.py
 	@$(PYTHON) version/v8/test_assets/generate_xray_form_fixture_v8.py \
 		--output build/xray/public_form_1152x896.ppm

--- a/docs/site/_pages/v8-numerical-contracts.html
+++ b/docs/site/_pages/v8-numerical-contracts.html
@@ -163,6 +163,9 @@ make v7-regression-fast</code></pre>
 <p>Every X-ray failure follows the same additive progression. The report embeds these steps so another agent does not repeat an already diagnosed numerical bug.</p>
 
 <ol>
+  <li>Compare execution policy first: prefill segmentation, kernel batch shapes, position progression, cache reset/append behavior, and cache strides. A combined 1,307-row prefill is not numerically equivalent evidence for a backend that executes 33, 1,008, and 266-row segments.</li>
+  <li>For incremental decode, prove cache state before attention math: compare append index, current post-RoPE K/V, stored-row readback, the previous row, and hashes for every valid cache row.</li>
+  <li>Only when query and valid cache bytes agree, compare attention providers, split thresholds, worker partitions, probability/value rounding, and merge order.</li>
   <li>Stop at the first divergent semantic edge and classify its storage, compute, reduction, position, layout, circuit, binding, and threading contract.</li>
   <li>Resolve an exact compatible kernel-map capability. Zero or multiple providers hard-fail.</li>
   <li>Fix the existing implementation or add one new additive variant. Do not alter unrelated numerical variants.</li>
@@ -172,6 +175,15 @@ make v7-regression-fast</code></pre>
   <li>Rerun X-ray from the last passing checkpoint. The accepted fix must move the first divergence to a later semantic edge.</li>
   <li>Publish the capability evidence in the test-report accordion and nightly artifacts before promoting the route.</li>
 </ol>
+
+<p>The bounded execution-state comparator preserves this order in a machine-readable report:</p>
+
+<pre><code>python version/v8/scripts/xray_execution_state_v8.py \
+  --subject-trace build/xray/ck-execution-trace.json \
+  --oracle-trace build/xray/llama-execution-trace.json \
+  --output build/xray/execution-state-report.json</code></pre>
+
+<p>It stops at one of four useful boundaries: execution-policy mismatch, cache metadata/content mismatch, attention-input mismatch, or attention-arithmetic mismatch. Tensor bisection begins only after the execution and state contracts agree.</p>
 
 <h2>Measured BF16 Vision Progression</h2>
 

--- a/tests/test_v8_xray_execution_state.py
+++ b/tests/test_v8_xray_execution_state.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "version" / "v8" / "scripts" / "xray_execution_state_v8.py"
+SPEC = importlib.util.spec_from_file_location("xray_execution_state_v8", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+xray = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(xray)
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class XRayExecutionStateTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="xray_state_v8_")
+        self.root = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def artifact(self, role: str, values: np.ndarray, name: str | None = None):
+        path = self.root / f"{name or role}.f16"
+        np.asarray(values, dtype=np.float16).tofile(path)
+        return {
+            "checkpoint_id": f"decoder.layer.0.{role}", "role": role,
+            "tensor_path": str(path), "dtype": "fp16", "shape": list(values.shape),
+            "row_axis": 0, "sha256": digest(path),
+        }
+
+    def trace(self, backend: str, calls, artifacts=None):
+        return {
+            "schema": "cke.xray_execution_trace", "schema_version": 1, "backend": backend,
+            "run": {"model": "fixture", "phase": "mixed_prefill", "source": "unit"},
+            "execution": {"policy_id": "segmented_mixed_prefill", "calls": calls},
+            "state": {
+                "position_policy_id": "mrope", "position": [41, 41, 41],
+                "cache_token_count": 1307, "append_index": 1306,
+                "cache_layout": {
+                    "layout_id": "layer_head_token_channel", "base_address": "0x1234",
+                    "layer_stride_bytes": 65536, "head_stride_bytes": 8192,
+                    "token_stride_bytes": 256, "channel_stride_bytes": 2,
+                },
+            },
+            "artifacts": artifacts or [],
+        }
+
+    @staticmethod
+    def call(call_id: str, kind: str, start: int, count: int, action: str):
+        return {
+            "call_id": call_id, "kind": kind, "start": start, "count": count,
+            "position_start": start, "cache_action": action,
+            "kernel_batches": [{
+                "checkpoint_id": "decoder.layer.0.q_proj", "kernel_id": "gemm_q4k_q8k",
+                "m": count, "n": 4096, "k": 4096,
+            }],
+        }
+
+    def segmented_calls(self):
+        return [
+            self.call("text_before", "text", 0, 33, "reset"),
+            self.call("visual", "visual", 33, 1008, "append"),
+            self.call("text_after", "text", 1041, 266, "append"),
+        ]
+
+    def test_identical_execution_and_cache_trace_passes(self):
+        values = np.arange(24, dtype=np.float16).reshape(3, 8)
+        left_artifact = self.artifact("valid_key_cache", values, "left")
+        right_artifact = self.artifact("valid_key_cache", values, "right")
+        result = xray.compare_traces(
+            self.trace("ck", self.segmented_calls(), [left_artifact]),
+            self.trace("llamacpp", self.segmented_calls(), [right_artifact]),
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertTrue(result["checks"][-1]["exact_bytes"])
+
+    def test_combined_vs_segmented_prefill_fails_before_tensor_loading(self):
+        combined = [self.call("combined", "mixed", 0, 1307, "reset")]
+        left = self.trace("ck", combined)
+        left["execution"]["policy_id"] = "combined_mixed_prefill"
+        result = xray.compare_traces(left, self.trace("llamacpp", self.segmented_calls()))
+        self.assertEqual(result["first_divergence"]["classification"], "EXECUTION_POLICY_MISMATCH")
+        self.assertEqual(result["first_divergence"]["subject_calls"][0]["count"], 1307)
+        self.assertEqual([call["count"] for call in result["first_divergence"]["oracle_calls"]], [33, 1008, 266])
+        self.assertEqual(len(result["checks"]), 1)
+
+    def test_cache_append_index_mismatch_precedes_cache_bytes(self):
+        left = self.trace("ck", self.segmented_calls())
+        right = self.trace("llamacpp", self.segmented_calls())
+        left["state"]["append_index"] = 1305
+        result = xray.compare_traces(left, right)
+        self.assertEqual(result["first_divergence"]["classification"], "CACHE_STATE_METADATA_MISMATCH")
+        self.assertEqual(result["first_divergence"]["field"], "append_index")
+
+    def test_first_changed_cache_row_is_reported(self):
+        expected = np.arange(32, dtype=np.float16).reshape(4, 8)
+        actual = expected.copy()
+        actual[2, 5] += np.float16(1.0)
+        result = xray.compare_traces(
+            self.trace("ck", self.segmented_calls(), [self.artifact("valid_key_cache", actual, "actual")]),
+            self.trace("llamacpp", self.segmented_calls(), [self.artifact("valid_key_cache", expected, "expected")]),
+        )
+        failure = result["first_divergence"]
+        self.assertEqual(failure["classification"], "CACHE_CONTENT_DIVERGENCE")
+        self.assertEqual(failure["first_differing_row"], 2)
+        self.assertGreater(failure["metrics"]["max_abs"], 0.0)
+
+    def test_cache_append_roundtrip_is_checked_within_subject(self):
+        source = np.arange(16, dtype=np.float32).reshape(2, 8) / 7.0
+        stored = source.astype(np.float16)
+        stored[1, 4] += np.float16(0.25)
+        source_path = self.root / "new_key.f32"
+        source.tofile(source_path)
+        source_artifact = {
+            "checkpoint_id": "decoder.layer.0.new_key", "role": "new_key",
+            "tensor_path": str(source_path), "dtype": "fp32", "shape": [2, 8],
+            "row_axis": 0, "sha256": digest(source_path),
+        }
+        subject = self.trace("ck", self.segmented_calls(), [source_artifact, self.artifact("stored_key", stored)])
+        oracle = self.trace("llamacpp", self.segmented_calls(), [source_artifact, self.artifact("stored_key", source.astype(np.float16), "oracle_stored")])
+        result = xray.compare_traces(subject, oracle)
+        failure = result["first_divergence"]
+        self.assertEqual(failure["classification"], "CACHE_APPEND_ROUNDTRIP_DIVERGENCE")
+        self.assertEqual(failure["backend"], "ck")
+        self.assertEqual(failure["first_differing_row"], 1)
+
+    def test_identical_inputs_then_different_output_is_arithmetic(self):
+        query = np.arange(16, dtype=np.float16).reshape(2, 8)
+        expected = np.ones((2, 8), dtype=np.float16)
+        actual = expected.copy(); actual[1, 3] += np.float16(0.125)
+        result = xray.compare_traces(
+            self.trace("ck", self.segmented_calls(), [
+                self.artifact("query", query, "left_query"),
+                self.artifact("attention_output", actual, "left_output"),
+            ]),
+            self.trace("llamacpp", self.segmented_calls(), [
+                self.artifact("query", query, "right_query"),
+                self.artifact("attention_output", expected, "right_output"),
+            ]),
+        )
+        failure = result["first_divergence"]
+        self.assertEqual(failure["classification"], "ATTENTION_ARITHMETIC_DIVERGENCE")
+        self.assertEqual(failure["stage"], "attention_output")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/version/v8/schemas/xray_execution_trace.schema.json
+++ b/version/v8/schemas/xray_execution_trace.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cke.v8.xray_execution_trace",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "schema_version", "backend", "run", "execution", "state", "artifacts"],
+  "properties": {
+    "schema": {"const": "cke.xray_execution_trace"},
+    "schema_version": {"const": 1},
+    "backend": {"type": "string", "minLength": 1},
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model", "phase", "source"],
+      "properties": {
+        "model": {"type": "string", "minLength": 1},
+        "phase": {"enum": ["prefill", "mixed_prefill", "decode", "teacher_forced"]},
+        "source": {"type": "string", "minLength": 1}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_id", "calls"],
+      "properties": {
+        "policy_id": {"type": "string", "minLength": 1},
+        "calls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["call_id", "kind", "start", "count", "position_start", "cache_action"],
+            "properties": {
+              "call_id": {"type": "string", "minLength": 1},
+              "kind": {"type": "string", "minLength": 1},
+              "start": {"type": "integer", "minimum": 0},
+              "count": {"type": "integer", "minimum": 1},
+              "position_start": {"type": "integer", "minimum": 0},
+              "cache_action": {"enum": ["reset", "append", "preserve", "none"]},
+              "kernel_batches": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["checkpoint_id", "kernel_id", "m", "n", "k"],
+                  "properties": {
+                    "checkpoint_id": {"type": "string", "minLength": 1},
+                    "kernel_id": {"type": "string", "minLength": 1},
+                    "m": {"type": "integer", "minimum": 1},
+                    "n": {"type": "integer", "minimum": 1},
+                    "k": {"type": "integer", "minimum": 1}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["position_policy_id", "position", "cache_token_count", "append_index", "cache_layout"],
+      "properties": {
+        "position_policy_id": {"type": "string", "minLength": 1},
+        "position": {
+          "oneOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 0}}
+          ]
+        },
+        "cache_token_count": {"type": "integer", "minimum": 0},
+        "append_index": {"type": "integer", "minimum": 0},
+        "cache_layout": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["layout_id", "layer_stride_bytes", "head_stride_bytes", "token_stride_bytes", "channel_stride_bytes"],
+          "properties": {
+            "layout_id": {"type": "string", "minLength": 1},
+            "base_address": {"type": "string"},
+            "layer_stride_bytes": {"type": "integer", "minimum": 1},
+            "head_stride_bytes": {"type": "integer", "minimum": 1},
+            "token_stride_bytes": {"type": "integer", "minimum": 1},
+            "channel_stride_bytes": {"type": "integer", "minimum": 1}
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["checkpoint_id", "role", "tensor_path", "dtype", "shape", "row_axis", "sha256"],
+        "properties": {
+          "checkpoint_id": {"type": "string", "minLength": 1},
+          "role": {
+            "enum": [
+              "new_key", "new_value", "stored_key", "stored_value",
+              "previous_key_before", "previous_key_after",
+              "previous_value_before", "previous_value_after",
+              "valid_key_cache", "valid_value_cache",
+              "query", "attention_output", "logits"
+            ]
+          },
+          "tensor_path": {"type": "string", "minLength": 1},
+          "dtype": {"enum": ["fp32", "fp16", "bf16", "u8", "i32", "i64"]},
+          "shape": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 1}},
+          "row_axis": {"type": "integer", "minimum": 0},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    }
+  }
+}

--- a/version/v8/scripts/xray_execution_state_v8.py
+++ b/version/v8/scripts/xray_execution_state_v8.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Compare execution policy, cache state, and attention arithmetic in diagnostic order."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = Path(__file__).resolve().parents[1] / "schemas" / "xray_execution_trace.schema.json"
+
+ROLE_STAGE = {
+    "new_key": (2, "CACHE_APPEND_SOURCE_DIVERGENCE"),
+    "new_value": (2, "CACHE_APPEND_SOURCE_DIVERGENCE"),
+    "stored_key": (3, "CACHE_APPEND_ROUNDTRIP_DIVERGENCE"),
+    "stored_value": (3, "CACHE_APPEND_ROUNDTRIP_DIVERGENCE"),
+    "previous_key_before": (3, "CACHE_PREVIOUS_ROW_DIVERGENCE"),
+    "previous_key_after": (3, "CACHE_PREVIOUS_ROW_DIVERGENCE"),
+    "previous_value_before": (3, "CACHE_PREVIOUS_ROW_DIVERGENCE"),
+    "previous_value_after": (3, "CACHE_PREVIOUS_ROW_DIVERGENCE"),
+    "valid_key_cache": (4, "CACHE_CONTENT_DIVERGENCE"),
+    "valid_value_cache": (4, "CACHE_CONTENT_DIVERGENCE"),
+    "query": (5, "ATTENTION_INPUT_DIVERGENCE"),
+    "attention_output": (6, "ATTENTION_ARITHMETIC_DIVERGENCE"),
+    "logits": (7, "RANKING_DIVERGENCE"),
+}
+
+REMEDIATIONS = {
+    "EXECUTION_POLICY_MISMATCH": "Align prefill/decode segmentation and cache transitions in the circuit/runtime contract before tensor bisection.",
+    "KERNEL_BATCH_SHAPE_MISMATCH": "Make both backends invoke the same semantic kernel over equivalent M/N/K batches before comparing arithmetic.",
+    "POSITION_STATE_MISMATCH": "Align text/M-RoPE position policy and runtime position values before attention diagnostics.",
+    "CACHE_STATE_METADATA_MISMATCH": "Fix cache token count, append index, or physical strides before comparing cache bytes.",
+    "MISSING_STATE_ARTIFACT": "Export the requested bounded state artifact on both backends; do not substitute a downstream tensor.",
+    "CACHE_APPEND_SOURCE_DIVERGENCE": "Compare the current token post-RoPE K/V producer before cache storage.",
+    "CACHE_APPEND_ROUNDTRIP_DIVERGENCE": "Fix cache cast, append offset, or write/read layout; the newly stored row must round-trip exactly.",
+    "CACHE_PREVIOUS_ROW_DIVERGENCE": "Fix cache overwrite or stride arithmetic; appending a token must not modify the previous row.",
+    "CACHE_CONTENT_DIVERGENCE": "Find the first differing valid cache row and fix state history before attention arithmetic.",
+    "ATTENTION_INPUT_DIVERGENCE": "Align query and valid cache inputs before comparing attention providers.",
+    "ATTENTION_ARITHMETIC_DIVERGENCE": "With identical inputs, compare split threshold, worker partition, probability/value rounding, and reduction/merge order.",
+    "RANKING_DIVERGENCE": "Teacher-force the same token sequence and attribute the first material logit ranking flip.",
+    "DIAGNOSTIC_TRACE_ERROR": "Fix trace bounds, dtype, shape, checksum, or semantic role before diagnosing model math.",
+}
+
+
+class TraceError(RuntimeError):
+    pass
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TraceError(f"expected JSON object: {path}")
+    return value
+
+
+def _validate(trace: dict[str, Any], context: str) -> None:
+    schema = _load_json(SCHEMA)
+    errors = sorted(Draft202012Validator(schema).iter_errors(trace), key=lambda e: tuple(e.absolute_path))
+    if errors:
+        error = errors[0]
+        where = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        raise TraceError(f"{context} violates execution trace schema at {where}: {error.message}")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _dtype(name: str) -> np.dtype:
+    return {
+        "fp32": np.dtype(np.float32), "fp16": np.dtype(np.float16),
+        "bf16": np.dtype(np.uint16), "u8": np.dtype(np.uint8),
+        "i32": np.dtype(np.int32), "i64": np.dtype(np.int64),
+    }[name]
+
+
+def _load_artifact(entry: dict[str, Any]) -> tuple[np.ndarray, bytes]:
+    path = Path(entry["tensor_path"])
+    if not path.is_file():
+        raise TraceError(f"missing state artifact: {path}")
+    raw = path.read_bytes()
+    if _sha256(path) != entry["sha256"]:
+        raise TraceError(f"state artifact checksum changed: {path}")
+    values = np.frombuffer(raw, dtype=_dtype(entry["dtype"]))
+    shape = tuple(int(value) for value in entry["shape"])
+    if values.size != math.prod(shape):
+        raise TraceError(f"{entry['checkpoint_id']}: {values.size} values != shape {shape}")
+    values = values.reshape(shape)
+    if entry["dtype"] == "bf16":
+        values = (values.astype(np.uint32) << 16).view(np.float32)
+    elif entry["dtype"] in {"fp16", "fp32"}:
+        values = values.astype(np.float32)
+    return values, raw
+
+
+def _round_for_storage(values: np.ndarray, dtype: str) -> np.ndarray:
+    if dtype == "fp16":
+        return values.astype(np.float16).astype(np.float32)
+    if dtype == "bf16":
+        fp32 = values.astype(np.float32)
+        bits = fp32.view(np.uint32)
+        rounded = bits + np.uint32(0x7FFF) + ((bits >> 16) & np.uint32(1))
+        return ((rounded >> 16) << 16).view(np.float32)
+    if dtype == "fp32":
+        return values.astype(np.float32)
+    return values.astype(_dtype(dtype))
+
+
+def _row_evidence(left: np.ndarray, right: np.ndarray, row_axis: int) -> dict[str, Any]:
+    lhs = np.moveaxis(left, row_axis, 0).reshape(left.shape[row_axis], -1)
+    rhs = np.moveaxis(right, row_axis, 0).reshape(right.shape[row_axis], -1)
+    differing = np.flatnonzero(np.any(lhs != rhs, axis=1))
+    first = int(differing[0]) if differing.size else None
+    worst = None
+    if lhs.size:
+        row_max = np.max(np.abs(lhs.astype(np.float64) - rhs.astype(np.float64)), axis=1)
+        worst = int(np.argmax(row_max))
+    hashes = []
+    for index in sorted({0, max(0, lhs.shape[0] - 1), *(filter(lambda x: x is not None, [first, worst]))}):
+        hashes.append({
+            "row": int(index),
+            "subject_sha256": hashlib.sha256(np.ascontiguousarray(lhs[index]).tobytes()).hexdigest(),
+            "oracle_sha256": hashlib.sha256(np.ascontiguousarray(rhs[index]).tobytes()).hexdigest(),
+        })
+    return {"first_differing_row": first, "worst_row": worst, "row_hashes": hashes}
+
+
+def _tensor_metrics(left: np.ndarray, right: np.ndarray) -> dict[str, Any]:
+    lhs = left.astype(np.float64, copy=False)
+    rhs = right.astype(np.float64, copy=False)
+    diff = lhs - rhs
+    abs_diff = np.abs(diff)
+    denom = float(np.linalg.norm(lhs) * np.linalg.norm(rhs))
+    flat = int(np.argmax(abs_diff)) if abs_diff.size else 0
+    return {
+        "cosine": float(np.dot(lhs.reshape(-1), rhs.reshape(-1)) / denom) if denom else 1.0,
+        "rmse": float(np.sqrt(np.mean(diff * diff))) if diff.size else 0.0,
+        "max_abs": float(abs_diff.reshape(-1)[flat]) if diff.size else 0.0,
+        "mean_abs": float(np.mean(abs_diff)) if diff.size else 0.0,
+        "worst_flat_index": flat,
+        "finite": bool(np.isfinite(lhs).all() and np.isfinite(rhs).all()),
+    }
+
+
+def _fail(classification: str, **evidence: Any) -> dict[str, Any]:
+    return {
+        "status": "fail", "classification": classification,
+        "recommended_action": REMEDIATIONS[classification], **evidence,
+    }
+
+
+def _canonical_calls(trace: dict[str, Any]) -> list[dict[str, Any]]:
+    calls = []
+    for call in trace["execution"]["calls"]:
+        calls.append({key: call[key] for key in ("kind", "start", "count", "position_start", "cache_action")})
+    return calls
+
+
+def _kernel_batches(trace: dict[str, Any]) -> list[dict[str, Any]]:
+    return [batch for call in trace["execution"]["calls"] for batch in call.get("kernel_batches", [])]
+
+
+def _artifact_index(trace: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for entry in trace["artifacts"]:
+        role = entry["role"]
+        if role in indexed:
+            raise TraceError(f"duplicate state artifact role: {role}")
+        indexed[role] = entry
+    return indexed
+
+
+def _intra_trace_state_checks(trace: dict[str, Any], artifacts: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for stem in ("key", "value"):
+        source = artifacts.get(f"new_{stem}")
+        stored = artifacts.get(f"stored_{stem}")
+        if (source is None) != (stored is None):
+            return [_fail(
+                "MISSING_STATE_ARTIFACT", stage=f"{stem}_append_roundtrip", backend=trace["backend"],
+                source_present=source is not None, stored_present=stored is not None,
+            )]
+        if source is not None and stored is not None:
+            try:
+                source_values, _ = _load_artifact(source)
+                stored_values, _ = _load_artifact(stored)
+            except (TraceError, ValueError) as exc:
+                return [_fail("DIAGNOSTIC_TRACE_ERROR", stage=f"{stem}_append_roundtrip", detail=str(exc))]
+            expected = _round_for_storage(source_values, stored["dtype"])
+            if expected.shape != stored_values.shape:
+                return [_fail("DIAGNOSTIC_TRACE_ERROR", stage=f"{stem}_append_roundtrip",
+                              detail=f"source shape {expected.shape} != stored shape {stored_values.shape}")]
+            exact = bool(np.array_equal(expected, stored_values))
+            row_axis = int(stored["row_axis"])
+            evidence = {
+                "stage": f"{stem}_append_roundtrip", "backend": trace["backend"],
+                "status": "pass" if exact else "fail", "exact_after_storage_rounding": exact,
+                "source_dtype": source["dtype"], "storage_dtype": stored["dtype"],
+                "metrics": _tensor_metrics(expected, stored_values),
+                **_row_evidence(expected, stored_values, row_axis),
+            }
+            if not exact:
+                return [{**_fail("CACHE_APPEND_ROUNDTRIP_DIVERGENCE"), **evidence}]
+            checks.append(evidence)
+
+        before = artifacts.get(f"previous_{stem}_before")
+        after = artifacts.get(f"previous_{stem}_after")
+        if (before is None) != (after is None):
+            return [_fail(
+                "MISSING_STATE_ARTIFACT", stage=f"previous_{stem}_preservation", backend=trace["backend"],
+                before_present=before is not None, after_present=after is not None,
+            )]
+        if before is not None and after is not None:
+            try:
+                before_values, before_raw = _load_artifact(before)
+                after_values, after_raw = _load_artifact(after)
+            except (TraceError, ValueError) as exc:
+                return [_fail("DIAGNOSTIC_TRACE_ERROR", stage=f"previous_{stem}_preservation", detail=str(exc))]
+            exact = before["dtype"] == after["dtype"] and before_values.shape == after_values.shape and before_raw == after_raw
+            evidence = {
+                "stage": f"previous_{stem}_preservation", "backend": trace["backend"],
+                "status": "pass" if exact else "fail", "exact_bytes": exact,
+            }
+            if not exact:
+                if before_values.shape == after_values.shape:
+                    evidence["metrics"] = _tensor_metrics(before_values, after_values)
+                    evidence.update(_row_evidence(before_values, after_values, int(before["row_axis"])))
+                return [{**_fail("CACHE_PREVIOUS_ROW_DIVERGENCE"), **evidence}]
+            checks.append(evidence)
+    return checks
+
+
+def compare_traces(subject: dict[str, Any], oracle: dict[str, Any]) -> dict[str, Any]:
+    _validate(subject, "subject")
+    _validate(oracle, "oracle")
+    checks: list[dict[str, Any]] = []
+
+    subject_calls = _canonical_calls(subject)
+    oracle_calls = _canonical_calls(oracle)
+    if subject["execution"]["policy_id"] != oracle["execution"]["policy_id"] or subject_calls != oracle_calls:
+        checks.append(_fail(
+            "EXECUTION_POLICY_MISMATCH", stage="execution_contract",
+            subject_policy=subject["execution"]["policy_id"], oracle_policy=oracle["execution"]["policy_id"],
+            subject_calls=subject_calls, oracle_calls=oracle_calls,
+        ))
+        return _report(subject, oracle, checks)
+    checks.append({"stage": "execution_contract", "status": "pass"})
+
+    subject_batches = _kernel_batches(subject)
+    oracle_batches = _kernel_batches(oracle)
+    if subject_batches != oracle_batches:
+        checks.append(_fail("KERNEL_BATCH_SHAPE_MISMATCH", stage="kernel_batches", subject=subject_batches, oracle=oracle_batches))
+        return _report(subject, oracle, checks)
+    checks.append({"stage": "kernel_batches", "status": "pass"})
+
+    left_state, right_state = subject["state"], oracle["state"]
+    position_fields = ("position_policy_id", "position")
+    mismatch = next((field for field in position_fields if left_state[field] != right_state[field]), None)
+    if mismatch:
+        checks.append(_fail("POSITION_STATE_MISMATCH", stage="position_state", field=mismatch,
+                            subject=left_state[mismatch], oracle=right_state[mismatch]))
+        return _report(subject, oracle, checks)
+    checks.append({"stage": "position_state", "status": "pass"})
+
+    layout_left = {key: value for key, value in left_state["cache_layout"].items() if key != "base_address"}
+    layout_right = {key: value for key, value in right_state["cache_layout"].items() if key != "base_address"}
+    state_pairs = {
+        "cache_token_count": (left_state["cache_token_count"], right_state["cache_token_count"]),
+        "append_index": (left_state["append_index"], right_state["append_index"]),
+        "cache_layout": (layout_left, layout_right),
+    }
+    mismatch = next((field for field, values in state_pairs.items() if values[0] != values[1]), None)
+    if mismatch:
+        checks.append(_fail("CACHE_STATE_METADATA_MISMATCH", stage="cache_metadata", field=mismatch,
+                            subject=state_pairs[mismatch][0], oracle=state_pairs[mismatch][1],
+                            subject_base=left_state["cache_layout"].get("base_address"),
+                            oracle_base=right_state["cache_layout"].get("base_address")))
+        return _report(subject, oracle, checks)
+    checks.append({"stage": "cache_metadata", "status": "pass",
+                   "subject_base": left_state["cache_layout"].get("base_address"),
+                   "oracle_base": right_state["cache_layout"].get("base_address")})
+
+    try:
+        left_artifacts = _artifact_index(subject)
+        right_artifacts = _artifact_index(oracle)
+    except TraceError as exc:
+        checks.append(_fail("DIAGNOSTIC_TRACE_ERROR", stage="artifact_index", detail=str(exc)))
+        return _report(subject, oracle, checks)
+    for trace, artifacts in ((subject, left_artifacts), (oracle, right_artifacts)):
+        intra_checks = _intra_trace_state_checks(trace, artifacts)
+        checks.extend(intra_checks)
+        if intra_checks and intra_checks[-1]["status"] == "fail":
+            return _report(subject, oracle, checks)
+    roles = sorted(set(left_artifacts) | set(right_artifacts), key=lambda role: (ROLE_STAGE[role][0], role))
+    for role in roles:
+        left, right = left_artifacts.get(role), right_artifacts.get(role)
+        if left is None or right is None:
+            checks.append(_fail("MISSING_STATE_ARTIFACT", stage=role,
+                                subject_present=left is not None, oracle_present=right is not None))
+            return _report(subject, oracle, checks)
+        try:
+            left_values, left_raw = _load_artifact(left)
+            right_values, right_raw = _load_artifact(right)
+        except (TraceError, ValueError) as exc:
+            checks.append(_fail("DIAGNOSTIC_TRACE_ERROR", stage=role, detail=str(exc)))
+            return _report(subject, oracle, checks)
+        if left["dtype"] != right["dtype"] or left_values.shape != right_values.shape or left["row_axis"] != right["row_axis"]:
+            checks.append(_fail("DIAGNOSTIC_TRACE_ERROR", stage=role, detail="dtype, shape, or row axis differs",
+                                subject={"dtype": left["dtype"], "shape": list(left_values.shape), "row_axis": left["row_axis"]},
+                                oracle={"dtype": right["dtype"], "shape": list(right_values.shape), "row_axis": right["row_axis"]}))
+            return _report(subject, oracle, checks)
+        exact = left_raw == right_raw
+        evidence = {
+            "stage": role, "status": "pass" if exact else "fail", "exact_bytes": exact,
+            "shape": list(left_values.shape), "dtype": left["dtype"],
+            "metrics": _tensor_metrics(left_values, right_values),
+            **_row_evidence(left_values, right_values, int(left["row_axis"])),
+        }
+        if not exact:
+            classification = ROLE_STAGE[role][1]
+            checks.append({**_fail(classification), **evidence})
+            return _report(subject, oracle, checks)
+        checks.append(evidence)
+    return _report(subject, oracle, checks)
+
+
+def _report(subject: dict[str, Any], oracle: dict[str, Any], checks: list[dict[str, Any]]) -> dict[str, Any]:
+    first = next((check for check in checks if check["status"] == "fail"), None)
+    return {
+        "schema": "cke.xray_execution_state_report", "schema_version": 1,
+        "subject_backend": subject["backend"], "oracle_backend": oracle["backend"],
+        "status": "fail" if first else "pass", "checks": checks, "first_divergence": first,
+        "diagnostic_order": [
+            "execution_contract", "kernel_batches", "position_state", "cache_metadata",
+            "cache_append_source", "cache_append_roundtrip", "all_valid_cache_rows",
+            "attention_inputs", "attention_arithmetic", "ranking",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--subject-trace", type=Path, required=True)
+    parser.add_argument("--oracle-trace", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = compare_traces(_load_json(args.subject_trace), _load_json(args.oracle_trace))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    first = result.get("first_divergence") or {}
+    print(f"status={result['status']}")
+    if first:
+        print(f"stage={first.get('stage')}")
+        print(f"class={first.get('classification')}")
+        print(f"action={first.get('recommended_action')}")
+    return 1 if first else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Tensor-only parity can blame kernel arithmetic when the actual mismatch is execution segmentation, position progression, cache state, storage round-trip, or a diagnostic mode that changed backend execution. Qwen3-VL exposed this when persistent/replay and production/unfused comparisons appeared to conflict.

## What changed

- Add a fail-closed `cke.xray_execution_trace` schema.
- Compare execution policy and kernel batch shapes before loading tensors.
- Compare positions, cache count, append index, and physical strides.
- Verify new K/V storage round-trip and previous-row preservation within each backend.
- Compare every valid cache row with first/worst row hashes.
- Continue through query, attention output, and logits only after state passes.
- Wire the six fault-classification tests into numerical-contract and BF16 X-ray gates.

## Evidence

- Combined 1,307-row versus segmented 33 + 1,008 + 266 prefill is classified before tensor loading.
- Cache corruption reports the first and worst logical rows plus bounded hashes.
- Identical attention inputs with differing output is classified as arithmetic rather than state.
- FP16 llama.cpp split-KV oracle remains 17/17.

## Validation

- `python tests/test_v8_xray_execution_state.py`: 6/6
- `make test-bf16-xray`: PASS
- `make test-numerical-contracts`: PASS with local pinned llama.cpp
- staged `v7-regression-fast`: PASS
- staged `v8-regression-fast`: PASS
- full pre-push v7/v8 regressions: PASS
- `git diff --check`: PASS

## Regression coverage

The new cases inject execution-policy, cache-index, cache-content, storage-roundtrip, and attention-arithmetic faults. Existing tensor X-ray, resolver, model, attention, and llama.cpp oracle gates remain unchanged.

## Documentation

`docs/site/_pages/v8-numerical-contracts.html` now documents execution-first diagnosis, cache-state proof, and the bounded comparator CLI.

## Content handoff

- Audience: numerical-kernel, compiler, and inference-runtime engineers
- Angle: First-divergence tooling must prove execution and state before inspecting tensor math.
- Claims: X-ray now classifies execution, position, cache, attention-input, arithmetic, and ranking failures in deterministic order.
- Caveats: Backend capture adapters are the next integration; this PR does not claim Qwen3-VL parity closure.
- Sources: commit `be624d91`, execution schema, comparator, six fault tests, numerical-contract logs, and the v8 numerical-contract architecture page.