### PR TITLE
fix(v8/vision): close two-sample Qwen3-VL parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2427,6 +2427,9 @@ llamacpp-parity-full:
 	@echo "Running composed Q8 activation/projection parity at vision dimensions..."
 	@$(MAKE) --no-print-directory test-q8-composed-llama-parity
 	@echo ""
+	@echo "Running F16 GEMM production reduction contract against llama.cpp..."
+	@$(MAKE) --no-print-directory test-f16-gemm-llama-contract
+	@echo ""
 	@echo "Running head-major Q5 out-proj parity benchmark..."
 	@$(MAKE) --no-print-directory test-head-major-q5-outproj
 	@echo ""
@@ -2439,6 +2442,11 @@ test-llamacpp-parity-full: llamacpp-parity-full
 test-q8-composed-llama-parity: $(LIB)
 	@CK_BUILD_DIR="$(BUILD_DIR)" LD_LIBRARY_PATH="$(CURDIR)/llama.cpp/build/bin:$${LD_LIBRARY_PATH}" \
 		$(PYTHON) unittest/test_q8_composed_llama_parity.py
+
+.PHONY: test-f16-gemm-llama-contract
+test-f16-gemm-llama-contract: $(LIB)
+	@CK_BUILD_DIR="$(BUILD_DIR)" LD_LIBRARY_PATH="$(CURDIR)/llama.cpp/build/bin:$${LD_LIBRARY_PATH}" \
+		$(PYTHON) unittest/test_f16_gemm_llama_contract.py
 
 # End-to-end llama.cpp compatibility suite
 # This lane is where model-family and stitched graph checks belong.
@@ -2508,6 +2516,9 @@ llamacpp-parity-nightly:
 	@echo ""
 	@echo "Running composed Q8 activation/projection parity at vision dimensions..."
 	@$(MAKE) --no-print-directory test-q8-composed-llama-parity
+	@echo ""
+	@echo "Running F16 GEMM production reduction contract against llama.cpp..."
+	@$(MAKE) --no-print-directory test-f16-gemm-llama-contract
 	@echo ""
 	@echo "Running comprehensive Q4/Q5/Q8 GEMV CK vs llama.cpp tests (quick)..."
 	@if [ -f "$(LLAMA_KERNEL_TEST)" ]; then \

--- a/docs/site/_pages/v8-numerical-contracts.html
+++ b/docs/site/_pages/v8-numerical-contracts.html
@@ -203,6 +203,26 @@ make v7-regression-fast</code></pre>
 
 <p>The next edge is always explicit. After output projection the resolver selects the BF16 residual capability, then X-ray continues through norm2, MLP, spatial merge, projector, final prefix, mixed-prefill logits, and teacher-forced generation. A green leaf test without this forward movement is evidence for a kernel only, not closure of the model bug.</p>
 
+<h2>Execution-Contract X-Ray</h2>
+
+<p>Tensor parity cannot diagnose a backend that executes the same mixed prefix with a different schedule. X-ray therefore records prefill segmentation, cache transitions, position transitions, exact shared-library identity, and the manifest-map identity alongside numerical checkpoints.</p>
+
+<table>
+  <thead><tr><th>Mixed-prefix contract</th><th>Required behavior</th><th>Failure meaning</th></tr></thead>
+  <tbody>
+    <tr><td>Segments</td><td><code>text_before -&gt; visual -&gt; text_after</code></td><td>A combined prefix changes projection reduction shape and rounding.</td></tr>
+    <tr><td>Cache transition</td><td><code>append_preserve</code></td><td>A segment must retain all prior K/V rows and append at the physical token offset.</td></tr>
+    <tr><td>Position transition</td><td><code>segment_defined</code></td><td>Physical cache position and semantic M-RoPE text position must not be conflated.</td></tr>
+    <tr><td>Runtime evidence</td><td>Exact generated library and manifest-map hashes</td><td>A stale converted manifest or rebuilt runtime invalidates attribution.</td></tr>
+  </tbody>
+</table>
+
+<p>On the 1,008-token Qwen3-VL form cases, the old single-call path diverged from llama.cpp as early as generated step 4. Circuit-driven segmented append removed the cache-state failure, but a later close-ranking flip remained. X-ray then showed that the visual M-RoPE cache was exact while only the rotated second half differed. Basis-vector replay isolated two compiler-visible rounding points: llama.cpp rounds the partner product before each <code>fmaf</code>, and its frequency recurrence uses the system <code>powf</code>, <code>sinf</code>, and <code>cosf</code> behavior. CK now names that evaluation order in the numerical contract and implements it explicitly.</p>
+
+<p>The resulting production gate is exact for both canonical OCR forms: each full <code>1008 x 16384</code> decoder-facing visual prefix matches llama.cpp across all 16,515,072 FP32 values, and both 128-token greedy runs match 128/128 top-1 tokens. Minimum logits cosine was 0.98892 and 0.99168 respectively, with at least 14/16 top-k overlap. This closes these two fixtures, not the unexecuted 40-image sweep or every multimodal family.</p>
+
+<p>The investigation also invalidated an earlier packed Q4_K&times;Q8_K diagnosis. The apparent packed-reduction failure was downstream of the M-RoPE ULP and a report that recorded the generated decoder library but not its dynamically loaded engine library. X-ray now defaults the raw llama.cpp oracle to one thread, rejects multi-threaded exact capture without an explicit opt-in, and records the engine, generated model, llama shim, and manifest identities. A downstream kernel is not blamed until exact-input replay and complete runtime provenance both pass.</p>
+
 <h2>Validation Commands</h2>
 
 <p><code>make test-numerical-contracts</code> is an executable gate, not only a schema check. It builds the engine and runs contract resolution, full attention numerics, and FP16 split-KV reduction cases. The focused commands below remain useful when attributing a failure.</p>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -193,6 +193,14 @@ void gemm_nt_f16(const float *A,
                  float *C,
                  int M, int N, int K);
 
+// Diagnostic oracle backed by the dynamically loaded ggml mul_mat graph.
+// Returns zero instead of falling back when the independent oracle is unavailable.
+int ck_gemm_nt_f16_ggml_oracle(const float *A,
+                               const void *B,
+                               const float *bias,
+                               float *C,
+                               int M, int N, int K);
+
 void gemm_nt_f16_clipped(const float *A,
                          const void *B,
                          const float *bias,
@@ -345,6 +353,8 @@ void quantize_row_q8_k(const float *x, void *y, int k);
 
 // Batch Q8_K quantization (row-major output for GEMM compatibility)
 void quantize_batch_q8_k(const float *x, void *y, int num_rows, int k);
+void quantize_batch_q8_k_4row_nearest_even(const float *x, void *y,
+                                            int num_rows, int k);
 
 void gemv_q4_k_q8_k(float *y,
                     const void *W,
@@ -901,6 +911,14 @@ void rmsnorm_forward(const float *input,
                      int d_model,
                      int aligned_embed_dim,
                      float eps);
+void rmsnorm_forward_fp32_square_fp64_sum(const float *input,
+                                          const float *gamma,
+                                          float *output,
+                                          float *rstd_cache,
+                                          int tokens,
+                                          int d_model,
+                                          int aligned_embed_dim,
+                                          float eps);
 void rmsnorm_forward_kv_lora(const float *input,
                              const float *gamma,
                              float *output,
@@ -944,6 +962,14 @@ void qk_norm_forward(float *q,
                      int num_tokens,
                      int head_dim,
                      float eps);
+void qk_norm_forward_prefill_exact(float *q, float *k,
+                                   const float *q_gamma, const float *k_gamma,
+                                   int num_heads, int num_kv_heads,
+                                   int num_tokens, int head_dim, float eps);
+void qk_norm_forward_decode_exact(float *q, float *k,
+                                  const float *q_gamma, const float *k_gamma,
+                                  int num_heads, int num_kv_heads,
+                                  int num_tokens, int head_dim, float eps);
 void q_norm_forward(float *q,
                     const float *q_gamma,
                     int num_heads,
@@ -1370,6 +1396,18 @@ void attention_forward_full_head_major_gqa_flash_strided(const float *q,
                                                          int aligned_head_dim,
                                                          int kv_stride_tokens);
 
+void attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided(
+    const float *q,
+    const float *k,
+    const float *v,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens);
+
 void attention_forward_full_head_major_gqa_flash_strided_bf16_storage(
     const float *q, const float *k, const float *v, float *output,
     int num_heads, int num_kv_heads, int num_tokens, int head_dim,
@@ -1558,6 +1596,38 @@ ck_attention_status_t attention_forward_decode_head_major_gqa_flash_f16cache_con
     int num_heads,
     int num_kv_heads,
     int kv_tokens,
+    int cache_capacity,
+    int head_dim,
+    int aligned_head_dim,
+    ck_attention_reduction_t reduction);
+
+// Causal prefill over a cache-preserving segment. Current-segment K/V rows
+// must already be appended at [past_tokens, past_tokens + q_tokens).
+ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(
+    const float *q,
+    const uint16_t *k_cache,
+    const uint16_t *v_cache,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int q_tokens,
+    int past_tokens,
+    int cache_capacity,
+    int head_dim,
+    int aligned_head_dim,
+    ck_attention_reduction_t reduction);
+
+// Causal prefill over a cache-preserving segment. Current-segment K/V rows
+// must already be appended at [past_tokens, past_tokens + q_tokens).
+ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(
+    const float *q,
+    const uint16_t *k_cache,
+    const uint16_t *v_cache,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int q_tokens,
+    int past_tokens,
     int cache_capacity,
     int head_dim,
     int aligned_head_dim,
@@ -3084,6 +3154,27 @@ void mrope_qk_imrope_positions(float *q,
                                float attn_factor,
                                float beta_fast,
                                float beta_slow);
+
+void mrope_qk_text_imrope(float *q,
+                          float *k,
+                          int num_heads,
+                          int num_kv_heads,
+                          int num_tokens,
+                          int head_dim,
+                          int aligned_head_dim,
+                          int pos_offset,
+                          int n_dims,
+                          int section_0,
+                          int section_1,
+                          int section_2,
+                          int section_3,
+                          int n_ctx_orig,
+                          float freq_base,
+                          float freq_scale,
+                          float ext_factor,
+                          float attn_factor,
+                          float beta_fast,
+                          float beta_slow);
 
 void rope_forward_qk_strided(float *q,
                              float *k,

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -908,6 +908,28 @@ static CK_NOINLINE CK_OPTNONE float ck_attention_strict_scale_f32(int head_dim)
     return scale;
 }
 
+typedef float (*ck_attention_math_f32_fn)(float);
+
+static float ck_attention_reference_expf(float value)
+{
+#if defined(__linux__)
+    static void *libm_handle = NULL;
+    static ck_attention_math_f32_fn fn = NULL;
+    static int resolved = 0;
+    if (!resolved) {
+        libm_handle = dlopen("libm.so.6", RTLD_NOW | RTLD_LOCAL);
+        if (libm_handle) {
+            fn = (ck_attention_math_f32_fn) dlsym(libm_handle, "expf");
+        }
+        resolved = 1;
+    }
+    if (fn) {
+        return fn(value);
+    }
+#endif
+    return expf(value);
+}
+
 static CK_NOINLINE CK_OPTNONE double ck_ggml_vec_soft_max_row(int n,
                                                               float *y,
                                                               const float *x,
@@ -2856,20 +2878,27 @@ static CK_NOINLINE CK_OPTNONE void ck_attention_matmul_f32_accum(float *c,
 }
 #endif
 
-static CK_NOINLINE CK_OPTNONE void attention_forward_full_head_major_gqa_ggml_tiled_strict(const float *q,
-                                                                                             const float *k,
-                                                                                             const float *v,
-                                                                                             float *output,
-                                                                                             int num_heads,
-                                                                                             int num_kv_heads,
-                                                                                             int num_tokens,
-                                                                                             int head_dim,
-                                                                                             int aligned_head_dim,
-                                                                                             int kv_stride_tokens)
+static CK_NOINLINE CK_OPTNONE void ck_attention_full_tiled_f16kv_fp32_range(
+    const float *q,
+    const float *k,
+    const float *v,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens,
+    int ith,
+    int nth)
 {
-    const float scale = ck_strict_parity_enabled()
-        ? ck_attention_strict_scale_f32(head_dim)
-        : 1.0f / sqrtf((float) head_dim);
+    if (!q || !k || !v || !output || num_heads <= 0 || num_kv_heads <= 0 ||
+        num_tokens <= 0 || head_dim <= 0 || aligned_head_dim < head_dim ||
+        kv_stride_tokens < num_tokens || num_heads % num_kv_heads != 0) {
+        return;
+    }
+
+    const float scale = ck_attention_strict_scale_f32(head_dim);
     const int T = num_tokens;
     const size_t kv_head_stride = (size_t) kv_stride_tokens * (size_t) aligned_head_dim;
 
@@ -2879,31 +2908,42 @@ static CK_NOINLINE CK_OPTNONE void attention_forward_full_head_major_gqa_ggml_ti
     float *kq = (float *) alloca((size_t) CK_GGML_FA_TILE_Q * (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
     float *vkq = (float *) alloca((size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
 
-    for (int h = 0; h < num_heads; ++h) {
+    const int total_rows = num_heads * T;
+    const int rows_per_worker = (total_rows + nth - 1) / nth;
+    int ir = rows_per_worker * ith;
+    const int ir1 = (ir + rows_per_worker) < total_rows
+        ? (ir + rows_per_worker)
+        : total_rows;
+
+    while (ir < ir1) {
+        const int h = ir / T;
+        const int iq = ir - h * T;
+        int tile_rows = ir1 - ir;
+        if (tile_rows > CK_GGML_FA_TILE_Q) tile_rows = CK_GGML_FA_TILE_Q;
+        if (tile_rows > T - iq) tile_rows = T - iq;
         const int kv_head = (int) ((long long) h * (long long) num_kv_heads / (long long) num_heads);
         const float *k_head = k + (size_t) kv_head * kv_head_stride;
         const float *v_head = v + (size_t) kv_head * kv_head_stride;
 
-        for (int iq = 0; iq < T; iq += CK_GGML_FA_TILE_Q) {
-            const int tile_rows = (T - iq) < CK_GGML_FA_TILE_Q ? (T - iq) : CK_GGML_FA_TILE_Q;
-            float sum_row[CK_GGML_FA_TILE_Q];
-            float max_row[CK_GGML_FA_TILE_Q];
+        float sum_row[CK_GGML_FA_TILE_Q];
+        float max_row[CK_GGML_FA_TILE_Q];
 
-            for (int tq = 0; tq < CK_GGML_FA_TILE_Q; ++tq) {
-                sum_row[tq] = 0.0f;
-                max_row[tq] = -INFINITY;
-            }
+        for (int tq = 0; tq < CK_GGML_FA_TILE_Q; ++tq) {
+            sum_row[tq] = 0.0f;
+            max_row[tq] = -INFINITY;
+        }
 
-            memset(vkq, 0, (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
-            memset(q_tile, 0, (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
-            memset(v_tile, 0, (size_t) CK_GGML_FA_TILE_KV * (size_t) head_dim * sizeof(float));
+        memset(vkq, 0, (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
+        memset(q_tile, 0, (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
+        memset(k_tile, 0, (size_t) head_dim * (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
+        memset(v_tile, 0, (size_t) CK_GGML_FA_TILE_KV * (size_t) head_dim * sizeof(float));
 
-            for (int tq = 0; tq < tile_rows; ++tq) {
-                const float *q_vec = q + qkv_index(h, iq + tq, 0, T, aligned_head_dim);
-                memcpy(q_tile + (size_t) tq * (size_t) head_dim, q_vec, (size_t) head_dim * sizeof(float));
-            }
+        for (int tq = 0; tq < tile_rows; ++tq) {
+            const float *q_vec = q + qkv_index(h, iq + tq, 0, T, aligned_head_dim);
+            memcpy(q_tile + (size_t) tq * (size_t) head_dim, q_vec, (size_t) head_dim * sizeof(float));
+        }
 
-            for (int ik = 0; ik < T; ik += CK_GGML_FA_TILE_KV) {
+        for (int ik = 0; ik < T; ik += CK_GGML_FA_TILE_KV) {
                 const int kv_tile = (T - ik) < CK_GGML_FA_TILE_KV ? (T - ik) : CK_GGML_FA_TILE_KV;
                 memset(kq, 0, (size_t) CK_GGML_FA_TILE_Q * (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
 
@@ -2911,8 +2951,10 @@ static CK_NOINLINE CK_OPTNONE void attention_forward_full_head_major_gqa_ggml_ti
                     const float *k_vec = k_head + (size_t) (ik + tk) * (size_t) aligned_head_dim;
                     const float *v_vec = v_head + (size_t) (ik + tk) * (size_t) aligned_head_dim;
                     for (int d = 0; d < head_dim; ++d) {
-                        k_tile[(size_t) d * (size_t) CK_GGML_FA_TILE_KV + (size_t) tk] = k_vec[d];
-                        v_tile[(size_t) tk * (size_t) head_dim + (size_t) d] = v_vec[d];
+                        k_tile[(size_t) d * (size_t) CK_GGML_FA_TILE_KV + (size_t) tk] =
+                            ck_round_fp16_scalar(k_vec[d]);
+                        v_tile[(size_t) tk * (size_t) head_dim + (size_t) d] =
+                            ck_round_fp16_scalar(v_vec[d]);
                     }
                 }
 
@@ -2946,14 +2988,17 @@ static CK_NOINLINE CK_OPTNONE void attention_forward_full_head_major_gqa_ggml_ti
                     const float old_max = max_row[tq];
                     const float new_max = old_max > tile_max ? old_max : tile_max;
                     if (new_max > old_max) {
-                        const float ms = expf(old_max - new_max);
+                        const float ms = ck_attention_reference_expf(old_max - new_max);
                         ck_vec_scale_f32_inplace(vkq + (size_t) tq * (size_t) head_dim,
                                                  head_dim,
                                                  ms);
                         sum_row[tq] *= ms;
                     }
                     max_row[tq] = new_max;
-                    sum_row[tq] += (float) ck_ggml_vec_soft_max_row(CK_GGML_FA_TILE_KV, kq_row, kq_row, new_max);
+                    sum_row[tq] = (float) (
+                        (double) sum_row[tq] +
+                        ck_ggml_vec_soft_max_row(
+                            CK_GGML_FA_TILE_KV, kq_row, kq_row, new_max));
                 }
 
                 ck_attention_matmul_f32_accum(vkq,
@@ -2964,17 +3009,80 @@ static CK_NOINLINE CK_OPTNONE void attention_forward_full_head_major_gqa_ggml_ti
                                               head_dim);
             }
 
-            for (int tq = 0; tq < tile_rows; ++tq) {
-                float *out_vec = output + qkv_index(h, iq + tq, 0, T, aligned_head_dim);
-                const float inv_sum = sum_row[tq] == 0.0f ? 0.0f : (1.0f / sum_row[tq]);
-                for (int d = 0; d < head_dim; ++d) {
-                    out_vec[d] = vkq[(size_t) tq * (size_t) head_dim + (size_t) d] * inv_sum;
-                }
-                for (int d = head_dim; d < aligned_head_dim; ++d) {
-                    out_vec[d] = 0.0f;
-                }
+        for (int tq = 0; tq < tile_rows; ++tq) {
+            float *out_vec = output + qkv_index(h, iq + tq, 0, T, aligned_head_dim);
+            const float inv_sum = sum_row[tq] == 0.0f ? 0.0f : (1.0f / sum_row[tq]);
+            for (int d = 0; d < head_dim; ++d) {
+                out_vec[d] = vkq[(size_t) tq * (size_t) head_dim + (size_t) d] * inv_sum;
+            }
+            for (int d = head_dim; d < aligned_head_dim; ++d) {
+                out_vec[d] = 0.0f;
             }
         }
+        ir += tile_rows;
+    }
+}
+
+typedef struct {
+    const float *q;
+    const float *k;
+    const float *v;
+    float *output;
+    int num_heads;
+    int num_kv_heads;
+    int num_tokens;
+    int head_dim;
+    int aligned_head_dim;
+    int kv_stride_tokens;
+} ck_attention_full_tiled_f16kv_fp32_args_t;
+
+static void ck_attention_full_tiled_f16kv_fp32_work(int ith, int nth, void *opaque)
+{
+    ck_attention_full_tiled_f16kv_fp32_args_t *args =
+        (ck_attention_full_tiled_f16kv_fp32_args_t *) opaque;
+    ck_attention_full_tiled_f16kv_fp32_range(
+        args->q, args->k, args->v, args->output,
+        args->num_heads, args->num_kv_heads, args->num_tokens,
+        args->head_dim, args->aligned_head_dim, args->kv_stride_tokens,
+        ith, nth);
+}
+
+void attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided(
+    const float *q,
+    const float *k,
+    const float *v,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int num_tokens,
+    int head_dim,
+    int aligned_head_dim,
+    int kv_stride_tokens)
+{
+    if (!q || !k || !v || !output || num_heads <= 0 || num_kv_heads <= 0 ||
+        num_tokens <= 0 || head_dim <= 0 || aligned_head_dim < head_dim ||
+        kv_stride_tokens < num_tokens || num_heads % num_kv_heads != 0) {
+        return;
+    }
+
+    ck_attention_full_tiled_f16kv_fp32_args_t args = {
+        .q = q,
+        .k = k,
+        .v = v,
+        .output = output,
+        .num_heads = num_heads,
+        .num_kv_heads = num_kv_heads,
+        .num_tokens = num_tokens,
+        .head_dim = head_dim,
+        .aligned_head_dim = aligned_head_dim,
+        .kv_stride_tokens = kv_stride_tokens,
+    };
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int active = pool ? ck_threadpool_n_threads(pool) : 1;
+    if (pool && active > 1) {
+        ck_threadpool_dispatch_n(pool, active, ck_attention_full_tiled_f16kv_fp32_work, &args);
+    } else {
+        ck_attention_full_tiled_f16kv_fp32_work(0, 1, &args);
     }
 }
 
@@ -5063,6 +5171,68 @@ ck_attention_status_t attention_forward_decode_head_major_gqa_flash_f16cache_con
     default:
         return CK_ATTENTION_STATUS_UNSUPPORTED_CONTRACT;
     }
+}
+
+ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(
+    const float *q,
+    const uint16_t *k_cache,
+    const uint16_t *v_cache,
+    float *output,
+    int num_heads,
+    int num_kv_heads,
+    int q_tokens,
+    int past_tokens,
+    int cache_capacity,
+    int head_dim,
+    int aligned_head_dim,
+    ck_attention_reduction_t reduction)
+{
+    if (!q || !k_cache || !v_cache || !output ||
+        num_heads <= 0 || num_kv_heads <= 0 || q_tokens <= 0 ||
+        past_tokens < 0 || past_tokens + q_tokens > cache_capacity ||
+        head_dim <= 0 || aligned_head_dim < head_dim) {
+        return CK_ATTENTION_STATUS_INVALID_ARGUMENT;
+    }
+
+    const size_t token_elems = (size_t) num_heads * (size_t) aligned_head_dim;
+    float *q_token = (float *) malloc(token_elems * sizeof(float));
+    float *out_token = (float *) malloc(token_elems * sizeof(float));
+    if (!q_token || !out_token) {
+        free(q_token);
+        free(out_token);
+        return CK_ATTENTION_STATUS_INVALID_ARGUMENT;
+    }
+
+    ck_attention_status_t status = CK_ATTENTION_STATUS_OK;
+    for (int t = 0; t < q_tokens; ++t) {
+        for (int h = 0; h < num_heads; ++h) {
+            const float *src = q +
+                ((size_t) h * (size_t) q_tokens + (size_t) t) * (size_t) aligned_head_dim;
+            memcpy(q_token + (size_t) h * (size_t) aligned_head_dim,
+                   src,
+                   (size_t) aligned_head_dim * sizeof(float));
+        }
+
+        status = attention_forward_decode_head_major_gqa_flash_f16cache_contract(
+            q_token, k_cache, v_cache, out_token,
+            num_heads, num_kv_heads, past_tokens + t + 1, cache_capacity,
+            head_dim, aligned_head_dim, reduction);
+        if (status != CK_ATTENTION_STATUS_OK) {
+            break;
+        }
+
+        for (int h = 0; h < num_heads; ++h) {
+            float *dst = output +
+                ((size_t) h * (size_t) q_tokens + (size_t) t) * (size_t) aligned_head_dim;
+            memcpy(dst,
+                   out_token + (size_t) h * (size_t) aligned_head_dim,
+                   (size_t) aligned_head_dim * sizeof(float));
+        }
+    }
+
+    free(q_token);
+    free(out_token);
+    return status;
 }
 
 void attention_forward_decode_head_major_gqa_flash_f16cache(const float *q_token,

--- a/src/kernels/gelu_kernels.c
+++ b/src/kernels/gelu_kernels.c
@@ -39,12 +39,6 @@ static inline float ck_gelu_tanh_f32(float x) {
     return 0.5f * x * (1.0f + tanhf(inner));
 }
 
-static inline float ck_gelu_tanh_ggml_f32(float x) {
-    const float gelu_coef_a = 0.044715f;
-    const float sqrt_2_over_pi = 0.79788456080286535588f;
-    return 0.5f * x * (1.0f + tanhf(sqrt_2_over_pi * x * (1.0f + gelu_coef_a * x * x)));
-}
-
 static ck_half ck_gelu_ggml_table_f16[1u << 16];
 static pthread_once_t ck_gelu_ggml_table_once = PTHREAD_ONCE_INIT;
 static pthread_once_t ck_gelu_ggml_runtime_once = PTHREAD_ONCE_INIT;
@@ -52,12 +46,44 @@ static pthread_once_t ck_gelu_ggml_runtime_once = PTHREAD_ONCE_INIT;
 typedef void (*ck_gelu_ggml_cpu_init_fn)(void);
 typedef ck_half (*ck_gelu_ggml_fp32_to_fp16_fn)(float);
 typedef float (*ck_gelu_ggml_fp16_to_fp32_fn)(ck_half);
+typedef float (*ck_gelu_math_f32_fn)(float);
 
 static const ck_half *ck_gelu_runtime_table_f16 = NULL;
 static ck_gelu_ggml_fp32_to_fp16_fn ck_gelu_runtime_fp32_to_fp16 = NULL;
 static ck_gelu_ggml_fp16_to_fp32_fn ck_gelu_runtime_fp16_to_fp32 = NULL;
 static void *ck_gelu_runtime_handle = NULL;
 static int ck_gelu_runtime_ready = 0;
+static ck_gelu_math_f32_fn ck_gelu_reference_tanhf = NULL;
+static pthread_once_t ck_gelu_reference_math_once = PTHREAD_ONCE_INIT;
+
+static void ck_gelu_reference_math_init(void) {
+#if defined(__linux__)
+    void *handle = dlopen("libm.so.6", RTLD_NOW | RTLD_LOCAL);
+    if (handle) {
+        ck_gelu_reference_tanhf = (ck_gelu_math_f32_fn) dlsym(handle, "tanhf");
+    }
+#endif
+}
+
+static ck_gelu_math_f32_fn ck_gelu_system_tanhf(void) {
+    pthread_once(&ck_gelu_reference_math_once, ck_gelu_reference_math_init);
+    return ck_gelu_reference_tanhf;
+}
+
+#if defined(__clang__) || defined(__INTEL_LLVM_COMPILER)
+#pragma float_control(precise, on, push)
+#endif
+static float ck_gelu_tanh_ggml_reference_f32(float x) {
+    const float gelu_coef_a = 0.044715f;
+    const float sqrt_2_over_pi = 0.79788456080286535588f;
+    ck_gelu_math_f32_fn reference_tanhf = ck_gelu_system_tanhf();
+    const float inner = sqrt_2_over_pi * x * (1.0f + gelu_coef_a * x * x);
+    const float tanh_value = reference_tanhf ? reference_tanhf(inner) : tanhf(inner);
+    return 0.5f * x * (1.0f + tanh_value);
+}
+#if defined(__clang__) || defined(__INTEL_LLVM_COMPILER)
+#pragma float_control(pop)
+#endif
 
 static void ck_gelu_try_bind_runtime(void *handle) {
     ck_gelu_ggml_cpu_init_fn cpu_init_fn =
@@ -96,7 +122,7 @@ static void ck_gelu_ggml_table_init(void) {
     for (uint32_t i = 0; i < (1u << 16); ++i) {
         const ck_half x_fp16 = (ck_half) i;
         const float x = ggml_fp16_to_fp32(x_fp16);
-        const float y = ck_gelu_tanh_ggml_f32(x);
+        const float y = ck_gelu_tanh_ggml_reference_f32(x);
         ck_gelu_ggml_table_f16[i] = ggml_fp32_to_fp16(y);
     }
 }

--- a/src/kernels/gemm_kernels_f16.c
+++ b/src/kernels/gemm_kernels_f16.c
@@ -259,6 +259,17 @@ static int gemm_nt_f16_ggml_strict(const float *A,
     return ok;
 }
 
+int ck_gemm_nt_f16_ggml_oracle(const float *A,
+                               const void *B,
+                               const float *bias,
+                               float *C,
+                               int M,
+                               int N,
+                               int K)
+{
+    return gemm_nt_f16_ggml_strict(A, B, bias, C, M, N, K);
+}
+
 /* ============================================================================
  * FP16 Conversion Utilities (if not using F16C)
  * ============================================================================ */
@@ -312,11 +323,10 @@ static inline void ck_f32_to_f16_row_local(uint16_t *dst, const float *src, int 
 #if defined(__F16C__) && defined(__AVX__)
 static inline float ck_hsum256_ps(__m256 v)
 {
-    __m128 lo = _mm256_castps256_ps128(v);
-    __m128 hi = _mm256_extractf128_ps(v, 1);
-    __m128 sum = _mm_add_ps(lo, hi);
-    sum = _mm_hadd_ps(sum, sum);
-    sum = _mm_hadd_ps(sum, sum);
+    __m128 sum = _mm_add_ps(_mm256_extractf128_ps(v, 1),
+                            _mm256_castps256_ps128(v));
+    sum = _mm_add_ps(sum, _mm_movehl_ps(sum, sum));
+    sum = _mm_add_ss(sum, _mm_movehdup_ps(sum));
     return _mm_cvtss_f32(sum);
 }
 

--- a/src/kernels/layernorm_kernels.c
+++ b/src/kernels/layernorm_kernels.c
@@ -40,7 +40,7 @@ void layernorm_naive_serial_matched_precision(const float *input,
                                               int tokens, int d_model, float eps);
 
 #if defined(__clang__) || defined(__INTEL_LLVM_COMPILER)
-#pragma float_control(precise, off, push)
+#pragma float_control(precise, on, push)
 #endif
 static void layernorm_forward_ggml_exact(const float *input,
                                          const float *gamma,

--- a/src/kernels/rope_kernels.c
+++ b/src/kernels/rope_kernels.c
@@ -75,6 +75,66 @@ typedef struct ggml_cgraph *(*ck_ggml_new_graph_fn)(struct ggml_context *);
 typedef void (*ck_ggml_build_forward_expand_fn)(struct ggml_cgraph *, struct ggml_tensor *);
 typedef enum ggml_status (*ck_ggml_graph_compute_with_ctx_fn)(struct ggml_context *, struct ggml_cgraph *, int);
 typedef void *(*ck_ggml_get_data_fn)(const struct ggml_tensor *);
+typedef float (*ck_rope_math_f32_fn)(float);
+typedef float (*ck_rope_math_f32_binary_fn)(float, float);
+
+static ck_rope_math_f32_fn ck_rope_resolve_system_math_f32(const char *name)
+{
+#if defined(__linux__)
+    static void *libm_handle = NULL;
+    if (!libm_handle) {
+        libm_handle = dlopen("libm.so.6", RTLD_NOW | RTLD_LOCAL);
+    }
+    if (libm_handle) {
+        ck_rope_math_f32_fn fn = (ck_rope_math_f32_fn)dlsym(libm_handle, name);
+        if (fn) {
+            return fn;
+        }
+    }
+#else
+    (void)name;
+#endif
+    return NULL;
+}
+
+/* ICX links libimf ahead of the system math library. Its sinf/cosf results can
+ * differ from a GCC-built ggml oracle by one ULP, which is enough to alter Q8
+ * blocks downstream. Resolve the platform libm implementation explicitly for
+ * the ggml-compatible M-RoPE arithmetic contract. */
+static float ck_rope_reference_cosf(float value)
+{
+    static ck_rope_math_f32_fn fn = NULL;
+    if (!fn) {
+        fn = ck_rope_resolve_system_math_f32("cosf");
+    }
+    return fn ? fn(value) : cosf(value);
+}
+
+static float ck_rope_reference_sinf(float value)
+{
+    static ck_rope_math_f32_fn fn = NULL;
+    if (!fn) {
+        fn = ck_rope_resolve_system_math_f32("sinf");
+    }
+    return fn ? fn(value) : sinf(value);
+}
+
+static float ck_rope_reference_powf(float base, float exponent)
+{
+    static ck_rope_math_f32_binary_fn fn = NULL;
+    if (!fn) {
+#if defined(__linux__)
+        static void *libm_handle = NULL;
+        if (!libm_handle) {
+            libm_handle = dlopen("libm.so.6", RTLD_NOW | RTLD_LOCAL);
+        }
+        if (libm_handle) {
+            fn = (ck_rope_math_f32_binary_fn)dlsym(libm_handle, "powf");
+        }
+#endif
+    }
+    return fn ? fn(base, exponent) : powf(base, exponent);
+}
 
 static void ck_rope_ensure_ggml_loaded(void)
 {
@@ -1210,8 +1270,22 @@ static void vision_mrope_yarn(
         mscale *= 1.0f + 0.1f * logf(1.0f / fmaxf(freq_scale, 1e-6f));
     }
 
-    *cos_theta = cosf(theta) * mscale;
-    *sin_theta = sinf(theta) * mscale;
+    *cos_theta = ck_rope_reference_cosf(theta) * mscale;
+    *sin_theta = ck_rope_reference_sinf(theta) * mscale;
+}
+
+static inline void mrope_rotate_pair(
+    float x0,
+    float x1,
+    float cos_theta,
+    float sin_theta,
+    float *out0,
+    float *out1
+) {
+    const float x1_sin = x1 * sin_theta;
+    const float x1_cos = x1 * cos_theta;
+    *out0 = fmaf(x0, cos_theta, -x1_sin);
+    *out1 = fmaf(x0, sin_theta, x1_cos);
 }
 
 static void vision_mrope_apply_head(
@@ -1250,7 +1324,7 @@ static void vision_mrope_apply_head(
     }
 
     const int num_pos = num_tokens;
-    const float theta_scale = powf(freq_base, -2.0f / (float) rope_pairs);
+    const float theta_scale = ck_rope_reference_powf(freq_base, -2.0f / (float) rope_pairs);
     float corr_dims[2] = {0.0f, (float) (rope_pairs - 1)};
     vision_mrope_yarn_corr_dims(rope_pairs, n_ctx_orig, freq_base, beta_fast, beta_slow, corr_dims);
 
@@ -1281,8 +1355,14 @@ static void vision_mrope_apply_head(
 
             const float x0 = row[pair];
             const float x1 = row[pair + rope_pairs];
-            row[pair] = x0 * cos_theta - x1 * sin_theta;
-            row[pair + rope_pairs] = x0 * sin_theta + x1 * cos_theta;
+            mrope_rotate_pair(
+                x0,
+                x1,
+                cos_theta,
+                sin_theta,
+                &row[pair],
+                &row[pair + rope_pairs]
+            );
 
             theta_y *= theta_scale;
             theta_x *= theta_scale;
@@ -1521,8 +1601,14 @@ static void explicit_mrope_apply_head(
 
             const float x0 = row[pair];
             const float x1 = row[pair + rope_pairs];
-            row[pair] = x0 * cos_theta - x1 * sin_theta;
-            row[pair + rope_pairs] = x0 * sin_theta + x1 * cos_theta;
+            mrope_rotate_pair(
+                x0,
+                x1,
+                cos_theta,
+                sin_theta,
+                &row[pair],
+                &row[pair + rope_pairs]
+            );
 
             theta_t *= theta_scale;
             theta_h *= theta_scale;
@@ -1546,7 +1632,8 @@ static void text_mrope_apply_head(
     float ext_factor,
     float attn_factor,
     float beta_fast,
-    float beta_slow
+    float beta_slow,
+    int is_imrope
 ) {
     if (!x || num_tokens <= 0 || head_dim <= 0 || aligned_head_dim < head_dim || n_dims <= 0) {
         return;
@@ -1580,7 +1667,15 @@ static void text_mrope_apply_head(
         for (int pair = 0; pair < rope_pairs; ++pair) {
             const int sector = sect_dims > 0 ? (pair % sect_dims) : pair;
             float theta = theta_t;
-            if (sector >= sections[0] && sector < sec_w) {
+            if (is_imrope && sector % 3 == 1 && sector < 3 * sections[1]) {
+                theta = theta_h;
+            } else if (is_imrope && sector % 3 == 2 && sector < 3 * sections[2]) {
+                theta = theta_w;
+            } else if (is_imrope && sector % 3 == 0 && sector < 3 * sections[0]) {
+                theta = theta_t;
+            } else if (is_imrope) {
+                theta = theta_e;
+            } else if (sector >= sections[0] && sector < sec_w) {
                 theta = theta_h;
             } else if (sector >= sec_w && sector < sec_e) {
                 theta = theta_w;
@@ -1603,8 +1698,14 @@ static void text_mrope_apply_head(
 
             const float x0 = row[pair];
             const float x1 = row[pair + rope_pairs];
-            row[pair] = x0 * cos_theta - x1 * sin_theta;
-            row[pair + rope_pairs] = x0 * sin_theta + x1 * cos_theta;
+            mrope_rotate_pair(
+                x0,
+                x1,
+                cos_theta,
+                sin_theta,
+                &row[pair],
+                &row[pair + rope_pairs]
+            );
 
             theta_t *= theta_scale;
             theta_h *= theta_scale;
@@ -1658,7 +1759,8 @@ void mrope_qk_text(float *q,
             ext_factor,
             attn_factor,
             beta_fast,
-            beta_slow
+            beta_slow,
+            0
         );
     }
 
@@ -1677,7 +1779,78 @@ void mrope_qk_text(float *q,
             ext_factor,
             attn_factor,
             beta_fast,
-            beta_slow
+            beta_slow,
+            0
+        );
+    }
+}
+
+void mrope_qk_text_imrope(float *q,
+                          float *k,
+                          int num_heads,
+                          int num_kv_heads,
+                          int num_tokens,
+                          int head_dim,
+                          int aligned_head_dim,
+                          int pos_offset,
+                          int n_dims,
+                          int section_0,
+                          int section_1,
+                          int section_2,
+                          int section_3,
+                          int n_ctx_orig,
+                          float freq_base,
+                          float freq_scale,
+                          float ext_factor,
+                          float attn_factor,
+                          float beta_fast,
+                          float beta_slow)
+{
+    if (!q || !k || num_heads <= 0 || num_kv_heads <= 0 || num_tokens <= 0) {
+        return;
+    }
+
+    const int sections[4] = {section_0, section_1, section_2, section_3};
+    const size_t q_head_stride = (size_t) num_tokens * (size_t) aligned_head_dim;
+    const size_t k_head_stride = (size_t) num_tokens * (size_t) aligned_head_dim;
+
+    for (int h = 0; h < num_heads; ++h) {
+        text_mrope_apply_head(
+            q + (size_t) h * q_head_stride,
+            num_tokens,
+            head_dim,
+            aligned_head_dim,
+            pos_offset,
+            n_dims,
+            sections,
+            n_ctx_orig,
+            freq_base,
+            freq_scale,
+            ext_factor,
+            attn_factor,
+            beta_fast,
+            beta_slow,
+            1
+        );
+    }
+
+    for (int h = 0; h < num_kv_heads; ++h) {
+        text_mrope_apply_head(
+            k + (size_t) h * k_head_stride,
+            num_tokens,
+            head_dim,
+            aligned_head_dim,
+            pos_offset,
+            n_dims,
+            sections,
+            n_ctx_orig,
+            freq_base,
+            freq_scale,
+            ext_factor,
+            attn_factor,
+            beta_fast,
+            beta_slow,
+            1
         );
     }
 }

--- a/src/kernels/vision_kernels.c
+++ b/src/kernels/vision_kernels.c
@@ -216,13 +216,13 @@ void position_embeddings_add_gemma4v_xy(float *x,
     }
 }
 
+/* GGML evaluates each interpolation sample in source traversal order and may
+ * contract only the sample*weight + accumulator expression. Use fmaf
+ * explicitly so Intel and GCC builds preserve that contract without enabling
+ * broader reassociation across source pixels. */
 #if defined(__clang__) || defined(__INTEL_LLVM_COMPILER)
-#pragma float_control(precise, off, push)
+#pragma float_control(precise, on, push)
 #endif
-/* GGML's antialiased interpolation is compiled with contraction enabled. Keep
- * that numerical contract local: forcing each intermediate to storage changes
- * Q8 activation blocks downstream even when the position error is only a few
- * ULPs. */
 CK_VISION_NOINLINE void position_embeddings_add_tiled_2d(float *x,
                                       const float *position_embd,
                                       int grid_h,
@@ -299,7 +299,7 @@ CK_VISION_NOINLINE void position_embeddings_add_tiled_2d(float *x,
                             continue;
                         }
                         const float sample = position_embd[((size_t) sy * (size_t) source_grid_size + (size_t) sx) * (size_t) embed_dim + (size_t) d];
-                        val += sample * weight;
+                        val = fmaf(sample, weight, val);
                         total_weight += weight;
                     }
                 }

--- a/tests/test_build_ir_v8_scaffold.py
+++ b/tests/test_build_ir_v8_scaffold.py
@@ -31,6 +31,7 @@ build_ir_v8 = _load_module("build_ir_v8_for_tests", V8_BUILD_PATH)
 def _normalized_template_doc(doc: dict) -> dict:
     normalized = json.loads(json.dumps(doc))
     normalized.pop("required_contracts", None)
+    normalized.pop("required_numerical_contracts", None)
     contract = normalized.get("contract")
     if isinstance(contract, dict):
         # Runtime preferences moved out of circuit flags in v8. They are not

--- a/tests/test_v8_attention_contracts.py
+++ b/tests/test_v8_attention_contracts.py
@@ -77,8 +77,28 @@ class AttentionContractV8Tests(unittest.TestCase):
             mode="bringup",
             source_circuit_path=self.vision_circuit_path,
         )
-        self.assertEqual(result["reduction"]["id"], "f16_kv_fp32_online")
+        self.assertEqual(
+            result["reduction"]["id"],
+            "f16_kv_tiled64_fp32_softmax_fp64_sum_update",
+        )
+        self.assertEqual(
+            result["kernel"]["id"],
+            "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+        )
+        self.assertEqual(result["production_blockers"], [])
         self.assertEqual(result["phase"], "prefill")
+
+    def test_qwen3vl_prefill_resolves_segmented_append_provider(self) -> None:
+        result = self.resolve("prefill")
+        self.assertEqual(
+            result["kernel"]["id"],
+            "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+        )
+        self.assertEqual(
+            result["requirements"]["execution.prefill_batching"],
+            "segmented_append",
+        )
+        self.assertEqual(result["requirements"]["tensor.kv.dtype"], "fp16")
 
     def test_production_rejects_unvalidated_circuit_request(self) -> None:
         with self.assertRaisesRegex(resolver.ContractError, "Production contract resolution rejected"):
@@ -231,9 +251,9 @@ class AttentionContractV8Tests(unittest.TestCase):
             ("nemotron_h", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash"),
             ("llama", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided_f16kv"),
             ("llama", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash_f16kv"),
-            ("qwen3vl", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided"),
+            ("qwen3vl", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract"),
             ("qwen3vl", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash_f16cache"),
-            ("qwen3_vl_vision", "vision_encoder.attention", "prefill", "attention_forward_full_head_major_gqa_flash_strided"),
+            ("qwen3_vl_vision", "vision_encoder.attention", "prefill", "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided"),
         )
         for circuit_name, operation, phase, expected in cases:
             with self.subTest(circuit=circuit_name, phase=phase):

--- a/tests/test_v8_codegen_bridge.py
+++ b/tests/test_v8_codegen_bridge.py
@@ -29,6 +29,7 @@ def _load_module(name: str, path: Path):
 
 
 build_ir_v8 = _load_module("build_ir_v8_codegen_bridge_tests", V8_BUILD_PATH)
+codegen_v8 = _load_module("codegen_v8_codegen_bridge_tests", V8_CODEGEN_PATH)
 
 
 def _entry(name: str, dtype: str, shape: list[int], offset: int) -> dict:
@@ -220,11 +221,42 @@ def _make_qwen3vl_decoder_manifest() -> dict:
 
 
 class V8CodegenBridgeTests(unittest.TestCase):
-    def test_builtin_qwen3vl_template_uses_text_mrope(self) -> None:
+    def test_multimodal_codegen_consumes_exact_resolved_text_mrope_provider(self) -> None:
+        operation = {
+            "op": "rope_qk",
+            "function": "mrope_qk_text_imrope",
+            "resolved_contract": {
+                "function": "mrope_qk_text_imrope",
+                "kernel_id": "mrope_qk_text_imrope",
+                "semantics": {"operator_family": "text_mrope"},
+            },
+        }
+        ir = {"operations": [dict(operation), dict(operation)]}
+        self.assertEqual(
+            codegen_v8._resolved_text_mrope_function(ir),
+            "mrope_qk_text_imrope",
+        )
+
+    def test_multimodal_codegen_rejects_inconsistent_text_mrope_provider(self) -> None:
+        ir = {
+            "operations": [{
+                "op": "rope_qk",
+                "function": "mrope_qk_text",
+                "resolved_contract": {
+                    "function": "mrope_qk_text_imrope",
+                    "kernel_id": "mrope_qk_text_imrope",
+                    "semantics": {"operator_family": "text_mrope"},
+                },
+            }]
+        }
+        with self.assertRaisesRegex(RuntimeError, "does not match"):
+            codegen_v8._resolved_text_mrope_function(ir)
+
+    def test_builtin_qwen3vl_template_uses_interleaved_text_mrope(self) -> None:
         doc = build_ir_v8._load_builtin_template_doc("qwen3vl")
         self.assertIsNotNone(doc)
         self.assertEqual(doc["contract"]["attention_contract"]["rope_layout"], "multi_section_1d")
-        self.assertEqual(doc["kernels"]["rope_qk"], "mrope_qk_text")
+        self.assertEqual(doc["kernels"]["rope_qk"], "mrope_qk_text_imrope")
 
     def test_qwen2_decode_uses_contracted_q8_kernels(self) -> None:
         manifest = _make_qwen2_decoder_manifest()
@@ -249,7 +281,7 @@ class V8CodegenBridgeTests(unittest.TestCase):
         self.assertEqual(by_op["mlp_gate_up"][0]["kernel"], "gemv_q5_0_q8_0")
         self.assertEqual(by_op["mlp_down"][0]["kernel"], "gemv_q6_k_q8_k")
 
-    def test_qwen3vl_decode_uses_text_mrope_kernel(self) -> None:
+    def test_qwen3vl_decode_uses_interleaved_text_mrope_kernel(self) -> None:
         manifest = _make_qwen3vl_decoder_manifest()
 
         ir1_ops = build_ir_v8.build_ir1_direct(
@@ -262,7 +294,7 @@ class V8CodegenBridgeTests(unittest.TestCase):
         for ir_op in ir1_ops:
             by_op.setdefault(ir_op["op"], []).append(ir_op)
 
-        self.assertEqual(by_op["rope_qk"][0]["kernel"], "mrope_qk_text")
+        self.assertEqual(by_op["rope_qk"][0]["kernel"], "mrope_qk_text_imrope")
         self.assertEqual(by_op["attn"][0]["kernel"], "attention_forward_decode_head_major_gqa_flash_f16cache")
         self.assertEqual(
             by_op["q_proj"][0]["resolved_execution"]["implementation"]["threading"]["runtime"],
@@ -325,7 +357,7 @@ class V8CodegenBridgeTests(unittest.TestCase):
             mlp_down_call = next(op for op in call_doc["operations"] if op["op"] == "mlp_down")
             kv_store_call = next(op for op in call_doc["operations"] if op["op"] == "kv_cache_store")
             kv_buf = next(buf for buf in layout_doc["memory"]["activations"]["buffers"] if buf["name"] == "kv_cache")
-            self.assertEqual(rope_call["function"], "mrope_qk_text")
+            self.assertEqual(rope_call["function"], "mrope_qk_text_imrope")
             self.assertEqual(attn_call["function"], "attention_forward_decode_head_major_gqa_flash_f16cache")
             self.assertEqual(kv_store_call["function"], "kv_cache_store_f16")
             self.assertEqual(kv_buf["dtype"], "fp16")
@@ -383,6 +415,7 @@ class V8CodegenBridgeTests(unittest.TestCase):
             decode_lowered = tmp / "lowered_decode.json"
             decode_call = tmp / "call_decode.json"
             c_path = tmp / "decoder_v8_qwen3vl_bridge.c"
+            prefill_only_c_path = tmp / "decoder_v8_qwen3vl_prefill_only.c"
 
             manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
@@ -429,30 +462,88 @@ class V8CodegenBridgeTests(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, msg=result.stderr)
 
+            # The bridge runner also builds a prefill-only shared object. Call
+            # IR must not leak the range function's local prefill_start_pos
+            # variable into the generated fallback decode function.
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(V8_CODEGEN_PATH),
+                    "--ir",
+                    str(prefill_call),
+                    "--layout",
+                    str(prefill_layout),
+                    "--output",
+                    str(prefill_only_c_path),
+                ],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            result = subprocess.run(
+                [
+                    "cc",
+                    "-fsyntax-only",
+                    "-fopenmp",
+                    "-Iinclude",
+                    "-Iversion/v8/src",
+                    str(prefill_only_c_path),
+                ],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            prefill_doc = json.loads(prefill_call.read_text(encoding="utf-8"))
+            prefill_ops = list(prefill_doc.get("operations") or [])
+            cache_copy_idx = next(
+                i for i, op in enumerate(prefill_ops) if op.get("op") == "kv_cache_batch_copy"
+            )
+            append_attn_idx = next(
+                i
+                for i, op in enumerate(prefill_ops)
+                if op.get("function")
+                == "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract"
+            )
+            self.assertLess(cache_copy_idx, append_attn_idx)
+            append_args = prefill_ops[append_attn_idx].get("args", [])
+            self.assertTrue(
+                any(
+                    arg.get("name") == "past_tokens"
+                    and arg.get("source") == "runtime:prefill_start_pos"
+                    and arg.get("expr") == "model->pos"
+                    for arg in append_args
+                )
+            )
+
             text = c_path.read_text(encoding="utf-8")
             self.assertIn("CK_EXPORT int ck_model_write_embeddings_ex", text)
             self.assertIn("CK_EXPORT int ck_model_forward_segments_grid_ex", text)
             self.assertIn("CK_EXPORT int ck_model_forward_mixed_ex", text)
             self.assertIn("CK_EXPORT int ck_model_forward_mixed_grid_ex", text)
             self.assertIn("if (prefix_grid_x > 0 && prefix_grid_y > 0 && prefix_grid_x * prefix_grid_y != prefix_tokens) return -10;", text)
-            self.assertIn("ck_qwen3vl_prefill_bridge_prepare", text)
-            self.assertIn("ck_qwen3vl_prefill_mrope_qk", text)
+            self.assertIn("ck_multimodal_prefill_bridge_prepare", text)
+            self.assertIn("ck_multimodal_prefill_mrope_qk", text)
             self.assertIn("mrope_qk_imrope_positions", text)
-            self.assertIn("ck_qwen3vl_prefill_deepstack_add(CKModel *model, int layer, int num_tokens)", text)
-            self.assertIn("ck_qwen3vl_prefill_deepstack_add(model, 0, num_tokens);", text)
+            self.assertIn("ck_multimodal_prefill_deepstack_add(CKModel *model, int layer, int num_tokens)", text)
+            self.assertIn("ck_multimodal_prefill_deepstack_add(model, 0, num_tokens);", text)
             self.assertIn("else if (debug_mlp_down_fp32 && ck_debug_mlp_down_fp32_input != NULL) {", text)
             self.assertIn("gemm_nt_q6_k(\n            ck_debug_mlp_down_fp32_input,", text)
             self.assertIn("gemm_nt_q6_k_q8_k(\n            (const void*)(model->bump + A_LAYER_INPUT),", text)
-            self.assertIn('const char *bridge_fp32_env = getenv("CK_V8_QWEN3VL_PREFILL_FP32");', text)
+            self.assertIn('const char *bridge_fp32_env = getenv("CK_V8_MULTIMODAL_PREFILL_FP32");', text)
             self.assertIn("int bridge_force_fp32 = bridge_fp32_env ? (atoi(bridge_fp32_env) != 0) : 0;", text)
-            self.assertIn("if (ck_qwen3vl_prefill_bridge_is_active() && bridge_force_fp32) {", text)
+            self.assertIn("if (ck_multimodal_prefill_bridge_is_active() && bridge_force_fp32) {", text)
             self.assertIn("debug_outproj_fp32 = 1;", text)
             self.assertIn("debug_mlp_down_fp32 = 1;", text)
-            self.assertIn("g_qwen3vl_prefill_total_tokens = total_tokens;", text)
-            self.assertIn("g_qwen3vl_prefill_prefix_start = prefix_start;", text)
-            self.assertIn("g_qwen3vl_prefill_prefix_tokens = prefix_tokens;", text)
-            self.assertIn("int rc = ck_embed_tokens_at(g_model, tokens_after, tokens_after_count, tokens_before_count + prefix_tokens);", text)
-            self.assertIn("ck_prefill_from_embedded(g_model, total_tokens);", text)
+            self.assertIn("g_multimodal_prefill_total_tokens = total_tokens;", text)
+            self.assertIn("g_multimodal_prefill_prefix_start = prefix_start;", text)
+            self.assertIn("g_multimodal_prefill_prefix_tokens = prefix_tokens;", text)
+            self.assertIn("int rc = ck_embed_tokens_at(g_model, tokens_after, tokens_after_count, 0);", text)
+            self.assertIn("ck_prefill_from_embedded_range(g_model, tokens_before_count, 0);", text)
+            self.assertIn("ck_prefill_from_embedded_range(g_model, prefix_tokens, tokens_before_count);", text)
+            self.assertIn("ck_prefill_from_embedded_range(g_model, tokens_after_count, tokens_before_count + prefix_tokens);", text)
             self.assertIn("uint16_t *kv_cache = (uint16_t*)model->kv_cache_f16;", text)
             self.assertIn("ck_fp32_to_fp16_soft(ks[d])", text)
             self.assertIn("ck_fp32_to_fp16_soft(vs[d])", text)
@@ -532,11 +623,11 @@ class V8CodegenBridgeTests(unittest.TestCase):
             self.assertIn("static void ck_prefill_from_embedded", text)
             self.assertIn("CK_EXPORT int ck_model_forward_segments_grid_ex", text)
             self.assertIn("CK_EXPORT int ck_model_forward_mixed_grid_ex", text)
-            self.assertIn("ck_qwen3vl_prefill_bridge_prepare", text)
-            self.assertIn("ck_qwen3vl_prefill_bridge_next_text_pos", text)
-            self.assertIn("ck_qwen3vl_prefill_mrope_qk", text)
+            self.assertIn("ck_multimodal_prefill_bridge_prepare", text)
+            self.assertIn("ck_multimodal_prefill_bridge_next_text_pos", text)
+            self.assertIn("ck_multimodal_prefill_mrope_qk", text)
             self.assertIn("mrope_qk_imrope_positions", text)
-            self.assertIn("ck_qwen3vl_prefill_deepstack_add(model, 0, num_tokens);", text)
+            self.assertIn("ck_multimodal_prefill_deepstack_add(model, 0, num_tokens);", text)
             self.assertIn("static void ck_decode_embedded(CKModel *model)", text)
             self.assertIn("static int ck_bridge_forward_staged", text)
             self.assertIn("g_bridge_deepstack_slices", text)
@@ -643,7 +734,7 @@ class V8CodegenBridgeTests(unittest.TestCase):
 
             text = c_path.read_text(encoding="utf-8")
             self.assertIn("#ifdef CK_PARITY_DUMP", text)
-            self.assertIn("ck_qwen3vl_prefill_deepstack_add(model, 0, num_tokens);", text)
+            self.assertIn("ck_multimodal_prefill_deepstack_add(model, 0, num_tokens);", text)
             self.assertNotIn("g_bridge_deepstack_slices + 0", text)
 
     def test_decoder_codegen_with_prefill_emits_multimodal_bridge_api(self) -> None:
@@ -790,10 +881,10 @@ class V8CodegenBridgeTests(unittest.TestCase):
             self.assertNotIn("vocab_size * sizeof(float)", text)
             self.assertIn("transpose_v_to_head_major layer=0", text)
             self.assertIn("float *buf = (float*)(model->bump + A_V_SCRATCH);", text)
-            self.assertIn("ck_qwen3vl_prefill_bridge_prepare", text)
-            self.assertIn("ck_qwen3vl_prefill_bridge_next_text_pos", text)
-            self.assertIn("model->rope_pos = ck_qwen3vl_prefill_bridge_is_active() ? ck_qwen3vl_prefill_bridge_next_text_pos() : num_tokens;", text)
-            self.assertIn("ck_prefill_from_embedded(g_model, total_tokens);", text)
+            self.assertIn("ck_multimodal_prefill_bridge_prepare", text)
+            self.assertIn("ck_multimodal_prefill_bridge_next_text_pos", text)
+            self.assertIn("model->rope_pos = ck_multimodal_prefill_bridge_is_active() ? ck_multimodal_prefill_bridge_next_text_pos() : prefill_rope_start_pos + num_tokens;", text)
+            self.assertIn("ck_prefill_from_embedded_range(g_model, prefix_tokens, tokens_before_count);", text)
             self.assertIn("ck_decode(g_model, tokens[i]);", text)
 
     def test_decoder_parity_dump_emits_decode_attention_kqv_dump(self) -> None:

--- a/tests/test_v8_dsl_policy.py
+++ b/tests/test_v8_dsl_policy.py
@@ -60,7 +60,10 @@ def lower():
 
     def test_model_literal_site_limit_is_fail_closed(self) -> None:
         policy = json.loads(audit.DEFAULT_POLICY.read_text(encoding="utf-8"))
-        policy["model_literal_site_limits"]["version/v8/scripts/codegen_v8.py"] = 4
+        relative_path = "version/v8/scripts/codegen_prefill_v8.py"
+        current = audit.audit()["model_literal_inventory"][relative_path]["sites"]
+        self.assertGreater(current, 0)
+        policy["model_literal_site_limits"][relative_path] = current - 1
         with tempfile.TemporaryDirectory() as temp:
             path = pathlib.Path(temp) / "policy.json"
             path.write_text(json.dumps(policy), encoding="utf-8")

--- a/tests/test_v8_kernel_call_abi.py
+++ b/tests/test_v8_kernel_call_abi.py
@@ -52,12 +52,12 @@ class V8KernelCallABITests(unittest.TestCase):
                     key=lambda error: tuple(str(part) for part in error.absolute_path),
                 )
                 self.assertEqual(errors, [])
-        self.assertEqual(governed, 28)
+        self.assertEqual(governed, 34)
 
     def test_map_owned_abis_do_not_exist_in_legacy_registries(self) -> None:
         call_abis = build_ir_v8.load_kernel_call_abis()
         legacy = build_ir_v8.load_kernel_bindings()
-        self.assertEqual(len(call_abis), 28)
+        self.assertEqual(len(call_abis), 34)
         for kernel_id, entry in call_abis.items():
             with self.subTest(kernel=kernel_id):
                 self.assertNotIn(kernel_id, legacy)

--- a/tests/test_v8_multitoken_eos_contract.py
+++ b/tests/test_v8_multitoken_eos_contract.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import tempfile
 import unittest
 from argparse import Namespace
 from pathlib import Path
@@ -47,6 +49,53 @@ class MultitokenEOSContractTests(unittest.TestCase):
         self.assertFalse(self.runner._is_matched_stop_token(151645, 4, stops))
         self.assertFalse(self.runner._is_matched_stop_token(4, 4, stops))
 
+    def test_exact_runtime_reuse_loads_only_declared_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            decoder_dir = Path(tmp)
+            (decoder_dir / "layout_decode.json").write_text(
+                json.dumps(
+                    {
+                        "config": {
+                            "embed_dim": 4096,
+                            "num_deepstack_layers": 3,
+                            "context_length": 4096,
+                            "vocab_size": 151936,
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            for name in ("weights.bump", "weights_manifest.map", "libdecoder_v8.so"):
+                (decoder_dir / name).touch()
+
+            runtime = self.runner._load_exact_decoder_runtime(
+                Path("decoder.gguf"),
+                decoder_dir,
+                so_override=None,
+                manifest_map_override=None,
+            )
+
+            self.assertEqual(runtime["embed_dim"], 4096)
+            self.assertEqual(runtime["input_embed_dim"], 16384)
+            self.assertEqual(runtime["context_length"], 4096)
+            self.assertEqual(runtime["so_path"], decoder_dir / "libdecoder_v8.so")
+            evidence = self.runner._runtime_evidence(runtime, exact_reuse=True)
+            self.assertTrue(evidence["exact_reuse"])
+            self.assertEqual(
+                evidence["shared_library"]["sha256"],
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+
+    def test_exact_runtime_reuse_fails_instead_of_regenerating(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(FileNotFoundError, "refusing to regenerate or guess"):
+                self.runner._load_exact_decoder_runtime(
+                    Path("decoder.gguf"),
+                    Path(tmp),
+                    so_override=None,
+                    manifest_map_override=None,
+                )
+
     def test_runner_records_eos_step_without_decoding_past_it(self) -> None:
         class Tokenizer:
             def decode(self, tokens, skip_special=False):
@@ -78,6 +127,7 @@ class MultitokenEOSContractTests(unittest.TestCase):
             "prefix_path": Path("prefix.f32"),
             "prefix_grid": (36, 28),
             "prefix_text_pos": 41,
+            "runtime": {},
         }
         comparison = {
             "top1_ck": 151645,
@@ -112,6 +162,7 @@ class MultitokenEOSContractTests(unittest.TestCase):
              mock.patch.object(self.runner, "_run_llama_greedy_sequence", return_value=llama_sequence), \
              mock.patch.object(self.runner, "_init_ck_state", return_value=(library, object(), 3)), \
              mock.patch.object(self.runner, "_ck_logits_from_buffer", return_value=np.zeros(3, dtype=np.float32)), \
+             mock.patch.object(self.runner, "_runtime_evidence", return_value={}), \
              mock.patch.object(self.runner.first_token.compare_first_token_logits_v7, "compare_logits", return_value=comparison), \
              mock.patch.object(self.runner, "_decode_topk", return_value=[]):
             report = self.runner.run_multimodal_multitoken_parity(args)

--- a/tests/test_v8_numerical_execution_contracts.py
+++ b/tests/test_v8_numerical_execution_contracts.py
@@ -197,6 +197,28 @@ class NumericalExecutionContractTests(unittest.TestCase):
         )
         self.assertEqual(plan["kernel"]["id"], "mrope_qk_vision_bf16_storage")
         self.assertEqual(plan["kernel"]["function"], "mrope_qk_vision_bf16_storage")
+
+    def test_qwen35_circuit_resolves_partial_width_text_mrope(self):
+        circuit_doc = resolver.load_json(
+            ROOT / "version" / "v8" / "circuits" / "qwen35.json"
+        )
+        plan = resolver.resolve_contract(
+            circuit_doc,
+            self.contracts,
+            self.kernels,
+            "decoder.mrope",
+            "prefill",
+            mode="production",
+        )
+        self.assertEqual(
+            plan["contract"]["id"],
+            "text_mrope_fp32_input_fp32_compute_fp32_output",
+        )
+        self.assertEqual(plan["kernel"]["id"], "mrope_qk_text")
+        self.assertEqual(plan["kernel"]["function"], "mrope_qk_text")
+        position = plan["contract"]["semantics"]["position_transform"]
+        self.assertEqual(position["rotary_width"], "configured_rotary_dim")
+        self.assertEqual(position["position_rank"], 4)
         self.assertEqual(plan["template_ops"], ["rope_qk"])
 
     def test_unsupported_mrope_storage_contract_hard_fails(self):
@@ -296,6 +318,25 @@ class NumericalExecutionContractTests(unittest.TestCase):
         contracts["contracts"]["qwen_mrope_invalid"] = base
         with self.assertRaisesRegex(resolver.ContractError, "redefines rotary width"):
             resolver.validate_contract_registry(contracts)
+
+    def test_multisection_rope_accepts_interleaved_axis_selection(self):
+        contracts = copy.deepcopy(self.contracts)
+        base = copy.deepcopy(contracts["contracts"][CONTRACT_ID])
+        base["operator_family"] = "text_mrope"
+        base["position_transform"] = {
+            "pairing": "multi_section",
+            "rotary_width": "mrope_n_dims",
+            "head_width": "head_dim",
+            "position_rank": 4,
+            "axis_order": ["temporal", "height", "width", "reserved"],
+            "section_interpretation": "interleaved_axis_selection",
+            "frequency_compute": "fp32",
+            "intermediate_compute": "fp32",
+            "rounding_points": [],
+            "threading": "serial",
+        }
+        contracts["contracts"]["qwen_text_imrope"] = base
+        resolver.validate_contract_registry(contracts)
 
     def test_mrope_width_must_match_full_rotary_width(self):
         contracts = copy.deepcopy(self.contracts)

--- a/tests/test_v8_qwen3vl_template.py
+++ b/tests/test_v8_qwen3vl_template.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import copy
 import importlib.util
 import io
 import json
@@ -193,6 +194,41 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
                 else:
                     self.assertEqual(mrope["kernel"], "mrope_qk_vision")
 
+            generated_c = root / "qwen3vl_vision.c"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(V8_CODEGEN_PATH),
+                    "--ir",
+                    str(paths["call"]),
+                    "--layout",
+                    str(paths["layout"]),
+                    "--output",
+                    str(generated_c),
+                ],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            generated = generated_c.read_text(encoding="utf-8")
+            self.assertIn("mrope_qk_vision(", generated)
+            self.assertNotIn("ck_multimodal_prefill_mrope_qk", generated)
+            result = subprocess.run(
+                [
+                    "cc",
+                    "-fsyntax-only",
+                    "-fopenmp",
+                    "-Iinclude",
+                    "-Iversion/v8/src",
+                    str(generated_c),
+                ],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
     def test_vision_mrope_classification_uses_semantics_not_kernel_name(self) -> None:
         operation = {
             "op": "rope_qk",
@@ -260,13 +296,19 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
 
             self.assertEqual(without_contract_metadata(contracted), without_contract_metadata(legacy))
 
-            expected_kernel = "attention_forward_full_head_major_gqa_flash_strided"
+            expected_kernel = "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided"
             for artifact in ("ir1", "lowered", "call"):
                 doc = contracted[artifact]
                 operations = doc if isinstance(doc, list) else doc.get("operations", doc.get("ops", []))
                 attn = next(item for item in operations if item.get("op") == "attn")
-                self.assertEqual(attn["required_contract"]["numerics.attention_reduction"], "f16_kv_fp32_online")
-                self.assertEqual(attn["resolved_contract"]["contract_id"], "f16_kv_fp32_online")
+                self.assertEqual(
+                    attn["required_contract"]["numerics.attention_reduction"],
+                    "f16_kv_tiled64_fp32_softmax_fp64_sum_update",
+                )
+                self.assertEqual(
+                    attn["resolved_contract"]["contract_id"],
+                    "f16_kv_tiled64_fp32_softmax_fp64_sum_update",
+                )
                 self.assertEqual(attn["resolved_contract"]["kernel_id"], expected_kernel)
                 if artifact == "call":
                     self.assertEqual(attn["function"], expected_kernel)
@@ -423,6 +465,14 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
         self.assertEqual(bridge["cache_policy"], "persistent_decoder_kv")
         self.assertEqual(bridge["runtime_policy"], "decode_staged")
         self.assertEqual(
+            bridge["prefill_schedule"],
+            {
+                "segments": ["text_before", "visual", "text_after"],
+                "cache_transition": "append_preserve",
+                "position_transition": "segment_defined",
+            },
+        )
+        self.assertEqual(
             run_multimodal_bridge_v8._bridge_runtime_from_policy(bridge),
             "decode-staged",
         )
@@ -440,6 +490,56 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             run_multimodal_bridge_v8._bridge_generation_mode_from_policy({}, fallback="mixed-replay"),
             "mixed-replay",
         )
+
+    def test_cached_manifest_refreshes_circuit_without_rewriting_weights(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            scripts = root / "scripts"
+            circuits = root / "circuits"
+            scripts.mkdir()
+            circuits.mkdir()
+            current = {"name": "fixture", "version": 2, "contract": {"mode": "current"}}
+            (circuits / "fixture.json").write_text(json.dumps(current), encoding="utf-8")
+            manifest_path = root / "weights_manifest.json"
+            manifest = {"template": {"name": "fixture", "version": 1}}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            with mock.patch.object(run_multimodal_bridge_v8, "SCRIPT_DIR", scripts):
+                refreshed = run_multimodal_bridge_v8._refresh_manifest_circuit_snapshot(
+                    manifest,
+                    manifest_path,
+                )
+
+            self.assertEqual(refreshed["template"], current)
+            self.assertEqual(
+                json.loads(manifest_path.read_text(encoding="utf-8"))["template"],
+                current,
+            )
+
+    def test_segmented_prefill_schedule_and_attention_requirement_are_atomic(self) -> None:
+        circuit = build_ir_v8._load_builtin_template_doc("qwen3vl")
+        self.assertIsNotNone(circuit)
+        build_ir_v8._validate_segmented_prefill_contract(circuit, source="test:qwen3vl")
+
+        missing_attention = copy.deepcopy(circuit)
+        del missing_attention["required_contracts"]["decoder.attention"]["phases"][
+            "prefill"
+        ]["requires"]["execution.prefill_batching"]
+        with self.assertRaisesRegex(RuntimeError, "schedule and attention provider disagree"):
+            build_ir_v8._validate_segmented_prefill_contract(
+                missing_attention,
+                source="test:missing-attention",
+            )
+
+        malformed_schedule = copy.deepcopy(circuit)
+        malformed_schedule["contract"]["multimodal_bridge"]["prefill_schedule"][
+            "segments"
+        ] = ["visual", "text_after"]
+        with self.assertRaisesRegex(RuntimeError, "unsupported mixed-prefill schedule"):
+            build_ir_v8._validate_segmented_prefill_contract(
+                malformed_schedule,
+                source="test:malformed-schedule",
+            )
 
     def test_builtin_template_declares_qwen3vl_vision_contract(self) -> None:
         doc = build_ir_v8._load_builtin_template_doc("qwen3_vl_vision")
@@ -551,7 +651,10 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
         legacy = build_ir_v8._resolve_manifest_numerical_contracts(manifest, "prefill")
         execution = build_ir_v8._resolve_manifest_execution_contracts(manifest, "prefill")
         self.assertEqual(len(legacy), 1)
-        self.assertEqual(legacy[0]["kernel"]["function"], "attention_forward_full_head_major_gqa_flash_strided")
+        self.assertEqual(
+            legacy[0]["kernel"]["function"],
+            "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+        )
         self.assertNotIn("vision.layer.attention", {plan["operation"] for plan in execution})
 
     def test_template_dtype_metadata_is_rejected(self) -> None:
@@ -777,7 +880,10 @@ class V8Qwen3VLTemplateTests(unittest.TestCase):
             self.assertEqual(qkv_packed_proj.get("function"), "gemm_nt_q8_0_q8_0_contract")
             self.assertNotIn("quantize_input_0", [op.get("op") for op in call_ops])
             attn = next(op for op in call_ops if op.get("op") == "attn")
-            self.assertEqual(attn.get("function"), "attention_forward_full_head_major_gqa_flash_strided")
+            self.assertEqual(
+                attn.get("function"),
+                "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+            )
             attn_idx = next(i for i, op in enumerate(call_ops) if op.get("op") == "attn")
             transpose_idx = next(i for i, op in enumerate(call_ops) if op.get("op") == "transpose_attn_out_to_token_major")
             out_proj_idx = next(i for i, op in enumerate(call_ops) if op.get("op") == "out_proj")

--- a/tests/test_v8_xray_vision_interface.py
+++ b/tests/test_v8_xray_vision_interface.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -57,6 +58,7 @@ class XRayVisionInterfaceTests(unittest.TestCase):
                 {"layer": 0, "op": "Kcur_rope", "status": "FAIL", "max_abs_diff": 0.2},
                 {"layer": 0, "op": "q_proj", "status": "FAIL", "max_abs_diff": 0.1},
                 {"layer": 0, "op": "ln1", "status": "PASS", "max_abs_diff": 0.0},
+                {"layer": -1, "op": "patch_bias", "status": "PASS", "max_abs_diff": 0.0},
                 {"layer": -1, "op": "inp_pos_emb", "status": "PASS", "max_abs_diff": 0.0},
             ]
         }
@@ -72,6 +74,7 @@ class XRayVisionInterfaceTests(unittest.TestCase):
         profile = xray.load_json(PROFILE)
         report = {
             "results": [
+                {"layer": -1, "op": "patch_bias", "status": "PASS", "max_abs_diff": 0.0},
                 {"layer": -1, "op": "inp_pos_emb", "status": "PASS", "max_abs_diff": 0.0},
                 {"layer": 0, "op": "ln1", "status": "PASS", "max_abs_diff": 0.0},
                 {"layer": 0, "op": "q_proj", "status": "PASS", "max_abs_diff": 0.0},
@@ -100,8 +103,8 @@ class XRayVisionInterfaceTests(unittest.TestCase):
         base = {
             "gguf": Path("model.gguf"),
             "output_dir": Path("out"),
-            "threads": 20,
-            "ck_threads": None,
+            "threads": 1,
+            "ck_threads": 20,
             "layer": 0,
             "image": None,
             "image_mode": "gradient",
@@ -118,6 +121,49 @@ class XRayVisionInterfaceTests(unittest.TestCase):
         self.assertNotIn("--strict-parity", production)
         self.assertEqual(strict[strict.index("--llama-flash-attn") + 1], "disabled")
         self.assertEqual(production[production.index("--llama-flash-attn") + 1], "enabled")
+        self.assertEqual(strict[strict.index("--ck-dump-layer") + 1], "0")
+        self.assertEqual(strict[strict.index("--threads") + 1], "1")
+        self.assertEqual(strict[strict.index("--ck-threads") + 1], "20")
+
+    def test_exact_llama_oracle_rejects_multiple_threads(self) -> None:
+        args = argparse.Namespace(threads=20, allow_nondeterministic_oracle=False)
+        with self.assertRaisesRegex(RuntimeError, "requires --threads 1"):
+            llama._validate_oracle_execution(args)
+
+    def test_nondeterministic_llama_oracle_requires_explicit_opt_in(self) -> None:
+        args = argparse.Namespace(threads=20, allow_nondeterministic_oracle=True)
+        result = llama._validate_oracle_execution(args)
+        self.assertFalse(result["deterministic"])
+        self.assertTrue(result["nondeterministic_opt_in"])
+
+    def test_ck_capture_is_bounded_to_global_and_requested_layer(self) -> None:
+        observed: dict[str, str | None] = {}
+
+        def capture_environment(**_kwargs) -> None:
+            observed["layer_filter"] = os.environ.get("CK_PARITY_LAYER_FILTER")
+
+        with tempfile.TemporaryDirectory(prefix="cke_xray_layer_filter_") as td:
+            with mock.patch.object(
+                llama.capture_adapter.npv8,
+                "_run_generated_encoder",
+                side_effect=capture_environment,
+            ):
+                llama.capture_adapter._run_generated_encoder_with_dump(
+                    model_so=Path("model.so"),
+                    weights_bump=Path("weights.bump"),
+                    manifest_map=Path("weights.map"),
+                    layout_path=Path("layout.json"),
+                    planar_image=[],
+                    dump_dir=Path(td),
+                    strict_parity=False,
+                    strict_dump_layer=None,
+                    dump_layer=26,
+                    ck_stop_op=None,
+                    dump_names="ln1,layer_out",
+                )
+
+        self.assertEqual(observed["layer_filter"], "-1,26")
+        self.assertNotIn("CK_PARITY_LAYER_FILTER", os.environ)
 
     def test_capture_adapter_is_documented_as_internal_to_xray(self) -> None:
         source = (SCRIPTS / "activation_parity_qwen3vl_mmproj_v8.py").read_text(encoding="utf-8")

--- a/unittest/test_attention_f16_split_kv.py
+++ b/unittest/test_attention_f16_split_kv.py
@@ -39,6 +39,12 @@ lib.attention_forward_decode_head_major_gqa_flash_f16cache_contract.argtypes = (
     _LEGACY_ARGS + [ctypes.c_int]
 )
 lib.attention_forward_decode_head_major_gqa_flash_f16cache_contract.restype = ctypes.c_int
+lib.attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.argtypes = [
+    _FLOAT_P, _U16_P, _U16_P, _FLOAT_P,
+    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+]
+lib.attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.restype = ctypes.c_int
 lib.ck_get_num_threads.argtypes = []
 lib.ck_get_num_threads.restype = ctypes.c_int
 lib.ck_set_strict_parity.argtypes = [ctypes.c_int]
@@ -437,6 +443,40 @@ def _run_contract(q, k, v, head_dim, reduction, fill=np.nan):
     return status, out
 
 
+def _prefill_append_matches_decode_loop_case():
+    heads, kv_heads, q_tokens, past_tokens = 4, 2, 3, 5
+    capacity, head_dim, aligned = 16, 8, 8
+    rng = np.random.default_rng(7003)
+    q = np.ascontiguousarray(rng.standard_normal((heads, q_tokens, aligned), dtype=np.float32))
+    k = _half_bits(rng.standard_normal((kv_heads, capacity, aligned), dtype=np.float32))
+    v = _half_bits(rng.standard_normal((kv_heads, capacity, aligned), dtype=np.float32))
+    actual = np.zeros_like(q)
+    status = lib.attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(
+        _f32_ptr(q), _u16_ptr(k), _u16_ptr(v), _f32_ptr(actual),
+        heads, kv_heads, q_tokens, past_tokens, capacity, head_dim, aligned, 1,
+    )
+    expected = np.zeros_like(q)
+    for token in range(q_tokens):
+        q_token = np.ascontiguousarray(q[:, token, :])
+        out_token = np.zeros((heads, aligned), dtype=np.float32)
+        token_status = lib.attention_forward_decode_head_major_gqa_flash_f16cache_contract(
+            _f32_ptr(q_token), _u16_ptr(k), _u16_ptr(v), _f32_ptr(out_token),
+            heads, kv_heads, past_tokens + token + 1, capacity,
+            head_dim, aligned, 1,
+        )
+        if token_status != 0:
+            status = token_status
+            break
+        expected[:, token, :] = out_token
+    diff = float(np.max(np.abs(actual - expected)))
+    return Result(
+        "prefill_append_matches_decode_loop",
+        diff if status == 0 else float("inf"),
+        0.0,
+        status == 0 and np.array_equal(actual, expected),
+    )
+
+
 @dataclass
 class Result:
     name: str
@@ -465,6 +505,7 @@ def _case(name, seed, heads, kv_heads, kv_tokens, head_dim, aligned, chunks, tol
 
 def main():
     results = []
+    results.append(_prefill_append_matches_decode_loop_case())
     results.append(_unfused_f16_causal_case())
     below, below_data = _case(
         "f16_split_below_threshold(KV=511,C=1)", 511, 8, 2, 511, 64, 64, 1, 2.0e-5,

--- a/unittest/test_attention_full.py
+++ b/unittest/test_attention_full.py
@@ -45,6 +45,20 @@ lib.attention_forward_full_head_major_gqa_flash_strided.argtypes = [
 ]
 lib.attention_forward_full_head_major_gqa_flash_strided.restype = None
 
+lib.attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided.argtypes = [
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+]
+lib.attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided.restype = None
+
 lib.attention_forward_full_head_major_gqa_exact_strided.argtypes = [
     ctypes.POINTER(ctypes.c_float),  # q
     ctypes.POINTER(ctypes.c_float),  # k
@@ -259,6 +273,43 @@ class TestAttentionFull(unittest.TestCase):
         )
         diff = max_diff(torch.from_numpy(out), ref)
         self.assertLessEqual(diff, 5e-5)
+
+    def test_full_tiled_f16kv_contract_qwen3vl_multi_tile(self) -> None:
+        """Exercise the contract-selected 64x64 path across key/query tiles."""
+        rng = np.random.default_rng(29)
+        heads = 16
+        kv_heads = 16
+        tokens = 129
+        head_dim = 72
+        stride_tokens = 137
+
+        q = rng.standard_normal((heads, tokens, head_dim), dtype=np.float32)
+        k = np.zeros((kv_heads, stride_tokens, head_dim), dtype=np.float32)
+        v = np.zeros_like(k)
+        k[:, :tokens] = rng.standard_normal((kv_heads, tokens, head_dim), dtype=np.float32)
+        v[:, :tokens] = rng.standard_normal((kv_heads, tokens, head_dim), dtype=np.float32)
+        out = np.zeros_like(q)
+        repeated = np.zeros_like(q)
+
+        args = (
+            numpy_to_ptr(q), numpy_to_ptr(k), numpy_to_ptr(v),
+            ctypes.c_int(heads), ctypes.c_int(kv_heads), ctypes.c_int(tokens),
+            ctypes.c_int(head_dim), ctypes.c_int(head_dim), ctypes.c_int(stride_tokens),
+        )
+        lib.attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided(
+            args[0], args[1], args[2], numpy_to_ptr(out), *args[3:]
+        )
+        lib.attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided(
+            args[0], args[1], args[2], numpy_to_ptr(repeated), *args[3:]
+        )
+
+        ref = full_attention_reference_kv_f16(
+            torch.from_numpy(q.copy()),
+            torch.from_numpy(k[:, :tokens].copy()),
+            torch.from_numpy(v[:, :tokens].copy()),
+        )
+        self.assertTrue(np.array_equal(out.view(np.uint32), repeated.view(np.uint32)))
+        self.assertLessEqual(max_diff(torch.from_numpy(out), ref), 5e-5)
 
     def test_full_exact_strided_matches_pytorch_reference(self) -> None:
         lib.attention_forward_full_head_major_gqa_exact_strided(

--- a/unittest/test_f16_gemm_llama_contract.py
+++ b/unittest/test_f16_gemm_llama_contract.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Production F16 GEMM parity against llama.cpp's actual mul_mat graph."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD = ROOT / os.environ.get("CK_BUILD_DIR", "build")
+LLAMA_ROOT = Path(os.environ.get("CK_LLAMA_CPP_ROOT", ROOT / "llama.cpp"))
+LLAMA_BIN = LLAMA_ROOT / "build" / "bin"
+M, N, K = 17, 288, 4304
+
+
+def _load() -> ctypes.CDLL:
+    for name in ("libggml-base.so", "libggml.so", "libggml-cpu.so"):
+        path = LLAMA_BIN / name
+        if not path.exists():
+            raise RuntimeError(f"missing llama.cpp library: {path}")
+        ctypes.CDLL(str(path), mode=ctypes.RTLD_GLOBAL)
+    ck_path = BUILD / "libckernel_engine.so"
+    if not ck_path.exists():
+        raise RuntimeError(f"missing CK library: {ck_path}")
+    ck = ctypes.CDLL(str(ck_path), mode=ctypes.RTLD_GLOBAL)
+    ck.ck_set_strict_parity.argtypes = [ctypes.c_int]
+    ck.gemm_nt_f16.argtypes = [
+        ctypes.POINTER(ctypes.c_float), ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+        ctypes.c_int, ctypes.c_int, ctypes.c_int,
+    ]
+    ck.ck_gemm_nt_f16_ggml_oracle.argtypes = ck.gemm_nt_f16.argtypes
+    ck.ck_gemm_nt_f16_ggml_oracle.restype = ctypes.c_int
+    return ck
+
+
+def _fixture() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    row = np.arange(M, dtype=np.float32)[:, None]
+    col = np.arange(K, dtype=np.float32)[None, :]
+    activation = (
+        np.sin(col * np.float32(0.013) + row * np.float32(0.17)) * np.float32(0.37)
+        + np.cos(col * np.float32(0.0031) - row * np.float32(0.11)) * np.float32(0.09)
+    ).astype(np.float32)
+    out = np.arange(N, dtype=np.float32)[:, None]
+    weights = (
+        np.sin(col * np.float32(0.007) + out * np.float32(0.019)) * np.float32(0.12)
+        + np.cos(col * np.float32(0.0023) - out * np.float32(0.023)) * np.float32(0.04)
+    ).astype(np.float16)
+    bias = (np.sin(np.arange(N, dtype=np.float32) * np.float32(0.021)) * np.float32(0.03)).astype(np.float32)
+    return np.ascontiguousarray(activation), np.ascontiguousarray(weights), bias
+
+
+def _run_production(ck: ctypes.CDLL, activation: np.ndarray, weights: np.ndarray,
+                    bias: np.ndarray | None) -> np.ndarray:
+    output = np.empty((M, N), dtype=np.float32)
+    ck.ck_set_strict_parity(0)
+    bias_ptr = (
+        bias.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+        if bias is not None else None
+    )
+    ck.gemm_nt_f16(
+        activation.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        ctypes.c_void_p(weights.ctypes.data),
+        bias_ptr,
+        output.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        M, N, K,
+    )
+    return output
+
+
+def _run_oracle(ck: ctypes.CDLL, activation: np.ndarray, weights: np.ndarray,
+                bias: np.ndarray | None) -> np.ndarray:
+    output = np.empty((M, N), dtype=np.float32)
+    bias_ptr = (
+        bias.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+        if bias is not None else None
+    )
+    ok = ck.ck_gemm_nt_f16_ggml_oracle(
+        activation.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        ctypes.c_void_p(weights.ctypes.data),
+        bias_ptr,
+        output.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        M, N, K,
+    )
+    if not ok:
+        raise RuntimeError("ggml F16 mul_mat oracle is unavailable; refusing CK fallback")
+    return output
+
+
+def _metrics(actual: np.ndarray, expected: np.ndarray) -> dict[str, object]:
+    delta = np.abs(actual.astype(np.float64) - expected.astype(np.float64))
+    return {
+        "bit_exact": bool(np.array_equal(actual, expected)),
+        "different_values": int(np.count_nonzero(actual != expected)),
+        "compared_values": int(actual.size),
+        "max_abs": float(np.max(delta, initial=0.0)),
+        "rmse": float(np.sqrt(np.mean(delta * delta))),
+    }
+
+
+def main() -> int:
+    ck = _load()
+    activation, weights, bias = _fixture()
+    oracle_no_bias = _run_oracle(ck, activation, weights, None)
+    production_no_bias = _run_production(ck, activation, weights, None)
+    oracle_bias = _run_oracle(ck, activation, weights, bias)
+    production_bias = _run_production(ck, activation, weights, bias)
+    repeat_bias = _run_production(ck, activation, weights, bias)
+
+    no_bias = _metrics(production_no_bias, oracle_no_bias)
+    with_bias = _metrics(production_bias, oracle_bias)
+    repeat = _metrics(repeat_bias, production_bias)
+    passed = bool(no_bias["bit_exact"] and with_bias["bit_exact"] and repeat["bit_exact"])
+    report = {
+        "schema": "cke.f16_gemm_llama_contract",
+        "schema_version": 1,
+        "status": "pass" if passed else "fail",
+        "shape": {"tokens": M, "outputs": N, "width": K},
+        "contract": {
+            "weight_storage": "fp16",
+            "activation_rounding": "fp16_rne_before_dot",
+            "accumulator": "fp32_simd_lanes",
+            "horizontal_reduction": "llamafile_avx_movehl_movehdup",
+            "output_storage": "fp32",
+        },
+        "before_bias": no_bias,
+        "after_bias": with_bias,
+        "thread_determinism": repeat,
+    }
+    print(json.dumps(report, indent=2))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unittest/test_gelu.py
+++ b/unittest/test_gelu.py
@@ -36,6 +36,12 @@ lib.gelu_exact_inplace.restype = None
 lib.gelu_ggml_inplace.argtypes = [ctypes.POINTER(ctypes.c_float), ctypes.c_size_t]
 lib.gelu_ggml_inplace.restype = None
 
+LLAMA_CPP_ROOT = Path(os.environ.get(
+    "CK_LLAMA_CPP_ROOT",
+    Path(__file__).resolve().parents[1] / "llama.cpp",
+))
+GGML_CPU_LIB = LLAMA_CPP_ROOT / "build" / "bin" / "libggml-cpu.so"
+
 lib.gelu_backward_exact.argtypes = [
     ctypes.POINTER(ctypes.c_float),  # input
     ctypes.POINTER(ctypes.c_float),  # d_output
@@ -64,7 +70,7 @@ lib.gelu_backward_scalar.restype = None
 
 def ggml_gelu_ref(x_arr):
     """Reference ggml fp16-table GELU using the local ggml table when available."""
-    ggml_lib_path = Path(__file__).resolve().parents[1] / "llama.cpp" / "build" / "bin" / "libggml-cpu.so"
+    ggml_lib_path = GGML_CPU_LIB
     try:
         ggml = ctypes.CDLL(str(ggml_lib_path))
         ggml.ggml_cpu_init()
@@ -188,7 +194,7 @@ def run_forward_tests(N=4096, warmup=10, iterations=1000):
     out_ggml = torch.from_numpy(out_ggml_np.copy())
     diff_ggml = max_diff(out_ggml, ggml_ref)
     kernel_time_ggml = time_function(c_gelu_ggml, warmup=warmup, iterations=iterations, name="C GELU GGML")
-    ggml_fp16_tol = 1e-4
+    ggml_fp16_tol = 0.0 if GGML_CPU_LIB.exists() else 1e-4
 
     report.add_result(TestResult(
         name="GGML (fp16 table)",
@@ -197,6 +203,33 @@ def run_forward_tests(N=4096, warmup=10, iterations=1000):
         tolerance=ggml_fp16_tol,
         pytorch_time=None,
         kernel_time=kernel_time_ggml
+    ))
+
+    # Values taken from a real Qwen3-VL layer-0 MLP-up boundary. These inputs
+    # sit near FP16 table transitions and exposed compiler/libm differences
+    # that random normal-distribution coverage did not fail reliably.
+    fixture_input_bits = np.array([
+        0xC09F2763, 0xC06F8B31, 0xC0941286, 0xC0774EC0,
+        0xC05C36E0, 0xC07EADC0, 0xC08FF4A0, 0xC08D41A3,
+        0xC086F51E, 0xC076CD06, 0xC0A11F64, 0xC06C3B42,
+        0xC040E00C, 0xC070CC5D, 0xC08BEB77, 0xC07454BA,
+    ], dtype=np.uint32)
+    fixture_expected_bits = np.array([
+        0xB4A00000, 0xB96DE000, 0xB6280000, 0xB90B2000,
+        0xBA4AE000, 0xB8A32000, 0xB6AC0000, 0xB70B0000,
+        0xB7C68000, 0xB9102000, 0xB4400000, 0xB993E000,
+        0xBB644000, 0xB95A8000, 0xB7310000, 0xB92A4000,
+    ], dtype=np.uint32)
+    fixture = fixture_input_bits.view(np.float32).copy()
+    lib.gelu_ggml_inplace(numpy_to_ptr(fixture), ctypes.c_size_t(fixture.size))
+    fixture_diff = int(np.count_nonzero(fixture.view(np.uint32) != fixture_expected_bits))
+    report.add_result(TestResult(
+        name="GGML Qwen3-VL boundary",
+        passed=fixture_diff == 0,
+        max_diff=float(fixture_diff),
+        tolerance=0.0,
+        pytorch_time=None,
+        kernel_time=None,
     ))
 
     return report

--- a/unittest/test_layernorm.py
+++ b/unittest/test_layernorm.py
@@ -37,6 +37,19 @@ lib.layernorm_naive_serial.argtypes = [
 ]
 lib.layernorm_naive_serial.restype = None
 
+lib.layernorm_naive_serial_matched_precision.argtypes = [
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_float,
+]
+lib.layernorm_naive_serial_matched_precision.restype = None
+
 lib.layernorm_forward_rolled_slice.argtypes = [
     ctypes.POINTER(ctypes.c_float),
     ctypes.POINTER(ctypes.c_float),
@@ -193,6 +206,84 @@ def run_c_layernorm_backward(upstream, x, gamma, mean, rstd):
 # ═══════════════════════════════════════════════════════════════════════════════
 # Tests
 # ═══════════════════════════════════════════════════════════════════════════════
+
+def ggml_layernorm_avx2_reference(x, gamma, beta, eps):
+    """Reproduce ggml's ordered AVX2 LayerNorm arithmetic."""
+    tokens, d_model = x.shape
+    if d_model % 8:
+        raise ValueError("the AVX2 oracle requires a width divisible by 8")
+
+    sqrtf = ctypes.CDLL("libm.so.6").sqrtf
+    sqrtf.argtypes = [ctypes.c_float]
+    sqrtf.restype = ctypes.c_float
+    output = np.empty_like(x)
+
+    for token in range(tokens):
+        sum_acc = 0.0
+        for value in x[token]:
+            sum_acc += float(value)
+        mean = np.float32(np.float32(sum_acc) / np.float32(d_model))
+        centered = np.subtract(x[token], mean, dtype=np.float32)
+
+        variance_acc = 0.0
+        for offset in range(0, d_model, 8):
+            squared = np.multiply(
+                centered[offset:offset + 8],
+                centered[offset:offset + 8],
+                dtype=np.float32,
+            )
+            lanes = np.add(squared[:4], squared[4:], dtype=np.float32)
+            lanes = np.add(lanes[:2], lanes[2:], dtype=np.float32)
+            chunk_sum = np.float32(lanes[0] + lanes[1])
+            variance_acc += float(chunk_sum)
+
+        variance = np.float32(variance_acc / float(d_model))
+        variance_eps = np.float32(variance + np.float32(eps))
+        scale = np.float32(
+            np.float32(1.0) /
+            np.float32(sqrtf(ctypes.c_float(variance_eps)))
+        )
+        normalized = np.multiply(centered, scale, dtype=np.float32)
+        normalized = np.multiply(normalized, gamma, dtype=np.float32)
+        output[token] = np.add(normalized, beta, dtype=np.float32)
+
+    return output
+
+
+def test_ggml_exact_layernorm_production_width():
+    """Guard the exact provider at Qwen3-VL's production hidden width."""
+    rng = np.random.default_rng(21)
+    tokens, d_model = 32, 1152
+    x = rng.standard_normal((tokens, d_model), dtype=np.float32)
+    gamma = rng.standard_normal(d_model, dtype=np.float32)
+    beta = rng.standard_normal(d_model, dtype=np.float32)
+    output = np.empty_like(x)
+
+    lib.layernorm_naive_serial_matched_precision(
+        numpy_to_ptr(x),
+        numpy_to_ptr(gamma),
+        numpy_to_ptr(beta),
+        numpy_to_ptr(output),
+        None,
+        None,
+        tokens,
+        d_model,
+        ctypes.c_float(1e-6),
+    )
+    reference = ggml_layernorm_avx2_reference(x, gamma, beta, 1e-6)
+    differing = int(np.count_nonzero(
+        output.view(np.uint32) != reference.view(np.uint32)
+    ))
+    diff = float(np.max(np.abs(output - reference)))
+    print(
+        "GGML-exact LayerNorm 32x1152: "
+        f"different={differing}/{output.size}, max_diff={diff:.2e}"
+    )
+    if differing:
+        raise AssertionError(
+            "matched LayerNorm changed ggml's ordered AVX2 arithmetic"
+        )
+
 
 def run_forward_tests(T=32, D=128, eps=1e-5, warmup=10, iterations=1000):
     """Run forward pass tests with accuracy and timing."""
@@ -425,6 +516,8 @@ def run_backward_tests(T=32, D=128, eps=1e-5, warmup=10, iterations=1000):
 
 if __name__ == "__main__":
     print_system_info()
+
+    test_ggml_exact_layernorm_production_width()
 
     # Forward tests
     fwd_report = run_forward_tests(T=32, D=128, warmup=10, iterations=1000)

--- a/unittest/test_rope.py
+++ b/unittest/test_rope.py
@@ -107,6 +107,30 @@ lib.rope_backward_qk_pairwise_with_rotary_dim.argtypes = [
 ]
 lib.rope_backward_qk_pairwise_with_rotary_dim.restype = None
 
+lib.mrope_qk_text_imrope.argtypes = [
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_float,
+    ctypes.c_float,
+    ctypes.c_float,
+    ctypes.c_float,
+    ctypes.c_float,
+    ctypes.c_float,
+]
+lib.mrope_qk_text_imrope.restype = None
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Reference implementations
@@ -991,6 +1015,109 @@ def run_pairwise_backward_tests(q_heads=20, kv_heads=4, T=16, D=128, warmup=5, i
     return report
 
 
+def _text_imrope_reference(x, pos_offset, n_dims, sections, freq_base):
+    """Qwen interleaved M-RoPE with implicit [pos, pos, pos, 0] axes."""
+    out = x.copy()
+    rope_pairs = n_dims // 2
+    theta_scale = np.float32(freq_base ** np.float32(-2.0 / n_dims))
+    section_total = sum(sections)
+    for head in range(x.shape[0]):
+        for tok in range(x.shape[1]):
+            base_pos = np.float32(pos_offset + tok)
+            theta_t = base_pos
+            theta_h = base_pos
+            theta_w = base_pos
+            theta_e = np.float32(0.0)
+            for pair in range(rope_pairs):
+                sector = pair % section_total
+                if sector % 3 == 1 and sector < 3 * sections[1]:
+                    theta = theta_h
+                elif sector % 3 == 2 and sector < 3 * sections[2]:
+                    theta = theta_w
+                elif sector % 3 == 0 and sector < 3 * sections[0]:
+                    theta = theta_t
+                else:
+                    theta = theta_e
+                cos_theta = np.float32(np.cos(theta))
+                sin_theta = np.float32(np.sin(theta))
+                x0 = x[head, tok, pair]
+                x1 = x[head, tok, pair + rope_pairs]
+                out[head, tok, pair] = np.float32(x0 * cos_theta - x1 * sin_theta)
+                out[head, tok, pair + rope_pairs] = np.float32(x0 * sin_theta + x1 * cos_theta)
+                theta_t = np.float32(theta_t * theta_scale)
+                theta_h = np.float32(theta_h * theta_scale)
+                theta_w = np.float32(theta_w * theta_scale)
+                theta_e = np.float32(theta_e * theta_scale)
+    return out
+
+
+def run_text_imrope_tests():
+    """Guard production-width Qwen text M-RoPE interleaving semantics."""
+    rng = np.random.default_rng(713)
+    q_heads, kv_heads, tokens, dim = 32, 8, 2, 128
+    sections = (24, 20, 20, 0)
+    position = 176
+    q_input = (rng.standard_normal((q_heads, tokens, dim)) * 8.0).astype(np.float32)
+    k_input = (rng.standard_normal((kv_heads, tokens, dim)) * 8.0).astype(np.float32)
+    q_output = q_input.copy()
+    k_output = k_input.copy()
+
+    lib.mrope_qk_text_imrope(
+        numpy_to_ptr(q_output),
+        numpy_to_ptr(k_output),
+        q_heads,
+        kv_heads,
+        tokens,
+        dim,
+        dim,
+        position,
+        dim,
+        *sections,
+        262144,
+        ctypes.c_float(5000000.0),
+        ctypes.c_float(1.0),
+        ctypes.c_float(0.0),
+        ctypes.c_float(1.0),
+        ctypes.c_float(0.0),
+        ctypes.c_float(0.0),
+    )
+
+    q_ref = _text_imrope_reference(q_input, position, dim, sections, 5000000.0)
+    k_ref = _text_imrope_reference(k_input, position, dim, sections, 5000000.0)
+    formula_diff = max(
+        float(np.max(np.abs(q_output - q_ref))),
+        float(np.max(np.abs(k_output - k_ref))),
+    )
+    # Pair 61 falls outside all three interleaved axes and must use the
+    # zero-valued extra position. Contiguous section routing rotates it.
+    tail_exact = bool(
+        np.array_equal(q_output[:, :, 61], q_input[:, :, 61])
+        and np.array_equal(q_output[:, :, 125], q_input[:, :, 125])
+        and np.array_equal(k_output[:, :, 61], k_input[:, :, 61])
+        and np.array_equal(k_output[:, :, 125], k_input[:, :, 125])
+    )
+
+    report = TestReport(
+        test_name="Text M-RoPE Interleaved Contract",
+        dtype="fp32",
+        shape="QH=32, KVH=8, T=2, D=128, sections=[24,20,20,0]",
+        cpu_info=get_cpu_info(),
+    )
+    report.add_result(TestResult(
+        name="Qwen interleaved formula",
+        passed=formula_diff <= 2e-5,
+        max_diff=formula_diff,
+        tolerance=2e-5,
+    ))
+    report.add_result(TestResult(
+        name="Qwen extra-axis tail routing",
+        passed=tail_exact,
+        max_diff=0.0 if tail_exact else 1.0,
+        tolerance=0.0,
+    ))
+    return report
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Main
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1048,6 +1175,10 @@ if __name__ == "__main__":
     pairwise_bwd_report = run_pairwise_backward_tests()
     pairwise_bwd_report.print_report()
     all_reports.append(pairwise_bwd_report)
+
+    text_imrope_report = run_text_imrope_tests()
+    text_imrope_report.print_report()
+    all_reports.append(text_imrope_report)
 
     # Backward tests
     bwd_report = run_backward_tests(H=8, T=64, D=64, warmup=10, iterations=500)

--- a/unittest/test_vision.py
+++ b/unittest/test_vision.py
@@ -691,7 +691,7 @@ def test_position_embeddings_add_tiled_2d_qwen3vl_resize_order(
     grid_h=56,
     grid_w=72,
     source_grid_size=48,
-    embed_dim=64,
+    embed_dim=1152,
     merge_size=2,
 ):
     print(
@@ -724,10 +724,9 @@ def test_position_embeddings_add_tiled_2d_qwen3vl_resize_order(
     diff = max_diff(out_c, ref)
     print(f"Max diff: {diff:.2e}")
 
-    # The production contract permits contraction in the interpolation node,
-    # as ggml does. GCC and Intel/Clang can therefore differ by a few ULPs;
-    # the full llama X-ray gate separately requires backend-exact output.
-    if diff > 2.5e-5:
+    # This is the production Qwen3-VL geometry. The kernel uses an explicit
+    # ordered FMA contract, so compiler-dependent reassociation is a failure.
+    if diff != 0.0:
         raise AssertionError("position_embeddings_add_tiled_2d Qwen3-VL resize order mismatch!")
 
 
@@ -1073,6 +1072,60 @@ def _ref_qwen3vl_vision_mrope_qk(
     return apply(q), apply(k)
 
 
+def _ref_ggml_vision_mrope_exact(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    n_dims: int,
+    sections: list[int],
+    freq_base: float = 10000.0,
+) -> torch.Tensor:
+    """Reference ggml's FP32/libm/FMA vision M-RoPE contract."""
+    libm = ctypes.CDLL("libm.so.6")
+    cosf = libm.cosf
+    sinf = libm.sinf
+    fmaf = libm.fmaf
+    cosf.argtypes = [ctypes.c_float]
+    sinf.argtypes = [ctypes.c_float]
+    fmaf.argtypes = [ctypes.c_float, ctypes.c_float, ctypes.c_float]
+    cosf.restype = ctypes.c_float
+    sinf.restype = ctypes.c_float
+    fmaf.restype = ctypes.c_float
+
+    out = x.numpy().copy()
+    pos = positions.numpy()
+    rope_pairs = n_dims // 2
+    powf = libm.powf
+    powf.argtypes = [ctypes.c_float, ctypes.c_float]
+    powf.restype = ctypes.c_float
+    theta_scale = np.float32(powf(
+        ctypes.c_float(freq_base),
+        ctypes.c_float(np.float32(-2.0) / np.float32(rope_pairs)),
+    ))
+    for head in range(out.shape[0]):
+        for token in range(out.shape[1]):
+            theta_y = np.float32(pos[0, token])
+            theta_x = np.float32(pos[1, token])
+            for pair in range(rope_pairs):
+                if pair == sections[0]:
+                    theta_x = np.float32(pos[1, token])
+                theta = theta_x if pair >= sections[0] else theta_y
+                cosine = np.float32(cosf(ctypes.c_float(theta)))
+                sine = np.float32(sinf(ctypes.c_float(theta)))
+                x0 = np.float32(out[head, token, pair])
+                x1 = np.float32(out[head, token, pair + rope_pairs])
+                x1_sin = np.float32(x1 * sine)
+                x1_cos = np.float32(x1 * cosine)
+                out[head, token, pair] = np.float32(fmaf(
+                    ctypes.c_float(x0), ctypes.c_float(cosine), ctypes.c_float(-x1_sin)
+                ))
+                out[head, token, pair + rope_pairs] = np.float32(fmaf(
+                    ctypes.c_float(x0), ctypes.c_float(sine), ctypes.c_float(x1_cos)
+                ))
+                theta_y = np.float32(theta_y * theta_scale)
+                theta_x = np.float32(theta_x * theta_scale)
+    return torch.from_numpy(out)
+
+
 def test_vision_position_ids(grid_h=4, grid_w=4, merge_size=2):
     print(f"\n--- Testing vision_position_ids_2d_merge ({grid_h}x{grid_w}, merge {merge_size}) ---")
     ref = _ref_vision_position_ids(grid_h, grid_w, merge_size)
@@ -1150,6 +1203,28 @@ def test_mrope_qk_vision_qwen3vl_full_head():
     test_mrope_qk_vision(num_heads=2, num_kv_heads=2, num_tokens=4, head_dim=72)
 
 
+def test_mrope_qk_vision_ggml_libm_exact():
+    """Catch ICX libimf trigonometric drift at production rotary width."""
+    torch.manual_seed(713)
+    head_dim = 72
+    sections = [18, 18, 0, 0]
+    q = torch.randn(1, 72, head_dim, dtype=torch.float32)
+    k = torch.randn(1, 72, head_dim, dtype=torch.float32)
+    positions = _ref_vision_position_ids(1, 72, 1)
+    ref_q = _ref_ggml_vision_mrope_exact(q, positions, head_dim, sections)
+    ref_k = _ref_ggml_vision_mrope_exact(k, positions, head_dim, sections)
+    out_q, out_k = run_c_mrope_qk(q, k, positions, head_dim, sections)
+    q_differing = int(torch.count_nonzero(out_q.view(torch.int32) != ref_q.view(torch.int32)))
+    k_differing = int(torch.count_nonzero(out_k.view(torch.int32) != ref_k.view(torch.int32)))
+    print(
+        "GGML/libm-exact vision M-RoPE: "
+        f"Q different={q_differing}/{out_q.numel()}, "
+        f"K different={k_differing}/{out_k.numel()}"
+    )
+    if q_differing or k_differing:
+        raise AssertionError("vision M-RoPE changed the ggml system-libm contract")
+
+
 if __name__ == "__main__":
     test_im2patch()
     test_patch2im()
@@ -1169,6 +1244,7 @@ if __name__ == "__main__":
     test_feature_concat_inplace_expand()
     test_mrope_qk_vision()
     test_mrope_qk_vision_qwen3vl_full_head()
+    test_mrope_qk_vision_ggml_libm_exact()
     test_mrope_qk_vision_storage_matrix()
     
     # Test a non-multiple size just in case (though ViT usually uses multiples)

--- a/version/v7/scripts/parity_test.py
+++ b/version/v7/scripts/parity_test.py
@@ -156,7 +156,10 @@ def _is_plausible_header(h: Dict) -> bool:
         return False
     if h["dtype"] < 0 or h["dtype"] > 16:
         return False
-    if h["elem_count"] < 0 or h["elem_count"] > (1 << 31):
+    # Instrumented tensor records are always non-empty. Rejecting a zero count
+    # prevents a corrupt/truncated header from reaching NumPy reductions as an
+    # apparently valid empty tensor.
+    if h["elem_count"] <= 0 or h["elem_count"] > (1 << 31):
         return False
     rank = int(h.get("rank", 0))
     if rank < 0 or rank > 4:

--- a/version/v8/circuits/qwen35.json
+++ b/version/v8/circuits/qwen35.json
@@ -117,6 +117,30 @@
       }
     }
   },
+  "required_numerical_contracts": {
+    "decoder.mrope": {
+      "op": "rope",
+      "template_ops": ["rope_qk"],
+      "phases": {
+        "prefill": {
+          "contract_id": "text_mrope_fp32_input_fp32_compute_fp32_output",
+          "validation": "validated",
+          "evidence": "Qwen3.5 regression validates configured partial-width text M-RoPE through call IR and end-to-end inference."
+        },
+        "decode": {
+          "contract_id": "text_mrope_fp32_input_fp32_compute_fp32_output",
+          "validation": "validated",
+          "evidence": "Qwen3.5 regression validates configured partial-width text M-RoPE through call IR and end-to-end inference."
+        }
+      },
+      "checkpoint": {
+        "id": "decoder.layer.{layer}.mrope.output",
+        "producer": "rope_qk",
+        "logical_layout": "head_major",
+        "axis_names": ["head", "token", "channel"]
+      }
+    }
+  },
   "sequence": ["decoder"],
   "block_types": {
     "decoder": {

--- a/version/v8/circuits/qwen3_vl_vision.json
+++ b/version/v8/circuits/qwen3_vl_vision.json
@@ -92,7 +92,7 @@
     "gelu": "gelu_ggml_inplace",
     "projector_gelu": "gelu_ggml_inplace",
     "branch_gelu": "gelu_ggml_inplace",
-    "attn_prefill": "attention_forward_full_head_major_gqa_flash_strided"
+    "attn_prefill": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided"
   },
   "required_contracts": {
     "vision_encoder.attention": {
@@ -107,10 +107,10 @@
             "tensor.q.dtype": "fp32",
             "tensor.kv.dtype": "fp32",
             "tensor.layout": "head_major",
-            "numerics.attention_reduction": "f16_kv_fp32_online"
+            "numerics.attention_reduction": "f16_kv_tiled64_fp32_softmax_fp64_sum_update"
           },
-          "validation": "observed",
-          "evidence": "Public full-attention routes pass contiguous, strided, threaded, and head_dim=72 numerical tests; stitched encoder parity remains the production gate."
+          "validation": "validated",
+          "evidence": "The direct llama.cpp tiled-flash oracle is byte-exact for Qwen3-VL T=4032, H=16, D=72 after FP16 K/V rounding and the FP64-add/FP32-store softmax-sum boundary."
         }
       },
       "selector": {
@@ -424,6 +424,33 @@
         ]
       }
     },
+    "vision.layer.mlp_down.fp16": {
+      "op": "gemm",
+      "template_ops": [
+        "mlp_down"
+      ],
+      "selector": {
+        "config_not_equals": {
+          "vision_projection_storage_boundary": "bf16"
+        }
+      },
+      "phases": {
+        "prefill": {
+          "contract_id": "fp16_weight_fp16_input_llamafile_avx_fp32_output",
+          "validation": "validated",
+          "evidence": "unittest/test_f16_gemm_llama_contract.py and Qwen3-VL layer-0 production X-ray at 4032x4304x1152"
+        }
+      },
+      "checkpoint": {
+        "id": "vision.layer.{layer}.mlp.down",
+        "producer": "mlp_down",
+        "logical_layout": "token_major",
+        "axis_names": [
+          "token",
+          "channel"
+        ]
+      }
+    },
     "vision.layer.mlp_projection": {
       "op": "gemm",
       "template_ops": [
@@ -445,6 +472,33 @@
       "checkpoint": {
         "id": "vision.layer.{layer}.mlp.projection",
         "producer": "mlp_projection",
+        "logical_layout": "token_major",
+        "axis_names": [
+          "token",
+          "channel"
+        ]
+      }
+    },
+    "vision.layer.mlp_activation.fp32": {
+      "op": "gelu",
+      "template_ops": [
+        "gelu"
+      ],
+      "selector": {
+        "config_not_equals": {
+          "vision_activation_storage_boundary": "bf16"
+        }
+      },
+      "phases": {
+        "prefill": {
+          "contract_id": "gelu_fp32_input_fp16_table_fp32_output",
+          "validation": "validated",
+          "evidence": "unittest/test_gelu.py::GGML Qwen3-VL boundary and layer-0 X-ray full-tensor equality"
+        }
+      },
+      "checkpoint": {
+        "id": "vision.layer.{layer}.mlp.activation",
+        "producer": "gelu",
         "logical_layout": "token_major",
         "axis_names": [
           "token",

--- a/version/v8/circuits/qwen3vl.json
+++ b/version/v8/circuits/qwen3vl.json
@@ -97,12 +97,17 @@
       "position_policy": "mrope_2d",
       "cache_policy": "persistent_decoder_kv",
       "runtime_policy": "decode_staged",
+      "prefill_schedule": {
+        "segments": ["text_before", "visual", "text_after"],
+        "cache_transition": "append_preserve",
+        "position_transition": "segment_defined"
+      },
       "image_begin_marker": "<|vision_start|>",
       "image_end_marker": "<|vision_end|>"
     }
   },
   "kernels": {
-    "rope_qk": "mrope_qk_text"
+    "rope_qk": "mrope_qk_text_imrope"
   },
   "required_contracts": {
     "decoder.attention": {
@@ -112,13 +117,14 @@
         "prefill": {
           "requires": {
             "execution.phase": "prefill",
+            "execution.prefill_batching": "segmented_append",
             "tensor.q.dtype": "fp32",
-            "tensor.kv.dtype": "fp32",
+            "tensor.kv.dtype": "fp16",
             "tensor.layout": "head_major",
-            "numerics.attention_reduction": "fp32_online"
+            "numerics.attention_reduction": "f16_online_fp32_merge"
           },
           "validation": "observed",
-          "evidence": "Mixed-prefix full replay remains the production gate; the selected causal FP32 route has leaf coverage."
+          "evidence": "Segmented mixed-prefix replay requires cache-preserving append attention; leaf and stitched parity are the production gates."
         },
         "decode": {
           "requires": {
@@ -131,6 +137,30 @@
           "validation": "observed",
           "evidence": "Public routing and llama.cpp oracle cases pass at KV 511, 512, and 1058; full multimodal parity remains the production gate."
         }
+      }
+    }
+  },
+  "required_numerical_contracts": {
+    "decoder.mrope": {
+      "op": "rope",
+      "template_ops": ["rope_qk"],
+      "phases": {
+        "prefill": {
+          "contract_id": "text_imrope_fp32_input_fp32_compute_fp32_output",
+          "validation": "validated",
+          "evidence": "Production-width interleaved sector routing is checked against the GGML formula and stitched multimodal prefill."
+        },
+        "decode": {
+          "contract_id": "text_imrope_fp32_input_fp32_compute_fp32_output",
+          "validation": "validated",
+          "evidence": "Exact llama Q/K inputs isolate interleaved text M-RoPE before cache append and attention."
+        }
+      },
+      "checkpoint": {
+        "id": "decoder.layer.{layer}.mrope.output",
+        "producer": "rope_qk",
+        "logical_layout": "head_major",
+        "axis_names": ["head", "token", "channel"]
       }
     }
   },

--- a/version/v8/contracts/attention_reductions.json
+++ b/version/v8/contracts/attention_reductions.json
@@ -49,6 +49,30 @@
         "reference": "PyTorch with K/V explicitly rounded through FP16"
       }
     },
+    "f16_kv_tiled64_fp32_softmax_fp64_sum_update": {
+      "status": "validated",
+      "q_compute": "fp32",
+      "k_compute": "fp16_rounded",
+      "score_accumulator": "fp32",
+      "softmax_statistics": "fp32",
+      "value_compute": "fp16_rounded",
+      "value_accumulator": "fp32",
+      "partial_storage": "fp32",
+      "partial_merge": "fp32_chunk_order",
+      "partition": {
+        "kind": "query_key_tiles",
+        "query_tile_size": 64,
+        "key_tile_size": 64,
+        "softmax_sum_update": "fp64_add_then_fp32_store",
+        "worker_partition": "contiguous_head_query_rows"
+      },
+      "description": "Full attention with 64x64 query/key tiles, FP32 Q, FP16-rounded K/V, FP32 score and value accumulation, and an ascending key-tile online-softmax merge whose double-width sum addition is rounded back to FP32 after each tile.",
+      "validation": {
+        "test": "unittest/test_attention_full.py and version/v8/scripts/replay_attention_from_dumps_v8.py",
+        "cases": ["Qwen3-VL T=4032 H=16 D=72", "strided GQA", "threaded query ranges"],
+        "reference": "llama.cpp GGML tiled flash attention with F16 K/V and GGML_PREC_F32"
+      }
+    },
     "f16_online_single_range": {
       "status": "observed",
       "q_compute": "fp16_rounded",

--- a/version/v8/contracts/numerical_execution.json
+++ b/version/v8/contracts/numerical_execution.json
@@ -3,6 +3,36 @@
   "schema_version": 1,
   "engine_contract_version": "8",
   "contracts": {
+    "rmsnorm_fp32_square_fp64_sum_fp32_output": {
+      "operator_family": "rmsnorm",
+      "status": "validated",
+      "storage": {"input": "fp32", "weight": "fp32", "output": "fp32"},
+      "compute": {
+        "input": "fp32",
+        "weight": "fp32",
+        "accumulator": "fp64",
+        "contraction": "disabled",
+        "evaluation_order": "fp32_square_then_fp64_ascending_sum_then_fp32_mean_rsqrt_scale_weight"
+      },
+      "rounding": {
+        "mode": "rne",
+        "points": ["square_product", "reduction_finalize", "reciprocal_sqrt", "normalization_scale", "weight_scale"]
+      },
+      "reduction": {
+        "kind": "normalization",
+        "order": "left_to_right",
+        "partial_accumulator": "fp64",
+        "merge_order": "none"
+      },
+      "threading": {
+        "work_partition": "independent_rows",
+        "split_strategy": "independent_outputs",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": null,
+      "description": "RMSNorm with FP32 square products, an ascending FP64 row sum, FP32 mean and reciprocal square root, and ordered FP32 normalization and weight multiplies."
+    },
     "bf16_weight_bf16_input_fp32_dot_fp32_output": {
       "operator_family": "gemm",
       "status": "observed",
@@ -151,13 +181,118 @@
       },
       "description": "Align-corners tiled 2D position interpolation with FP32 rational coordinates and contracted float32 evaluation order."
     },
+    "text_mrope_fp32_input_fp32_compute_fp32_output": {
+      "operator_family": "text_mrope",
+      "status": "validated",
+      "compute": {
+        "input": "fp32",
+        "weight": "fp32",
+        "accumulator": "fp32",
+        "contraction": "enabled",
+        "evaluation_order": "glibc_powf_sinf_cosf_then_rounded_partner_product_then_fma"
+      },
+      "reduction": {
+        "kind": "none",
+        "order": "none",
+        "partial_accumulator": "none",
+        "merge_order": "none"
+      },
+      "threading": {
+        "work_partition": "serial",
+        "split_strategy": "serial",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": {
+        "pairing": "multi_section",
+        "rotary_width": "configured_rotary_dim",
+        "head_width": "head_dim",
+        "position_rank": 4,
+        "axis_order": ["text", "text_copy_1", "text_copy_2", "reserved"],
+        "section_interpretation": "axis_selection",
+        "frequency_compute": "fp32",
+        "intermediate_compute": "fp32",
+        "rounding_points": [
+          "partner_sin_product",
+          "partner_cos_product",
+          "fma_output"
+        ],
+        "threading": "serial"
+      },
+      "storage": {
+        "input": "fp32",
+        "weight": "fp32",
+        "output": "fp32"
+      },
+      "rounding": {
+        "mode": "none",
+        "points": []
+      },
+      "description": "Text M-RoPE rotates the configured prefix of each head using one semantic text position expanded across four axis-selection streams."
+    },
+    "text_imrope_fp32_input_fp32_compute_fp32_output": {
+      "operator_family": "text_mrope",
+      "status": "validated",
+      "compute": {
+        "input": "fp32",
+        "weight": "fp32",
+        "accumulator": "fp32",
+        "contraction": "enabled",
+        "evaluation_order": "glibc_powf_sinf_cosf_then_rounded_partner_product_then_fma"
+      },
+      "reduction": {
+        "kind": "none",
+        "order": "none",
+        "partial_accumulator": "none",
+        "merge_order": "none"
+      },
+      "threading": {
+        "work_partition": "serial",
+        "split_strategy": "serial",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": {
+        "pairing": "multi_section",
+        "rotary_width": "head_dim",
+        "head_width": "head_dim",
+        "position_rank": 4,
+        "axis_order": [
+          "temporal",
+          "height",
+          "width",
+          "reserved"
+        ],
+        "section_interpretation": "interleaved_axis_selection",
+        "frequency_compute": "fp32",
+        "intermediate_compute": "fp32",
+        "rounding_points": [
+          "partner_sin_product",
+          "partner_cos_product",
+          "fma_output"
+        ],
+        "threading": "serial"
+      },
+      "storage": {
+        "input": "fp32",
+        "weight": "fp32",
+        "output": "fp32"
+      },
+      "rounding": {
+        "mode": "none",
+        "points": []
+      },
+      "description": "Text M-RoPE uses full-width split-half rotation with Qwen-style interleaved temporal, height, width, and reserved-axis selection."
+    },
     "vision_mrope_fp32_input_fp32_compute_fp32_output": {
       "operator_family": "vision_mrope",
       "status": "validated",
       "compute": {
         "input": "fp32",
         "weight": "fp32",
-        "accumulator": "fp32"
+        "accumulator": "fp32",
+        "contraction": "enabled",
+        "evaluation_order": "glibc_powf_sinf_cosf_then_rounded_partner_product_then_fma"
       },
       "reduction": {
         "kind": "none",
@@ -185,7 +320,11 @@
         "section_interpretation": "axis_selection",
         "frequency_compute": "fp32",
         "intermediate_compute": "fp32",
-        "rounding_points": [],
+        "rounding_points": [
+          "partner_sin_product",
+          "partner_cos_product",
+          "fma_output"
+        ],
         "threading": "serial"
       },
       "storage": {
@@ -205,7 +344,9 @@
       "compute": {
         "input": "fp32",
         "weight": "fp32",
-        "accumulator": "fp32"
+        "accumulator": "fp32",
+        "contraction": "enabled",
+        "evaluation_order": "glibc_powf_sinf_cosf_then_rounded_partner_product_then_fma"
       },
       "reduction": {
         "kind": "none",
@@ -233,7 +374,11 @@
         "section_interpretation": "axis_selection",
         "frequency_compute": "fp32",
         "intermediate_compute": "fp32",
-        "rounding_points": [],
+        "rounding_points": [
+          "partner_sin_product",
+          "partner_cos_product",
+          "fma_output"
+        ],
         "threading": "serial"
       },
       "storage": {
@@ -255,7 +400,9 @@
       "compute": {
         "input": "fp32",
         "weight": "fp32",
-        "accumulator": "fp32"
+        "accumulator": "fp32",
+        "contraction": "enabled",
+        "evaluation_order": "glibc_powf_sinf_cosf_then_rounded_partner_product_then_fma"
       },
       "reduction": {
         "kind": "none",
@@ -283,7 +430,11 @@
         "section_interpretation": "axis_selection",
         "frequency_compute": "fp32",
         "intermediate_compute": "fp32",
-        "rounding_points": [],
+        "rounding_points": [
+          "partner_sin_product",
+          "partner_cos_product",
+          "fma_output"
+        ],
         "threading": "serial"
       },
       "storage": {
@@ -578,6 +729,80 @@
       },
       "position_transform": null,
       "description": "PyTorch tanh-approximate GELU over BF16-valued inputs with FP32 elementwise compute and BF16 RNE output storage."
+    },
+    "gelu_fp32_input_fp16_table_fp32_output": {
+      "operator_family": "gelu",
+      "status": "validated",
+      "storage": {
+        "input": "fp32",
+        "weight": "fp32",
+        "output": "fp32"
+      },
+      "compute": {
+        "input": "fp16_rne",
+        "weight": "fp32",
+        "accumulator": "fp32",
+        "contraction": "disabled",
+        "evaluation_order": "fp16_rne_input_then_ggml_fp16_lookup_table_then_fp32_widen"
+      },
+      "rounding": {
+        "mode": "rne",
+        "points": [
+          "input_load",
+          "output_store"
+        ]
+      },
+      "reduction": {
+        "kind": "none",
+        "order": "none",
+        "partial_accumulator": "none",
+        "merge_order": "none"
+      },
+      "threading": {
+        "work_partition": "serial",
+        "split_strategy": "serial",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": null,
+      "description": "llama.cpp CPU GELU semantics: round FP32 input to FP16, index the GGML FP16 GELU table, then widen the FP16 result to FP32."
+    },
+    "fp16_weight_fp16_input_llamafile_avx_fp32_output": {
+      "operator_family": "gemm",
+      "status": "validated",
+      "storage": {
+        "input": "fp32",
+        "weight": "fp16",
+        "output": "fp32"
+      },
+      "compute": {
+        "input": "fp16_rne",
+        "weight": "fp16",
+        "accumulator": "fp32",
+        "contraction": "enabled",
+        "evaluation_order": "single_simd_accumulator_ascending_k_then_llamafile_avx_movehl_movehdup_horizontal_reduce"
+      },
+      "rounding": {
+        "mode": "rne",
+        "points": [
+          "input_load",
+          "reduction_finalize"
+        ]
+      },
+      "reduction": {
+        "kind": "dot_product",
+        "order": "ascending_k",
+        "partial_accumulator": "fp32",
+        "merge_order": "pairwise_tree"
+      },
+      "threading": {
+        "work_partition": "independent_rows",
+        "split_strategy": "independent_outputs",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": null,
+      "description": "FP16-weight GEMM matching llama.cpp's AVX llamafile path, including FP16-RNE activation conversion, FMA lane accumulation, and movehl/movehdup horizontal reduction."
     },
     "bf16_weight_bf16_input_amx_tile32_dot_bf16_output": {
       "status": "validated",

--- a/version/v8/dsl_policy.json
+++ b/version/v8/dsl_policy.json
@@ -14,8 +14,8 @@
   "model_literal_site_limits": {
     "version/v8/scripts/build_ir_v8.py": 37,
     "version/v8/scripts/codegen_core_v8.py": 12,
-    "version/v8/scripts/codegen_prefill_v8.py": 22,
-    "version/v8/scripts/codegen_v8.py": 5
+    "version/v8/scripts/codegen_prefill_v8.py": 12,
+    "version/v8/scripts/codegen_v8.py": 0
   },
   "compiler_files": {
     "version/v8/scripts/build_ir_v8.py": {

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,12 +5,12 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "version/v8/kernel_maps",
     "counts": {
-      "total": 200,
+      "total": 203,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
         "assistant_layer_scale": 1,
-        "attention": 18,
+        "attention": 20,
         "attention_projection": 1,
         "attention_sliding": 6,
         "attn_gate_sigmoid_mul": 1,
@@ -73,7 +73,7 @@
         "residual_add": 2,
         "residual_save": 1,
         "rmsnorm": 2,
-        "rope": 11,
+        "rope": 12,
         "rope_backward": 2,
         "rope_init": 2,
         "rowwise_bias_add": 1,
@@ -2152,6 +2152,176 @@
       "notes": "Gemma4 no-scale causal sliding-window attention. Gemma4 uses attention_scale=1.0 in llama.cpp, not 1/sqrt(head_dim).",
       "name": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4",
       "_source_file": "attention_forward_causal_head_major_gqa_flash_strided_sliding_gemma4.json"
+    },
+    {
+      "id": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+      "op": "attention",
+      "variant": "causal_head_major_gqa_prefill_append_f16cache_contract",
+      "mode": "prefill",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "prefill"
+        ],
+        "execution.prefill_batching": [
+          "segmented_append"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp16"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "f16_online_fp32_merge"
+        ]
+      },
+      "supported_reductions": {
+        "f16_online_fp32_merge": {
+          "status": "observed",
+          "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+          "explicit_selector": true,
+          "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
+          "notes": "Cache-preserving segmented causal prefill using the validated FP16 decode reduction contract for each query row."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "kv_chunks_by_workers"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "q_tokens",
+            "head_dim"
+          ]
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp16",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ]
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp16",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "q_tokens",
+            "head_dim"
+          ]
+        }
+      ],
+      "dims": [
+        "num_heads",
+        "num_kv_heads",
+        "q_tokens",
+        "past_tokens",
+        "cache_capacity",
+        "head_dim",
+        "aligned_head_dim"
+      ],
+      "params": [
+        {
+          "name": "reduction",
+          "dtype": "ck_attention_reduction_t"
+        }
+      ],
+      "impl": {
+        "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+        "c_declaration": "ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(const float *q, const uint16_t *k_cache, const uint16_t *v_cache, float *output, int num_heads, int num_kv_heads, int q_tokens, int past_tokens, int cache_capacity, int head_dim, int aligned_head_dim, ck_attention_reduction_t reduction);",
+        "sources": [
+          "src/kernels/attention_kernels.c"
+        ]
+      },
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "name": "q",
+            "source": "scratch:q_scratch",
+            "cast": "const float*"
+          },
+          {
+            "name": "k_cache",
+            "source": "runtime:kv_cache_k_layer_f16",
+            "cast": "const uint16_t*"
+          },
+          {
+            "name": "v_cache",
+            "source": "runtime:kv_cache_v_layer_f16",
+            "cast": "const uint16_t*"
+          },
+          {
+            "name": "output",
+            "source": "output:out",
+            "cast": "float*"
+          },
+          {
+            "name": "num_heads",
+            "source": "dim:num_heads"
+          },
+          {
+            "name": "num_kv_heads",
+            "source": "dim:num_kv_heads"
+          },
+          {
+            "name": "q_tokens",
+            "source": "dim:seq_len"
+          },
+          {
+            "name": "past_tokens",
+            "source": "runtime:prefill_start_pos"
+          },
+          {
+            "name": "cache_capacity",
+            "source": "dim:max_seq_len"
+          },
+          {
+            "name": "head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "aligned_head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "reduction",
+            "source": "const:CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE"
+          }
+        ]
+      },
+      "name": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+      "_source_file": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.json"
     },
     {
       "id": "attention_forward_causal_head_major_shared_kv_gemma4",
@@ -4321,6 +4491,248 @@
       },
       "name": "attention_forward_full_head_major_gqa_sdpa_bf16_storage",
       "_source_file": "attention_forward_full_head_major_gqa_sdpa_bf16_storage.json"
+    },
+    {
+      "id": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+      "op": "attention",
+      "variant": "full_tiled64_f16kv_fp32",
+      "mode": "prefill",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "prefill"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp32"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "f16_kv_tiled64_fp32_softmax_fp64_sum_update"
+        ]
+      },
+      "supported_reductions": {
+        "f16_kv_tiled64_fp32_softmax_fp64_sum_update": {
+          "status": "validated",
+          "function": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+          "explicit_selector": true,
+          "selector": "circuit_required_contract",
+          "notes": "Exact 64x64 tiled full-attention provider with FP16-rounded K/V and the contract-defined softmax sum update."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "compile_time",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": [
+            "independent_query_blocks"
+          ],
+          "dispatch": [
+            "ck_threadpool_dispatch_n"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "FP32 query tensor"
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "runtime_buffers": [
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "K tensor rounded through FP16 on tile load"
+        },
+        {
+          "name": "v",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "S",
+            "D"
+          ],
+          "desc": "V tensor rounded through FP16 on tile load"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "FP32 attention output"
+        }
+      ],
+      "scratch": [
+        {
+          "name": "thread_tiles",
+          "dtype": "fp32",
+          "size_bytes": "per_thread((64*D)+(64*64)+(64*D)+(64*D))",
+          "desc": "Bounded query, key, value, score, and output tiles"
+        }
+      ],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "S",
+        "D"
+      ],
+      "params": [
+        {
+          "name": "kv_stride_tokens",
+          "dtype": "int32",
+          "desc": "K/V token stride"
+        },
+        {
+          "name": "head_dim",
+          "dtype": "int32",
+          "desc": "Logical head width"
+        },
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Physical head stride"
+        }
+      ],
+      "parallelization": {
+        "supported": [
+          "query_blocks"
+        ],
+        "preferred": {
+          "prefill": "query_blocks"
+        },
+        "strategies": [
+          {
+            "name": "query_blocks",
+            "partition_dim": "H*T",
+            "param_style": "ith_nth",
+            "notes": "Contiguous head/query row ranges; each query retains ascending key-tile reduction order."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "D": 1,
+          "T": 1
+        },
+        "notes": "Full bidirectional attention. num_heads must be divisible by num_kv_heads, aligned_head_dim >= head_dim, and kv_stride_tokens >= num_tokens."
+      },
+      "impl": {
+        "function": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+        "c_declaration": "void attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+        "sources": [
+          "src/kernels/attention_kernels.c",
+          "src/kernels/softmax_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "avx2",
+            "requires": [
+              "avx2",
+              "fma",
+              "f16c"
+            ],
+            "compile_flags": [
+              "-mavx2",
+              "-mfma",
+              "-mf16c"
+            ]
+          },
+          {
+            "name": "portable",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_attention_full.py"
+        ],
+        "oracle": [
+          "version/v8/scripts/replay_attention_from_dumps_v8.py --mode tiled_f16kv"
+        ]
+      },
+      "notes": "Contract-selected GGML-compatible tiled full attention. This provider is additive and does not replace online or BF16 SDPA contracts.",
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "name": "q",
+            "source": "scratch:q_scratch",
+            "cast": "float*"
+          },
+          {
+            "name": "k",
+            "source": "scratch:k_scratch",
+            "cast": "float*"
+          },
+          {
+            "name": "v",
+            "source": "scratch:v_scratch",
+            "cast": "float*"
+          },
+          {
+            "name": "output",
+            "source": "output:out",
+            "cast": "float*"
+          },
+          {
+            "name": "num_heads",
+            "source": "dim:num_heads"
+          },
+          {
+            "name": "num_kv_heads",
+            "source": "dim:num_kv_heads"
+          },
+          {
+            "name": "num_tokens",
+            "source": "dim:seq_len"
+          },
+          {
+            "name": "head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "aligned_head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "kv_stride_tokens",
+            "source": "dim:max_seq_len"
+          }
+        ]
+      },
+      "name": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+      "_source_file": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided.json"
     },
     {
       "id": "attn_gate_sigmoid_mul_backward_f32",
@@ -7931,9 +8343,59 @@
           "src/kernels/gelu_kernels.c"
         ]
       },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "numerical_capabilities": [
+        {
+          "contract_id": "gelu_fp32_input_fp16_table_fp32_output",
+          "status": "validated",
+          "phases": [
+            "prefill"
+          ],
+          "function": "gelu_ggml_inplace",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "scalar",
+            "threading": {
+              "runtime": "serial",
+              "work_partition": [
+                "serial"
+              ],
+              "dispatch": [
+                "inline"
+              ],
+              "reduction_order_effect": "none"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "none",
+            "merge_order": "none",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "serial"
+          }
+        }
+      ],
       "tests": {
         "unit": [
-          "unittest/test_gelu.py"
+          "unittest/test_gelu.py::GGML Qwen3-VL boundary"
+        ]
+      },
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "cast": "float*",
+            "name": "data",
+            "source": "output:out"
+          },
+          {
+            "name": "n",
+            "source": "dim:gelu_elems"
+          }
         ]
       },
       "notes": "GGML-compatible FP16-table GELU used for llama.cpp activation parity.",
@@ -8968,9 +9430,80 @@
           "src/kernels/gemm_kernels_f16.c"
         ]
       },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "numerical_capabilities": [
+        {
+          "contract_id": "fp16_weight_fp16_input_llamafile_avx_fp32_output",
+          "status": "validated",
+          "phases": [
+            "prefill"
+          ],
+          "function": "gemm_nt_f16",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "compile_time",
+            "threading": {
+              "runtime": "ck_threadpool",
+              "work_partition": [
+                "independent_rows"
+              ],
+              "dispatch": [
+                "ck_threadpool_dispatch_n"
+              ],
+              "reduction_order_effect": "contract_defined"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "fp32",
+            "merge_order": "pairwise_tree",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "independent_outputs"
+          }
+        }
+      ],
       "tests": {
         "unit": [
-          "tests/test_v8_qwen3vl_template.py"
+          "unittest/test_f16_gemm_llama_contract.py"
+        ]
+      },
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "cast": "const float*",
+            "name": "A",
+            "source": "activation:a"
+          },
+          {
+            "name": "B",
+            "source": "weight:_first_weight"
+          },
+          {
+            "name": "bias",
+            "source": "weight_f:_bias"
+          },
+          {
+            "cast": "float*",
+            "name": "C",
+            "source": "output:c"
+          },
+          {
+            "name": "M",
+            "source": "dim:_m"
+          },
+          {
+            "name": "N",
+            "source": "dim:_output_dim"
+          },
+          {
+            "name": "K",
+            "source": "dim:_input_dim"
+          }
         ]
       },
       "notes": "Generic FP16-weight GEMM wrapper for dense NT matmul lowering.",
@@ -16841,8 +17374,392 @@
         ]
       },
       "notes": "Text multi-section RoPE for Q/K using implicit 1D positions expanded to the four-stream GGML contract.",
+      "numerical_capabilities": [
+        {
+          "contract_id": "text_mrope_fp32_input_fp32_compute_fp32_output",
+          "status": "validated",
+          "phases": [
+            "prefill",
+            "decode"
+          ],
+          "function": "mrope_qk_text",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "scalar",
+            "threading": {
+              "runtime": "serial",
+              "work_partition": [
+                "serial"
+              ],
+              "dispatch": [
+                "inline"
+              ],
+              "reduction_order_effect": "none"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "none",
+            "merge_order": "none",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "serial"
+          }
+        }
+      ],
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "cast": "float*",
+            "name": "q",
+            "source": "output:q"
+          },
+          {
+            "cast": "float*",
+            "name": "k",
+            "source": "output:k"
+          },
+          {
+            "name": "num_heads",
+            "source": "dim:num_heads"
+          },
+          {
+            "name": "num_kv_heads",
+            "source": "dim:num_kv_heads"
+          },
+          {
+            "name": "num_tokens",
+            "source": "dim:seq_len"
+          },
+          {
+            "name": "head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "aligned_head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "pos_offset",
+            "source": "runtime:pos"
+          },
+          {
+            "name": "n_dims",
+            "source": "dim:n_dims"
+          },
+          {
+            "name": "section_0",
+            "source": "dim:section_0"
+          },
+          {
+            "name": "section_1",
+            "source": "dim:section_1"
+          },
+          {
+            "name": "section_2",
+            "source": "dim:section_2"
+          },
+          {
+            "name": "section_3",
+            "source": "dim:section_3"
+          },
+          {
+            "name": "n_ctx_orig",
+            "source": "dim:n_ctx_orig"
+          },
+          {
+            "name": "freq_base",
+            "source": "dim:freq_base"
+          },
+          {
+            "name": "freq_scale",
+            "source": "dim:freq_scale"
+          },
+          {
+            "name": "ext_factor",
+            "source": "dim:ext_factor"
+          },
+          {
+            "name": "attn_factor",
+            "source": "dim:attn_factor"
+          },
+          {
+            "name": "beta_fast",
+            "source": "dim:beta_fast"
+          },
+          {
+            "name": "beta_slow",
+            "source": "dim:beta_slow"
+          }
+        ]
+      },
       "name": "mrope_qk_text",
       "_source_file": "mrope_qk_text.json"
+    },
+    {
+      "id": "mrope_qk_text_imrope",
+      "op": "rope",
+      "variant": "fp32_head_major_text_imrope",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor [heads, tokens, head_dim] rotated in-place"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ],
+          "desc": "Key tensor [kv_heads, tokens, head_dim] rotated in-place"
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "H",
+            "T",
+            "D"
+          ],
+          "desc": "Query tensor after interleaved text M-RoPE"
+        },
+        {
+          "name": "k",
+          "dtype": "fp32",
+          "shape": [
+            "KV",
+            "T",
+            "D"
+          ],
+          "desc": "Key tensor after interleaved text M-RoPE"
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "H",
+        "KV",
+        "T",
+        "D",
+        "n_dims"
+      ],
+      "params": [
+        {
+          "name": "aligned_head_dim",
+          "dtype": "int32",
+          "desc": "Aligned head dimension for scratch row stride"
+        },
+        {
+          "name": "pos_offset",
+          "dtype": "int32",
+          "desc": "Starting text position for the current token slice"
+        },
+        {
+          "name": "n_dims",
+          "dtype": "int32",
+          "desc": "Rotary width used by the text M-RoPE kernel"
+        },
+        {
+          "name": "section_0",
+          "dtype": "int32",
+          "desc": "Temporal-axis interleave width"
+        },
+        {
+          "name": "section_1",
+          "dtype": "int32",
+          "desc": "Height-axis interleave width"
+        },
+        {
+          "name": "section_2",
+          "dtype": "int32",
+          "desc": "Width-axis interleave width"
+        },
+        {
+          "name": "section_3",
+          "dtype": "int32",
+          "desc": "Extra-axis interleave width"
+        },
+        {
+          "name": "n_ctx_orig",
+          "dtype": "int32",
+          "desc": "Original context length for YaRN-style scaling"
+        },
+        {
+          "name": "freq_base",
+          "dtype": "fp32",
+          "desc": "Base rotary frequency"
+        },
+        {
+          "name": "freq_scale",
+          "dtype": "fp32",
+          "desc": "Frequency scaling factor"
+        },
+        {
+          "name": "ext_factor",
+          "dtype": "fp32",
+          "desc": "Extrapolation factor"
+        },
+        {
+          "name": "attn_factor",
+          "dtype": "fp32",
+          "desc": "Attention scaling factor"
+        },
+        {
+          "name": "beta_fast",
+          "dtype": "fp32",
+          "desc": "YaRN beta_fast"
+        },
+        {
+          "name": "beta_slow",
+          "dtype": "fp32",
+          "desc": "YaRN beta_slow"
+        }
+      ],
+      "impl": {
+        "function": "mrope_qk_text_imrope",
+        "c_declaration": "void mrope_qk_text_imrope(float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int n_dims, int section_0, int section_1, int section_2, int section_3, int n_ctx_orig, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow);",
+        "sources": [
+          "src/kernels/rope_kernels.c"
+        ]
+      },
+      "notes": "Text M-RoPE using Qwen-style three-axis interleaving and an implicit [position, position, position, 0] position tuple.",
+      "numerical_capabilities": [
+        {
+          "contract_id": "text_imrope_fp32_input_fp32_compute_fp32_output",
+          "status": "validated",
+          "phases": [
+            "prefill",
+            "decode"
+          ],
+          "function": "mrope_qk_text_imrope",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "scalar",
+            "threading": {
+              "runtime": "serial",
+              "work_partition": [
+                "serial"
+              ],
+              "dispatch": [
+                "inline"
+              ],
+              "reduction_order_effect": "none"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "none",
+            "merge_order": "none",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "serial"
+          }
+        }
+      ],
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "cast": "float*",
+            "name": "q",
+            "source": "output:q"
+          },
+          {
+            "cast": "float*",
+            "name": "k",
+            "source": "output:k"
+          },
+          {
+            "name": "num_heads",
+            "source": "dim:num_heads"
+          },
+          {
+            "name": "num_kv_heads",
+            "source": "dim:num_kv_heads"
+          },
+          {
+            "name": "num_tokens",
+            "source": "dim:seq_len"
+          },
+          {
+            "name": "head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "aligned_head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "pos_offset",
+            "source": "runtime:pos"
+          },
+          {
+            "name": "n_dims",
+            "source": "dim:n_dims"
+          },
+          {
+            "name": "section_0",
+            "source": "dim:section_0"
+          },
+          {
+            "name": "section_1",
+            "source": "dim:section_1"
+          },
+          {
+            "name": "section_2",
+            "source": "dim:section_2"
+          },
+          {
+            "name": "section_3",
+            "source": "dim:section_3"
+          },
+          {
+            "name": "n_ctx_orig",
+            "source": "dim:n_ctx_orig"
+          },
+          {
+            "name": "freq_base",
+            "source": "dim:freq_base"
+          },
+          {
+            "name": "freq_scale",
+            "source": "dim:freq_scale"
+          },
+          {
+            "name": "ext_factor",
+            "source": "dim:ext_factor"
+          },
+          {
+            "name": "attn_factor",
+            "source": "dim:attn_factor"
+          },
+          {
+            "name": "beta_fast",
+            "source": "dim:beta_fast"
+          },
+          {
+            "name": "beta_slow",
+            "source": "dim:beta_slow"
+          }
+        ]
+      },
+      "name": "mrope_qk_text_imrope",
+      "_source_file": "mrope_qk_text_imrope.json"
     },
     {
       "id": "mrope_qk_vision",

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.json
@@ -1,0 +1,67 @@
+{
+  "id": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+  "op": "attention",
+  "variant": "causal_head_major_gqa_prefill_append_f16cache_contract",
+  "mode": "prefill",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["prefill"],
+    "execution.prefill_batching": ["segmented_append"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp16"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["f16_online_fp32_merge"]
+  },
+  "supported_reductions": {
+    "f16_online_fp32_merge": {
+      "status": "observed",
+      "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+      "explicit_selector": true,
+      "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
+      "notes": "Cache-preserving segmented causal prefill using the validated FP16 decode reduction contract for each query row."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["kv_chunks_by_workers"],
+      "dispatch": ["ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "contract_defined"
+    }
+  },
+  "inputs": [
+    {"name": "q", "dtype": "fp32", "shape": ["num_heads", "q_tokens", "head_dim"]},
+    {"name": "k_cache", "dtype": "fp16", "shape": ["num_kv_heads", "cache_capacity", "head_dim"]},
+    {"name": "v_cache", "dtype": "fp16", "shape": ["num_kv_heads", "cache_capacity", "head_dim"]}
+  ],
+  "outputs": [
+    {"name": "output", "dtype": "fp32", "shape": ["num_heads", "q_tokens", "head_dim"]}
+  ],
+  "dims": ["num_heads", "num_kv_heads", "q_tokens", "past_tokens", "cache_capacity", "head_dim", "aligned_head_dim"],
+  "params": [
+    {"name": "reduction", "dtype": "ck_attention_reduction_t"}
+  ],
+  "impl": {
+    "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+    "c_declaration": "ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(const float *q, const uint16_t *k_cache, const uint16_t *v_cache, float *output, int num_heads, int num_kv_heads, int q_tokens, int past_tokens, int cache_capacity, int head_dim, int aligned_head_dim, ck_attention_reduction_t reduction);",
+    "sources": ["src/kernels/attention_kernels.c"]
+  },
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {"name": "q", "source": "scratch:q_scratch", "cast": "const float*"},
+      {"name": "k_cache", "source": "runtime:kv_cache_k_layer_f16", "cast": "const uint16_t*"},
+      {"name": "v_cache", "source": "runtime:kv_cache_v_layer_f16", "cast": "const uint16_t*"},
+      {"name": "output", "source": "output:out", "cast": "float*"},
+      {"name": "num_heads", "source": "dim:num_heads"},
+      {"name": "num_kv_heads", "source": "dim:num_kv_heads"},
+      {"name": "q_tokens", "source": "dim:seq_len"},
+      {"name": "past_tokens", "source": "runtime:prefill_start_pos"},
+      {"name": "cache_capacity", "source": "dim:max_seq_len"},
+      {"name": "head_dim", "source": "dim:head_dim"},
+      {"name": "aligned_head_dim", "source": "dim:head_dim"},
+      {"name": "reduction", "source": "const:CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE"}
+    ]
+  }
+}

--- a/version/v8/kernel_maps/attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided.json
+++ b/version/v8/kernel_maps/attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided.json
@@ -1,0 +1,94 @@
+{
+  "id": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+  "op": "attention",
+  "variant": "full_tiled64_f16kv_fp32",
+  "mode": "prefill",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["prefill"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp32"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["f16_kv_tiled64_fp32_softmax_fp64_sum_update"]
+  },
+  "supported_reductions": {
+    "f16_kv_tiled64_fp32_softmax_fp64_sum_update": {
+      "status": "validated",
+      "function": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+      "explicit_selector": true,
+      "selector": "circuit_required_contract",
+      "notes": "Exact 64x64 tiled full-attention provider with FP16-rounded K/V and the contract-defined softmax sum update."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "compile_time",
+    "threading": {
+      "runtime": "ck_threadpool",
+      "work_partition": ["independent_query_blocks"],
+      "dispatch": ["ck_threadpool_dispatch_n"],
+      "reduction_order_effect": "contract_defined"
+    }
+  },
+  "quant": {"weight": "none", "activation": "fp32", "output": "fp32"},
+  "inputs": [
+    {"name": "q", "dtype": "fp32", "shape": ["H", "T", "D"], "desc": "FP32 query tensor"}
+  ],
+  "weights": [],
+  "activations": [],
+  "runtime_buffers": [
+    {"name": "k", "dtype": "fp32", "shape": ["KV", "S", "D"], "desc": "K tensor rounded through FP16 on tile load"},
+    {"name": "v", "dtype": "fp32", "shape": ["KV", "S", "D"], "desc": "V tensor rounded through FP16 on tile load"}
+  ],
+  "outputs": [
+    {"name": "out", "dtype": "fp32", "shape": ["H", "T", "D"], "desc": "FP32 attention output"}
+  ],
+  "scratch": [
+    {"name": "thread_tiles", "dtype": "fp32", "size_bytes": "per_thread((64*D)+(64*64)+(64*D)+(64*D))", "desc": "Bounded query, key, value, score, and output tiles"}
+  ],
+  "dims": ["H", "KV", "T", "S", "D"],
+  "params": [
+    {"name": "kv_stride_tokens", "dtype": "int32", "desc": "K/V token stride"},
+    {"name": "head_dim", "dtype": "int32", "desc": "Logical head width"},
+    {"name": "aligned_head_dim", "dtype": "int32", "desc": "Physical head stride"}
+  ],
+  "parallelization": {
+    "supported": ["query_blocks"],
+    "preferred": {"prefill": "query_blocks"},
+    "strategies": [
+      {"name": "query_blocks", "partition_dim": "H*T", "param_style": "ith_nth", "notes": "Contiguous head/query row ranges; each query retains ascending key-tile reduction order."}
+    ]
+  },
+  "constraints": {
+    "alignment": {"D": 1, "T": 1},
+    "notes": "Full bidirectional attention. num_heads must be divisible by num_kv_heads, aligned_head_dim >= head_dim, and kv_stride_tokens >= num_tokens."
+  },
+  "impl": {
+    "function": "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided",
+    "c_declaration": "void attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided(const float *q, const float *k, const float *v, float *output, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int kv_stride_tokens);",
+    "sources": ["src/kernels/attention_kernels.c", "src/kernels/softmax_kernels.c"],
+    "variants": [
+      {"name": "avx2", "requires": ["avx2", "fma", "f16c"], "compile_flags": ["-mavx2", "-mfma", "-mf16c"]},
+      {"name": "portable", "requires": [], "compile_flags": []}
+    ]
+  },
+  "tests": {
+    "unit": ["unittest/test_attention_full.py"],
+    "oracle": ["version/v8/scripts/replay_attention_from_dumps_v8.py --mode tiled_f16kv"]
+  },
+  "notes": "Contract-selected GGML-compatible tiled full attention. This provider is additive and does not replace online or BF16 SDPA contracts.",
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {"name": "q", "source": "scratch:q_scratch", "cast": "float*"},
+      {"name": "k", "source": "scratch:k_scratch", "cast": "float*"},
+      {"name": "v", "source": "scratch:v_scratch", "cast": "float*"},
+      {"name": "output", "source": "output:out", "cast": "float*"},
+      {"name": "num_heads", "source": "dim:num_heads"},
+      {"name": "num_kv_heads", "source": "dim:num_kv_heads"},
+      {"name": "num_tokens", "source": "dim:seq_len"},
+      {"name": "head_dim", "source": "dim:head_dim"},
+      {"name": "aligned_head_dim", "source": "dim:head_dim"},
+      {"name": "kv_stride_tokens", "source": "dim:max_seq_len"}
+    ]
+  }
+}

--- a/version/v8/kernel_maps/gelu_ggml_inplace.json
+++ b/version/v8/kernel_maps/gelu_ggml_inplace.json
@@ -30,8 +30,48 @@
     "c_declaration": "void gelu_ggml_inplace(float *data, size_t n);",
     "sources": ["src/kernels/gelu_kernels.c"]
   },
+  "modes": {"inference": true, "training": false, "backward": false},
+  "numerical_capabilities": [
+    {
+      "contract_id": "gelu_fp32_input_fp16_table_fp32_output",
+      "status": "validated",
+      "phases": ["prefill"],
+      "function": "gelu_ggml_inplace",
+      "explicit_selector": true,
+      "implementation": {
+        "isa_dispatch": "scalar",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": ["serial"],
+          "dispatch": ["inline"],
+          "reduction_order_effect": "none"
+        }
+      },
+      "arithmetic": {
+        "partial_accumulator": "none",
+        "merge_order": "none",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false,
+        "split_strategy": "serial"
+      }
+    }
+  ],
   "tests": {
-    "unit": ["unittest/test_gelu.py"]
+    "unit": ["unittest/test_gelu.py::GGML Qwen3-VL boundary"]
+  },
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {
+        "cast": "float*",
+        "name": "data",
+        "source": "output:out"
+      },
+      {
+        "name": "n",
+        "source": "dim:gelu_elems"
+      }
+    ]
   },
   "notes": "GGML-compatible FP16-table GELU used for llama.cpp activation parity."
 }

--- a/version/v8/kernel_maps/gemm_nt_f16.json
+++ b/version/v8/kernel_maps/gemm_nt_f16.json
@@ -46,8 +46,69 @@
     "c_declaration": "void gemm_nt_f16(const float *A, const void *B, const float *bias, float *C, int M, int N, int K);",
     "sources": ["src/kernels/gemm_kernels_f16.c"]
   },
+  "modes": {"inference": true, "training": false, "backward": false},
+  "numerical_capabilities": [
+    {
+      "contract_id": "fp16_weight_fp16_input_llamafile_avx_fp32_output",
+      "status": "validated",
+      "phases": ["prefill"],
+      "function": "gemm_nt_f16",
+      "explicit_selector": true,
+      "implementation": {
+        "isa_dispatch": "compile_time",
+        "threading": {
+          "runtime": "ck_threadpool",
+          "work_partition": ["independent_rows"],
+          "dispatch": ["ck_threadpool_dispatch_n"],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "arithmetic": {
+        "partial_accumulator": "fp32",
+        "merge_order": "pairwise_tree",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false,
+        "split_strategy": "independent_outputs"
+      }
+    }
+  ],
   "tests": {
-    "unit": ["tests/test_v8_qwen3vl_template.py"]
+    "unit": ["unittest/test_f16_gemm_llama_contract.py"]
+  },
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {
+        "cast": "const float*",
+        "name": "A",
+        "source": "activation:a"
+      },
+      {
+        "name": "B",
+        "source": "weight:_first_weight"
+      },
+      {
+        "name": "bias",
+        "source": "weight_f:_bias"
+      },
+      {
+        "cast": "float*",
+        "name": "C",
+        "source": "output:c"
+      },
+      {
+        "name": "M",
+        "source": "dim:_m"
+      },
+      {
+        "name": "N",
+        "source": "dim:_output_dim"
+      },
+      {
+        "name": "K",
+        "source": "dim:_input_dim"
+      }
+    ]
   },
   "notes": "Generic FP16-weight GEMM wrapper for dense NT matmul lowering."
 }

--- a/version/v8/kernel_maps/kernel_bindings.overlay.json
+++ b/version/v8/kernel_maps/kernel_bindings.overlay.json
@@ -679,57 +679,8 @@
         }
       ]
     },
-    "gelu_ggml_inplace": {
-      "note": "GGML-compatible in-place GELU binding for llama.cpp parity-sensitive v8 paths.",
-      "params": [
-        {
-          "cast": "float*",
-          "name": "data",
-          "source": "output:out"
-        },
-        {
-          "name": "n",
-          "source": "dim:gelu_elems"
-        }
-      ]
-    },
     "gemm_naive_parallel": {
       "note": "Exact FP32 NT GEMM binding for parity-sensitive matmuls.",
-      "params": [
-        {
-          "cast": "const float*",
-          "name": "A",
-          "source": "activation:a"
-        },
-        {
-          "name": "B",
-          "source": "weight:_first_weight"
-        },
-        {
-          "name": "bias",
-          "source": "weight_f:_bias"
-        },
-        {
-          "cast": "float*",
-          "name": "C",
-          "source": "output:c"
-        },
-        {
-          "name": "M",
-          "source": "dim:_m"
-        },
-        {
-          "name": "N",
-          "source": "dim:_output_dim"
-        },
-        {
-          "name": "K",
-          "source": "dim:_input_dim"
-        }
-      ]
-    },
-    "gemm_nt_f16": {
-      "note": "FP16-weight dense GEMM wrapper with the standard matmul ABI.",
       "params": [
         {
           "cast": "const float*",
@@ -1257,93 +1208,6 @@
         {
           "name": "eps",
           "source": "dim:rms_eps"
-        }
-      ]
-    },
-    "mrope_qk_text": {
-      "note": "Text multi-section RoPE driven by runtime token position offset.",
-      "params": [
-        {
-          "cast": "float*",
-          "name": "q",
-          "source": "output:q"
-        },
-        {
-          "cast": "float*",
-          "name": "k",
-          "source": "output:k"
-        },
-        {
-          "name": "num_heads",
-          "source": "dim:num_heads"
-        },
-        {
-          "name": "num_kv_heads",
-          "source": "dim:num_kv_heads"
-        },
-        {
-          "name": "num_tokens",
-          "source": "dim:seq_len"
-        },
-        {
-          "name": "head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "aligned_head_dim",
-          "source": "dim:head_dim"
-        },
-        {
-          "name": "pos_offset",
-          "source": "runtime:pos"
-        },
-        {
-          "name": "n_dims",
-          "source": "dim:n_dims"
-        },
-        {
-          "name": "section_0",
-          "source": "dim:section_0"
-        },
-        {
-          "name": "section_1",
-          "source": "dim:section_1"
-        },
-        {
-          "name": "section_2",
-          "source": "dim:section_2"
-        },
-        {
-          "name": "section_3",
-          "source": "dim:section_3"
-        },
-        {
-          "name": "n_ctx_orig",
-          "source": "dim:n_ctx_orig"
-        },
-        {
-          "name": "freq_base",
-          "source": "dim:freq_base"
-        },
-        {
-          "name": "freq_scale",
-          "source": "dim:freq_scale"
-        },
-        {
-          "name": "ext_factor",
-          "source": "dim:ext_factor"
-        },
-        {
-          "name": "attn_factor",
-          "source": "dim:attn_factor"
-        },
-        {
-          "name": "beta_fast",
-          "source": "dim:beta_fast"
-        },
-        {
-          "name": "beta_slow",
-          "source": "dim:beta_slow"
         }
       ]
     },

--- a/version/v8/kernel_maps/mrope_qk_text_imrope.json
+++ b/version/v8/kernel_maps/mrope_qk_text_imrope.json
@@ -1,7 +1,7 @@
 {
-  "id": "mrope_qk_text",
+  "id": "mrope_qk_text_imrope",
   "op": "rope",
-  "variant": "fp32_head_major_text_mrope",
+  "variant": "fp32_head_major_text_imrope",
   "quant": {
     "weight": "none",
     "activation": "fp32",
@@ -28,13 +28,13 @@
       "name": "q",
       "dtype": "fp32",
       "shape": ["H", "T", "D"],
-      "desc": "Query tensor after text M-RoPE"
+      "desc": "Query tensor after interleaved text M-RoPE"
     },
     {
       "name": "k",
       "dtype": "fp32",
       "shape": ["KV", "T", "D"],
-      "desc": "Key tensor after text M-RoPE"
+      "desc": "Key tensor after interleaved text M-RoPE"
     }
   ],
   "scratch": [],
@@ -58,22 +58,22 @@
     {
       "name": "section_0",
       "dtype": "int32",
-      "desc": "First section width"
+      "desc": "Temporal-axis interleave width"
     },
     {
       "name": "section_1",
       "dtype": "int32",
-      "desc": "Second section width"
+      "desc": "Height-axis interleave width"
     },
     {
       "name": "section_2",
       "dtype": "int32",
-      "desc": "Third section width"
+      "desc": "Width-axis interleave width"
     },
     {
       "name": "section_3",
       "dtype": "int32",
-      "desc": "Fourth section width"
+      "desc": "Extra-axis interleave width"
     },
     {
       "name": "n_ctx_orig",
@@ -112,17 +112,17 @@
     }
   ],
   "impl": {
-    "function": "mrope_qk_text",
-    "c_declaration": "void mrope_qk_text(float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int n_dims, int section_0, int section_1, int section_2, int section_3, int n_ctx_orig, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow);",
+    "function": "mrope_qk_text_imrope",
+    "c_declaration": "void mrope_qk_text_imrope(float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int n_dims, int section_0, int section_1, int section_2, int section_3, int n_ctx_orig, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow);",
     "sources": ["src/kernels/rope_kernels.c"]
   },
-  "notes": "Text multi-section RoPE for Q/K using implicit 1D positions expanded to the four-stream GGML contract.",
+  "notes": "Text M-RoPE using Qwen-style three-axis interleaving and an implicit [position, position, position, 0] position tuple.",
   "numerical_capabilities": [
     {
-      "contract_id": "text_mrope_fp32_input_fp32_compute_fp32_output",
+      "contract_id": "text_imrope_fp32_input_fp32_compute_fp32_output",
       "status": "validated",
       "phases": ["prefill", "decode"],
-      "function": "mrope_qk_text",
+      "function": "mrope_qk_text_imrope",
       "explicit_selector": true,
       "implementation": {
         "isa_dispatch": "scalar",

--- a/version/v8/parity_profiles/qwen3vl_llamacpp_q8_v1.json
+++ b/version/v8/parity_profiles/qwen3vl_llamacpp_q8_v1.json
@@ -27,6 +27,7 @@
     }
   },
   "checkpoint_order": [
+    "vision.frontend.patch_bias.output",
     "vision.frontend.position.output",
     "vision.layer.{layer}.norm1.output",
     "vision.layer.{layer}.q.pre_rope",
@@ -45,6 +46,14 @@
   ],
   "interval_expansions": {},
   "backend_mappings": {
+    "vision.frontend.patch_bias.output": {
+      "producer": "patch_bias_add",
+      "logical_layout": "token_major",
+      "axis_names": ["token", "channel"],
+      "capture_tensor": "patch_bias",
+      "result_tensor": "patch_bias",
+      "result_layer": -1
+    },
     "vision.frontend.position.output": {
       "producer": "position_embeddings",
       "logical_layout": "token_major",

--- a/version/v8/schemas/attention_kernel_capability.schema.json
+++ b/version/v8/schemas/attention_kernel_capability.schema.json
@@ -15,6 +15,7 @@
       "required": ["execution.phase", "tensor.q.dtype", "tensor.kv.dtype", "tensor.layout", "numerics.attention_reduction"],
       "properties": {
         "execution.phase": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["prefill", "decode"]}},
+        "execution.prefill_batching": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["full_sequence", "segmented_append"]}},
         "tensor.q.dtype": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["fp32", "fp16", "bf16"]}},
         "tensor.kv.dtype": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["fp32", "fp16", "bf16"]}},
         "tensor.layout": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["head_major", "token_major"]}},

--- a/version/v8/schemas/attention_reduction_registry.schema.json
+++ b/version/v8/schemas/attention_reduction_registry.schema.json
@@ -59,11 +59,23 @@
           "additionalProperties": false,
           "required": ["kind"],
           "properties": {
-            "kind": {"enum": ["single_range", "kv_chunks_by_workers"]},
+            "kind": {"enum": ["single_range", "kv_chunks_by_workers", "query_key_tiles"]},
             "threshold": {"type": "integer", "minimum": 1},
             "below_threshold_chunks": {"type": "integer", "minimum": 1},
-            "at_or_above_threshold_chunks": {"enum": ["runtime_worker_count"]}
-          }
+            "at_or_above_threshold_chunks": {"enum": ["runtime_worker_count"]},
+            "query_tile_size": {"type": "integer", "minimum": 1},
+            "key_tile_size": {"type": "integer", "minimum": 1},
+            "softmax_sum_update": {"enum": ["fp32_add", "fp64_add_then_fp32_store"]},
+            "worker_partition": {"enum": ["contiguous_head_query_rows"]}
+          },
+          "allOf": [
+            {
+              "if": {"properties": {"kind": {"const": "query_key_tiles"}}},
+              "then": {
+                "required": ["query_tile_size", "key_tile_size", "softmax_sum_update", "worker_partition"]
+              }
+            }
+          ]
         },
         "description": {"type": "string", "minLength": 1},
         "validation": {

--- a/version/v8/schemas/attention_required_contracts.schema.json
+++ b/version/v8/schemas/attention_required_contracts.schema.json
@@ -122,6 +122,12 @@
                 "decode"
               ]
             },
+            "execution.prefill_batching": {
+              "enum": [
+                "full_sequence",
+                "segmented_append"
+              ]
+            },
             "tensor.q.dtype": {
               "enum": [
                 "fp32",

--- a/version/v8/schemas/numerical_execution_contract_registry.schema.json
+++ b/version/v8/schemas/numerical_execution_contract_registry.schema.json
@@ -48,7 +48,9 @@
             "gemm",
             "spatial_position_interpolation",
             "vision_mrope",
+            "text_mrope",
             "layernorm",
+            "rmsnorm",
             "attention",
             "residual_add",
             "gelu"
@@ -73,6 +75,7 @@
             "input": {
               "enum": [
                 "fp32",
+                "fp64",
                 "fp16",
                 "bf16",
                 "q8_0",
@@ -132,6 +135,7 @@
             "accumulator": {
               "enum": [
                 "fp32",
+                "fp64",
                 "fp16",
                 "bf16",
                 "int32"
@@ -175,7 +179,12 @@
                   "partial_store",
                   "softmax_probability_store",
                   "partial_merge",
-                  "output_store"
+                  "output_store",
+                  "square_product",
+                  "reduction_finalize",
+                  "reciprocal_sqrt",
+                  "normalization_scale",
+                  "weight_scale"
                 ]
               }
             }
@@ -214,6 +223,7 @@
               "enum": [
                 "none",
                 "fp32",
+                "fp64",
                 "fp16",
                 "bf16",
                 "int32"
@@ -320,6 +330,7 @@
                   "enum": [
                     "not_applicable",
                     "axis_selection",
+                    "interleaved_axis_selection",
                     "contiguous_widths"
                   ]
                 },

--- a/version/v8/schemas/numerical_kernel_capability.schema.json
+++ b/version/v8/schemas/numerical_kernel_capability.schema.json
@@ -30,7 +30,7 @@
       "type": "object", "additionalProperties": false,
       "required": ["partial_accumulator", "merge_order", "deterministic", "thread_count_changes_arithmetic_order", "split_strategy"],
       "properties": {
-        "partial_accumulator": {"enum": ["none", "fp32", "fp16", "bf16", "int32"]},
+        "partial_accumulator": {"enum": ["none", "fp32", "fp64", "fp16", "bf16", "int32"]},
         "merge_order": {"enum": ["none", "ascending_chunk", "pairwise_tree", "implementation_defined"]},
         "deterministic": {"type": "boolean"},
         "thread_count_changes_arithmetic_order": {"type": "boolean"},

--- a/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
+++ b/version/v8/scripts/activation_parity_qwen3vl_mmproj_v8.py
@@ -17,6 +17,7 @@ llamacpp`` so checkpoint ordering and reports use the standard X-ray surface.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import subprocess
@@ -43,6 +44,31 @@ import parity_test  # type: ignore  # noqa: E402
 
 def _run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
     subprocess.run(cmd, cwd=str(cwd or REPO_ROOT), env=env, check=True)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _binary_provenance(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise RuntimeError(f"required X-ray binary is missing: {path}")
+    comment = subprocess.run(
+        ["readelf", "-p", ".comment", str(path)],
+        cwd=str(REPO_ROOT),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        "path": str(path.resolve()),
+        "sha256": _sha256(path),
+        "elf_comment": comment.stdout.strip() if comment.returncode == 0 else None,
+    }
 
 
 def _compile_generated_dump_model(output_dir: Path, c_path: Path) -> Path:
@@ -168,6 +194,7 @@ def _run_generated_encoder_with_dump(
     dump_dir: Path,
     strict_parity: bool,
     strict_dump_layer: int | None,
+    dump_layer: int | None,
     ck_stop_op: int | None,
     dump_names: str | None,
 ) -> None:
@@ -186,6 +213,13 @@ def _run_generated_encoder_with_dump(
         "CK_STRICT_ATTN_DUMP_LAYER",
         None if strict_dump_layer is None else str(strict_dump_layer),
     )
+    # Keep global frontend checkpoints and the requested transformer layer.
+    # Without this bound, a late-layer X-ray emits every prior layer and can
+    # produce multi-gigabyte dumps before attribution begins.
+    old_layer_filter = _with_env_var(
+        "CK_PARITY_LAYER_FILTER",
+        None if dump_layer is None else f"-1,{int(dump_layer)}",
+    )
     old_stop_op = _with_env_var("CK_STOP_OP", None if ck_stop_op is None else str(int(ck_stop_op)))
     old_filter = _with_env_var("CK_PARITY_OP_FILTER", dump_names)
     try:
@@ -200,6 +234,7 @@ def _run_generated_encoder_with_dump(
     finally:
         _restore_env_var("CK_PARITY_OP_FILTER", old_filter)
         _restore_env_var("CK_STOP_OP", old_stop_op)
+        _restore_env_var("CK_PARITY_LAYER_FILTER", old_layer_filter)
         _restore_env_var("CK_STRICT_ATTN_DUMP_LAYER", old_dump_layer)
         _restore_env_var("CK_PARITY_DIR", old_dump)
 
@@ -290,6 +325,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional comma-separated llama dump filter, e.g. patch_bias,inp_pos_emb,ln1,Qcur,Qcur_rope,Kcur,Kcur_rope,Vcur,kqv_out,attn_out",
     )
     ap.add_argument("--llama-dump-layer", type=int, default=None, help="Optional exact llama layer id filter; globals remain included")
+    ap.add_argument("--ck-dump-layer", type=int, default=None, help="Optional exact CK layer id filter; global frontend checkpoints remain included")
     ap.add_argument("--ck-strict-dump-layer", type=int, default=None, help="Optional exact CK strict-attention dump layer filter")
     ap.add_argument(
         "--ck-dump-names",
@@ -319,6 +355,12 @@ def main(argv: list[str] | None = None) -> int:
     ck_stop_op = _resolve_ck_stop_op(output_dir, args.ck_stop_op, args.ck_stop_layer)
     model_so = _compile_generated_dump_model(output_dir, c_path)
     shim_so = npv8._compile_mtmd_shim(output_dir)
+    engine_so = BUILD_DIR / "libckernel_engine.so"
+    binary_provenance = {
+        "engine": _binary_provenance(engine_so),
+        "generated_model": _binary_provenance(model_so),
+        "llama_shim": _binary_provenance(shim_so),
+    }
 
     config = report["config"]
     height = int(config.get("image_height", config.get("image_size")))
@@ -351,6 +393,7 @@ def main(argv: list[str] | None = None) -> int:
         dump_dir=ck_dump_dir,
         strict_parity=bool(args.strict_parity),
         strict_dump_layer=args.ck_strict_dump_layer,
+        dump_layer=args.ck_dump_layer,
         ck_stop_op=ck_stop_op,
         dump_names=args.ck_dump_names or args.llama_dump_names,
     )
@@ -366,6 +409,11 @@ def main(argv: list[str] | None = None) -> int:
         dump_layer=args.llama_dump_layer,
         flash_attn_type={"disabled": 0, "auto": -1, "enabled": 1}[args.llama_flash_attn],
     )
+    engine_sha_after_capture = _sha256(engine_so)
+    if engine_sha_after_capture != binary_provenance["engine"]["sha256"]:
+        raise RuntimeError(
+            "build/libckernel_engine.so changed during X-ray capture; discard the mixed-build report"
+        )
 
     ck_dump = _merge_ck_dump_artifacts(ck_dump_dir)
     ref_dump = llama_dump_dir / "dump.bin"
@@ -400,11 +448,13 @@ def main(argv: list[str] | None = None) -> int:
             "llama_cpp": args.threads,
             "ck_runtime": ck_threads,
         },
+        "binary_provenance": binary_provenance,
         "strict_parity": bool(args.strict_parity),
         "llama_flash_attn": args.llama_flash_attn,
         "llama_dump_names": args.llama_dump_names,
         "ck_dump_names": args.ck_dump_names or args.llama_dump_names,
         "llama_dump_layer": args.llama_dump_layer,
+        "ck_dump_layer": args.ck_dump_layer,
         "atol": args.atol,
         "rtol": args.rtol,
         "ck_dump": str(ck_dump),

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -338,6 +338,24 @@ def _is_vision_mrope_operation(operation: Dict[str, Any]) -> bool:
     return str(params.get("rope_mode", "")).strip().lower() == "vision"
 
 
+def _is_text_mrope_operation(operation: Dict[str, Any]) -> bool:
+    """Classify text M-RoPE from resolved contract semantics."""
+    resolved = operation.get("resolved_contract")
+    semantics = resolved.get("semantics") if isinstance(resolved, dict) else None
+    position = semantics.get("position_transform") if isinstance(semantics, dict) else None
+    if isinstance(semantics, dict):
+        return bool(
+            semantics.get("operator_family") == "text_mrope"
+            and isinstance(position, dict)
+            and position.get("pairing") == "multi_section"
+        )
+
+    if str(operation.get("op", "")) != "rope_qk":
+        return False
+    params = operation.get("params") if isinstance(operation.get("params"), dict) else {}
+    return str(params.get("rope_mode", "")).strip().lower() == "text_mrope"
+
+
 def _attach_semantic_checkpoints(
     template: Dict[str, Any],
     arranged_kernels: List[Dict[str, Any]],
@@ -724,6 +742,10 @@ def _hydrate_manifest_template(manifest: Dict[str, Any]) -> Dict[str, Any]:
         manifest["template"] = _merge_template_defaults(built_in, template_doc)
     elif built_in:
         manifest["template"] = copy.deepcopy(built_in)
+    _validate_segmented_prefill_contract(
+        manifest.get("template") if isinstance(manifest.get("template"), dict) else None,
+        source=f"manifest:{template_name or '<embedded>'}",
+    )
     _raise_on_forbidden_template_metadata(
         manifest.get("template") if isinstance(manifest.get("template"), dict) else None,
         source=f"manifest:{template_name or '<embedded>'}",
@@ -740,6 +762,46 @@ def _hydrate_manifest_template(manifest: Dict[str, Any]) -> Dict[str, Any]:
         hydrated_config["multimodal_bridge_contract"] = copy.deepcopy(bridge_contract)
     manifest["config"] = hydrated_config
     return manifest
+
+
+def _validate_segmented_prefill_contract(
+    circuit: Optional[Dict[str, Any]],
+    *,
+    source: str,
+) -> None:
+    if not isinstance(circuit, dict):
+        return
+    contract = circuit.get("contract") if isinstance(circuit.get("contract"), dict) else {}
+    bridge = contract.get("multimodal_bridge") if isinstance(contract.get("multimodal_bridge"), dict) else {}
+    schedule = bridge.get("prefill_schedule") if isinstance(bridge.get("prefill_schedule"), dict) else {}
+    schedule_is_segmented = bool(schedule) and (
+        schedule.get("segments") == ["text_before", "visual", "text_after"]
+        and schedule.get("cache_transition") == "append_preserve"
+        and schedule.get("position_transition") == "segment_defined"
+    )
+    if schedule and not schedule_is_segmented:
+        raise RuntimeError(
+            "HARD CONTRACT FAULT: unsupported mixed-prefill schedule in "
+            f"{source}. The segmented append contract requires text_before, visual, text_after; "
+            "append_preserve; and segment_defined."
+        )
+
+    required = circuit.get("required_contracts")
+    required = required if isinstance(required, dict) else {}
+    attention = required.get("decoder.attention")
+    attention = attention if isinstance(attention, dict) else {}
+    phases = attention.get("phases") if isinstance(attention.get("phases"), dict) else {}
+    prefill = phases.get("prefill") if isinstance(phases.get("prefill"), dict) else {}
+    requirements = prefill.get("requires") if isinstance(prefill.get("requires"), dict) else {}
+    attention_is_segmented = requirements.get("execution.prefill_batching") == "segmented_append"
+
+    if schedule_is_segmented != attention_is_segmented:
+        raise RuntimeError(
+            "HARD CONTRACT FAULT: segmented mixed-prefill schedule and attention provider disagree "
+            f"in {source}. Declare both multimodal_bridge.prefill_schedule.cache_transition="
+            "append_preserve and decoder.attention.prefill execution.prefill_batching="
+            "segmented_append, or declare neither."
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -7266,6 +7328,47 @@ def generate_ir_lower_1(
             # also exists.
             if op["op"] in ("attn", "attn_sliding", "attn_shared_kv", "attn_sliding_shared_kv"):
                 layer = op["layer"]
+                required_contract = op.get("required_contract") if isinstance(op.get("required_contract"), dict) else {}
+                segmented_append = required_contract.get("execution.prefill_batching") == "segmented_append"
+                if segmented_append and not uses_kv_cache:
+                    raise RuntimeError(
+                        "HARD CONTRACT FAULT: segmented_append attention requires a persistent KV cache. "
+                        "Fix the circuit cache contract; do not fall back to full-sequence prefill."
+                    )
+                kv_batch_copy_op = None
+                if uses_kv_cache:
+                    shared_q_prefill = op["op"] in ("attn_shared_kv", "attn_sliding_shared_kv")
+                    copy_src = "q_scratch" if shared_q_prefill else "k_scratch"
+                    kv_batch_copy_op = {
+                        "idx": len(final_ops),
+                        "kernel": "kv_cache_batch_copy",
+                        "op": "kv_cache_batch_copy",
+                        "layer": layer,
+                        "section": op["section"],
+                        "function": "kv_cache_batch_copy",
+                        "weights": {},
+                        "inputs": {
+                            "k_src": {"type": "scratch", "source": copy_src},
+                            "v_src": {"type": "scratch", "source": "q_scratch" if shared_q_prefill else "v_scratch"},
+                        },
+                        "outputs": {
+                            "k_dst": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
+                            "v_dst": {"type": "kv_cache", "buffer": f"kv_cache_v_L{layer}"},
+                        },
+                        "scratch": [],
+                        "params": {
+                            "num_kv_heads": int(config.get("num_kv_heads", 1)),
+                            "head_dim": int(config.get("head_dim", 1)),
+                            "seq_len": int(config.get("context_length", config.get("context_len", 1))),
+                        },
+                        "_auto_inserted": True,
+                        "_cache_append": segmented_append,
+                    }
+                if segmented_append:
+                    # The append provider reads current K/V through the persistent
+                    # cache, so store this segment immediately before attention.
+                    final_ops.insert(len(final_ops) - 1, kv_batch_copy_op)
+                    kv_store_count += 1
                 transpose_attn_out_op = {
                     "idx": len(final_ops),
                     "kernel": "transpose_attn_out_to_token_major",
@@ -7280,38 +7383,10 @@ def generate_ir_lower_1(
                     "_auto_inserted": True,
                 }
                 final_ops.append(transpose_attn_out_op)
-                if uses_kv_cache:
+                if uses_kv_cache and not segmented_append:
                     # TODO(contract): validate this op against runtime_invariants contract:
                     # _kv_copy_bytes must exist and match
                     # (num_kv_heads * head_dim * seq_len * sizeof(fp32)).
-                    shared_q_prefill = op["op"] in ("attn_shared_kv", "attn_sliding_shared_kv")
-                    copy_src = "q_scratch" if shared_q_prefill else "k_scratch"
-                    kv_batch_copy_op = {
-                        "idx": len(final_ops),
-                        "kernel": "kv_cache_batch_copy",
-                        "op": "kv_cache_batch_copy",
-                        "layer": layer,
-                        "section": op["section"],
-                        "function": "kv_cache_batch_copy",  # Codegen emits two memcpy calls (K and V)
-                        "weights": {},
-                        "inputs": {
-                            "k_src": {"type": "scratch", "source": copy_src},
-                            "v_src": {"type": "scratch", "source": "q_scratch" if shared_q_prefill else "v_scratch"},
-                        },
-                        "outputs": {
-                            "k_dst": {"type": "kv_cache", "buffer": f"kv_cache_k_L{layer}"},
-                            "v_dst": {"type": "kv_cache", "buffer": f"kv_cache_v_L{layer}"},
-                        },
-                        "scratch": [],
-                        "params": {
-                            "num_kv_heads": int(config.get("num_kv_heads", 1)),
-                            "head_dim": int(config.get("head_dim", 1)),
-                            # Prefill copies a token batch into KV cache; use configured max context
-                            # as the conservative compile-time dimension for call-IR binding.
-                            "seq_len": int(config.get("context_length", config.get("context_len", 1))),
-                        },
-                        "_auto_inserted": True,
-                    }
                     final_ops.append(kv_batch_copy_op)
                     kv_store_count += 1
 
@@ -9987,7 +10062,7 @@ def generate_ir_lower_2(
             params.setdefault("beta_fast", float(config.get("vision_mrope_beta_fast", 32.0)))
             params.setdefault("beta_slow", float(config.get("vision_mrope_beta_slow", 1.0)))
             params.setdefault("n_ctx_orig", int(config.get("vision_mrope_original_context_length", 32768)))
-        if op_type == "rope_qk" and ir_op.get("kernel", "") == "mrope_qk_text":
+        if op_type == "rope_qk" and _is_text_mrope_operation(ir_op):
             sections = config.get("mrope_sections")
             if not isinstance(sections, list) or len(sections) != 4:
                 default_section = max(1, int(params.get("head_dim", 0) or 0) // 4)
@@ -11001,6 +11076,14 @@ def generate_ir_lower_3(lowered_ir: Dict, mode: str) -> Dict:
                         expr = "model->pos + 1"
                     else:
                         expr = str(params.get("seq_len", 1))
+                elif key == "prefill_start_pos":
+                    if mode != "prefill":
+                        op_errors.append(f"{func}.{name}: prefill_start_pos is invalid in {mode} mode")
+                        expr = "0"
+                    else:
+                        # Call IR names persistent runtime state, not a local
+                        # variable owned by one generated prefill function.
+                        expr = "model->pos"
                 elif key == "layer":
                     expr = str(layer)
                 else:

--- a/version/v8/scripts/codegen_prefill_v8.py
+++ b/version/v8/scripts/codegen_prefill_v8.py
@@ -278,8 +278,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
         float *v_scratch = (float*)(model->bump + A_V_SCRATCH);
         uint16_t *kv_cache = (uint16_t*)model->kv_cache_f16;
         for (int h = 0; h < Hkv; h++) {{
-            uint16_t *k_dst = {k_base_expr} + (size_t)h*cache_stride*D;
-            uint16_t *v_dst = {v_base_expr} + (size_t)h*cache_stride*D;
+            uint16_t *k_dst = {k_base_expr} + ((size_t)h*cache_stride + (size_t)prefill_start_pos)*D;
+            uint16_t *v_dst = {v_base_expr} + ((size_t)h*cache_stride + (size_t)prefill_start_pos)*D;
             const float *k_src = k_scratch + h*num_tokens*D;
             const float *v_src = v_scratch + h*num_tokens*D;
             for (int t = 0; t < num_tokens; ++t) {{
@@ -307,13 +307,13 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             /* K: copy from scratch[h, 0:num_tokens, :] to cache[h, 0:num_tokens, :] */
             /* Scratch is compact: stride = num_tokens, Cache has stride = cache_stride */
             memcpy(
-                {k_base_expr} + (size_t)h*cache_stride*D,
+                {k_base_expr} + ((size_t)h*cache_stride + (size_t)prefill_start_pos)*D,
                 k_scratch + h*num_tokens*D,
                 (size_t)num_tokens * D * sizeof(float)
             );
             /* V: copy from scratch[h, 0:num_tokens, :] to cache[h, 0:num_tokens, :] */
             memcpy(
-                {v_base_expr} + (size_t)h*cache_stride*D,
+                {v_base_expr} + ((size_t)h*cache_stride + (size_t)prefill_start_pos)*D,
                 v_scratch + h*num_tokens*D,
                 (size_t)num_tokens * D * sizeof(float)
             );
@@ -479,6 +479,8 @@ def emit_prefill_op(op: Dict, seq_idx: int, config: Dict, profile: bool = False,
             expr = "num_tokens"
         elif source in ("param:seq_len", "runtime:seq_len"):
             expr = "num_tokens"
+        elif source == "runtime:prefill_start_pos":
+            expr = "prefill_start_pos"
         elif name_lc in dynamic_token_arg_names and source in {"dim:_m", "param:_m", "runtime:kv_tokens", "runtime:cache_len"}:
             expr = "num_tokens"
         elif name_lc in {"seq_len", "num_tokens", "token_count", "tokens", "rows"} and str(expr).isdigit():
@@ -1080,6 +1082,7 @@ def emit_prefill_function(ops: List[Dict], config: Dict, profile: bool = False, 
  * ============================================================================ */
 static void ck_prefill(CKModel *model, const int32_t *tokens, int num_tokens) {
     if (!model || !tokens || num_tokens <= 0) return;
+    const int prefill_start_pos = 0;
 
     /* Clamp to max context */
     if (num_tokens > MAX_SEQ_LEN) num_tokens = MAX_SEQ_LEN;
@@ -1299,71 +1302,86 @@ def _has_multimodal_bridge_contract(config: Dict) -> bool:
     return bool(str(bridge.get("prefix_policy", "") or "").strip())
 
 
-def _emit_qwen3vl_prefill_bridge_helpers(config: Dict) -> str:
+def _has_segmented_append_prefill_contract(config: Dict) -> bool:
+    bridge = config.get("multimodal_bridge_contract")
+    if not isinstance(bridge, dict):
+        return False
+    schedule = bridge.get("prefill_schedule")
+    if not isinstance(schedule, dict):
+        return False
+    return (
+        schedule.get("segments") == ["text_before", "visual", "text_after"]
+        and schedule.get("cache_transition") == "append_preserve"
+        and schedule.get("position_transition") == "segment_defined"
+    )
+
+
+def _emit_multimodal_prefill_bridge_helpers(config: Dict, text_mrope_function: str) -> str:
     embed_dim = int(config.get("embed_dim", 0) or 0)
     num_deepstack_layers = int(config.get("num_deepstack_layers", 0) or 0)
     if embed_dim <= 0 or num_deepstack_layers <= 0:
         return ""
 
     return f"""
-static int g_qwen3vl_prefill_bridge_active = 0;
-static int g_qwen3vl_prefill_text_pos = 0;
-static int g_qwen3vl_prefill_total_tokens = 0;
-static int g_qwen3vl_prefill_prefix_start = 0;
-static int g_qwen3vl_prefill_prefix_tokens = 0;
-static int32_t *g_qwen3vl_prefill_positions = NULL;
-static const float *g_qwen3vl_prefill_rows = NULL;
-static int g_qwen3vl_prefill_row_dim = 0;
+static int g_multimodal_prefill_bridge_active = 0;
+static int g_multimodal_prefill_text_pos = 0;
+static int g_multimodal_prefill_total_tokens = 0;
+static int g_multimodal_prefill_prefix_start = 0;
+static int g_multimodal_prefill_prefix_tokens = 0;
+static int32_t *g_multimodal_prefill_positions = NULL;
+static const float *g_multimodal_prefill_rows = NULL;
+static int g_multimodal_prefill_row_dim = 0;
 
-static void ck_qwen3vl_prefill_bridge_clear(void) {{
-    g_qwen3vl_prefill_bridge_active = 0;
-    g_qwen3vl_prefill_text_pos = 0;
-    g_qwen3vl_prefill_total_tokens = 0;
-    g_qwen3vl_prefill_prefix_start = 0;
-    g_qwen3vl_prefill_prefix_tokens = 0;
-    free(g_qwen3vl_prefill_positions);
-    g_qwen3vl_prefill_positions = NULL;
-    g_qwen3vl_prefill_rows = NULL;
-    g_qwen3vl_prefill_row_dim = 0;
+static void ck_multimodal_prefill_bridge_clear(void) {{
+    g_multimodal_prefill_bridge_active = 0;
+    g_multimodal_prefill_text_pos = 0;
+    g_multimodal_prefill_total_tokens = 0;
+    g_multimodal_prefill_prefix_start = 0;
+    g_multimodal_prefill_prefix_tokens = 0;
+    free(g_multimodal_prefill_positions);
+    g_multimodal_prefill_positions = NULL;
+    g_multimodal_prefill_rows = NULL;
+    g_multimodal_prefill_row_dim = 0;
 }}
 
-static void ck_qwen3vl_prefill_bridge_free(void) {{
-    ck_qwen3vl_prefill_bridge_clear();
+static void ck_multimodal_prefill_bridge_free(void) {{
+    ck_multimodal_prefill_bridge_clear();
 }}
 
-static int ck_qwen3vl_prefill_bridge_text_pos(void) {{
-    return g_qwen3vl_prefill_text_pos;
+static int ck_multimodal_prefill_bridge_text_pos(void) {{
+    return g_multimodal_prefill_text_pos;
 }}
 
-static int ck_qwen3vl_prefill_bridge_next_text_pos(void) {{
-    if (!g_qwen3vl_prefill_bridge_active || g_qwen3vl_prefill_prefix_tokens <= 0) return g_qwen3vl_prefill_text_pos;
-    const int prefix_end = g_qwen3vl_prefill_prefix_start + g_qwen3vl_prefill_prefix_tokens;
-    const int suffix_tokens = g_qwen3vl_prefill_total_tokens > prefix_end ? (g_qwen3vl_prefill_total_tokens - prefix_end) : 0;
-    return g_qwen3vl_prefill_text_pos + suffix_tokens;
+static int ck_multimodal_prefill_bridge_next_text_pos(void) {{
+    if (!g_multimodal_prefill_bridge_active || g_multimodal_prefill_prefix_tokens <= 0) return g_multimodal_prefill_text_pos;
+    const int prefix_end = g_multimodal_prefill_prefix_start + g_multimodal_prefill_prefix_tokens;
+    const int suffix_tokens = g_multimodal_prefill_total_tokens > prefix_end ? (g_multimodal_prefill_total_tokens - prefix_end) : 0;
+    return g_multimodal_prefill_text_pos + suffix_tokens;
 }}
 
-static int ck_qwen3vl_prefill_bridge_is_active(void) {{
-    return g_qwen3vl_prefill_bridge_active;
+static int ck_multimodal_prefill_bridge_is_active(void) {{
+    return g_multimodal_prefill_bridge_active;
 }}
 
-static int ck_qwen3vl_prefill_bridge_prepare(const float *rows,
+static int ck_multimodal_prefill_bridge_prepare(const float *rows,
                                              int total_tokens,
                                              int prefix_start,
+                                             int position_base,
                                              int prefix_tokens,
                                              int row_dim,
                                              int grid_x,
                                              int grid_y,
                                              int text_pos) {{
-    ck_qwen3vl_prefill_bridge_clear();
+    ck_multimodal_prefill_bridge_clear();
     if (!rows || total_tokens <= 0 || prefix_tokens <= 0 || row_dim < {embed_dim}) return -1;
     if (grid_x <= 0 || grid_y <= 0) return -2;
     if (grid_x * grid_y != prefix_tokens) return -3;
     if (prefix_start < 0 || prefix_start > total_tokens) return -4;
     if (prefix_tokens > total_tokens - prefix_start) return -5;
 
-    g_qwen3vl_prefill_positions = (int32_t*)malloc((size_t)4 * (size_t)total_tokens * sizeof(int32_t));
-    if (!g_qwen3vl_prefill_positions) {{
-        ck_qwen3vl_prefill_bridge_clear();
+    g_multimodal_prefill_positions = (int32_t*)malloc((size_t)4 * (size_t)total_tokens * sizeof(int32_t));
+    if (!g_multimodal_prefill_positions) {{
+        ck_multimodal_prefill_bridge_clear();
         return -6;
     }}
 
@@ -1383,52 +1401,52 @@ static int ck_qwen3vl_prefill_bridge_prepare(const float *rows,
             const int local_tok = tok - prefix_start;
             const int x = local_tok % grid_x;
             const int y = local_tok / grid_x;
-            pos0 = prefix_start;
-            pos1 = prefix_start + y;
-            pos2 = prefix_start + x;
+            pos0 = position_base;
+            pos1 = position_base + y;
+            pos2 = position_base + x;
         }} else {{
             const int32_t pos = resolved_text_pos + (tok - prefix_end);
             pos0 = pos;
             pos1 = pos;
             pos2 = pos;
         }}
-        g_qwen3vl_prefill_positions[tok] = pos0;
-        g_qwen3vl_prefill_positions[tok + total_tokens] = pos1;
-        g_qwen3vl_prefill_positions[tok + 2 * total_tokens] = pos2;
-        g_qwen3vl_prefill_positions[tok + 3 * total_tokens] = 0;
+        g_multimodal_prefill_positions[tok] = pos0;
+        g_multimodal_prefill_positions[tok + total_tokens] = pos1;
+        g_multimodal_prefill_positions[tok + 2 * total_tokens] = pos2;
+        g_multimodal_prefill_positions[tok + 3 * total_tokens] = 0;
     }}
 
-    g_qwen3vl_prefill_rows = rows;
-    g_qwen3vl_prefill_row_dim = row_dim;
-    g_qwen3vl_prefill_total_tokens = total_tokens;
-    g_qwen3vl_prefill_prefix_start = prefix_start;
-    g_qwen3vl_prefill_prefix_tokens = prefix_tokens;
-    g_qwen3vl_prefill_text_pos = resolved_text_pos;
-    g_qwen3vl_prefill_bridge_active = 1;
+    g_multimodal_prefill_rows = rows;
+    g_multimodal_prefill_row_dim = row_dim;
+    g_multimodal_prefill_total_tokens = total_tokens;
+    g_multimodal_prefill_prefix_start = prefix_start;
+    g_multimodal_prefill_prefix_tokens = prefix_tokens;
+    g_multimodal_prefill_text_pos = resolved_text_pos;
+    g_multimodal_prefill_bridge_active = 1;
     return 0;
 }}
 
-static void ck_qwen3vl_prefill_mrope_qk(float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int n_dims, int section_0, int section_1, int section_2, int section_3, int n_ctx_orig, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow) {{
-    if (g_qwen3vl_prefill_bridge_active && g_qwen3vl_prefill_positions && g_qwen3vl_prefill_total_tokens == num_tokens) {{
-        mrope_qk_imrope_positions(q, k, g_qwen3vl_prefill_positions, num_heads, num_kv_heads, num_tokens, head_dim, aligned_head_dim, n_dims, section_0, section_1, section_2, section_3, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
+static void ck_multimodal_prefill_mrope_qk(float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int n_dims, int section_0, int section_1, int section_2, int section_3, int n_ctx_orig, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow) {{
+    if (g_multimodal_prefill_bridge_active && g_multimodal_prefill_positions && g_multimodal_prefill_total_tokens == num_tokens) {{
+        mrope_qk_imrope_positions(q, k, g_multimodal_prefill_positions, num_heads, num_kv_heads, num_tokens, head_dim, aligned_head_dim, n_dims, section_0, section_1, section_2, section_3, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
         return;
     }}
-    mrope_qk_text(q, k, num_heads, num_kv_heads, num_tokens, head_dim, aligned_head_dim, pos_offset, n_dims, section_0, section_1, section_2, section_3, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
+    {text_mrope_function}(q, k, num_heads, num_kv_heads, num_tokens, head_dim, aligned_head_dim, pos_offset, n_dims, section_0, section_1, section_2, section_3, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
 }}
 
-static void ck_qwen3vl_prefill_deepstack_add(CKModel *model, int layer, int num_tokens) {{
+static void ck_multimodal_prefill_deepstack_add(CKModel *model, int layer, int num_tokens) {{
     const char *disable_env = getenv("CK_QWEN3VL_DISABLE_PREFILL_DEEPSTACK");
     if (disable_env && atoi(disable_env) != 0) return;
-    if (!model || !g_qwen3vl_prefill_bridge_active || !g_qwen3vl_prefill_rows) return;
+    if (!model || !g_multimodal_prefill_bridge_active || !g_multimodal_prefill_rows) return;
     if (layer < 0 || layer >= {num_deepstack_layers}) return;
-    if (g_qwen3vl_prefill_prefix_tokens <= 0) return;
+    if (g_multimodal_prefill_prefix_tokens <= 0) return;
     const size_t slice_offset = (size_t){embed_dim} + (size_t)layer * (size_t){embed_dim};
     const size_t need = slice_offset + (size_t){embed_dim};
-    if ((size_t)g_qwen3vl_prefill_row_dim < need) return;
+    if ((size_t)g_multimodal_prefill_row_dim < need) return;
     float *dst = (float*)(model->bump + A_EMBEDDED_INPUT);
-    for (int tok = 0; tok < g_qwen3vl_prefill_prefix_tokens; ++tok) {{
-        const float *src = g_qwen3vl_prefill_rows + (size_t)tok * (size_t)g_qwen3vl_prefill_row_dim + slice_offset;
-        float *dst_row = dst + (size_t)(g_qwen3vl_prefill_prefix_start + tok) * (size_t){embed_dim};
+    for (int tok = 0; tok < g_multimodal_prefill_prefix_tokens; ++tok) {{
+        const float *src = g_multimodal_prefill_rows + (size_t)tok * (size_t)g_multimodal_prefill_row_dim + slice_offset;
+        float *dst_row = dst + (size_t)(g_multimodal_prefill_prefix_start + tok) * (size_t){embed_dim};
         for (int i = 0; i < {embed_dim}; ++i) {{
             dst_row[i] += src[i];
         }}
@@ -1717,8 +1735,38 @@ def emit_prefill_from_embedded_function(
     embed_scale_emitted = False
     has_multimodal_bridge = _has_multimodal_bridge_contract(config)
     q4_gateup_swiglu_x16_default = int(bool(config.get("prefill_gateup_swiglu_fusion_default", True)))
-    num_deepstack_layers = int(config.get("num_deepstack_layers", 0) or 0) if has_multimodal_bridge else 0
-    helper_block = _emit_qwen3vl_prefill_bridge_helpers(config) if has_multimodal_bridge else ""
+    text_mrope_ops = [
+        op
+        for op in ops
+        if str(op.get("op", "")) == "rope_qk"
+        and (
+            ((op.get("resolved_contract") or {}).get("semantics") or {}).get(
+                "operator_family"
+            )
+            == "text_mrope"
+        )
+    ]
+    rope_functions = {
+        str(op.get("function", "") or "").strip() for op in text_mrope_ops
+    }
+    rope_functions.discard("")
+    if text_mrope_ops and len(rope_functions) != 1:
+        raise ValueError(
+            "multimodal prefill requires exactly one resolved rope_qk function; "
+            f"got {sorted(rope_functions)}"
+        )
+    text_mrope_function = next(iter(rope_functions), "")
+    has_decoder_multimodal_bridge = has_multimodal_bridge and bool(text_mrope_function)
+    num_deepstack_layers = (
+        int(config.get("num_deepstack_layers", 0) or 0)
+        if has_decoder_multimodal_bridge
+        else 0
+    )
+    helper_block = (
+        _emit_multimodal_prefill_bridge_helpers(config, text_mrope_function)
+        if has_decoder_multimodal_bridge
+        else ""
+    )
     if helper_block:
         lines.append(helper_block)
 
@@ -1731,11 +1779,13 @@ def emit_prefill_from_embedded_function(
  *   - token rows after num_tokens are don't-care
  *   - dense_embedding_lookup must be skipped to preserve external prefixes
  * ============================================================================ */
-static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
+static void ck_prefill_from_embedded_range(CKModel *model, int num_tokens, int prefill_start_pos) {
     if (!model || num_tokens <= 0) return;
+    if (prefill_start_pos < 0 || prefill_start_pos >= MAX_SEQ_LEN) return;
 
     /* Clamp to max context */
-    if (num_tokens > MAX_SEQ_LEN) num_tokens = MAX_SEQ_LEN;
+    if (num_tokens > MAX_SEQ_LEN - prefill_start_pos) num_tokens = MAX_SEQ_LEN - prefill_start_pos;
+    const int prefill_rope_start_pos = model->rope_pos;
 
     const char *stop_env = getenv("CK_STOP_OP");
     int stop_seq = stop_env ? atoi(stop_env) : -1;
@@ -1783,11 +1833,11 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
     )
     prologue = prologue.replace("CK_Q4_GATEUP_SWIGLU_X16_DEFAULT", str(q4_gateup_swiglu_x16_default))
     lines.append(prologue)
-    if has_multimodal_bridge:
+    if has_decoder_multimodal_bridge:
         lines.append(
-            """    const char *bridge_fp32_env = getenv("CK_V8_QWEN3VL_PREFILL_FP32");
+            """    const char *bridge_fp32_env = getenv("CK_V8_MULTIMODAL_PREFILL_FP32");
     int bridge_force_fp32 = bridge_fp32_env ? (atoi(bridge_fp32_env) != 0) : 0;
-    if (ck_qwen3vl_prefill_bridge_is_active() && bridge_force_fp32) {
+    if (ck_multimodal_prefill_bridge_is_active() && bridge_force_fp32) {
         debug_outproj_fp32 = 1;
         debug_mlp_down_fp32 = 1;
     }
@@ -1920,8 +1970,12 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
             )
         else:
             op_code = emit_prefill_op(op, seq_idx, config, profile=profile, dump=dump)
-            if has_multimodal_bridge and op_type == "rope_qk":
-                op_code = op_code.replace("mrope_qk_text(", "ck_qwen3vl_prefill_mrope_qk(")
+            if has_decoder_multimodal_bridge and op_type == "rope_qk":
+                resolved_rope_function = str(op.get("function", "") or "").strip()
+                op_code = op_code.replace(
+                    f"{resolved_rope_function}(",
+                    "ck_multimodal_prefill_mrope_qk(",
+                )
         swiglu_block_guard = skip_swiglu_guard if op_type in {"silu_mul", "swiglu"} else None
         if skip_swiglu_guard and op_type in {"silu_mul", "swiglu"}:
             op_code = f"    if (!{skip_swiglu_guard}) {{\n" + "\n".join("    " + line if line else line for line in op_code.splitlines()) + "\n    }"
@@ -1966,20 +2020,25 @@ static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {
                     )
         lines.append(op_code)
         lines.append(f"    if (stop_seq == {seq_idx}) return;")
-        if has_multimodal_bridge and op_type == "residual_add":
+        if has_decoder_multimodal_bridge and op_type == "residual_add":
             residual_add_count_total += 1
             if residual_add_count_total % 2 == 0:
                 deepstack_layer = residual_add_count_total // 2 - 1
                 if 0 <= deepstack_layer < num_deepstack_layers:
-                    lines.append(f"    ck_qwen3vl_prefill_deepstack_add(model, {deepstack_layer}, num_tokens);")
+                    lines.append(f"    ck_multimodal_prefill_deepstack_add(model, {deepstack_layer}, num_tokens);")
         lines.append("")
 
-    lines.append("    model->pos = num_tokens;")
-    if has_multimodal_bridge:
-        lines.append("    model->rope_pos = ck_qwen3vl_prefill_bridge_is_active() ? ck_qwen3vl_prefill_bridge_next_text_pos() : num_tokens;")
-        lines.append("    ck_qwen3vl_prefill_bridge_clear();")
+    lines.append("    model->pos = prefill_start_pos + num_tokens;")
+    if has_decoder_multimodal_bridge:
+        lines.append("    model->rope_pos = ck_multimodal_prefill_bridge_is_active() ? ck_multimodal_prefill_bridge_next_text_pos() : prefill_rope_start_pos + num_tokens;")
+        lines.append("    ck_multimodal_prefill_bridge_clear();")
     else:
         lines.append("    model->rope_pos = num_tokens;")
+    lines.append("}")
+    lines.append("")
+    lines.append("static void ck_prefill_from_embedded(CKModel *model, int num_tokens) {")
+    lines.append("    if (model) model->rope_pos = 0;")
+    lines.append("    ck_prefill_from_embedded_range(model, num_tokens, 0);")
     lines.append("}")
     return "\n".join(lines)
 
@@ -2000,6 +2059,7 @@ def emit_multimodal_bridge_api(ops: List[Dict], config: Dict | None = None) -> s
 
     config = dict(config or {})
     has_multimodal_bridge = _has_multimodal_bridge_contract(config)
+    has_segmented_append = _has_segmented_append_prefill_contract(config)
 
     token_ids_expr = _find_arg_expr(args_list, arg_name="token_ids") or "(int32_t*)(model->bump + A_TOKEN_IDS)"
     token_embeddings_expr = _find_arg_expr(args_list, arg_name="token_embeddings")
@@ -2014,15 +2074,17 @@ def emit_multimodal_bridge_api(ops: List[Dict], config: Dict | None = None) -> s
     if not token_embeddings_expr:
         return ""
 
-    qwen_prepare_block_mixed = ""
-    qwen_prepare_block_segments = ""
+    bridge_prepare_block_mixed = ""
+    bridge_prepare_block_segments = ""
+    bridge_prepare_block_visual_segment = ""
     if has_multimodal_bridge:
-        qwen_prepare_block_mixed = """
+        bridge_prepare_block_mixed = """
         if (prefix_embed_dim > aligned_embed_dim) {
             if (prefix_grid_x > 0 && prefix_grid_y > 0) {
-                int prep_rc = ck_qwen3vl_prefill_bridge_prepare(
+                int prep_rc = ck_multimodal_prefill_bridge_prepare(
                     prefix_embeddings,
                     prefix_tokens + token_count,
+                    0,
                     0,
                     prefix_tokens,
                     prefix_embed_dim,
@@ -2034,9 +2096,10 @@ def emit_multimodal_bridge_api(ops: List[Dict], config: Dict | None = None) -> s
             } else {
                 const int side = (int)(sqrt((double)prefix_tokens) + 0.5);
                 if (side > 0 && side * side == prefix_tokens) {
-                    int prep_rc = ck_qwen3vl_prefill_bridge_prepare(
+                    int prep_rc = ck_multimodal_prefill_bridge_prepare(
                         prefix_embeddings,
                         prefix_tokens + token_count,
+                        0,
                         0,
                         prefix_tokens,
                         prefix_embed_dim,
@@ -2049,12 +2112,13 @@ def emit_multimodal_bridge_api(ops: List[Dict], config: Dict | None = None) -> s
             }
         }
 """
-        qwen_prepare_block_segments = """
+        bridge_prepare_block_segments = """
         if (prefix_embed_dim > aligned_embed_dim) {
             if (prefix_grid_x > 0 && prefix_grid_y > 0) {
-                int prep_rc = ck_qwen3vl_prefill_bridge_prepare(
+                int prep_rc = ck_multimodal_prefill_bridge_prepare(
                     prefix_embeddings,
                     total_tokens,
+                    tokens_before_count,
                     tokens_before_count,
                     prefix_tokens,
                     prefix_embed_dim,
@@ -2066,9 +2130,10 @@ def emit_multimodal_bridge_api(ops: List[Dict], config: Dict | None = None) -> s
             } else {
                 const int side = (int)(sqrt((double)prefix_tokens) + 0.5);
                 if (side > 0 && side * side == prefix_tokens) {
-                    int prep_rc = ck_qwen3vl_prefill_bridge_prepare(
+                    int prep_rc = ck_multimodal_prefill_bridge_prepare(
                         prefix_embeddings,
                         total_tokens,
+                        tokens_before_count,
                         tokens_before_count,
                         prefix_tokens,
                         prefix_embed_dim,
@@ -2080,6 +2145,85 @@ def emit_multimodal_bridge_api(ops: List[Dict], config: Dict | None = None) -> s
                 }
             }
         }
+"""
+        bridge_prepare_block_visual_segment = """
+        if (prefix_embed_dim > aligned_embed_dim) {
+            if (prefix_grid_x > 0 && prefix_grid_y > 0) {
+                int prep_rc = ck_multimodal_prefill_bridge_prepare(
+                    prefix_embeddings,
+                    prefix_tokens,
+                    0,
+                    tokens_before_count,
+                    prefix_tokens,
+                    prefix_embed_dim,
+                    prefix_grid_x,
+                    prefix_grid_y,
+                    prefix_text_pos
+                );
+                if (prep_rc != 0) return prep_rc;
+            } else {
+                const int side = (int)(sqrt((double)prefix_tokens) + 0.5);
+                if (side > 0 && side * side == prefix_tokens) {
+                    int prep_rc = ck_multimodal_prefill_bridge_prepare(
+                        prefix_embeddings,
+                        prefix_tokens,
+                        0,
+                        tokens_before_count,
+                        prefix_tokens,
+                        prefix_embed_dim,
+                        side,
+                        side,
+                        tokens_before_count + side
+                    );
+                    if (prep_rc != 0) return prep_rc;
+                }
+            }
+        }
+"""
+
+    if has_segmented_append:
+        segments_execute_block = f"""
+    const int aligned_embed_dim = ({aligned_embed_dim_expr});
+    if (tokens_before_count > 0) {{
+        int rc = ck_embed_tokens_at(g_model, tokens_before, tokens_before_count, 0);
+        if (rc < 0) return rc;
+        g_model->rope_pos = 0;
+        ck_prefill_from_embedded_range(g_model, tokens_before_count, 0);
+    }}
+    if (prefix_tokens > 0) {{
+        if (prefix_embed_dim <= 0) prefix_embed_dim = aligned_embed_dim;
+        if (prefix_embed_dim < ({embed_dim_expr})) return -13;
+        int rc = ck_write_embeddings_at_ex(g_model, prefix_embeddings, prefix_tokens, prefix_embed_dim, 0);
+        if (rc < 0) return rc;
+{bridge_prepare_block_visual_segment}        g_model->rope_pos = tokens_before_count;
+        ck_prefill_from_embedded_range(g_model, prefix_tokens, tokens_before_count);
+    }}
+    if (tokens_after_count > 0) {{
+        int rc = ck_embed_tokens_at(g_model, tokens_after, tokens_after_count, 0);
+        if (rc < 0) return rc;
+        g_model->rope_pos = prefix_text_pos;
+        ck_prefill_from_embedded_range(g_model, tokens_after_count, tokens_before_count + prefix_tokens);
+    }}
+"""
+    else:
+        segments_execute_block = f"""
+    const int aligned_embed_dim = ({aligned_embed_dim_expr});
+    if (tokens_before_count > 0) {{
+        int rc = ck_embed_tokens_at(g_model, tokens_before, tokens_before_count, 0);
+        if (rc < 0) return rc;
+    }}
+    if (prefix_tokens > 0) {{
+        if (prefix_embed_dim <= 0) prefix_embed_dim = aligned_embed_dim;
+        if (prefix_embed_dim < ({embed_dim_expr})) return -13;
+        int rc = ck_write_embeddings_at_ex(g_model, prefix_embeddings, prefix_tokens, prefix_embed_dim, tokens_before_count);
+        if (rc < 0) return rc;
+{bridge_prepare_block_segments}    }}
+    if (tokens_after_count > 0) {{
+        int rc = ck_embed_tokens_at(g_model, tokens_after, tokens_after_count, tokens_before_count + prefix_tokens);
+        if (rc < 0) return rc;
+    }}
+
+    ck_prefill_from_embedded(g_model, total_tokens);
 """
 
     return f"""
@@ -2216,23 +2360,7 @@ CK_EXPORT int ck_model_forward_segments_grid_ex(const int32_t *tokens_before,
     g_model->rope_pos = 0;
     g_model->bridge_has_explicit_positions = 0;
 
-    const int aligned_embed_dim = ({aligned_embed_dim_expr});
-    if (tokens_before_count > 0) {{
-        int rc = ck_embed_tokens_at(g_model, tokens_before, tokens_before_count, 0);
-        if (rc < 0) return rc;
-    }}
-    if (prefix_tokens > 0) {{
-        if (prefix_embed_dim <= 0) prefix_embed_dim = aligned_embed_dim;
-        if (prefix_embed_dim < ({embed_dim_expr})) return -13;
-        int rc = ck_write_embeddings_at_ex(g_model, prefix_embeddings, prefix_tokens, prefix_embed_dim, tokens_before_count);
-        if (rc < 0) return rc;
-{qwen_prepare_block_segments}    }}
-    if (tokens_after_count > 0) {{
-        int rc = ck_embed_tokens_at(g_model, tokens_after, tokens_after_count, tokens_before_count + prefix_tokens);
-        if (rc < 0) return rc;
-    }}
-
-    ck_prefill_from_embedded(g_model, total_tokens);
+{segments_execute_block}
     if (output) memcpy(output, g_model->logits, VOCAB_SIZE * sizeof(float));
     return 0;
 }}
@@ -2266,7 +2394,7 @@ CK_EXPORT int ck_model_forward_mixed_grid_ex(const float *prefix_embeddings,
     if (prefix_tokens > 0) {{
         if (prefix_embed_dim <= 0) prefix_embed_dim = aligned_embed_dim;
         if (prefix_embed_dim < ({embed_dim_expr})) return -11;
-{qwen_prepare_block_mixed}        int rc = ck_write_embeddings_at_ex(g_model, prefix_embeddings, prefix_tokens, prefix_embed_dim, 0);
+{bridge_prepare_block_mixed}        int rc = ck_write_embeddings_at_ex(g_model, prefix_embeddings, prefix_tokens, prefix_embed_dim, 0);
         if (rc < 0) return rc;
     }}
     if (token_count > 0) {{

--- a/version/v8/scripts/codegen_v8.py
+++ b/version/v8/scripts/codegen_v8.py
@@ -357,7 +357,42 @@ def _extract_c_function(code: str, signature: str) -> tuple[int, int, str] | Non
     return start, end, code[start:end]
 
 
-def _inject_decode_runtime_multimodal_fallback(code: str, layout_obj: Dict[str, Any]) -> str:
+def _resolved_text_mrope_function(ir_obj: Dict[str, Any]) -> str:
+    matches: list[tuple[str, str, str]] = []
+    for op in list(ir_obj.get("operations") or []):
+        if str(op.get("op", "")) != "rope_qk":
+            continue
+        resolved = op.get("resolved_contract") or {}
+        semantics = resolved.get("semantics") or {}
+        if semantics.get("operator_family") != "text_mrope":
+            continue
+        matches.append(
+            (
+                str(op.get("function", "") or "").strip(),
+                str(resolved.get("function", "") or "").strip(),
+                str(resolved.get("kernel_id", "") or "").strip(),
+            )
+        )
+    unique = set(matches)
+    if len(unique) != 1:
+        raise RuntimeError(
+            "multimodal decode requires exactly one resolved text_mrope provider; "
+            f"got {sorted(unique)}"
+        )
+    function, contract_function, kernel_id = next(iter(unique))
+    if not function or function != contract_function:
+        raise RuntimeError(
+            "text_mrope call IR function does not match its resolved contract: "
+            f"call={function!r} contract={contract_function!r} kernel={kernel_id!r}"
+        )
+    return function
+
+
+def _inject_decode_runtime_multimodal_fallback(
+    code: str,
+    layout_obj: Dict[str, Any],
+    ir_obj: Dict[str, Any],
+) -> str:
     cfg = dict(layout_obj.get("config", {}) or {})
     if str(cfg.get("logits_layout", "")).lower() != "last":
         return code
@@ -378,7 +413,7 @@ def _inject_decode_runtime_multimodal_fallback(code: str, layout_obj: Dict[str, 
         input_embed_dim = embed_dim
     deepstack_elems = max(1, num_deepstack_layers * embed_dim)
 
-    def _inject_qwen3vl_deepstack_residuals(src: str) -> str:
+    def _inject_multimodal_deepstack_residuals(src: str) -> str:
         if not (has_multimodal_bridge and num_deepstack_layers > 0):
             return src
 
@@ -434,7 +469,7 @@ def _inject_decode_runtime_multimodal_fallback(code: str, layout_obj: Dict[str, 
     if decode_fn is None:
         raise RuntimeError("unable to locate ck_decode for decode-runtime multimodal fallback")
     _, decode_end, decode_src = decode_fn
-    decode_src = _inject_qwen3vl_deepstack_residuals(decode_src)
+    decode_src = _inject_multimodal_deepstack_residuals(decode_src)
     embedded_decode = decode_src.replace(
         "static void ck_decode(CKModel *model, int32_t token) {",
         "static void ck_decode_embedded(CKModel *model) {",
@@ -459,23 +494,31 @@ def _inject_decode_runtime_multimodal_fallback(code: str, layout_obj: Dict[str, 
     code = code[:decode_end] + "\n\n" + embedded_decode + code[decode_end:]
 
     if has_multimodal_bridge:
-        rope_wrapper = """static void ck_qwen3vl_runtime_mrope_qk(CKModel *model, float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int n_dims, int section_0, int section_1, int section_2, int section_3, int n_ctx_orig, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow) {
-    if (model && model->bridge_has_explicit_positions) {
+        text_mrope_function = _resolved_text_mrope_function(ir_obj)
+        rope_wrapper = f"""static void ck_multimodal_runtime_mrope_qk(CKModel *model, float *q, float *k, int num_heads, int num_kv_heads, int num_tokens, int head_dim, int aligned_head_dim, int pos_offset, int n_dims, int section_0, int section_1, int section_2, int section_3, int n_ctx_orig, float freq_base, float freq_scale, float ext_factor, float attn_factor, float beta_fast, float beta_slow) {{
+    if (model && model->bridge_has_explicit_positions) {{
         mrope_qk_imrope_positions(q, k, model->bridge_positions, num_heads, num_kv_heads, num_tokens, head_dim, aligned_head_dim, n_dims, section_0, section_1, section_2, section_3, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
         return;
-    }
-    mrope_qk_text(q, k, num_heads, num_kv_heads, num_tokens, head_dim, aligned_head_dim, pos_offset, n_dims, section_0, section_1, section_2, section_3, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
-}
+    }}
+    {text_mrope_function}(q, k, num_heads, num_kv_heads, num_tokens, head_dim, aligned_head_dim, pos_offset, n_dims, section_0, section_1, section_2, section_3, n_ctx_orig, freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow);
+}}
 """
         code = code.replace(decode_sig, rope_wrapper + "\n" + decode_sig, 1)
-        code = code.replace("mrope_qk_text(", "ck_qwen3vl_runtime_mrope_qk(model, ")
-        code = code.replace("    ck_qwen3vl_runtime_mrope_qk(model, q, k, ", "    mrope_qk_text(q, k, ", 1)
-        prefill_helper = _extract_c_function(code, "static void ck_qwen3vl_prefill_mrope_qk(")
+        code = code.replace(
+            f"{text_mrope_function}(",
+            "ck_multimodal_runtime_mrope_qk(model, ",
+        )
+        code = code.replace(
+            "    ck_multimodal_runtime_mrope_qk(model, q, k, ",
+            f"    {text_mrope_function}(q, k, ",
+            1,
+        )
+        prefill_helper = _extract_c_function(code, "static void ck_multimodal_prefill_mrope_qk(")
         if prefill_helper is not None:
             helper_start, helper_end, helper_src = prefill_helper
             helper_patched = helper_src.replace(
-                "    ck_qwen3vl_runtime_mrope_qk(model, q, k, ",
-                "    mrope_qk_text(q, k, ",
+                "    ck_multimodal_runtime_mrope_qk(model, q, k, ",
+                f"    {text_mrope_function}(q, k, ",
                 1,
             )
             code = code[:helper_start] + helper_patched + code[helper_end:]
@@ -1041,7 +1084,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
             code = code + "\n\n" + prefill_code
             if args.prefill_layout is None:
-                code = _inject_decode_runtime_multimodal_fallback(code, layout_obj)
+                code = _inject_decode_runtime_multimodal_fallback(code, layout_obj, ir_obj)
         elif str(layout_obj.get("mode", "")).lower() == "prefill":
             code = _inject_prefill_multimodal_bridge(
                 code,

--- a/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
+++ b/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
@@ -6,12 +6,13 @@ Tokenizer-free multimodal multi-token greedy parity probe.
 
 This is the multimodal counterpart to compare_multitoken_logits_v8.py.  It
 starts from a bridge_report.json + prefix.f32 produced by run_multimodal_bridge_v8,
-does one CK mixed visual/text prefill, then advances CK through real
+does the circuit-selected CK mixed visual/text prefill schedule, then advances CK through real
 ck_model_decode calls while llama.cpp replays the same generated suffix.
 """
 
 import argparse
 import ctypes
+import hashlib
 import json
 import os
 import re
@@ -213,6 +214,70 @@ def _run_llama_greedy_sequence(inputs: dict[str, Any], args: argparse.Namespace)
             "logits": logits.reshape((steps, n_vocab)),
         }
 
+def _load_exact_decoder_runtime(
+    gguf_path: Path,
+    decoder_dir: Path,
+    *,
+    so_override: Path | None,
+    manifest_map_override: Path | None,
+) -> dict[str, Any]:
+    layout_path = decoder_dir / "layout_decode.json"
+    weights_bump = decoder_dir / "weights.bump"
+    manifest_map = manifest_map_override or (decoder_dir / "weights_manifest.map")
+    so_path = so_override or (decoder_dir / "libdecoder_v8.so")
+    required = [layout_path, weights_bump, manifest_map, so_path]
+    missing = [str(path) for path in required if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(
+            "exact decoder runtime is incomplete; refusing to regenerate or guess: "
+            + ", ".join(missing)
+        )
+
+    layout = first_token.bridge_runner_v8._load_layout(layout_path)
+    cfg = dict(layout.get("config", {}) or {})
+    embed_dim = int(cfg.get("embed_dim", 0) or 0)
+    num_deepstack_layers = int(cfg.get("num_deepstack_layers", 0) or 0)
+    input_embed_dim = int(cfg.get("input_embed_dim", 0) or 0)
+    if input_embed_dim <= 0 and embed_dim > 0 and num_deepstack_layers > 0:
+        input_embed_dim = embed_dim * (1 + num_deepstack_layers)
+    if input_embed_dim <= 0:
+        input_embed_dim = embed_dim
+    return {
+        "gguf": gguf_path,
+        "workdir": decoder_dir,
+        "so_path": so_path,
+        "weights_bump": weights_bump,
+        "manifest_map": manifest_map,
+        "decode_layout_path": layout_path,
+        "embed_dim": embed_dim,
+        "input_embed_dim": input_embed_dim,
+        "num_deepstack_layers": num_deepstack_layers,
+        "context_length": int(cfg.get("context_length", cfg.get("context_len", 0)) or 0),
+        "vocab_size": int(cfg.get("vocab_size", 0) or 0),
+    }
+
+
+def _runtime_evidence(runtime: dict[str, Any], *, exact_reuse: bool) -> dict[str, Any]:
+    def describe(path_value: Any) -> dict[str, Any]:
+        path = Path(path_value).resolve()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else None
+        return {"path": str(path), "sha256": digest}
+
+    return {
+        "exact_reuse": bool(exact_reuse),
+        "shared_library": describe(runtime["so_path"]),
+        "engine_library": describe(REPO_ROOT / "build" / "libckernel_engine.so"),
+        "manifest_map": describe(runtime["manifest_map"]),
+        "weights_bump_path": str(Path(runtime["weights_bump"]).resolve()),
+        "context_length": int(runtime.get("context_length", 0) or 0),
+    }
+
+
+def _ck_threads(args: argparse.Namespace) -> int:
+    explicit = getattr(args, "ck_threads", None)
+    return int(args.threads if explicit is None else explicit)
+
+
 def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> dict[str, Any]:
     bridge_report = first_token._load_bridge_report(args.bridge_report.resolve())
     gguf_value = str(((bridge_report.get("decoder_runtime") or {}).get("gguf") or "")).strip()
@@ -221,7 +286,8 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
     gguf_path = Path(gguf_value).resolve()
     workdir = args.workdir.resolve()
     workdir.mkdir(parents=True, exist_ok=True)
-    if bool(getattr(args, "reuse_bridge_decoder_runtime", False)):
+    exact_runtime = bool(getattr(args, "reuse_bridge_decoder_runtime_exact", False))
+    if bool(getattr(args, "reuse_bridge_decoder_runtime", False)) or exact_runtime:
         decoder_workdir = str(((bridge_report.get("decoder_runtime") or {}).get("workdir") or "")).strip()
         if not decoder_workdir:
             raise ValueError("bridge report does not include decoder_runtime.workdir")
@@ -230,12 +296,20 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
         decoder_dir = workdir / "decoder"
 
     requested_ctx_len = int(args.ctx_len or bridge_report.get("decoder_context_len") or 256)
-    runtime = first_token.bridge_runner_v8._prepare_decoder_runtime(
-        gguf_path,
-        decoder_dir,
-        parity_dump=bool(parity_dump),
-        context_override=max(1, requested_ctx_len),
-    )
+    if exact_runtime:
+        runtime = _load_exact_decoder_runtime(
+            gguf_path,
+            decoder_dir,
+            so_override=getattr(args, "ck_runtime_so", None),
+            manifest_map_override=getattr(args, "ck_runtime_manifest_map", None),
+        )
+    else:
+        runtime = first_token.bridge_runner_v8._prepare_decoder_runtime(
+            gguf_path,
+            decoder_dir,
+            parity_dump=bool(parity_dump),
+            context_override=max(1, requested_ctx_len),
+        )
     tokenizer = GGUFTokenizer.from_gguf(str(gguf_path))
     _, tokens_before, tokens_after, prompt_meta = first_token._resolve_prompt_token_segments(
         tokenizer,
@@ -259,7 +333,14 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
     )
     total_prompt_tokens = len(tokens_before) + len(tokens_after)
     resolved_ctx_len = max(int(requested_ctx_len), int(prefix_tokens) + total_prompt_tokens, 1)
-    if resolved_ctx_len != requested_ctx_len:
+    if resolved_ctx_len != requested_ctx_len and exact_runtime:
+        effective_context = int(runtime.get("context_length", 0) or 0)
+        if effective_context < resolved_ctx_len:
+            raise RuntimeError(
+                "exact decoder runtime context is too small: "
+                f"required={resolved_ctx_len} effective={effective_context}"
+            )
+    elif resolved_ctx_len != requested_ctx_len:
         runtime = first_token.bridge_runner_v8._prepare_decoder_runtime(
             gguf_path,
             decoder_dir,
@@ -380,7 +461,7 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
             prefix_row_dim=int(inputs["prefix_row_dim"]),
             ctx_len=int(inputs["ctx_len"]),
             top_k=int(args.top_k),
-            threads=int(args.threads),
+            threads=_ck_threads(args),
             dump_root=dump_dir.resolve(),
             dump_names=str(args.dump_names),
             dump_pass=str(args.dump_pass),
@@ -754,10 +835,19 @@ def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]
         "ctx_len": int(inputs["ctx_len"]),
         "requested_ctx_len": int(inputs["requested_ctx_len"]),
         "threads": int(args.threads),
+        "ck_threads": _ck_threads(args),
+        "thread_config": {
+            "llama_cpp": int(args.threads),
+            "ck_runtime": _ck_threads(args),
+        },
         "top_k": int(args.top_k),
         "llama_decode_mode": str(args.llama_decode_mode),
         "llama_greedy_generated": llama_generated,
         "append_on_divergence": str(args.append_on_divergence),
+        "ck_runtime": _runtime_evidence(
+            inputs["runtime"],
+            exact_reuse=bool(getattr(args, "reuse_bridge_decoder_runtime_exact", False)),
+        ),
         "stop_token_ids": sorted(stop_token_ids),
         "stop_reason": stop_reason,
         "prompt_tokens_before_image": inputs["tokens_before"],
@@ -798,10 +888,23 @@ def main() -> int:
     ap.add_argument("--prefix-text-pos", type=int, default=None)
     ap.add_argument("--workdir", required=True, type=Path)
     ap.add_argument("--reuse-bridge-decoder-runtime", action="store_true", help="Reuse decoder_runtime.workdir from bridge_report instead of creating a new decoder copy under --workdir")
+    ap.add_argument(
+        "--reuse-bridge-decoder-runtime-exact",
+        action="store_true",
+        help="Trust the existing bridge decoder artifacts without regeneration; fail if any required artifact is missing",
+    )
+    ap.add_argument("--ck-runtime-so", type=Path, default=None, help="Explicit CK decoder shared library for exact-runtime parity")
+    ap.add_argument("--ck-runtime-manifest-map", type=Path, default=None, help="Explicit CK decoder manifest map for exact-runtime parity")
     ap.add_argument("--ctx-len", type=int, default=None)
     ap.add_argument("--max-new-tokens", type=int, default=16)
     ap.add_argument("--top-k", type=int, default=16)
-    ap.add_argument("--threads", type=int, default=0)
+    ap.add_argument("--threads", type=int, default=1, help="llama.cpp oracle threads")
+    ap.add_argument(
+        "--ck-threads",
+        type=int,
+        default=None,
+        help="CK runtime threads; defaults to --threads when omitted",
+    )
     ap.add_argument("--llama-decode-mode", choices=["batched", "sequential"], default="sequential")
     ap.add_argument("--llama-no-repack", action="store_true", help="Disable llama.cpp CPU tensor repacking in the replay helper")
     ap.add_argument("--llama-repack-fallback", action=argparse.BooleanOptionalAction, default=True, help="Retry a failed llama replay step with --no-repack")
@@ -828,9 +931,10 @@ def main() -> int:
     ap.add_argument("--summary", action="store_true")
     args = ap.parse_args()
 
-    if args.threads > 0:
-        os.environ["CK_NUM_THREADS"] = str(int(args.threads))
-        os.environ["OMP_NUM_THREADS"] = str(int(args.threads))
+    ck_threads = _ck_threads(args)
+    if ck_threads > 0:
+        os.environ["CK_NUM_THREADS"] = str(ck_threads)
+        os.environ["OMP_NUM_THREADS"] = str(ck_threads)
     report = run_multimodal_multitoken_parity(args)
     if args.dump_step is not None:
         report["step_dump"] = _capture_step_dump(report, args)

--- a/version/v8/scripts/replay_attention_from_dumps_v8.py
+++ b/version/v8/scripts/replay_attention_from_dumps_v8.py
@@ -78,6 +78,8 @@ def _resolve_attention_fn(lib: ctypes.CDLL, mode: str) -> Callable[..., None]:
         fn = lib.attention_forward_full_head_major_gqa_exact_strided
     elif mode == "flash":
         fn = lib.attention_forward_full_head_major_gqa_flash_strided
+    elif mode == "tiled_f16kv":
+        fn = lib.attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided
     else:
         raise ValueError(f"unsupported mode: {mode}")
 
@@ -110,7 +112,11 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Replay full-attention kernels from parity dumps")
     ap.add_argument("--dump", type=Path, required=True, help="Path to dump.bin")
     ap.add_argument("--layer", type=int, default=0)
-    ap.add_argument("--mode", choices=("ggml", "exact", "flash"), default="ggml")
+    ap.add_argument(
+        "--mode",
+        choices=("ggml", "exact", "flash", "tiled_f16kv"),
+        default="ggml",
+    )
     ap.add_argument("--strict", action="store_true")
     ap.add_argument("--disable-multihead-oracle", action="store_true")
     ap.add_argument("--disable-regular-oracle", action="store_true")
@@ -119,6 +125,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--head-dim", type=int, default=72)
     ap.add_argument("--aligned-head-dim", type=int, default=None)
     ap.add_argument("--output", type=Path, default=None)
+    ap.add_argument("--raw-output", type=Path, default=None)
     args = ap.parse_args(argv)
 
     dumps = parity_test.read_dump_file(args.dump)
@@ -185,6 +192,7 @@ def main(argv: list[str] | None = None) -> int:
 
     token_major = _to_token_major(out, num_tokens, args.num_heads, aligned_head_dim)[..., : args.head_dim]
     metrics = _metrics(token_major, ref)
+    bitwise_equal = token_major.view(np.uint32) == ref.view(np.uint32)
     worst_idx = np.unravel_index(np.argmax(np.abs(token_major - ref)), token_major.shape)
     report = {
         "mode": args.mode,
@@ -197,6 +205,11 @@ def main(argv: list[str] | None = None) -> int:
         "disable_multihead_oracle": args.disable_multihead_oracle,
         "disable_regular_oracle": args.disable_regular_oracle,
         "metrics": metrics,
+        "bitwise": {
+            "equal": int(np.count_nonzero(bitwise_equal)),
+            "different": int(bitwise_equal.size - np.count_nonzero(bitwise_equal)),
+            "total": int(bitwise_equal.size),
+        },
         "worst_index": {
             "query": int(worst_idx[0]),
             "head": int(worst_idx[1]),
@@ -209,6 +222,8 @@ def main(argv: list[str] | None = None) -> int:
     print(json.dumps(report, indent=2))
     if args.output is not None:
         args.output.write_text(json.dumps(report, indent=2) + "\n")
+    if args.raw_output is not None:
+        np.save(args.raw_output, token_major)
     return 0
 
 

--- a/version/v8/scripts/resolve_numerical_execution_contracts_v8.py
+++ b/version/v8/scripts/resolve_numerical_execution_contracts_v8.py
@@ -92,11 +92,15 @@ def validate_contract_registry(doc: Dict[str, Any]) -> None:
                     f"position_rank={transform['position_rank']} axis_order={transform['axis_order']}",
                     "make the position rank equal the number of named axes.",
                 )
-            if transform["pairing"] == "multi_section" and transform["section_interpretation"] != "axis_selection":
+            section_semantics = transform["section_interpretation"]
+            if transform["pairing"] == "multi_section" and section_semantics not in {
+                "axis_selection",
+                "interleaved_axis_selection",
+            }:
                 raise hard_fault(
                     f"multi-section position contract {contract_id!r} redefines rotary width",
                     "Qwen-style M-RoPE sections select position axes; rotary_width remains independent.",
-                    "set section_interpretation to axis_selection and validate the full rotary width separately.",
+                    "use axis_selection or interleaved_axis_selection and validate the full rotary width separately.",
                 )
             rotary_width = transform.get("rotary_width_value")
             head_width = transform.get("head_width_value")

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -1289,6 +1289,30 @@ def _ensure_engine_lib(openmp: bool = False) -> None:
     _run(cmd)
 
 
+def _refresh_manifest_circuit_snapshot(
+    manifest: dict[str, Any],
+    manifest_path: Path,
+) -> dict[str, Any]:
+    template = manifest.get("template") if isinstance(manifest.get("template"), dict) else {}
+    circuit_name = str(template.get("name") or "").strip().lower()
+    if not circuit_name:
+        return manifest
+    circuit_path = SCRIPT_DIR.parent / "circuits" / f"{circuit_name}.json"
+    if not circuit_path.is_file():
+        return manifest
+    current = _json_read(circuit_path)
+    if not isinstance(current, dict):
+        raise RuntimeError(f"versioned circuit is not a JSON object: {circuit_path}")
+    if template != current:
+        manifest = dict(manifest)
+        manifest["template"] = current
+        _json_write(manifest_path, manifest)
+        _log_progress(
+            f"refreshed cached manifest circuit={circuit_name} source={circuit_path}"
+        )
+    return manifest
+
+
 def _run_converter(
     gguf_path: Path,
     output_dir: Path,
@@ -1304,6 +1328,7 @@ def _run_converter(
     if _artifacts_match_fingerprint(stamp_path, fingerprint, [bump_path, manifest_path, config_path]):
         with manifest_path.open("r", encoding="utf-8") as f:
             manifest = json.load(f)
+        manifest = _refresh_manifest_circuit_snapshot(manifest, manifest_path)
         return manifest, manifest_path, bump_path, config_path
 
     old_argv = sys.argv[:]
@@ -1328,6 +1353,7 @@ def _run_converter(
 
     with manifest_path.open("r", encoding="utf-8") as f:
         manifest = json.load(f)
+    manifest = _refresh_manifest_circuit_snapshot(manifest, manifest_path)
     _json_write(stamp_path, fingerprint)
     return manifest, manifest_path, bump_path, config_path
 

--- a/version/v8/scripts/stitched_parity_v8.py
+++ b/version/v8/scripts/stitched_parity_v8.py
@@ -274,6 +274,8 @@ def _granular_command(args: argparse.Namespace, layer: int, out_dir: Path, out_j
         "disabled" if args.execution_mode == "strict" else "enabled",
         "--llama-dump-layer",
         str(int(layer)),
+        "--ck-dump-layer",
+        str(int(layer)),
         "--ck-strict-dump-layer",
         str(int(layer)),
         "--llama-dump-names",

--- a/version/v8/scripts/xray_qwen3vl_llamacpp_v8.py
+++ b/version/v8/scripts/xray_qwen3vl_llamacpp_v8.py
@@ -154,6 +154,7 @@ def _capture_args(args: argparse.Namespace, profile: dict[str, Any], report_path
         "--ck-threads", str(args.ck_threads or args.threads),
         "--llama-dump-names", ",".join(names),
         "--llama-dump-layer", str(args.layer),
+        "--ck-dump-layer", str(args.layer),
         "--ck-stop-layer", str(args.layer),
         "--quiet",
         "--report", str(report_path),
@@ -172,7 +173,24 @@ def _capture_args(args: argparse.Namespace, profile: dict[str, Any], report_path
     return command
 
 
+def _validate_oracle_execution(args: argparse.Namespace) -> dict[str, Any]:
+    oracle_threads = int(args.threads)
+    deterministic = oracle_threads == 1
+    if not deterministic and not bool(args.allow_nondeterministic_oracle):
+        raise RuntimeError(
+            "exact llama.cpp X-ray capture requires --threads 1 because multi-threaded "
+            "GGML reductions can change dump bytes between runs; pass "
+            "--allow-nondeterministic-oracle only for explicitly non-exact diagnostics"
+        )
+    return {
+        "threads": oracle_threads,
+        "deterministic": deterministic,
+        "nondeterministic_opt_in": bool(args.allow_nondeterministic_oracle),
+    }
+
+
 def run(args: argparse.Namespace) -> dict[str, Any]:
+    oracle_execution = _validate_oracle_execution(args)
     profile = xray.load_json(args.profile)
     xray.validate(profile, xray.PROFILE_SCHEMA, "llama.cpp parity profile")
     if profile["backend"] != "llamacpp":
@@ -192,6 +210,8 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "schema_version": 1,
         "backend": "llamacpp",
         "execution_mode": args.execution_mode,
+        "oracle_execution": oracle_execution,
+        "subject_execution": {"threads": int(args.ck_threads)},
         "status": report["status"],
         "rounds": [{
             "round": 0,
@@ -217,8 +237,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--image-max-tokens", type=int)
     parser.add_argument("--layer", type=int, default=0)
     parser.add_argument("--profile", type=Path, default=DEFAULT_PROFILE)
-    parser.add_argument("--threads", type=int, default=20)
-    parser.add_argument("--ck-threads", type=int)
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=1,
+        help="llama.cpp oracle threads; exact X-ray capture requires 1",
+    )
+    parser.add_argument("--ck-threads", type=int, default=20)
+    parser.add_argument(
+        "--allow-nondeterministic-oracle",
+        action="store_true",
+        help="permit a multi-threaded llama.cpp oracle for non-exact diagnostics",
+    )
     parser.add_argument(
         "--execution-mode",
         choices=("strict", "production"),


### PR DESCRIPTION
## Why
Qwen3-VL mixed prefill and vision M-RoPE differed from llama.cpp in execution schedule and float evaluation order. Those differences appeared later as plausible Q4 or persistent-KV failures, making attribution slow and misleading.

## What changed
- Declare circuit-owned `text_before -> visual -> text_after` segmented prefill with cache-preserving append and separate semantic positions.
- Resolve append attention, text M-RoPE, LayerNorm, GELU, F16 GEMM, and vision attention through explicit numerical capabilities and map-owned call ABIs.
- Match ggml M-RoPE `powf`/`sinf`/`cosf`, rounded partner products, and FMA evaluation order.
- Make X-ray use a deterministic one-thread llama vision oracle and record CK engine/generated-model/llama binary hashes.
- Stop multitoken comparison at bridge-declared EOS and report CK/oracle thread modes.
- Move Qwen3.5 partial-width text M-RoPE into its circuit and kernel map after the family regression exposed missing call-IR parameters.
- Reduce checked DSL model-literal debt from 78 to 61 sites, including `codegen_v8.py` from 5 to 0.

## Evidence
- Canonical OCR sample 1: 1008x16384 prefix, 16,515,072/16,515,072 FP32 values exact; 128/128 greedy tokens match llama.cpp.
- Canonical OCR sample 2: 1008x16384 prefix, 16,515,072/16,515,072 FP32 values exact; 128/128 greedy tokens match llama.cpp.
- Production-width vision M-RoPE: zero differing Q values and zero differing K values.
- FP16 split-KV oracle: 18/18, including KV 511, 512, 1058, and 1609.
- Direct ggml F16 `mul_mat`: 4,896/4,896 values exact before and after bias.
- The earlier packed-Q4 step-54/74 hypothesis was rejected after deterministic encoder attribution.

## Validation
- `make test-v8-qwen3vl`
- `make test-numerical-contracts` with the local llama.cpp oracle
- `make test-v8-dsl`
- `make test-f16-gemm-llama-contract`
- Forced Qwen3.5 conversion, compile, prefill, and decode
- `make v8-regression-fast`: Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige pass
- Pre-commit staged snapshot: v7 and v8 regressions pass
- Pre-push: build, v8 contracts/E2E, v7/v8 regressions, and training-kernel parity pass

## Regression coverage
Circuit/codegen schedule tests, numerical resolver hard failures, production M-RoPE fixtures, FP16 attention thresholds, direct ggml F16 GEMM, EOS handling, deterministic oracle enforcement, runtime provenance, X-ray interface tests, DSL policy, and Qwen3.5 call-IR generation are all covered.

## Documentation
`docs/site/_pages/v8-numerical-contracts.html` records the method, exact evidence, rejected attribution, ownership boundaries, and remaining scope.

## Content handoff
- Audience: CPU inference, compiler, numerical-parity, and multimodal runtime engineers.
- Angle: How a segmented execution schedule and one-ULP M-RoPE behavior masqueraded as a quantized-kernel failure.
- Claims: Two canonical Qwen3-VL OCR prefixes are byte exact and both 128-token greedy traces match llama.cpp; deterministic X-ray provenance now prevents cross-runtime misattribution.
- Caveats: This does not establish the 40-image sweep or universal multimodal parity; performance work remains a separate gate.
- Sources: Commit `6a89855f`, the numerical-contract documentation page, Qwen3-VL parity reports, direct oracle tests, and staged/pre-push regression logs.