### PR TITLE
Docs/contributor onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,18 @@ Depending on the circuit and model lane, generated `libmodel.so` runtimes can pr
 
 ## Contributing
 
+CKE is deep, but a first contribution does not require understanding the entire compiler or solving multimodal numerical parity. Choose the smallest level that matches the evidence you can produce:
+
+| Level | Contribution surface | Good first result |
+|---|---|---|
+| 1 | Documentation, distribution compatibility, and build fixes | Reproduce one workflow on a named Linux distribution and repair or document the exact failure |
+| 2 | Reproducible benchmarks and profiling adapters | Add a perf, flamegraph, VTune, Advisor, or distribution-specific profiling path with a captured artifact |
+| 3 | Reference tests and numerical fixtures | Compare one operation or tensor boundary against PyTorch, llama.cpp, SciPy, or another independent oracle |
+| 4 | Kernel implementation and optimization | Add or tune one kernel while preserving parity, supported-ISA dispatch, and benchmark evidence |
+| 5 | Compiler, DSL, multimodal parity, and distributed execution | Change cross-layer architecture with explicit contracts, regression coverage, and end-to-end evidence |
+
+See the [Contributor Path](https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html) for bounded starter tasks, the pull-request evidence contract, Discord onboarding, and the complete contribution ladder. Small, well-supported improvements are welcome; unresolved core research is not an onboarding requirement.
+
 Useful contributions include:
 
 - A numerically justified kernel capability and independent oracle test.

--- a/docs/site/_pages/contributing.html
+++ b/docs/site/_pages/contributing.html
@@ -1,105 +1,180 @@
-<!-- TITLE: Developer Guide -->
+<!-- TITLE: Contributor Path -->
 <!-- NAV: contributing -->
 
-<h1>Developer Guide</h1>
+<style>
+.contrib-hero { position: relative; overflow: hidden; margin: 0 0 2rem; padding: 2.4rem; border: 1px solid rgba(7,173,248,.35); border-radius: 18px; background: radial-gradient(circle at 85% 15%, rgba(7,173,248,.18), transparent 34%), linear-gradient(135deg, #26333a, #202529 58%, #302c20); }
+.contrib-hero:before { content: ''; position: absolute; inset: 0; pointer-events: none; opacity: .18; background-image: linear-gradient(rgba(255,255,255,.08) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.08) 1px, transparent 1px); background-size: 34px 34px; }
+.contrib-hero > * { position: relative; }
+.contrib-kicker { color: var(--orange); font: 700 .78rem 'JetBrains Mono', monospace; letter-spacing: .13em; text-transform: uppercase; }
+.contrib-hero h1 { max-width: 900px; margin: .55rem 0 .9rem; font-size: clamp(2.2rem, 5vw, 4.8rem); line-height: .98; }
+.contrib-lead { max-width: 880px; color: var(--text-secondary); font-size: 1.14rem; }
+.contrib-actions { display: flex; gap: .75rem; flex-wrap: wrap; margin-top: 1.35rem; }
+.contrib-button { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .75rem 1rem; border: 1px solid var(--orange); border-radius: 7px; color: var(--dark); background: var(--orange); font-weight: 750; text-decoration: none; }
+.contrib-button.secondary { color: var(--white); border-color: var(--grey-light); background: rgba(255,255,255,.045); }
+.contrib-figure { margin: 2rem 0; padding: .7rem; border: 1px solid var(--grey); border-radius: 14px; background: #171d22; }
+.contrib-figure img { display: block; width: 100%; height: auto; border-radius: 10px; }
+.contrib-figure figcaption { padding: .75rem .45rem .2rem; color: var(--text-muted); font-size: .86rem; }
+.contrib-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin: 1rem 0 2rem; }
+.contrib-card { padding: 1.35rem; border: 1px solid var(--grey); border-top: 4px solid var(--blue); border-radius: 10px; background: var(--dark-card); }
+.contrib-card.green { border-top-color: var(--green); }
+.contrib-card.orange { border-top-color: var(--orange); }
+.contrib-card h3 { margin-top: 0; }
+.contrib-levels { display: grid; gap: .8rem; margin: 1rem 0 2rem; }
+.contrib-level { display: grid; grid-template-columns: 100px minmax(0, 1.15fr) minmax(0, 1fr); gap: 1rem; align-items: start; padding: 1rem 1.1rem; border: 1px solid var(--grey); border-left: 5px solid var(--green); border-radius: 8px; background: rgba(255,255,255,.025); }
+.contrib-level:nth-child(2), .contrib-level:nth-child(3) { border-left-color: var(--blue); }
+.contrib-level:nth-child(4), .contrib-level:nth-child(5) { border-left-color: var(--orange); }
+.contrib-level-id { color: var(--orange); font: 800 .82rem 'JetBrains Mono', monospace; letter-spacing: .06em; }
+.contrib-level strong { display: block; margin-bottom: .25rem; color: var(--white); }
+.contrib-level p { margin: 0; color: var(--text-secondary); }
+.contrib-flow { counter-reset: onboarding; display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .65rem; margin: 1rem 0 2rem; }
+.contrib-step { min-height: 150px; padding: 1rem; border: 1px solid var(--grey); border-radius: 9px; background: var(--dark-card); }
+.contrib-step:before { counter-increment: onboarding; content: counter(onboarding, decimal-leading-zero); display: block; margin-bottom: .65rem; color: var(--blue); font: 800 1rem 'JetBrains Mono', monospace; }
+.contrib-step strong { display: block; margin-bottom: .35rem; color: var(--white); }
+.contrib-step p { margin: 0; color: var(--text-muted); font-size: .88rem; }
+.contrib-callout { margin: 1.5rem 0; padding: 1.25rem 1.4rem; border: 1px solid rgba(71,180,117,.4); border-left: 5px solid var(--green); border-radius: 8px; background: rgba(71,180,117,.07); }
+.contrib-callout.warning { border-color: rgba(255,180,0,.4); border-left-color: var(--orange); background: rgba(255,180,0,.065); }
+.contrib-table { width: 100%; border-collapse: collapse; margin: 1rem 0 2rem; }
+.contrib-table th, .contrib-table td { padding: .8rem; border: 1px solid var(--grey); vertical-align: top; text-align: left; }
+.contrib-table th { color: var(--orange); background: rgba(255,180,0,.07); }
+@media (max-width: 900px) { .contrib-grid { grid-template-columns: 1fr; } .contrib-level { grid-template-columns: 82px 1fr; } .contrib-level > :last-child { grid-column: 2; } .contrib-flow { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 600px) { .contrib-hero { padding: 1.5rem; } .contrib-level { grid-template-columns: 1fr; } .contrib-level > :last-child { grid-column: auto; } .contrib-flow { grid-template-columns: 1fr; } .contrib-actions, .contrib-button { width: 100%; } .contrib-table { display: block; overflow-x: auto; } }
+</style>
 
-<p>So you want to hack on the engine? Welcome!</p>
-<p>This guide explains how to add a new kernel (operation) to the system, from the math implementation to the compiler integration.</p>
+<section class="contrib-hero">
+  <div class="contrib-kicker">Build evidence with us</div>
+  <h1>Start small. Learn one boundary. Make it reproducible.</h1>
+  <p class="contrib-lead">C-Kernel-Engine spans model mathematics, generated C, numerical contracts, SIMD kernels, Linux profiling, multimodal execution, and future distributed CPU systems. You do not need to understand all of it before contributing. Begin with one bounded problem whose result another engineer can reproduce.</p>
+  <div class="contrib-actions">
+    <a class="contrib-button" href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues">Find or open an issue</a>
+    <a class="contrib-button secondary" href="quickstart.html">Build CKE first</a>
+    <a class="contrib-button secondary" href="test-report.html">Inspect current evidence</a>
+  </div>
+</section>
 
-<h2>Enable Git Hooks (Required)</h2>
-<p>This repo ships both a scoped pre-commit regression gate in <code>.githooks/pre-commit</code> and heavier push-time validation in <code>.githooks/pre-push</code>. The fast <code>v7</code> family regression runs in the local loop, while legacy <code>v6.6</code> compatibility is only checked at push time when shared/runtime-sensitive paths changed. Git does <strong>not</strong> enable repo hooks automatically on clone/pull.</p>
+<section class="contrib-callout">
+  <h2 style="margin-top:0">The hard research problem is not the entrance exam</h2>
+  <p style="margin-bottom:0">Current work may involve Qwen3-VL long-context divergence, BF16 reduction semantics, AVX2/AVX-512/AMX dispatch, compiler ownership, or multimodal parity. Those are Level-5 problems. A distribution fix, profiler adapter, benchmark artifact, documentation correction, or independent numerical fixture is a complete and useful contribution.</p>
+</section>
+
+<figure class="contrib-figure svg-viewer" data-title="CKE contributor ladder">
+  <img src="assets/contributor-ladder.svg" alt="Five-level CKE contributor ladder from documentation and compatibility through profiling, numerical tests, kernels, and compiler or distributed systems work">
+  <figcaption>Progression is optional, not a ranking. Own the smallest level where you can produce a reliable result.</figcaption>
+</figure>
+
+<h2>The Five Contribution Levels</h2>
+
+<div class="contrib-levels">
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 1</div>
+    <div><strong>Documentation, compatibility, and build fixes</strong><p>Improve setup instructions, repair one distribution-specific failure, clarify a command, or make an existing workflow reproducible on a named machine.</p></div>
+    <div><strong>Completion evidence</strong><p>Environment details, failing command, corrected command or patch, and proof the documented path now succeeds.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 2</div>
+    <div><strong>Benchmarks and profiling adapters</strong><p>Add a repeatable perf, FlameGraph, flamegraph-rs, VTune, Advisor, cache, assembly, or power-measurement lane without breaking existing platforms.</p></div>
+    <div><strong>Completion evidence</strong><p>Exact command, CPU and compiler metadata, workload, raw artifact, interpretation, and known sources of measurement noise.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 3</div>
+    <div><strong>Reference tests and numerical fixtures</strong><p>Exercise one operation or canonical tensor boundary against PyTorch, llama.cpp, SciPy, a finite-difference gradient, or another independent implementation.</p></div>
+    <div><strong>Completion evidence</strong><p>Deterministic fixture, independent oracle, tolerance and dtype policy, failure reproduction, and regression test.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 4</div>
+    <div><strong>Kernel implementation and optimization</strong><p>Implement or tune one C kernel, SIMD route, memory layout, fusion, quantized path, or thread-pool boundary.</p></div>
+    <div><strong>Completion evidence</strong><p>Parity first, supported-ISA detection, before/after benchmark, profiler attribution, fallback behavior, and no unsupported performance claim.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 5</div>
+    <div><strong>Compiler, DSL, multimodal, and distributed systems</strong><p>Change circuit semantics, lowering, kernel binding, generated runtime ownership, numerical X-ray attribution, multimodal stitching, or multi-node execution.</p></div>
+    <div><strong>Completion evidence</strong><p>Written contract, cross-layer tests, generated-C inspection, architecture regression coverage, migration impact, and end-to-end evidence.</p></div>
+  </article>
+</div>
+
+<h2>Three Good First Paths</h2>
+
+<div class="contrib-grid">
+  <article class="contrib-card green">
+    <h3>Linux distribution and profiling adapter</h3>
+    <p>Build one known model on Arch, CachyOS, Fedora, Debian, or another Linux environment. Preserve Ubuntu behavior while adding explicit commands for the platform's profiler package and interface.</p>
+    <p><strong>Concrete example:</strong> detect or document <code>flamegraph-rs</code> on Arch/CachyOS instead of assuming the Perl FlameGraph command line, then capture the resulting SVG and baseline metadata.</p>
+  </article>
+  <article class="contrib-card">
+    <h3>Reproducible benchmark artifact</h3>
+    <p>Run one supported model with a fixed prompt and thread count. Record CPU topology, ISA flags, compiler, CKE commit, model hash, command, prompt-eval rate, decode rate, RSS, and profiler output.</p>
+    <p>The contribution is the reproducible evidence package, not a context-free tokens-per-second number.</p>
+  </article>
+  <article class="contrib-card orange">
+    <h3>One numerical boundary</h3>
+    <p>Choose RMSNorm, RoPE, quantized dot product, softmax, Conv1D, attention, or another bounded operation. Compare CKE against an independent oracle using deterministic tensors and an explicit precision policy.</p>
+    <p>Do not begin with complete model generation unless the smaller boundary already passes.</p>
+  </article>
+  <article class="contrib-card">
+    <h3>Documentation that follows the code</h3>
+    <p>Reproduce a public guide from a clean checkout. Correct stale paths, unsupported assumptions, missing dependencies, or unclear evidence labels. Link every claim to the current implementation or test.</p>
+    <p>Documentation-only changes still need reproduction evidence.</p>
+  </article>
+</div>
+
+<h2>The Onboarding Loop</h2>
+
+<div class="contrib-flow">
+  <article class="contrib-step"><strong>Build</strong><p>Follow the quickstart and record your machine, OS, CPU, compiler, and commit.</p></article>
+  <article class="contrib-step"><strong>Choose one boundary</strong><p>Use an existing issue or open a focused issue describing one observable failure or missing path.</p></article>
+  <article class="contrib-step"><strong>Reproduce</strong><p>Capture the failing and passing commands before broadening the change.</p></article>
+  <article class="contrib-step"><strong>Open a draft PR</strong><p>Share direction early. Do not wait until a large rewrite is complete.</p></article>
+  <article class="contrib-step"><strong>Close with evidence</strong><p>Attach tests, artifacts, limits, and the exact claim the change supports.</p></article>
+</div>
+
+<h2>Discord Onboarding</h2>
+
+<section class="contrib-callout">
+  <p><strong>If you are already in the CKE Discord:</strong> introduce yourself with your operating system, CPU, compiler, the CKE path you successfully ran, and one contribution level that interests you. Link a focused GitHub issue or draft PR so technical decisions remain searchable outside chat.</p>
+  <p><strong>If you need an invite:</strong> open a short onboarding issue in the CKE repository. The public repository remains the durable source for scope, commands, patches, evidence, and review; Discord is for coordination and questions, not the only copy of a technical decision.</p>
+  <p style="margin-bottom:0"><strong>Good first message:</strong> "I built commit <code>&lt;sha&gt;</code> on <code>&lt;OS&gt;</code> with <code>&lt;CPU/compiler&gt;</code>. I want to work at Level 2 on the Arch/CachyOS flamegraph-rs path. Here is my baseline command and draft issue."</p>
+</section>
+
+<h2>Pull Request Evidence Contract</h2>
+
+<table class="contrib-table">
+  <thead><tr><th>Include</th><th>Why it matters</th></tr></thead>
+  <tbody>
+    <tr><td>Problem and bounded scope</td><td>Reviewers can tell what changed and what deliberately did not.</td></tr>
+    <tr><td>Hardware, OS, compiler, model, and commit</td><td>CPU behavior and performance claims are environment-dependent.</td></tr>
+    <tr><td>Exact reproduction commands</td><td>Another contributor can rerun the result without reconstructing your shell history.</td></tr>
+    <tr><td>Independent correctness evidence</td><td>An implementation must not validate only against itself.</td></tr>
+    <tr><td>Before/after artifacts for performance work</td><td>Optimization requires attribution, not intuition or CPU utilization alone.</td></tr>
+    <tr><td>Known limits and unsupported cases</td><td>A narrow validated path must not become a broad accidental claim.</td></tr>
+    <tr><td>Focused commit history</td><td>Intent remains inspectable and unrelated changes do not hide in the patch.</td></tr>
+  </tbody>
+</table>
+
+<h2>Build and Test Before Review</h2>
+
+<p>Enable the repository hooks after cloning:</p>
+
 <pre><code>./scripts/setup-hooks.sh
-</code></pre>
-<p>Verify:</p>
-<pre><code>git config core.hooksPath
-</code></pre>
-<p>It should print <code>.githooks</code>. If not, commits and pushes will <strong>not</strong> run the repo hooks.</p>
+git config core.hooksPath</code></pre>
 
-<h2>Workflow: Adding a New Kernel</h2>
-
-<p>Let's say you want to add a <code>GELU_TANH</code> op.</p>
-
-<h3>1. Define the Op in IR</h3>
-
-<p>Open <code>include/ckernel_ir.h</code> and add your op to the <code>CKOpType</code> enum:</p>
-
-<pre><code>typedef enum {
-    // ...
-    CK_OP_SWIGLU,
-    CK_OP_GELU_TANH, // <--- Add this
-    // ...
-} CKOpType;</code></pre>
-
-<h3>2. Implement the Kernel</h3>
-
-<p>Create a new file <code>src/kernels/gelu_tanh.c</code> (or add to <code>src/kernels/gelu_kernels.c</code> if it fits):</p>
-
-<pre><code>#include &lt;math.h&gt;
-
-void gelu_tanh_forward(const float *x, float *y, int n) {
-    // fast tanh approximation...
-    for (int i = 0; i < n; ++i) {
-        // ...
-    }
-}</code></pre>
-
-<p>Then expose it in <code>include/ckernel_engine.h</code>:</p>
-
-<pre><code>void gelu_tanh_forward(const float *x, float *y, int n);</code></pre>
-
-<h3>3. Register the Op Name</h3>
-
-<p>Open <code>src/ckernel_registry.c</code> and map the enum to a string name:</p>
-
-<pre><code>static const char *ck_op_name(CKOpType op) {
-    switch (op) {
-        // ...
-        case CK_OP_GELU_TANH: return "GELU_TANH";
-        // ...
-    }
-}</code></pre>
-
-<p>And ensure <code>ck_op_supported</code> returns 1 for it.</p>
-
-<h3>4. Update the Code Generator</h3>
-
-<p>Open <code>src/ckernel_codegen.c</code>. You need to ensure the runtime knows how to emit code for this op.</p>
-<p>First, update the local <code>op_name</code> helper if it duplicates the registry logic.</p>
-<p>Then, if you are emitting a full runtime (in <code>emit_runtime_preamble</code> or the main loop inside <code>ck_codegen_emit_runtime</code>), you need to make sure your kernel's source file is included in the output <code>ai.c</code>.</p>
-
-<p>For example, in <code>emit_runtime_preamble</code>:</p>
-
-<pre><code>if (emit_source_filtered(out, "src/kernels/gelu_tanh.c") != 0) return -1;</code></pre>
-
-<h3>5. Add a Test</h3>
-
-<p>We verify everything against PyTorch. Create <code>unittest/test_gelu_tanh.py</code>:</p>
-
-<pre><code>import torch
-import ctypes
-import numpy as np
-
-# Load your new library (you might need to add a target to Makefile first!)
-lib = ctypes.CDLL("build/libckernel_gelu.so") 
-
-def test_gelu_tanh():
-    # ... setup input ...
-    # ... call C function ...
-    # ... compare with torch.nn.functional.gelu(..., approximate='tanh') ...</code></pre>
-
-<h3>6. Build and Verify</h3>
+<p>The configured path should be <code>.githooks</code>. Run the tests relevant to your changed boundary and report exactly what ran. Do not claim the complete engine passed if you ran only a scoped test.</p>
 
 <pre><code>make
-make test</code></pre>
+make test
 
-<h2>Compiler Architecture</h2>
+# Examples of focused Python gates
+python3 -m pytest tests/test_v8_attention_contracts.py
+python3 -m pytest tests/test_v8_numerical_execution_contracts.py</code></pre>
 
-<p>The "Compiler" is just <code>ckernel_ir_demo.c</code>. It doesn't generate machine code directly; it generates <strong>C source code</strong>. This is known as "Transpilation" or "Source-to-Source" compilation.</p>
+<section class="contrib-callout warning">
+  <h2 style="margin-top:0">AI assistance does not transfer responsibility</h2>
+  <p style="margin-bottom:0">AI tools may help inspect code, propose tests, or draft a patch. The contributor still owns every equation, hardware assumption, generated artifact, claim, and line submitted. Correct-looking code without independent evidence is not a completed contribution.</p>
+</section>
 
-<ol>
-    <li><strong>Parser</strong>: Reads <code>config.json</code> -> <code>CKModelConfig</code>.</li>
-    <li><strong>IR Builder</strong>: Constructs <code>CKIRGraph</code> (a flat list of nodes).</li>
-    <li><strong>Codegen</strong>: Walks the <code>CKIRGraph</code> and prints C code to a file (<code>ai.c</code>).</li>
-</ol>
+<h2>Where To Go Next</h2>
 
-<p>This generated <code>ai.c</code> is <strong>standalone</strong>. It contains all the kernel code (inlined/included) and a <code>main()</code> function. You can compile it with <code>gcc -O3 ai.c -o ai</code> and run it anywhere, without needing the original library.</p>
+<div class="contrib-grid">
+  <article class="contrib-card"><h3>Understand the runtime</h3><p><a href="quickstart.html">Quickstart</a>, <a href="architecture.html">architecture</a>, <a href="ir-pipeline.html">IR pipeline</a>, and <a href="v8-runbook.html">v8 runbook</a>.</p></article>
+  <article class="contrib-card"><h3>Work on performance</h3><p><a href="profiling.html">Profiling guide</a>, <a href="kernel-tuning-methodology.html">kernel tuning methodology</a>, and <a href="simd-architecture.html">SIMD architecture</a>.</p></article>
+  <article class="contrib-card"><h3>Work on correctness</h3><p><a href="pytorch-parity.html">PyTorch parity</a>, <a href="divergence-harness.html">divergence harness</a>, and <a href="v8-numerical-contracts.html">numerical contracts</a>.</p></article>
+  <article class="contrib-card"><h3>Coordinate publicly</h3><p><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues">Issues</a>, <a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/pulls">draft pull requests</a>, and the current <a href="test-report.html">test report</a>.</p></article>
+</div>

--- a/docs/site/_partials/api_content.html
+++ b/docs/site/_partials/api_content.html
@@ -60,7 +60,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_0(const void * weight_q5_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_0 GEMM - batched matrix multiply with Q5_0 weights (32-element blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_0 x Q8_0 GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -70,7 +70,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_1(const void * weight_q5_1, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_1 GEMM - batched matrix multiply with Q5_1 weights (32-element blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_1 x Q8_0 GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -80,7 +80,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_k(const void * weight_q5_k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_K GEMM - batched matrix multiply with Q5_K weights (256-element super-blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_K x Q8_K GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -90,7 +90,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q6_k(const void * weight_q6k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q6_K GEMM - batched matrix multiply with Q6_K weights.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q6_K x Q8_K GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -100,7 +100,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q8_0(const void * weight_q8_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q8_0 GEMM - batched matrix multiply with Q8_0 weights (32-element blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q8_0 x Q8_0 GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -2122,7 +2122,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void mega_fused_attention_decode(float * output, const float * input, const float * residual, const float * ln1_gamma, const float * wq, const float * bq, const float * wk, const float * bk, const float * wv, const float * bv, const float * wo, const float * bo, float * kv_cache_k, float * kv_cache_v, const float * rope_cos, const float * rope_sin, int pos, int embed_dim, int aligned_embed_dim, int num_heads, int num_kv_heads, int head_dim, int aligned_head_dim, int cache_capacity, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Full mega-fused attention for decode.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Mega-fused attention for decode mode (single token)</p>
         </div>
 
 
@@ -4237,7 +4237,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_bool</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out_val)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -4347,7 +4347,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_string</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out_str)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -4437,7 +4437,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_serialize_json_with_plan</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const struct CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -4966,8 +4966,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_murmurhash3_str</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * str, uint32_t seed)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">MurmurHash3-32bit for string (null-terminated).</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * key, uint32_t seed)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -5487,7 +5487,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q5_0_q8_0(const void * weight_q5_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -5497,7 +5497,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q8_0_q8_0(const void * weight_q8_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -5626,8 +5626,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_merge</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left_id, int32_t right_id, int32_t merged_id, int32_t priority)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a BPE merge rule.</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left, int32_t right, int32_t merged)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -5646,8 +5646,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_token</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int32_t id, float score)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a token to vocabulary.</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int len)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -5697,7 +5697,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_decode(const CKTokenizer * tok, const int32_t * ids, int num_ids, char * text, int max_len)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Decode token IDs to text.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -5717,7 +5717,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_encode(const CKTokenizer * tok, const char * text, int text_len, int32_t * ids, int max_ids)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Encode text to token IDs using greedy longest-match.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -5996,7 +5996,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_lookup</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token, int len)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -6216,8 +6216,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_vocab_size</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get vocabulary size.</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -7726,7 +7726,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">geglu_backward_fp32</code>
                 <span class="badge badge-blue" style="margin-left: 0.5rem;">Backward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int tokens, int dim)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int n_tokens, int dim)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">GeGLU backward pass (fp32) Testtest_geglu.py::TestGeGLU::test_geglu_backward_fp32</p>
         </div>
 
@@ -9758,7 +9758,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">parse_args</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">CLIArgs parse_args(int argc, char ** argv)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">bool parse_args(int argc, char ** argv, CLIOptions * opt)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-10 21:47</span>
+        <span class="folder-updated">Updated: 2026-07-14 12:49</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -28,27 +28,59 @@ version/v6.6
 version/v7
 |-- artifacts
 |   `-- svg_dsl
+|       |-- gen1_archive_2026-04-05
+|       `-- spec_archive_2026-04-08
 |-- contracts
 |-- data
 |   |-- eval_contracts
+|   |-- generated
+|   |   |-- toy_svg_semantic_shapes_tokenizer
+|   |   `-- toy_svg_structured_atoms_tokenizer
+|   |-- probe_contracts
 |   |-- spec03
+|   |   |-- contracts
+|   |   |-- holdout
+|   |   |-- manifests
+|   |   |-- midtrain
+|   |   |-- normalized
+|   |   |-- pretrain
+|   |   |-- raw_assets
+|   |   |-- sft
+|   |   `-- tokenizer
 |   `-- spec04
+|       |-- contracts
+|       |-- holdout
+|       |-- manifests
+|       |-- midtrain
+|       |-- normalized
+|       |-- pretrain
+|       |-- raw_assets
+|       |-- sft
+|       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
+|       |-- catalog
+|       |-- core
+|       |-- programs
+|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
 |-- reports
-|   |-- spec12_gold_mappings
-|   |-- spec13b_gold_mappings
-|   |-- spec14a_gold_mappings
-|   |-- spec14b_gold_mappings
-|   |-- spec15a_gold_mappings
-|   |-- spec15b_gold_mappings
-|   |-- spec_broader_1_family_packs
-|   `-- spec_broader_1_gold_mappings
+|   |-- spec12_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec12_gold_mappings
+|   |-- spec13b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec13b_gold_mappings
+|   |-- spec14a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14a_gold_mappings
+|   |-- spec14b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14b_gold_mappings
+|   |-- spec15a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15a_gold_mappings
+|   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
+|   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
+|   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
+|-- runs
+|   |-- logs
+|   `-- overnight_monitor
+|       `-- spec10
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -61,7 +93,7 @@ version/v7
 `-- tools
     `-- src
 
-55 directories
+87 directories
 </pre>
 </div>
 

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 12:49</span>
+        <span class="folder-updated">Updated: 2026-07-14 13:04</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -33,10 +33,6 @@ version/v7
 |-- contracts
 |-- data
 |   |-- eval_contracts
-|   |-- generated
-|   |   |-- toy_svg_semantic_shapes_tokenizer
-|   |   `-- toy_svg_structured_atoms_tokenizer
-|   |-- probe_contracts
 |   |-- spec03
 |   |   |-- contracts
 |   |   |-- holdout
@@ -51,20 +47,13 @@ version/v7
 |       |-- contracts
 |       |-- holdout
 |       |-- manifests
-|       |-- midtrain
 |       |-- normalized
-|       |-- pretrain
 |       |-- raw_assets
-|       |-- sft
 |       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
-|       |-- catalog
-|       |-- core
-|       |-- programs
-|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
@@ -77,10 +66,6 @@ version/v7
 |   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
 |   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
 |   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
-|-- runs
-|   |-- logs
-|   `-- overnight_monitor
-|       `-- spec10
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -93,7 +78,7 @@ version/v7
 `-- tools
     `-- src
 
-87 directories
+72 directories
 </pre>
 </div>
 

--- a/docs/site/_partials/footer.html
+++ b/docs/site/_partials/footer.html
@@ -213,6 +213,7 @@
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
                     <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>

--- a/docs/site/_partials/header.html
+++ b/docs/site/_partials/header.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,6 +863,7 @@
             <a href="spectrum.html" class="{{NAV_SPECTRUM}}" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="{{NAV_QUICKSTART}}">Getting Started</a>
             <a href="developer-guide.html" class="{{NAV_DEVGUIDE}}">Developer Guide</a>
+            <a href="contributing.html" class="{{NAV_CONTRIBUTING}}">Contribute</a>
             <a href="scaling.html" class="{{NAV_SCALING}}">Scaling</a>
             <a href="support-hardware.html" class="{{NAV_SUPPORT}}" style="color:var(--green)">Support Lab</a>
             <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1080,7 +1083,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_0(const void * weight_q5_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_0 GEMM - batched matrix multiply with Q5_0 weights (32-element blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_0 x Q8_0 GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -1090,7 +1093,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_1(const void * weight_q5_1, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_1 GEMM - batched matrix multiply with Q5_1 weights (32-element blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_1 x Q8_0 GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -1100,7 +1103,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q5_k(const void * weight_q5_k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q5_K GEMM - batched matrix multiply with Q5_K weights (256-element super-blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q5_K x Q8_K GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -1110,7 +1113,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q6_k(const void * weight_q6k, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q6_K GEMM - batched matrix multiply with Q6_K weights.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q6_K x Q8_K GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -1120,7 +1123,7 @@
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_gemm_q8_0(const void * weight_q8_0, const float * input_f32, float * output, int rows, int cols, int n_tokens)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Q8_0 GEMM - batched matrix multiply with Q8_0 weights (32-element blocks)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Test Q8_0 x Q8_0 GEMM (batch matrix multiply)</p>
         </div>
 
 
@@ -3142,7 +3145,7 @@ test_attention.py::TestAttentionForward::test_flash_decode</p>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void mega_fused_attention_decode(float * output, const float * input, const float * residual, const float * ln1_gamma, const float * wq, const float * bq, const float * wk, const float * bk, const float * wv, const float * bv, const float * wo, const float * bo, float * kv_cache_k, float * kv_cache_v, const float * rope_cos, const float * rope_sin, int pos, int embed_dim, int aligned_embed_dim, int num_heads, int num_kv_heads, int head_dim, int aligned_head_dim, int cache_capacity, float eps)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Full mega-fused attention for decode.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Mega-fused attention for decode mode (single token)</p>
         </div>
 
 
@@ -5257,7 +5260,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_bool</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_bool(const char * json, const char * key, const char * end, int * out_val)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -5367,7 +5370,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_parse_string</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_parse_string(const char * start, const char * end, char ** out_str)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -5457,7 +5460,7 @@ test_multi_layer_parity.py::TestMultiLayerParity::test_residual_add</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_ir_v2_serialize_json_with_plan</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const struct CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_ir_v2_serialize_json_with_plan(const CKIRV2Graph * graph, const CKMemPlan * plan, const char * mode, int tokens_override, int base_context_window, const char * path)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -5986,8 +5989,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_murmurhash3_str</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * str, uint32_t seed)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">MurmurHash3-32bit for string (null-terminated).</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">uint32_t ck_murmurhash3_str(const char * key, uint32_t seed)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -6507,7 +6510,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q5_0_q8_0(const void * weight_q5_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q5_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -6517,7 +6520,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void ck_test_vec_dot_q8_0_q8_0(const void * weight_q8_0, const void * input_q8_0, float * output, int cols)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product (takes pre-quantized Q8_0 input)</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Direct Q8_0 x Q8_0 dot product test (takes pre-quantized Q8_0 input)</p>
         </div>
 
 
@@ -6646,8 +6649,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_merge</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left_id, int32_t right_id, int32_t merged_id, int32_t priority)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a BPE merge rule.</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_merge(CKTokenizer * tok, int32_t left, int32_t right, int32_t merged)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -6666,8 +6669,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_add_token</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int32_t id, float score)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Add a token to vocabulary.</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_add_token(CKTokenizer * tok, const char * token, int len)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -6717,7 +6720,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_decode(const CKTokenizer * tok, const int32_t * ids, int num_ids, char * text, int max_len)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Decode token IDs to text.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -6737,7 +6740,7 @@ hugepage_mode
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
             <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_encode(const CKTokenizer * tok, const char * text, int text_len, int32_t * ids, int max_ids)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Encode text to token IDs using greedy longest-match.</p>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -7016,7 +7019,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_lookup</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int32_t ck_tokenizer_lookup(const CKTokenizer * tok, const char * token, int len)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -7236,8 +7239,8 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">ck_tokenizer_vocab_size</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">size_t ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
-            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">Get vocabulary size.</p>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">int ck_tokenizer_vocab_size(const CKTokenizer * tok)</pre>
+            <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
 
@@ -8746,7 +8749,7 @@ hugepage_mode
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">geglu_backward_fp32</code>
                 <span class="badge badge-blue" style="margin-left: 0.5rem;">Backward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int tokens, int dim)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">void geglu_backward_fp32(const float * x, const float * d_out, float * d_x, int n_tokens, int dim)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;">GeGLU backward pass (fp32) Testtest_geglu.py::TestGeGLU::test_geglu_backward_fp32</p>
         </div>
 
@@ -10778,7 +10781,7 @@ The IR graph structure (number of layers, op types)</p>
                 <code style="font-size: 1rem; background: none; color: var(--orange); padding: 0;">parse_args</code>
                 <span class="badge badge-green" style="margin-left: 0.5rem;">Forward</span>
             </div>
-            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">CLIArgs parse_args(int argc, char ** argv)</pre>
+            <pre style="margin: 0.5rem 0; font-size: 0.8rem; overflow-x: auto;">bool parse_args(int argc, char ** argv, CLIOptions * opt)</pre>
             <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem;"></p>
         </div>
 
@@ -12963,7 +12966,8 @@ rmsnorm_backward(d_norm_out, input, gamma, rstd_cache, d_input, d_gamma, tokens,
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -12971,13 +12975,14 @@ rmsnorm_backward(d_norm_out, input, gamma, rstd_cache, d_input, d_gamma, tokens,
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture-links.html
+++ b/docs/site/architecture-links.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1484,7 +1487,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1492,13 +1496,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -1263,7 +1263,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 12:49</span>
+        <span class="folder-updated">Updated: 2026-07-14 13:04</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1294,10 +1294,6 @@ version/v7
 |-- contracts
 |-- data
 |   |-- eval_contracts
-|   |-- generated
-|   |   |-- toy_svg_semantic_shapes_tokenizer
-|   |   `-- toy_svg_structured_atoms_tokenizer
-|   |-- probe_contracts
 |   |-- spec03
 |   |   |-- contracts
 |   |   |-- holdout
@@ -1312,20 +1308,13 @@ version/v7
 |       |-- contracts
 |       |-- holdout
 |       |-- manifests
-|       |-- midtrain
 |       |-- normalized
-|       |-- pretrain
 |       |-- raw_assets
-|       |-- sft
 |       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
-|       |-- catalog
-|       |-- core
-|       |-- programs
-|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
@@ -1338,10 +1327,6 @@ version/v7
 |   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
 |   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
 |   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
-|-- runs
-|   |-- logs
-|   `-- overnight_monitor
-|       `-- spec10
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -1354,7 +1339,7 @@ version/v7
 `-- tools
     `-- src
 
-87 directories
+72 directories
 </pre>
 </div>
 

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -966,6 +969,8 @@
 <h2>Active v8 Compiler Architecture</h2>
 
 <p>The active v8 inference compiler consumes three authoritative inputs: model weights, an architecture circuit, and executable kernel maps. The circuit owns graph structure and required semantics. Kernel maps own ABI and implementation capability. The DSL resolves and stitches; generated C does not guess.</p>
+
+<p>This boundary is executable policy, not only documentation. The v8 and v7 DSL audits reject new model-family dispatch in generic compiler/codegen functions, including dispatch hidden behind local aliases. Exact kernel operations do not fall back to broader families, malformed per-layer dimensions fail, and circuit weight policies are schema validated. New-model support must therefore extend a circuit, a kernel map, or a tested kernel instead of accumulating another compiler conditional.</p>
 
 <div class="img-container svg-viewer" data-title="v8 Numerical Contract Architecture">
     <img src="assets/v8-numerical-contracts.svg" alt="v8 weights, circuits, kernel maps, numerical contract resolution, IR lowering and generated C">
@@ -1258,7 +1263,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-11 03:52</span>
+        <span class="folder-updated">Updated: 2026-07-14 12:49</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1282,31 +1287,61 @@ version/v6.6
 |-- tools
 `-- unittest
 version/v7
-|-- .cache
-|   `-- reports
 |-- artifacts
 |   `-- svg_dsl
+|       |-- gen1_archive_2026-04-05
+|       `-- spec_archive_2026-04-08
 |-- contracts
 |-- data
 |   |-- eval_contracts
+|   |-- generated
+|   |   |-- toy_svg_semantic_shapes_tokenizer
+|   |   `-- toy_svg_structured_atoms_tokenizer
+|   |-- probe_contracts
 |   |-- spec03
+|   |   |-- contracts
+|   |   |-- holdout
+|   |   |-- manifests
+|   |   |-- midtrain
+|   |   |-- normalized
+|   |   |-- pretrain
+|   |   |-- raw_assets
+|   |   |-- sft
+|   |   `-- tokenizer
 |   `-- spec04
+|       |-- contracts
+|       |-- holdout
+|       |-- manifests
+|       |-- midtrain
+|       |-- normalized
+|       |-- pretrain
+|       |-- raw_assets
+|       |-- sft
+|       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
+|       |-- catalog
+|       |-- core
+|       |-- programs
+|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
 |-- reports
-|   |-- spec12_gold_mappings
-|   |-- spec13b_gold_mappings
-|   |-- spec14a_gold_mappings
-|   |-- spec14b_gold_mappings
-|   |-- spec15a_gold_mappings
-|   |-- spec15b_gold_mappings
-|   |-- spec_broader_1_family_packs
-|   `-- spec_broader_1_gold_mappings
+|   |-- spec12_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec12_gold_mappings
+|   |-- spec13b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec13b_gold_mappings
+|   |-- spec14a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14a_gold_mappings
+|   |-- spec14b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14b_gold_mappings
+|   |-- spec15a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15a_gold_mappings
+|   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
+|   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
+|   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
+|-- runs
+|   |-- logs
+|   `-- overnight_monitor
+|       `-- spec10
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -1319,7 +1354,7 @@ version/v7
 `-- tools
     `-- src
 
-57 directories
+87 directories
 </pre>
 </div>
 
@@ -1584,7 +1619,8 @@ version/v7
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1592,13 +1628,14 @@ version/v7
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/assets/contributor-ladder.svg
+++ b/docs/site/assets/contributor-ladder.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">C-Kernel-Engine contributor ladder</title>
+  <desc id="desc">Five contribution levels progress from documentation and Linux compatibility through profiling, numerical tests, kernels, and compiler or distributed systems work.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#171d22"/>
+      <stop offset="1" stop-color="#252d33"/>
+    </linearGradient>
+    <linearGradient id="path" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#47b475"/>
+      <stop offset="0.52" stop-color="#07adf8"/>
+      <stop offset="1" stop-color="#ffb400"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#000" flood-opacity=".28"/>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#fff" stroke-opacity=".035"/>
+    </pattern>
+  </defs>
+  <rect width="1600" height="900" rx="28" fill="url(#bg)"/>
+  <rect width="1600" height="900" rx="28" fill="url(#grid)"/>
+
+  <text x="90" y="100" fill="#ffb400" font-family="monospace" font-size="22" font-weight="700" letter-spacing="4">CONTRIBUTOR PATH</text>
+  <text x="90" y="163" fill="#fff" font-family="sans-serif" font-size="48" font-weight="800">Start where you can produce evidence.</text>
+  <text x="90" y="208" fill="#aeb9c0" font-family="sans-serif" font-size="25">You do not need to understand the entire engine before improving one boundary.</text>
+
+  <path d="M132 713 C330 713 320 611 488 611 S650 509 808 509 S970 407 1128 407 S1260 305 1452 305" fill="none" stroke="url(#path)" stroke-width="10" stroke-linecap="round" opacity=".8"/>
+
+  <g filter="url(#shadow)" font-family="sans-serif">
+    <g transform="translate(85 590)">
+      <rect width="270" height="205" rx="18" fill="#24372f" stroke="#47b475" stroke-width="3"/>
+      <text x="24" y="42" fill="#47b475" font-family="monospace" font-size="20" font-weight="700">LEVEL 1</text>
+      <text x="24" y="82" fill="#fff" font-size="27" font-weight="750">Make it work</text>
+      <text x="24" y="118" fill="#c6d0cc" font-size="19">Docs, builds, Linux</text>
+      <text x="24" y="147" fill="#c6d0cc" font-size="19">distribution support</text>
+      <text x="24" y="184" fill="#8fa59a" font-size="16">One reproducible fix</text>
+    </g>
+
+    <g transform="translate(385 488)">
+      <rect width="270" height="205" rx="18" fill="#20343b" stroke="#20a9ce" stroke-width="3"/>
+      <text x="24" y="42" fill="#38b9df" font-family="monospace" font-size="20" font-weight="700">LEVEL 2</text>
+      <text x="24" y="82" fill="#fff" font-size="27" font-weight="750">Measure it</text>
+      <text x="24" y="118" fill="#c5d2d7" font-size="19">Benchmarks, perf,</text>
+      <text x="24" y="147" fill="#c5d2d7" font-size="19">flamegraphs, profilers</text>
+      <text x="24" y="184" fill="#8da7b0" font-size="16">Artifact plus commands</text>
+    </g>
+
+    <g transform="translate(685 386)">
+      <rect width="270" height="205" rx="18" fill="#1e3541" stroke="#07adf8" stroke-width="3"/>
+      <text x="24" y="42" fill="#07adf8" font-family="monospace" font-size="20" font-weight="700">LEVEL 3</text>
+      <text x="24" y="82" fill="#fff" font-size="27" font-weight="750">Prove it</text>
+      <text x="24" y="118" fill="#c5d2d7" font-size="19">Reference tests and</text>
+      <text x="24" y="147" fill="#c5d2d7" font-size="19">numerical fixtures</text>
+      <text x="24" y="184" fill="#8da7b0" font-size="16">Independent oracle</text>
+    </g>
+
+    <g transform="translate(985 284)">
+      <rect width="270" height="205" rx="18" fill="#3a3421" stroke="#e7a817" stroke-width="3"/>
+      <text x="24" y="42" fill="#ffbf2f" font-family="monospace" font-size="20" font-weight="700">LEVEL 4</text>
+      <text x="24" y="82" fill="#fff" font-size="27" font-weight="750">Optimize it</text>
+      <text x="24" y="118" fill="#d7d0bc" font-size="19">Kernel code, SIMD,</text>
+      <text x="24" y="147" fill="#d7d0bc" font-size="19">memory and threading</text>
+      <text x="24" y="184" fill="#afa686" font-size="16">Parity before speed</text>
+    </g>
+
+    <g transform="translate(1285 182)">
+      <rect width="230" height="205" rx="18" fill="#3b2e1a" stroke="#ffb400" stroke-width="3"/>
+      <text x="22" y="42" fill="#ffb400" font-family="monospace" font-size="20" font-weight="700">LEVEL 5</text>
+      <text x="22" y="82" fill="#fff" font-size="27" font-weight="750">Connect it</text>
+      <text x="22" y="118" fill="#ddd2bc" font-size="18">Compiler, DSL,</text>
+      <text x="22" y="146" fill="#ddd2bc" font-size="18">multimodal, cluster</text>
+      <text x="22" y="184" fill="#b3a285" font-size="16">Cross-layer contracts</text>
+    </g>
+  </g>
+
+  <g transform="translate(90 832)" font-family="sans-serif">
+    <circle cx="10" cy="-7" r="8" fill="#47b475"/>
+    <text x="30" y="0" fill="#b7c1c7" font-size="19">Small contributions are complete contributions.</text>
+    <circle cx="485" cy="-7" r="8" fill="#07adf8"/>
+    <text x="505" y="0" fill="#b7c1c7" font-size="19">Open a draft PR before the work grows.</text>
+    <circle cx="1010" cy="-7" r="8" fill="#ffb400"/>
+    <text x="1030" y="0" fill="#b7c1c7" font-size="19">Every claim needs evidence.</text>
+  </g>
+</svg>

--- a/docs/site/bf16-amx-performance-study.html
+++ b/docs/site/bf16-amx-performance-study.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mega-Fused Attention  | C-Kernel-Engine</title>
+    <title>BF16 AMX Performance Study  | C-Kernel-Engine</title>
     <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta name="robots" content="index,follow">
-    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html">
-    <meta property="og:title" content="Mega-Fused Attention  | C-Kernel-Engine">
+    <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/bf16-amx-performance-study.html">
+    <meta property="og:title" content="BF16 AMX Performance Study  | C-Kernel-Engine">
     <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html">
+    <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/bf16-amx-performance-study.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <style>
         :root {
@@ -949,778 +949,159 @@
         </nav>
     </header>
     <main>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mega-Fused Attention - C-Kernel-Engine</title>
-    <style>
-        /* SVG Viewer Styles */
-        .svg-viewer {
-            cursor: pointer;
-            display: inline-block;
-            border: 2px solid #ffb400;
-            padding: 10px;
-            margin: 10px;
-            border-radius: 8px;
-            transition: all 0.2s;
-        }
-        .svg-viewer:hover {
-            background: #333;
-            border-color: #ffc107;
-        }
-        .svg-viewer img {
-            max-width: 400px;
-            display: block;
-        }
-        .svg-viewer .label {
-            text-align: center;
-            color: #adb5bd;
-            font-size: 12px;
-            margin-top: 8px;
-        }
 
-        /* Fullscreen overlay */
-        #svg-overlay {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.95);
-            z-index: 999999;
-        }
-        #svg-overlay .toolbar {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            padding: 15px 20px;
-            background: #111;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            z-index: 1000000;
-        }
-        #svg-overlay .title {
-            color: #ccc;
-            font-size: 16px;
-        }
-        #svg-overlay .controls button {
-            background: #333;
-            color: #ffb400;
-            border: 1px solid #555;
-            padding: 10px 20px;
-            cursor: pointer;
-            margin-left: 10px;
-            border-radius: 4px;
-            font-size: 16px;
-        }
-        #svg-overlay .controls button:hover {
-            background: #444;
-        }
-        #svg-overlay .image-container {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100vh;
-            padding-top: 60px;
-        }
-        #svg-overlay .image-container img {
-            max-width: 90%;
-            max-height: 85vh;
-        }
-        #svg-overlay .nav-btn {
-            position: fixed;
-            top: 50%;
-            transform: translateY(-50%);
-            background: #222;
-            color: #ffb400;
-            border: none;
-            font-size: 40px;
-            padding: 20px;
-            cursor: pointer;
-            z-index: 1000000;
-        }
-        #svg-overlay .nav-prev { left: 20px; }
-        #svg-overlay .nav-next { right: 20px; }
-    </style>
-</head>
-<body>
-    <main>
+<style>
+.study-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+    margin: 1rem 0;
+}
+.study-card {
+    border: 1px solid var(--grey);
+    border-left: 4px solid var(--orange);
+    border-radius: 8px;
+    padding: 1rem;
+    background: rgba(255,255,255,0.02);
+}
+.study-card h3 { margin-top: 0; }
+.study-metric {
+    display: block;
+    color: var(--orange);
+    font-size: 1.35rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+.study-table td:first-child { font-weight: 600; }
+</style>
 
-<h1>Mega-Fused Attention</h1>
+<h1>BF16 AMX Performance Study</h1>
+
+<p>This study tracks the numerical and performance work used to move a Qwen3-VL BF16 vision encoder toward its
+PyTorch reference. It records unsuccessful experiments as well as accepted changes. The measurements come from a
+managed Xeon container using a local 4032-patch form fixture, so they establish software behavior on this allocation,
+not bare-metal platform limits.</p>
 
 <div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Planned Feature - Not Yet Implemented</strong><br>
-        This page documents the design for mega-fusion. Implementation is planned for a future version.
-    </div>
+    <strong>Correctness remains the gate.</strong> Every optimization is checked against the same PyTorch prefix and
+    BF16 numerical contracts. A faster kernel is rejected when it materially worsens the stitched encoder result.
 </div>
 
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg>
+<div class="study-grid">
+    <div class="study-card">
+        <span class="study-metric">270.8 s to 24.6 s</span>
+        <h3>Encoder Progression</h3>
+        <p>Measured CK wall time fell by about 11.0x after native BF16 projection work, selective AMX use, and
+        independent-head attention scheduling, and four-row native projection tiling.</p>
     </div>
-    <div>
-        <strong>The Holy Grail of Attention Optimization</strong><br>
-        Eliminate ALL intermediate DRAM traffic for the entire attention block: RMSNorm → QKV → RoPE → Flash Attention → OutProj
+    <div class="study-card">
+        <span class="study-metric">129.3 s to 12.7 s</span>
+        <h3>Attention Hotspot</h3>
+        <p>Partitioning independent heads through the CK threadpool produced the largest end-to-end gain while keeping
+        each head's FP32 reduction order unchanged.</p>
     </div>
-</div>
-
-<div style="background: #1a1a2e; padding: 20px; border-radius: 10px; margin: 20px 0;">
-    <h3 style="color: #ffb400; margin-top: 0;">Interactive SVG Diagrams</h3>
-    <p style="color: #adb5bd; margin-bottom: 20px;">Click any diagram to open fullscreen viewer with zoom and navigation</p>
-
-    <div class="svg-viewer" data-title="Mega-Fused Attention Architecture">
-        <img src="assets/mega_fused_attention.svg" alt="Mega-Fused Attention Architecture">
-        <div class="label">Architecture Overview</div>
-    </div>
-
-    <div class="svg-viewer" data-title="Per-Head Fusion: Mathematical Cache Constraints">
-        <img src="assets/per_head_fusion_math.svg" alt="Per-Head Fusion Math">
-        <div class="label">Cache Constraint Formulas</div>
-    </div>
-
-    <div class="svg-viewer" data-title="Bias-Corrected Fusion: Quantization Considerations">
-        <img src="assets/bias_corrected_fusion.svg" alt="Bias-Corrected Fusion">
-        <div class="label">Q4_K Bias Correction in Fusion</div>
-    </div>
-
-    <div class="svg-viewer" data-title="Hardware-Aware Blocking: Cache-Optimized Tiling">
-        <img src="assets/hardware_aware_blocking.svg" alt="Hardware-Aware Blocking">
-        <div class="label">L1/L2 Cache Blocking Strategy</div>
+    <div class="study-card">
+        <span class="study-metric">8.3 ms</span>
+        <h3>AMX Projection</h3>
+        <p>The weight-reuse AMX microkernel reached 8.3 ms on the practical M=4032, N=3456, K=1152 projection,
+        compared with roughly 62 ms for the original native path and 4.6 ms for PyTorch.</p>
     </div>
 </div>
 
-<h2>The Problem: Memory-Bound Attention</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Current v6.5 Attention (Already Fused, But Not Mega-Fused)</h3>
-    <p>Our current <code>attention_decode_fused.c</code> already fuses 10 kernels into 1, but intermediates still flow through stack/heap:</p>
-</div>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Operation</th><th>Current Implementation</th><th>Mega-Fused Target</th></tr>
-        </thead>
-        <tbody>
-            <tr><td>RMSNorm</td><td>ln1_row[aligned_D] on stack</td><td>In ZMM registers</td></tr>
-            <tr><td>QKV Projection</td><td>q_token, k_token, v_token on heap</td><td>Stream directly to GEMM</td></tr>
-            <tr><td>RoPE</td><td>In-place on q_token/k_token</td><td>In-place, Q/K stay in L2</td></tr>
-            <tr><td>Flash Attention</td><td>attn_token on heap</td><td>O, m, l in registers</td></tr>
-            <tr><td>Output Projection</td><td>proj_out on heap + residual</td><td>Direct to MLP, add residual in store</td></tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Current Memory Traffic (Decode Mode)</h3>
-    <pre>
-Attention block intermediates on stack/heap per layer:
-  ln1_row:        2048 × 4B =   8KB  (RMSNorm output)
-  q_token:        2048 × 4B =   8KB  (Q projection)
-  k_token:        1024 × 4B =   4KB  (K projection)
-  v_token:        1024 × 4B =   4KB  (V projection)
-  attn_token:     2048 × 4B =   8KB  (Attention output)
-  ─────────────────────────────────────────────
-  Total per layer:               32KB unnecessary traffic
-
-For 24 layers: 768KB of intermediates per token!
-    </pre>
-</div>
-
-<h2>The Solution: Mega-Fusion</h2>
-
-<div class="grid grid-2">
-    <div class="card card-red">
-        <h3 style="margin-top: 0;">Before: Cache-Oblivious</h3>
-        <pre>
-RMSNorm → [DRAM] → QKV → [DRAM] → RoPE
-                           ↓
-Flash Attn ← [DRAM] ← KV Cache
-                           ↓
-OutProj → [DRAM] → Residual
-
-Result: ~800KB DRAM traffic per layer
-        Memory-bound (AI ~ 0.5 FLOPs/byte)
-        </pre>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">After: Mega-Fused</h3>
-        <pre>
-RMSNorm → [registers] → QKV → [L2]
-              ↓              ↓
-         [registers] ← RoPE ←┘
-              ↓
-Flash Attn → [registers] → OutProj
-              ↓
-      Residual Add (in store)
-
-Result: ~8KB DRAM traffic per layer
-        Compute-bound (AI ~ 4000 FLOPs/byte)
-        </pre>
-    </div>
-</div>
-
-<h2>Memory Traffic Comparison</h2>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Metric</th><th>Current v6.5</th><th>Mega-Fused</th><th>Reduction</th></tr>
-        </thead>
-        <tbody>
-            <tr><td>DRAM Reads</td><td>~40KB activations × 24</td><td>4KB (input only)</td><td><strong>240×</strong></td></tr>
-            <tr><td>DRAM Writes</td><td>~40KB activations × 24</td><td>4KB (output only)</td><td><strong>240×</strong></td></tr>
-            <tr><td>Arithmetic Intensity</td><td>~0.5 FLOPs/byte</td><td>~4000 FLOPs/byte</td><td><strong>8000×</strong></td></tr>
-            <tr><td>Memory-Bound?</td><td>Yes (bottleneck)</td><td>No (compute-bound)</td><td>-</td></tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>Expected Speedup: 5-10× for Attention</strong><br>
-        Moving from memory-bound to compute-bound is the single biggest optimization possible. Current v6.5 is 30× slower than llama.cpp partly because of this.
-    </div>
-</div>
-
-<h2>Mega-Fusion Time Calculations</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Cache Line Math</h3>
-    <pre>
-Cache line size: 64 bytes = 512 bits
-
-For FP16 (2 bytes per element):
-    Elements per cache line: 64 / 2 = 32 elements
-    Embed dim H = 4096 (LLaMA 7B)
-    Cache lines per token: H / 32 = 128 cache lines
-
-For FP32 (4 bytes per element):
-    Elements per cache line: 64 / 4 = 16 elements
-    Cache lines per token: H / 16 = 256 cache lines
-    </pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">FLOPs Per Cache Line</h3>
-    <pre>
-For ONE layer, ONE cache line (32 elements):
-═══════════════════════════════════════════
-
-Attention (Q @ Kᵀ @ V):
-    QKᵀ:  d_k FLOPs
-    (QKᵀ)V: d_k × d_v FLOPs
-    Total: ~2 × d_k × d_v FLOPs
-
-MLP (gate, up, down):
-    gate:  d × 4d FLOPs
-    up:    d × 4d FLOPs
-    down:  4d × d FLOPs
-    Total: ~6 × d × d FLOPs
-
-Per cache line, per layer (d=128):
-    Attention: ~2 × 64 × 128 = 16,384 FLOPs
-    MLP:       ~6 × 128 × 128 = 98,304 FLOPs
-    Total:     ~114,688 FLOPs
-    </pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Time Per Cache Line (CPU)</h3>
-    <pre>
-CPU (Xeon, 5 TFLOPS sustained for BF16):
-═══════════════════════════════════════════
-Time per cache line: 114,688 FLOPs / 5 TFLOPS
-                   = 22.9 nanoseconds
-
-For 32 layers:
-    Time: 32 × 22.9 ns = 733 ns = 0.73 μs
-
-For 100 layers:
-    Time: 100 × 22.9 ns = 2.29 μs
-    </pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Full Token Computation Time</h3>
-    <pre>
-For H=4096, 128 cache lines per token:
-═══════════════════════════════════════════
-
-Time per token (compute only):
-    128 cache lines × 0.73 μs/cache_line
-    = 93 μs = 0.093 ms
-
-For 32 layers:  93 μs/token
-For 100 layers: 290 μs/token
-
-At 0.093 ms/token:
-    10,000 tokens = 0.93 seconds
-    Throughput: ~10,000 tokens/second
-    </pre>
-</div>
-
-<h2>Weight Loading: The Real Cost</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Weights Are Shared Across Tokens!</h3>
-    <pre>
-Model: LLaMA 7B
-Weights: 7B × 2 bytes (FP16) = 14 GB
-
-Weights loaded ONCE, then cached:
-    Load time: 14 GB / 500 GB/s = 28 ms
-
-After weights cached:
-    Subsequent tokens: 0.093 ms/token (compute only)
-
-Time Breakdown:
-    First token: 28 ms (load) + 0.093 ms = 28.1 ms
-    Token 2-1000: 0.093 ms each
-    </pre>
-</div>
-
-<h2>With vs Without Mega-Fusion</h2>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Metric</th><th>Without Mega-Fusion</th><th>With Mega-Fusion</th></tr>
-        </thead>
-        <tbody>
-            <tr><td>DRAM reads (activations)</td><td>1K × 4096 × 2 × 32 = 256 MB</td><td>8 MB (once)</td></tr>
-            <tr><td>DRAM writes (activations)</td><td>1K × 4096 × 2 × 32 = 256 MB</td><td>8 MB (once)</td></tr>
-            <tr><td>DRAM traffic total</td><td>512 MB + 14 GB = 14.5 GB</td><td>14 GB + 16 MB = 14 GB</td></tr>
-            <tr><td>Time (500 GB/s)</td><td>~100-200 ms</td><td>~121 ms</td></tr>
-            <tr><td>Memory-bound?</td><td>Yes</td><td>No (compute-bound)</td></tr>
-        </tbody>
-    </table>
-</div>
-
-<h2>MoE Fusion Boundary</h2>
-
-<div class="card card-yellow">
-    <h3 style="margin-top: 0;">Stop Mega-Fusion at Routing Decision</h3>
-    <pre>
-For MoE models (e.g., Mixtral):
-═══════════════════════════════════════════
-
-Mega-fuse UP TO the routing decision:
-
-    X → RMSNorm → QKV → RoPE → [ROUTE HERE]
-                                    ↑
-                                    Stop!
-                                    Need X for gate calculation
-
-    From X, compute gate = softmax(X @ W_gate)
-    gate selects top-k experts
-    Each expert: X @ W_expert_i
-    Merge: Σ gate_i × expert_output
-
-    Then resume mega-fusion for down layers
-
-Fusion boundary:
-    ✓ Fusable: RMSNorm, QKV, RoPE, Attention, MLP (before gate)
-    ✗ Not fusable: Gate computation, Expert selection, Expert forward
-    </pre>
-</div>
-
-<h2>The Complete Formula</h2>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Mega Fusion Time Equation</h3>
-    <pre>
-┌─────────────────────────────────────────────────────────────────┐
-│                                                                 │
-│   T_total = T_weight_load + N_layers × T_cache_line            │
-│                                                                 │
-│   Where:                                                       │
-│                                                                 │
-│   T_weight_load = Model_size / Memory_bandwidth                 │
-│                                                                 │
-│   T_cache_line = FLOPs_per_cache_line / Compute_FLOPS           │
-│                                                                 │
-│   N_cache_lines = H / (Cache_line_size / sizeof(dtype))         │
-│                                                                 │
-│   N_layers_total = N_cache_lines × N_layers                     │
-│                                                                 │
-│   T_token = T_weight_load + T_compute                           │
-│           = Model_size/BW + (H × N_layers × FLOPs_element)/FPS  │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-    </pre>
-</div>
-
-<h2>Numbers for Different Models</h2>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Model</th><th>Params</th><th>Weights</th><th>TTFT (est)</th><th>Decode</th></tr>
-        </thead>
-        <tbody>
-            <tr><td>Qwen 0.5B</td><td>0.5B</td><td>1 GB</td><td>~2 ms</td><td>~3 μs</td></tr>
-            <tr><td>Qwen 1.5B</td><td>1.5B</td><td>3 GB</td><td>~6 ms</td><td>~9 μs</td></tr>
-            <tr><td>LLaMA 7B</td><td>7B</td><td>14 GB</td><td>~28 ms</td><td>~93 μs</td></tr>
-            <tr><td>LLaMA 13B</td><td>13B</td><td>26 GB</td><td>~52 ms</td><td>~174 μs</td></tr>
-            <tr><td>LLaMA 30B</td><td>30B</td><td>60 GB</td><td>~120 ms</td><td>~400 μs</td></tr>
-        </tbody>
-    </table>
-    <p><em>Assumptions: BF16, LLaMA architecture, 500 GB/s memory bandwidth, 5 TFLOPS sustained compute, weights loaded once, cached in L3</em></p>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>Verdict: Mega-Fusion is Practical!</strong><br>
-        For Qwen 0.5B-7B on CPU:<br>
-        - TTFT under 30 ms ✓<br>
-        - Decode under 100 μs/token ✓<br>
-        - No activation DRAM traffic (all in L3) ✓<br>
-        - Thousands of concurrent users (TB memory) ✓<br>
-        - Energy efficient (300W vs 700W per GPU) ✓
-    </div>
-</div>
-
-<h2>Architecture: Keep Everything in Registers</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Working Set Per Head (AVX-512)</h3>
-    <pre>
-Q_head:    64 × 64 × 2B =   8KB  (in L1, streaming from L2)
-K_head:    64 × 64 × 2B =   8KB  (stream from KV cache in L2)
-V_head:    64 × 64 × 2B =   8KB  (stream from KV cache in L2)
-O_accum:   64 × 64 × 4B =  16KB  (in ZMM registers)
-m, l:      2 × 64 × 4B = 512B   (online softmax stats in registers)
-───────────────────────────────────────────
-Total per head:              ~40KB ✓ fits in L1 + registers
-
-For 32 heads (sequential):  ~1.3MB working set
-    </pre>
-</div>
-
-<h2>Implementation Roadmap</h2>
-
-<div class="grid grid-4">
-    <div class="card">
-        <h3 style="margin-top: 0;">Phase 1</h3>
-        <h4 style="color: #69db7c;">Register Allocation</h4>
-        <ul>
-            <li>Define ZMM register layout for attention</li>
-            <li>Allocate: Q accum, K/V tiles, O accum, softmax stats</li>
-            <li>Create <code>mega_fused_attn.h</code></li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Phase 2</h3>
-        <h4 style="color: #ffd43b;">RMSNorm → QKV</h4>
-        <ul>
-            <li>Fuse rmsnorm + 3 GEMMs into one pass</li>
-            <li>Q/K/V never touch DRAM</li>
-            <li>Direct to RoPE in L2</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Phase 3</h3>
-        <h4 style="color: #ff922b;">Flash Attention</h4>
-        <ul>
-            <li>Implement tiled online softmax</li>
-            <li>O, m, l stay in registers</li>
-            <li>Stream K/V tiles from L2</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Phase 4</h3>
-        <h4 style="color: #ff6b6b;">OutProj + Residual</h4>
-        <ul>
-            <li>O → W_o GEMM in registers</li>
-            <li>Add residual in final store</li>
-            <li>Single write to DRAM</li>
-        </ul>
-    </div>
-</div>
-
-<h2>Code Structure</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">New Kernel: mega_fused_attention.c</h3>
-    <pre>
-src/kernels/
-├── attention_decode_fused.c    # Current (good, but not mega-fused)
-├── attention_flash_true.c      # Flash attention primitives
-└── mega_fused_attention.c      # NEW: Full mega-fusion
-    </pre>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">API Design</h3>
-    <pre>
-/**
- * @brief Mega-fused attention for decode (single token)
- *
- * Reads:  input[hidden], W_qkv[3×hidden×hidden], W_o[hidden×hidden]
- *         KV cache, rope_cos/sin
- * Writes: output[hidden]
- *
- * All intermediates stay in registers/L1/L2. Single DRAM round-trip.
- */
-void mega_fused_attention_decode(
-    float *output,           // [hidden] - DRAM write (4KB)
-    const float *input,      // [hidden] - DRAM read (4KB)
-    const float *W_qkv,      // Weights streamed through L3
-    const float *W_o,        // Weights streamed through L3
-    float *kv_cache_k,       // [seq, hidden_kv] - in L2
-    float *kv_cache_v,       // [seq, hidden_kv] - in L2
-    const float *rope_cos,   // [max_seq] - in L1
-    const float *rope_sin,   // [max_seq] - in L1
-    int pos,                 // Current position
-    int hidden,              // Model hidden dimension
-    int num_heads,           // Number of attention heads
-    int num_kv_heads,        // Number of KV heads
-    int head_dim,            // Head dimension
-    int max_seq              // Max sequence length
-);
-    </pre>
-</div>
-
-<h2>Register Allocation Strategy (AVX-512)</h2>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Registers</th><th>Purpose</th><th>Size</th></tr>
-        </thead>
-        <tbody>
-            <tr><td>Z0-Z11</td><td>Q accumulators (6×64 tile)</td><td>768B</td></tr>
-            <tr><td>Z12-Z17</td><td>K tile streaming</td><td>384B</td></tr>
-            <tr><td>Z18-Z23</td><td>V tile streaming</td><td>384B</td></tr>
-            <tr><td>Z24-Z27</td><td>O accumulators</td><td>256B</td></tr>
-            <tr><td>Z28-Z29</td><td>Softmax stats (m_i, l_i)</td><td>128B</td></tr>
-            <tr><td>Z30-Z31</td><td>Temps, RoPE, scaling</td><td>128B</td></tr>
-        </tbody>
-    </table>
-    <p><strong>Total:</strong> 32 ZMM registers = 1KB of register storage</p>
-</div>
-
-<h2>Online Softmax: The Flash Attention Secret</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Why We Don't Materialize S = Q × K^T</h3>
-    <p>For hidden=2048, seq=2048: S would be 16MB. Too big for registers!</p>
-    <p><strong>Solution:</strong> Tile the computation and use online softmax:</p>
-    <pre>
-// For each K/V tile from KV cache:
-S_ij = Q_tile @ K_tile.T / sqrt(d)    // [64×64] in registers ← NOT S!
-
-// Online softmax update (m = max, l = sum):
-m_new = max(m, rowmax(S_ij))           // running max per row
-P_ij = exp(S_ij - m_new)               // safe softmax
-l_new = exp(m - m_new)*l + rowsum(P_ij) // running sum
-
-// Output update:
-O_new = (exp(m - m_new)*l*O + P_ij @ V_tile) / l_new
-
-// Key: O, m, l stay in registers across ALL tiles!
-    </pre>
-</div>
-
-<h2>Integration with v6.5</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Replace in layer_forward</h3>
-    <p>Current <code>attention_decode_fused.c</code> calls 5 functions with intermediates on stack:</p>
-    <pre>
-ck_layer_forward_rmsnorm_swiglu_decode_fused_attn_impl():
-  rmsnorm_forward(..., ln1_row, ...)           # Writes to stack
-  ck_qkv_project_head_major_token(..., q_token, k_token, v_token)  # Writes to heap
-  rope_forward_qk(q_token, k_token, ...)       # Reads from heap
-  attention_forward_decode_head_major_gqa_regular(..., attn_token)  # Writes to heap
-  ck_attention_project_head_major_decode_token_residual(...)         # Reads from heap
-    </pre>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Mega-Fused Alternative</h3>
-    <pre>
-mega_fused_attention_decode():
-  // All intermediates in registers/L1/L2
-  rmsnorm_in_registers(x_norm)
-  qkv_fused_projection(q, k, v, x_norm)
-  rope_in_place(q, k)
-  flash_attention_online(o, q, k, v, kv_cache)
-  out_projection_with_residual(output, o, residual)
-
-  // Single write to DRAM
-  output[hidden] = ...
-    </pre>
-</div>
-
-<h2>Expected Performance Impact</h2>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">Before Mega-Fusion</h3>
-        <ul>
-            <li>DRAM bandwidth: Bottleneck</li>
-            <li>AI: ~0.5 FLOPs/byte</li>
-            <li>Memory-bound: ~1 tok/s</li>
-            <li>30× slower than llama.cpp</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">After Mega-Fusion</h3>
-        <ul>
-            <li>DRAM bandwidth: Not bottleneck</li>
-            <li>AI: ~4000 FLOPs/byte</li>
-            <li>Compute-bound: ~5-10 tok/s</li>
-            <li>Within 3-5× of llama.cpp</li>
-        </ul>
-    </div>
-</div>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-    </div>
-    <div>
-        <strong>Prerequisite: AVX-512 or AMX</strong><br>
-        Mega-fusion requires at least 32 ZMM registers (AVX-512) or AMX tiles. On AVX-only machines, we'll need a modified approach using stack buffers in L1.
-    </div>
-</div>
-
-<h2>References</h2>
+<h2>Measured Progression</h2>
+
+<table class="study-table">
+    <thead>
+        <tr><th>Configuration</th><th>CK Encoder</th><th>PyTorch</th><th>Prefix Cosine</th><th>Relative RMSE</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>Original stitched encoder</td><td>~270.8 s</td><td>~12.5 s</td><td>0.99857</td><td>5.20%</td></tr>
+        <tr><td>Native paired-BF16 projections</td><td>~148.3 s</td><td>9.39 s</td><td>0.99863</td><td>5.08%</td></tr>
+        <tr><td>Head-parallel attention and selective AMX projectors</td><td>~28.1 s</td><td>~10.0 s</td><td>0.99858</td><td>5.09%</td></tr>
+        <tr><td>Four-row native projection reuse</td><td>~24.6 s</td><td>9.49 s</td><td>0.99858</td><td>5.09%</td></tr>
+    </tbody>
+</table>
+
+<p>PyTorch reported oneDNN BRGEMM execution using an AVX-512 AMX path and blocked layouts. The CK comparison is not
+an attempt to duplicate oneDNN dispatch. CK declares exact numerical contracts and kernel identities in its circuit
+and kernel maps, then measures those implementations through the generated model.</p>
+
+<h2>Projection Microkernel</h2>
+
+<table class="study-table">
+    <thead><tr><th>Implementation</th><th>Practical Projection Time</th><th>Disposition</th></tr></thead>
+    <tbody>
+        <tr><td>Original native BF16</td><td>~62 ms</td><td>Baseline</td></tr>
+        <tr><td>Initial AMX tile kernel</td><td>~19.9 ms</td><td>Improved, but left weight reuse on the table</td></tr>
+        <tr><td>AMX with weight-tile reuse</td><td>~8.3 ms</td><td>Accepted for selected projector operations</td></tr>
+        <tr><td>PyTorch/oneDNN</td><td>~4.6 ms</td><td>Reference</td></tr>
+    </tbody>
+</table>
+
+<p>The AMX provider is additive. Its contract specifies BF16 inputs and weights, FP32 tile accumulation, ascending K
+tiles, BF16 round-to-nearest-even output storage, and independent output tiles. The circuit selects it explicitly for
+projector operations. Layer projections continue to use the native paired-BF16 provider because applying AMX to every
+layer slightly worsened final-prefix accuracy.</p>
+
+<p>The AMX entry point is fail-closed. Unsupported builds, invalid tile shapes, workspace allocation failure, or
+per-thread tile-permission failure terminate with a hard kernel-contract fault instead of silently running the native
+paired-dot reduction. Portable performance sweeps query the compiled runtime capability and report AMX as skipped
+when it is unavailable; a hardware skip is never counted as AMX numerical or performance evidence.</p>
+
+<p>A separate M=32, N=3456, K=1152 thread sweep found a best CK AMX time of 0.133 ms at 16 threads versus 0.135 ms
+for PyTorch. The output was bit-exact and invariant across the tested thread counts. This is leaf-kernel evidence, not
+an end-to-end claim: it shows that AMX instruction throughput is no longer the limiting factor for that projection
+shape.</p>
+
+<h2>Rejected Experiment</h2>
+
+<p>Splitting each attention head into two query-row jobs increased the available job count but repeated V
+transposition and weakened locality. Attention regressed from approximately 12.7 seconds to 16.3 seconds. The change
+was reverted. More jobs are not automatically more parallel efficiency; the unit of work must preserve reuse.</p>
+
+<p>A shared-V query-block variant preserved the prefix exactly but regressed CK encoder time from approximately
+24.6 seconds to 25.8 seconds. A row-parallel LayerNorm variant was bit-exact in isolation but regressed encoder time
+to about 26.7 seconds. Both were rejected; the patch retains only changes that improved the full generated model.</p>
+
+<h2>Evidence Rules</h2>
 
 <ul>
-    <li><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/blob/main/docs/MEGA_FUSED.md" target="_blank" rel="noopener noreferrer">Original Mega-Fusion Proposal</a></li>
-    <li><a href="https://arxiv.org/abs/2205.14135">Flash Attention (Dao et al.)</a></li>
-    <li><a href="profiling.html">Profiling Guide</a> - Verify speedup with perf</li>
+    <li>Record commit, compiler, ISA, thread count, model shape, and container constraints.</li>
+    <li>Measure the production shape in isolation and in the generated end-to-end circuit.</li>
+    <li>Report prefix cosine and relative RMSE alongside wall time.</li>
+    <li>Keep arithmetic order and threading behavior in numerical contracts and kernel maps.</li>
+    <li>Retain rejected experiments when they explain cache, reuse, or scheduling behavior.</li>
+    <li>Do not publish private input artifacts or managed-platform identifiers.</li>
 </ul>
 
-    </main>
+<h2>Content and Reproduction Handoff</h2>
 
-    <!-- SVG Viewer Overlay -->
-    <div id="svg-overlay">
-        <div class="toolbar">
-            <span class="title" id="svg-title">Image</span>
-            <div class="controls">
-                <button onclick="svgViewer.zoomOut()">-</button>
-                <button onclick="svgViewer.resetZoom()">Reset</button>
-                <button onclick="svgViewer.zoomIn()">+</button>
-                <button onclick="svgViewer.close()">Close X</button>
-            </div>
-        </div>
-        <button class="nav-btn nav-prev" onclick="svgViewer.prev()">←</button>
-        <button class="nav-btn nav-next" onclick="svgViewer.next()">→</button>
-        <div class="image-container" id="svg-container">
-            <img id="svg-image" src="" alt="Preview">
-        </div>
-    </div>
+<p>The implementation and its portable evidence are kept together in the repository. Content based on this study
+should link to the exact commit and distinguish the managed-Xeon measurements above from results reproduced on
+another machine.</p>
 
-    <script>
-    var svgViewer = (function() {
-        var overlay = document.getElementById('svg-overlay');
-        var img = document.getElementById('svg-image');
-        var titleEl = document.getElementById('svg-title');
-        var container = document.getElementById('svg-container');
-        var images = [];
-        var currentIndex = 0;
-        var scale = 1;
-        var panX = 0, panY = 0;
+<ul>
+    <li><code>src/kernels/gemm_kernels_bf16.c</code>: native paired-BF16 and AMX projection implementations.</li>
+    <li><code>src/kernels/attention_kernels.c</code>: independent-head BF16 attention scheduling.</li>
+    <li><code>version/v8/circuits/qwen3_vl_vision.json</code>: circuit-owned numerical requirements.</li>
+    <li><code>version/v8/kernel_maps/</code>: exact providers, arithmetic contracts, ISA and threading capabilities.</li>
+    <li><code>unittest/bf16/test_qwen3vl_performance_sweep_bf16.py</code>: deterministic thread and accuracy sweep.</li>
+    <li><code>version/v8/.cache/reports/bf16_performance_sweep_latest.json</code>: generated local report path.</li>
+</ul>
 
-        // Find all images
-        document.querySelectorAll('.svg-viewer').forEach(function(viewer, index) {
-            var viewerImg = viewer.querySelector('img');
-            if (viewerImg) {
-                images.push({
-                    src: viewerImg.src,
-                    title: viewer.getAttribute('data-title') || 'Image ' + (index + 1)
-                });
-                viewer.onclick = function() {
-                    open(index);
-                };
-            }
-        });
+<pre><code>make test-bf16-performance-sweep</code></pre>
 
-        console.log('Found ' + images.length + ' images for viewer');
+<p>The repository does not treat the summarized Xeon timings as a replacement for raw evidence. A publishable
+machine-specific package should additionally preserve the generated JSON report, exact command transcript, commit,
+CPU and compiler manifest, and sanitized profiler exports. Until that package is attached, the timings on this page
+must be described as measured managed-Xeon results, not independently reproducible bare-metal limits.</p>
 
-        // Wheel zoom
-        container.addEventListener('wheel', function(e) {
-            e.preventDefault();
-            scale += e.deltaY > 0 ? -0.2 : 0.2;
-            scale = Math.max(0.5, Math.min(5, scale));
-            img.style.transform = 'scale(' + scale + ') translate(' + panX + 'px, ' + panY + 'px)';
-        });
+<h2>Next Measurements</h2>
 
-        // Keyboard
-        document.addEventListener('keydown', function(e) {
-            if (overlay.style.display !== 'block') return;
-            if (e.key === 'Escape') close();
-            if (e.key === 'ArrowLeft') prev();
-            if (e.key === 'ArrowRight') next();
-        });
-
-        function open(index) {
-            currentIndex = index;
-            scale = 1;
-            panX = 0;
-            panY = 0;
-            img.src = images[index].src;
-            img.style.transform = '';
-            titleEl.textContent = images[index].title + ' (' + (index + 1) + '/' + images.length + ')';
-            overlay.style.display = 'block';
-            document.body.style.overflow = 'hidden';
-            console.log('Opened image: ' + images[index].src);
-        }
-
-        function close() {
-            overlay.style.display = 'none';
-            document.body.style.overflow = '';
-        }
-
-        function prev() {
-            open((currentIndex - 1 + images.length) % images.length);
-        }
-
-        function next() {
-            open((currentIndex + 1) % images.length);
-        }
-
-        function zoomIn() {
-            scale = Math.min(5, scale + 0.25);
-            img.style.transform = 'scale(' + scale + ')';
-        }
-
-        function zoomOut() {
-            scale = Math.max(0.5, scale - 0.25);
-            img.style.transform = 'scale(' + scale + ')';
-        }
-
-        function resetZoom() {
-            scale = 1;
-            panX = 0;
-            panY = 0;
-            img.style.transform = '';
-        }
-
-        return { open: open, close: close, prev: prev, next: next, zoomIn: zoomIn, zoomOut: zoomOut, resetZoom: resetZoom };
-    })();
-    </script>
-</body>
-</html>
+<p>The remaining encoder gap is concentrated in native layer projections and attention. The next work is to profile
+those two paths with controlled thread sweeps and hardware counters where available, while keeping mixed-prefill and
+teacher-forced parity as acceptance gates. Results from managed infrastructure must remain separate from future
+privileged bare-metal AMX, NUMA, memory-channel, and power measurements.</p>
     </main>
 
     <!-- SVG Viewer Overlay (shared across all pages) -->

--- a/docs/site/build.sh
+++ b/docs/site/build.sh
@@ -155,13 +155,19 @@ for page in "$PAGES_DIR"/*.html; do
         header="${header//\{\{META_DESCRIPTION\}\}/$page_description}"
         header="${header//\{\{META_ROBOTS\}\}/$page_robots}"
 
-        # Clear all nav active states
+        # Mark the current page before clearing the remaining nav placeholders.
+        if [ -n "$nav_active" ]; then
+            header="${header//\{\{NAV_${nav_active^^}\}\}/active}"
+        fi
+
+        # Clear all remaining nav active states.
         header="${header//\{\{NAV_INDEX\}\}/}"
         header="${header//\{\{NAV_SPECTRUM\}\}/}"
         header="${header//\{\{NAV_QUICKSTART\}\}/}"
         header="${header//\{\{NAV_DEVGUIDE\}\}/}"
         header="${header//\{\{NAV_SCALING\}\}/}"
         header="${header//\{\{NAV_SUPPORT\}\}/}"
+        header="${header//\{\{NAV_CKU\}\}/}"
         header="${header//\{\{NAV_ARCHITECTURE\}\}/}"
         header="${header//\{\{NAV_FLASH_ATTENTION\}\}/}"
         header="${header//\{\{NAV_KERNELS\}\}/}"
@@ -181,10 +187,6 @@ for page in "$PAGES_DIR"/*.html; do
         header="${header//\{\{NAV_API\}\}/}"
         header="${header//\{\{NAV_CONTRIBUTING\}\}/}"
         header="${header//\{\{NAV_THREADPOOL\}\}/}"
-
-        if [ -n "$nav_active" ]; then
-            header="${header//\{\{NAV_${nav_active^^}\}\}/active}"
-        fi
 
         # Replace date variables in footer
         footer="${footer//\{\{YEAR\}\}/$CURRENT_YEAR}"

--- a/docs/site/cke-throughput-unit.html
+++ b/docs/site/cke-throughput-unit.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,7 +863,9 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
             <a href="cke-throughput-unit.html" class="active" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
@@ -1594,7 +1597,8 @@ CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1602,13 +1606,14 @@ CKU                    = active_bytes_per_token / seconds_per_token</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/codegen.html
+++ b/docs/site/codegen.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1753,7 +1756,8 @@ static size_t bump(size_t *off, size_t bytes) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1761,13 +1765,14 @@ static size_t bump(size_t *off, size_t bytes) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/concepts.html
+++ b/docs/site/concepts.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2203,7 +2206,8 @@ With weight tying: W = E  (same matrix!)
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2211,13 +2215,14 @@ With weight tying: W = E  (same matrix!)
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/contributing.html
+++ b/docs/site/contributing.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Developer Guide  | C-Kernel-Engine</title>
-    <meta name="description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <title>Contributor Path: Start Small and Build Evidence | C-Kernel-Engine</title>
+    <meta name="description" content="Five contribution levels for C-Kernel-Engine, from Linux compatibility and profiling through numerical fixtures, CPU kernels, compiler work, multimodal parity, and distributed execution.">
     <meta name="robots" content="index,follow">
     <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html">
-    <meta property="og:title" content="Developer Guide  | C-Kernel-Engine">
-    <meta property="og:description" content="C-Kernel-Engine documentation for a CPU-native AI runtime, kernels, code generation, training, and inference on Linux systems.">
+    <meta property="og:title" content="Contributor Path: Start Small and Build Evidence | C-Kernel-Engine">
+    <meta property="og:description" content="Five contribution levels for C-Kernel-Engine, from Linux compatibility and profiling through numerical fixtures, CPU kernels, compiler work, multimodal parity, and distributed execution.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="active">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -947,108 +950,183 @@
     </header>
     <main>
 
-<h1>Developer Guide</h1>
+<style>
+.contrib-hero { position: relative; overflow: hidden; margin: 0 0 2rem; padding: 2.4rem; border: 1px solid rgba(7,173,248,.35); border-radius: 18px; background: radial-gradient(circle at 85% 15%, rgba(7,173,248,.18), transparent 34%), linear-gradient(135deg, #26333a, #202529 58%, #302c20); }
+.contrib-hero:before { content: ''; position: absolute; inset: 0; pointer-events: none; opacity: .18; background-image: linear-gradient(rgba(255,255,255,.08) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.08) 1px, transparent 1px); background-size: 34px 34px; }
+.contrib-hero > * { position: relative; }
+.contrib-kicker { color: var(--orange); font: 700 .78rem 'JetBrains Mono', monospace; letter-spacing: .13em; text-transform: uppercase; }
+.contrib-hero h1 { max-width: 900px; margin: .55rem 0 .9rem; font-size: clamp(2.2rem, 5vw, 4.8rem); line-height: .98; }
+.contrib-lead { max-width: 880px; color: var(--text-secondary); font-size: 1.14rem; }
+.contrib-actions { display: flex; gap: .75rem; flex-wrap: wrap; margin-top: 1.35rem; }
+.contrib-button { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .75rem 1rem; border: 1px solid var(--orange); border-radius: 7px; color: var(--dark); background: var(--orange); font-weight: 750; text-decoration: none; }
+.contrib-button.secondary { color: var(--white); border-color: var(--grey-light); background: rgba(255,255,255,.045); }
+.contrib-figure { margin: 2rem 0; padding: .7rem; border: 1px solid var(--grey); border-radius: 14px; background: #171d22; }
+.contrib-figure img { display: block; width: 100%; height: auto; border-radius: 10px; }
+.contrib-figure figcaption { padding: .75rem .45rem .2rem; color: var(--text-muted); font-size: .86rem; }
+.contrib-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin: 1rem 0 2rem; }
+.contrib-card { padding: 1.35rem; border: 1px solid var(--grey); border-top: 4px solid var(--blue); border-radius: 10px; background: var(--dark-card); }
+.contrib-card.green { border-top-color: var(--green); }
+.contrib-card.orange { border-top-color: var(--orange); }
+.contrib-card h3 { margin-top: 0; }
+.contrib-levels { display: grid; gap: .8rem; margin: 1rem 0 2rem; }
+.contrib-level { display: grid; grid-template-columns: 100px minmax(0, 1.15fr) minmax(0, 1fr); gap: 1rem; align-items: start; padding: 1rem 1.1rem; border: 1px solid var(--grey); border-left: 5px solid var(--green); border-radius: 8px; background: rgba(255,255,255,.025); }
+.contrib-level:nth-child(2), .contrib-level:nth-child(3) { border-left-color: var(--blue); }
+.contrib-level:nth-child(4), .contrib-level:nth-child(5) { border-left-color: var(--orange); }
+.contrib-level-id { color: var(--orange); font: 800 .82rem 'JetBrains Mono', monospace; letter-spacing: .06em; }
+.contrib-level strong { display: block; margin-bottom: .25rem; color: var(--white); }
+.contrib-level p { margin: 0; color: var(--text-secondary); }
+.contrib-flow { counter-reset: onboarding; display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .65rem; margin: 1rem 0 2rem; }
+.contrib-step { min-height: 150px; padding: 1rem; border: 1px solid var(--grey); border-radius: 9px; background: var(--dark-card); }
+.contrib-step:before { counter-increment: onboarding; content: counter(onboarding, decimal-leading-zero); display: block; margin-bottom: .65rem; color: var(--blue); font: 800 1rem 'JetBrains Mono', monospace; }
+.contrib-step strong { display: block; margin-bottom: .35rem; color: var(--white); }
+.contrib-step p { margin: 0; color: var(--text-muted); font-size: .88rem; }
+.contrib-callout { margin: 1.5rem 0; padding: 1.25rem 1.4rem; border: 1px solid rgba(71,180,117,.4); border-left: 5px solid var(--green); border-radius: 8px; background: rgba(71,180,117,.07); }
+.contrib-callout.warning { border-color: rgba(255,180,0,.4); border-left-color: var(--orange); background: rgba(255,180,0,.065); }
+.contrib-table { width: 100%; border-collapse: collapse; margin: 1rem 0 2rem; }
+.contrib-table th, .contrib-table td { padding: .8rem; border: 1px solid var(--grey); vertical-align: top; text-align: left; }
+.contrib-table th { color: var(--orange); background: rgba(255,180,0,.07); }
+@media (max-width: 900px) { .contrib-grid { grid-template-columns: 1fr; } .contrib-level { grid-template-columns: 82px 1fr; } .contrib-level > :last-child { grid-column: 2; } .contrib-flow { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 600px) { .contrib-hero { padding: 1.5rem; } .contrib-level { grid-template-columns: 1fr; } .contrib-level > :last-child { grid-column: auto; } .contrib-flow { grid-template-columns: 1fr; } .contrib-actions, .contrib-button { width: 100%; } .contrib-table { display: block; overflow-x: auto; } }
+</style>
 
-<p>So you want to hack on the engine? Welcome!</p>
-<p>This guide explains how to add a new kernel (operation) to the system, from the math implementation to the compiler integration.</p>
+<section class="contrib-hero">
+  <div class="contrib-kicker">Build evidence with us</div>
+  <h1>Start small. Learn one boundary. Make it reproducible.</h1>
+  <p class="contrib-lead">C-Kernel-Engine spans model mathematics, generated C, numerical contracts, SIMD kernels, Linux profiling, multimodal execution, and future distributed CPU systems. You do not need to understand all of it before contributing. Begin with one bounded problem whose result another engineer can reproduce.</p>
+  <div class="contrib-actions">
+    <a class="contrib-button" href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues">Find or open an issue</a>
+    <a class="contrib-button secondary" href="quickstart.html">Build CKE first</a>
+    <a class="contrib-button secondary" href="test-report.html">Inspect current evidence</a>
+  </div>
+</section>
 
-<h2>Enable Git Hooks (Required)</h2>
-<p>This repo ships both a scoped pre-commit regression gate in <code>.githooks/pre-commit</code> and heavier push-time validation in <code>.githooks/pre-push</code>. The fast <code>v7</code> family regression runs in the local loop, while legacy <code>v6.6</code> compatibility is only checked at push time when shared/runtime-sensitive paths changed. Git does <strong>not</strong> enable repo hooks automatically on clone/pull.</p>
+<section class="contrib-callout">
+  <h2 style="margin-top:0">The hard research problem is not the entrance exam</h2>
+  <p style="margin-bottom:0">Current work may involve Qwen3-VL long-context divergence, BF16 reduction semantics, AVX2/AVX-512/AMX dispatch, compiler ownership, or multimodal parity. Those are Level-5 problems. A distribution fix, profiler adapter, benchmark artifact, documentation correction, or independent numerical fixture is a complete and useful contribution.</p>
+</section>
+
+<figure class="contrib-figure svg-viewer" data-title="CKE contributor ladder">
+  <img src="assets/contributor-ladder.svg" alt="Five-level CKE contributor ladder from documentation and compatibility through profiling, numerical tests, kernels, and compiler or distributed systems work">
+  <figcaption>Progression is optional, not a ranking. Own the smallest level where you can produce a reliable result.</figcaption>
+</figure>
+
+<h2>The Five Contribution Levels</h2>
+
+<div class="contrib-levels">
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 1</div>
+    <div><strong>Documentation, compatibility, and build fixes</strong><p>Improve setup instructions, repair one distribution-specific failure, clarify a command, or make an existing workflow reproducible on a named machine.</p></div>
+    <div><strong>Completion evidence</strong><p>Environment details, failing command, corrected command or patch, and proof the documented path now succeeds.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 2</div>
+    <div><strong>Benchmarks and profiling adapters</strong><p>Add a repeatable perf, FlameGraph, flamegraph-rs, VTune, Advisor, cache, assembly, or power-measurement lane without breaking existing platforms.</p></div>
+    <div><strong>Completion evidence</strong><p>Exact command, CPU and compiler metadata, workload, raw artifact, interpretation, and known sources of measurement noise.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 3</div>
+    <div><strong>Reference tests and numerical fixtures</strong><p>Exercise one operation or canonical tensor boundary against PyTorch, llama.cpp, SciPy, a finite-difference gradient, or another independent implementation.</p></div>
+    <div><strong>Completion evidence</strong><p>Deterministic fixture, independent oracle, tolerance and dtype policy, failure reproduction, and regression test.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 4</div>
+    <div><strong>Kernel implementation and optimization</strong><p>Implement or tune one C kernel, SIMD route, memory layout, fusion, quantized path, or thread-pool boundary.</p></div>
+    <div><strong>Completion evidence</strong><p>Parity first, supported-ISA detection, before/after benchmark, profiler attribution, fallback behavior, and no unsupported performance claim.</p></div>
+  </article>
+  <article class="contrib-level">
+    <div class="contrib-level-id">LEVEL 5</div>
+    <div><strong>Compiler, DSL, multimodal, and distributed systems</strong><p>Change circuit semantics, lowering, kernel binding, generated runtime ownership, numerical X-ray attribution, multimodal stitching, or multi-node execution.</p></div>
+    <div><strong>Completion evidence</strong><p>Written contract, cross-layer tests, generated-C inspection, architecture regression coverage, migration impact, and end-to-end evidence.</p></div>
+  </article>
+</div>
+
+<h2>Three Good First Paths</h2>
+
+<div class="contrib-grid">
+  <article class="contrib-card green">
+    <h3>Linux distribution and profiling adapter</h3>
+    <p>Build one known model on Arch, CachyOS, Fedora, Debian, or another Linux environment. Preserve Ubuntu behavior while adding explicit commands for the platform's profiler package and interface.</p>
+    <p><strong>Concrete example:</strong> detect or document <code>flamegraph-rs</code> on Arch/CachyOS instead of assuming the Perl FlameGraph command line, then capture the resulting SVG and baseline metadata.</p>
+  </article>
+  <article class="contrib-card">
+    <h3>Reproducible benchmark artifact</h3>
+    <p>Run one supported model with a fixed prompt and thread count. Record CPU topology, ISA flags, compiler, CKE commit, model hash, command, prompt-eval rate, decode rate, RSS, and profiler output.</p>
+    <p>The contribution is the reproducible evidence package, not a context-free tokens-per-second number.</p>
+  </article>
+  <article class="contrib-card orange">
+    <h3>One numerical boundary</h3>
+    <p>Choose RMSNorm, RoPE, quantized dot product, softmax, Conv1D, attention, or another bounded operation. Compare CKE against an independent oracle using deterministic tensors and an explicit precision policy.</p>
+    <p>Do not begin with complete model generation unless the smaller boundary already passes.</p>
+  </article>
+  <article class="contrib-card">
+    <h3>Documentation that follows the code</h3>
+    <p>Reproduce a public guide from a clean checkout. Correct stale paths, unsupported assumptions, missing dependencies, or unclear evidence labels. Link every claim to the current implementation or test.</p>
+    <p>Documentation-only changes still need reproduction evidence.</p>
+  </article>
+</div>
+
+<h2>The Onboarding Loop</h2>
+
+<div class="contrib-flow">
+  <article class="contrib-step"><strong>Build</strong><p>Follow the quickstart and record your machine, OS, CPU, compiler, and commit.</p></article>
+  <article class="contrib-step"><strong>Choose one boundary</strong><p>Use an existing issue or open a focused issue describing one observable failure or missing path.</p></article>
+  <article class="contrib-step"><strong>Reproduce</strong><p>Capture the failing and passing commands before broadening the change.</p></article>
+  <article class="contrib-step"><strong>Open a draft PR</strong><p>Share direction early. Do not wait until a large rewrite is complete.</p></article>
+  <article class="contrib-step"><strong>Close with evidence</strong><p>Attach tests, artifacts, limits, and the exact claim the change supports.</p></article>
+</div>
+
+<h2>Discord Onboarding</h2>
+
+<section class="contrib-callout">
+  <p><strong>If you are already in the CKE Discord:</strong> introduce yourself with your operating system, CPU, compiler, the CKE path you successfully ran, and one contribution level that interests you. Link a focused GitHub issue or draft PR so technical decisions remain searchable outside chat.</p>
+  <p><strong>If you need an invite:</strong> open a short onboarding issue in the CKE repository. The public repository remains the durable source for scope, commands, patches, evidence, and review; Discord is for coordination and questions, not the only copy of a technical decision.</p>
+  <p style="margin-bottom:0"><strong>Good first message:</strong> "I built commit <code>&lt;sha&gt;</code> on <code>&lt;OS&gt;</code> with <code>&lt;CPU/compiler&gt;</code>. I want to work at Level 2 on the Arch/CachyOS flamegraph-rs path. Here is my baseline command and draft issue."</p>
+</section>
+
+<h2>Pull Request Evidence Contract</h2>
+
+<table class="contrib-table">
+  <thead><tr><th>Include</th><th>Why it matters</th></tr></thead>
+  <tbody>
+    <tr><td>Problem and bounded scope</td><td>Reviewers can tell what changed and what deliberately did not.</td></tr>
+    <tr><td>Hardware, OS, compiler, model, and commit</td><td>CPU behavior and performance claims are environment-dependent.</td></tr>
+    <tr><td>Exact reproduction commands</td><td>Another contributor can rerun the result without reconstructing your shell history.</td></tr>
+    <tr><td>Independent correctness evidence</td><td>An implementation must not validate only against itself.</td></tr>
+    <tr><td>Before/after artifacts for performance work</td><td>Optimization requires attribution, not intuition or CPU utilization alone.</td></tr>
+    <tr><td>Known limits and unsupported cases</td><td>A narrow validated path must not become a broad accidental claim.</td></tr>
+    <tr><td>Focused commit history</td><td>Intent remains inspectable and unrelated changes do not hide in the patch.</td></tr>
+  </tbody>
+</table>
+
+<h2>Build and Test Before Review</h2>
+
+<p>Enable the repository hooks after cloning:</p>
+
 <pre><code>./scripts/setup-hooks.sh
-</code></pre>
-<p>Verify:</p>
-<pre><code>git config core.hooksPath
-</code></pre>
-<p>It should print <code>.githooks</code>. If not, commits and pushes will <strong>not</strong> run the repo hooks.</p>
+git config core.hooksPath</code></pre>
 
-<h2>Workflow: Adding a New Kernel</h2>
-
-<p>Let's say you want to add a <code>GELU_TANH</code> op.</p>
-
-<h3>1. Define the Op in IR</h3>
-
-<p>Open <code>include/ckernel_ir.h</code> and add your op to the <code>CKOpType</code> enum:</p>
-
-<pre><code>typedef enum {
-    // ...
-    CK_OP_SWIGLU,
-    CK_OP_GELU_TANH, // <--- Add this
-    // ...
-} CKOpType;</code></pre>
-
-<h3>2. Implement the Kernel</h3>
-
-<p>Create a new file <code>src/kernels/gelu_tanh.c</code> (or add to <code>src/kernels/gelu_kernels.c</code> if it fits):</p>
-
-<pre><code>#include &lt;math.h&gt;
-
-void gelu_tanh_forward(const float *x, float *y, int n) {
-    // fast tanh approximation...
-    for (int i = 0; i < n; ++i) {
-        // ...
-    }
-}</code></pre>
-
-<p>Then expose it in <code>include/ckernel_engine.h</code>:</p>
-
-<pre><code>void gelu_tanh_forward(const float *x, float *y, int n);</code></pre>
-
-<h3>3. Register the Op Name</h3>
-
-<p>Open <code>src/ckernel_registry.c</code> and map the enum to a string name:</p>
-
-<pre><code>static const char *ck_op_name(CKOpType op) {
-    switch (op) {
-        // ...
-        case CK_OP_GELU_TANH: return "GELU_TANH";
-        // ...
-    }
-}</code></pre>
-
-<p>And ensure <code>ck_op_supported</code> returns 1 for it.</p>
-
-<h3>4. Update the Code Generator</h3>
-
-<p>Open <code>src/ckernel_codegen.c</code>. You need to ensure the runtime knows how to emit code for this op.</p>
-<p>First, update the local <code>op_name</code> helper if it duplicates the registry logic.</p>
-<p>Then, if you are emitting a full runtime (in <code>emit_runtime_preamble</code> or the main loop inside <code>ck_codegen_emit_runtime</code>), you need to make sure your kernel's source file is included in the output <code>ai.c</code>.</p>
-
-<p>For example, in <code>emit_runtime_preamble</code>:</p>
-
-<pre><code>if (emit_source_filtered(out, "src/kernels/gelu_tanh.c") != 0) return -1;</code></pre>
-
-<h3>5. Add a Test</h3>
-
-<p>We verify everything against PyTorch. Create <code>unittest/test_gelu_tanh.py</code>:</p>
-
-<pre><code>import torch
-import ctypes
-import numpy as np
-
-# Load your new library (you might need to add a target to Makefile first!)
-lib = ctypes.CDLL("build/libckernel_gelu.so") 
-
-def test_gelu_tanh():
-    # ... setup input ...
-    # ... call C function ...
-    # ... compare with torch.nn.functional.gelu(..., approximate='tanh') ...</code></pre>
-
-<h3>6. Build and Verify</h3>
+<p>The configured path should be <code>.githooks</code>. Run the tests relevant to your changed boundary and report exactly what ran. Do not claim the complete engine passed if you ran only a scoped test.</p>
 
 <pre><code>make
-make test</code></pre>
+make test
 
-<h2>Compiler Architecture</h2>
+# Examples of focused Python gates
+python3 -m pytest tests/test_v8_attention_contracts.py
+python3 -m pytest tests/test_v8_numerical_execution_contracts.py</code></pre>
 
-<p>The "Compiler" is just <code>ckernel_ir_demo.c</code>. It doesn't generate machine code directly; it generates <strong>C source code</strong>. This is known as "Transpilation" or "Source-to-Source" compilation.</p>
+<section class="contrib-callout warning">
+  <h2 style="margin-top:0">AI assistance does not transfer responsibility</h2>
+  <p style="margin-bottom:0">AI tools may help inspect code, propose tests, or draft a patch. The contributor still owns every equation, hardware assumption, generated artifact, claim, and line submitted. Correct-looking code without independent evidence is not a completed contribution.</p>
+</section>
 
-<ol>
-    <li><strong>Parser</strong>: Reads <code>config.json</code> -> <code>CKModelConfig</code>.</li>
-    <li><strong>IR Builder</strong>: Constructs <code>CKIRGraph</code> (a flat list of nodes).</li>
-    <li><strong>Codegen</strong>: Walks the <code>CKIRGraph</code> and prints C code to a file (<code>ai.c</code>).</li>
-</ol>
+<h2>Where To Go Next</h2>
 
-<p>This generated <code>ai.c</code> is <strong>standalone</strong>. It contains all the kernel code (inlined/included) and a <code>main()</code> function. You can compile it with <code>gcc -O3 ai.c -o ai</code> and run it anywhere, without needing the original library.</p>
+<div class="contrib-grid">
+  <article class="contrib-card"><h3>Understand the runtime</h3><p><a href="quickstart.html">Quickstart</a>, <a href="architecture.html">architecture</a>, <a href="ir-pipeline.html">IR pipeline</a>, and <a href="v8-runbook.html">v8 runbook</a>.</p></article>
+  <article class="contrib-card"><h3>Work on performance</h3><p><a href="profiling.html">Profiling guide</a>, <a href="kernel-tuning-methodology.html">kernel tuning methodology</a>, and <a href="simd-architecture.html">SIMD architecture</a>.</p></article>
+  <article class="contrib-card"><h3>Work on correctness</h3><p><a href="pytorch-parity.html">PyTorch parity</a>, <a href="divergence-harness.html">divergence harness</a>, and <a href="v8-numerical-contracts.html">numerical contracts</a>.</p></article>
+  <article class="contrib-card"><h3>Coordinate publicly</h3><p><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues">Issues</a>, <a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/pulls">draft pull requests</a>, and the current <a href="test-report.html">test report</a>.</p></article>
+</div>
     </main>
 
     <!-- SVG Viewer Overlay (shared across all pages) -->
@@ -1263,7 +1341,8 @@ make test</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1271,13 +1350,14 @@ make test</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions-dynamic.html
+++ b/docs/site/decisions-dynamic.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -925,7 +928,7 @@
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
-            <a href="decisions.html" class="">ADR</a>
+            <a href="decisions.html" class="active">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
                 <div class="nav-dropdown-menu">
@@ -1449,7 +1452,8 @@ details.adr pre {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1457,13 +1461,14 @@ details.adr pre {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/decisions.html
+++ b/docs/site/decisions.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -925,7 +928,7 @@
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
-            <a href="decisions.html" class="">ADR</a>
+            <a href="decisions.html" class="active">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
                 <div class="nav-dropdown-menu">
@@ -1923,7 +1926,8 @@ weight_mapping:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1931,13 +1935,14 @@ weight_mapping:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deltanet-deep-dive.html
+++ b/docs/site/deltanet-deep-dive.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2176,7 +2179,8 @@ void recurrent_conv_state_update_forward(
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2184,13 +2188,14 @@ void recurrent_conv_state_update_forward(
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/deterministic-memory.html
+++ b/docs/site/deterministic-memory.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1604,7 +1607,8 @@ class TrainingObserver:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1612,13 +1616,14 @@ class TrainingObserver:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/developer-guide.html
+++ b/docs/site/developer-guide.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1723,7 +1726,8 @@ make emit CONFIG=x.json OUT=out.c  # Generate runtime</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1731,13 +1735,14 @@ make emit CONFIG=x.json OUT=out.c  # Generate runtime</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/divergence-harness.html
+++ b/docs/site/divergence-harness.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1498,7 +1501,8 @@ ck_dump_tensor_head_major_token_major(q_buffer, layer_id, "Qcur", heads, tokens,
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1506,13 +1510,14 @@ ck_dump_tensor_head_major_token_major(q_buffer, layer_id, "Qcur", heads, tokens,
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/flash_attention.html
+++ b/docs/site/flash_attention.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -904,7 +907,7 @@
                         <a href="gemma4-speculative-pair.html">Gemma4 Speculative Pair<small>Backbone + MTP drafter circuit</small></a>
                         <a href="v8-mla-kimi.html">v8 MLA / Kimi<small>Explicit decode cache contract</small></a>
                         <a href="simd-architecture.html">SIMD Architecture<small>AVX-512, VNNI, AMX</small></a>
-                        <a href="flash_attention.html" class="">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
+                        <a href="flash_attention.html" class="active">Flash Attention Analysis<small>Why llama.cpp is faster</small></a>
                     </div>
                     <div class="menu-section">
                         <div class="menu-heading">Infrastructure</div>
@@ -1710,7 +1713,8 @@ pthread_setaffinity_np(pthread_self(),
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1718,13 +1722,14 @@ pthread_setaffinity_np(pthread_self(),
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout-temp.html
+++ b/docs/site/gemm-memory-layout-temp.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1388,7 +1391,8 @@ for (m_tile = 0; m_tile < M; m_tile += MB) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1396,13 +1400,14 @@ for (m_tile = 0; m_tile < M; m_tile += MB) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-memory-layout.html
+++ b/docs/site/gemm-memory-layout.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1644,7 +1647,8 @@ Token 2: offset 1972    ✗ Kernel expects 1904!</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1652,13 +1656,14 @@ Token 2: offset 1972    ✗ Kernel expects 1904!</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemm-optimization.html
+++ b/docs/site/gemm-optimization.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2542,7 +2545,8 @@ gemm_microkernel_packed(A, B, C, M, N, K);</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2550,13 +2554,14 @@ gemm_microkernel_packed(A, B, C, M, N, K);</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gemma4-speculative-pair.html
+++ b/docs/site/gemma4-speculative-pair.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1392,7 +1395,8 @@ int ck_gemma4_pair_generate_speculative(...);</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1400,13 +1404,14 @@ int ck_gemma4_pair_generate_speculative(...);</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-bump.html
+++ b/docs/site/gguf-bump.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1824,7 +1827,8 @@ make gguf-to-bump GGUF=models/qwen2.5-3b-instruct-q4_k_m.gguf
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1832,13 +1836,14 @@ make gguf-to-bump GGUF=models/qwen2.5-3b-instruct-q4_k_m.gguf
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/gguf-conversion.html
+++ b/docs/site/gguf-conversion.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2172,7 +2175,8 @@ with open(output_path, "w+b") as f:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2180,13 +2184,14 @@ with open(output_path, "w+b") as f:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1614,7 +1614,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 12:49</span>
+        <span class="folder-updated">Updated: 2026-07-14 13:04</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1645,10 +1645,6 @@ version/v7
 |-- contracts
 |-- data
 |   |-- eval_contracts
-|   |-- generated
-|   |   |-- toy_svg_semantic_shapes_tokenizer
-|   |   `-- toy_svg_structured_atoms_tokenizer
-|   |-- probe_contracts
 |   |-- spec03
 |   |   |-- contracts
 |   |   |-- holdout
@@ -1663,20 +1659,13 @@ version/v7
 |       |-- contracts
 |       |-- holdout
 |       |-- manifests
-|       |-- midtrain
 |       |-- normalized
-|       |-- pretrain
 |       |-- raw_assets
-|       |-- sft
 |       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
-|       |-- catalog
-|       |-- core
-|       |-- programs
-|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
@@ -1689,10 +1678,6 @@ version/v7
 |   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
 |   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
 |   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
-|-- runs
-|   |-- logs
-|   `-- overnight_monitor
-|       `-- spec10
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -1705,7 +1690,7 @@ version/v7
 `-- tools
     `-- src
 
-87 directories
+72 directories
 </pre>
 </div>
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -858,12 +859,14 @@
             <span></span>
         </button>
         <nav class="site-nav">
-            <a href="index.html" class="">Home</a>
+            <a href="index.html" class="active">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1377,6 +1380,30 @@
 ═══════════════════════════════════════════════════════════════════════ -->
 <h2>Performance</h2>
 
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Measured Across CPU Classes</h3>
+    <p>CKE performance engineering combines numerical parity, practical end-to-end workloads, Linux <code>perf</code>, flamegraphs, assembly inspection, Intel VTune, and Intel Advisor roofline analysis. The objective is to explain the distance from each machine's useful hardware limits and close it kernel by kernel, not to infer efficiency from peak FLOPS or CPU utilization alone.</p>
+    <table class="pillar-evidence">
+        <tr>
+            <td>Intel Core i7</td>
+            <td>Multiple-generation FP32 and quantized compatibility work, including a dedicated 14th Gen Core i7-14700T AVX2/FMA/AVX-VNNI profiling node. Native BF16 is not claimed on this host.</td>
+        </tr>
+        <tr>
+            <td>TI TDA4VM ARM</td>
+            <td>FP32 and quantized ARM NEON portability under embedded memory and power constraints.</td>
+        </tr>
+        <tr>
+            <td>Intel Xeon</td>
+            <td>External 2nd, 3rd, and 5th Gen validation lanes for FP32/quantized AVX-512 and VNNI where available, plus native BF16/AMX only when the host exposes those features.</td>
+        </tr>
+        <tr>
+            <td>Xeon 6</td>
+            <td>Planned native AMX BF16, AVX-512/VNNI, memory-channel, NUMA, power, and distributed-node laboratory. No Xeon 6 result is claimed yet.</td>
+        </tr>
+    </table>
+    <p style="margin-bottom: 0;">Coverage is reported per host, detected ISA, dtype, and workload; it does not imply every model passes every gate on every CPU. <a href="kernel-tuning-methodology.html">Read the tuning methodology</a> or <a href="profiling.html">reproduce the profiling lanes</a>.</p>
+</div>
+
 <div class="grid grid-2" style="gap: 1rem;">
     <div class="card">
         <h3 style="margin-top: 0;">Profiling + SIMD</h3>
@@ -1527,7 +1554,7 @@
 cd C-Kernel-Engine
 make                  # builds build/libckernel_engine.so
 make test             # runs all kernel parity tests vs PyTorch</pre>
-    <p style="color: var(--text-muted); font-size: 0.88rem; margin-bottom: 0;">Requires Linux, GCC, Python 3 + PyTorch for parity tests. AVX2 minimum; AVX-512 recommended.</p>
+    <p style="color: var(--text-muted); font-size: 0.88rem; margin-bottom: 0;">Requires Linux, a supported C toolchain, and Python 3 + PyTorch for parity tests. AVX2 is the current x86 production baseline; ARM NEON is an active portability lane; AVX-512, VNNI, BF16, and AMX paths are enabled only where the host supports them.</p>
 </div>
 
 <div class="grid grid-2" style="gap: 1rem; margin-top: 1rem;">
@@ -1566,6 +1593,18 @@ python version/v7/scripts/ck_run_v7.py train \
     </p>
 </div>
 
+<h2>Work With Us</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">CPU AI and High-Performance Linux Engineering</h3>
+    <p>CKE's methodology can be applied to CPU AI feasibility, C/Linux performance investigations, AVX/AVX-512/AMX or ARM NEON kernel work, numerical first-divergence analysis, model evaluation systems, and evidence-backed deployment planning.</p>
+    <p style="margin-bottom: 0;">
+        <a href="https://www.shivasnotes.com/work-with-us" class="btn btn-sm" target="_blank" rel="noopener noreferrer">Work With Us →</a>
+        <a href="https://antshiv.com/" class="btn btn-sm" style="margin-left:0.4rem;" target="_blank" rel="noopener noreferrer">antshiv.com →</a>
+        <a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine/issues" class="btn btn-sm" style="margin-left:0.4rem;" target="_blank" rel="noopener noreferrer">Project Issues →</a>
+    </p>
+</div>
+
 <!-- ═══════════════════════════════════════════════════════════════════════
      PROJECT STRUCTURE
 ═══════════════════════════════════════════════════════════════════════ -->
@@ -1575,7 +1614,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-10 21:47</span>
+        <span class="folder-updated">Updated: 2026-07-14 12:49</span>
     </div>
     <pre class="tree-output">
 src/kernels
@@ -1601,27 +1640,59 @@ version/v6.6
 version/v7
 |-- artifacts
 |   `-- svg_dsl
+|       |-- gen1_archive_2026-04-05
+|       `-- spec_archive_2026-04-08
 |-- contracts
 |-- data
 |   |-- eval_contracts
+|   |-- generated
+|   |   |-- toy_svg_semantic_shapes_tokenizer
+|   |   `-- toy_svg_structured_atoms_tokenizer
+|   |-- probe_contracts
 |   |-- spec03
+|   |   |-- contracts
+|   |   |-- holdout
+|   |   |-- manifests
+|   |   |-- midtrain
+|   |   |-- normalized
+|   |   |-- pretrain
+|   |   |-- raw_assets
+|   |   |-- sft
+|   |   `-- tokenizer
 |   `-- spec04
+|       |-- contracts
+|       |-- holdout
+|       |-- manifests
+|       |-- midtrain
+|       |-- normalized
+|       |-- pretrain
+|       |-- raw_assets
+|       |-- sft
+|       `-- tokenizer
 |-- docs
 |-- examples
 |-- experiments
 |   `-- svg_dsl
+|       |-- catalog
+|       |-- core
+|       |-- programs
+|       `-- renderers
 |-- include
 |-- kernel_maps
 |-- regression
 |-- reports
-|   |-- spec12_gold_mappings
-|   |-- spec13b_gold_mappings
-|   |-- spec14a_gold_mappings
-|   |-- spec14b_gold_mappings
-|   |-- spec15a_gold_mappings
-|   |-- spec15b_gold_mappings
-|   |-- spec_broader_1_family_packs
-|   `-- spec_broader_1_gold_mappings
+|   |-- spec12_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec12_gold_mappings
+|   |-- spec13b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec13b_gold_mappings
+|   |-- spec14a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14a_gold_mappings
+|   |-- spec14b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec14b_gold_mappings
+|   |-- spec15a_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15a_gold_mappings
+|   |-- spec15b_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec15b_gold_mappings
+|   |-- spec_broader_1_family_packs -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_family_packs
+|   `-- spec_broader_1_gold_mappings -&gt; ../artifacts/svg_dsl/spec_archive_2026-04-08/spec_broader_1_gold_mappings
+|-- runs
+|   |-- logs
+|   `-- overnight_monitor
+|       `-- spec10
 |-- scripts
 |   |-- dataset
 |   `-- parity
@@ -1634,7 +1705,7 @@ version/v7
 `-- tools
     `-- src
 
-55 directories
+87 directories
 </pre>
 </div>
 
@@ -1899,7 +1970,8 @@ version/v7
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1907,13 +1979,14 @@ version/v7
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-pipeline.html
+++ b/docs/site/ir-pipeline.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2253,7 +2256,8 @@ python version/v6.6/tools/open_ir_visualizer.py Qwen--Qwen3-0.6B-GGUF</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2261,13 +2265,14 @@ python version/v6.6/tools/open_ir_visualizer.py Qwen--Qwen3-0.6B-GGUF</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/ir-v2.html
+++ b/docs/site/ir-v2.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1649,7 +1652,8 @@ Page 2 (2-3GB)   → DRAM Bank 2 (Layer 12-17)
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1657,13 +1661,14 @@ Page 2 (2-3GB)   → DRAM Bank 2 (Layer 12-17)
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/iteration-philosophy.html
+++ b/docs/site/iteration-philosophy.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2567,7 +2570,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2575,13 +2579,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernel-tuning-methodology.html
+++ b/docs/site/kernel-tuning-methodology.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1145,6 +1148,70 @@ path, weight reuse, quantized GEMM dispatch, thread scheduling, and cache behavi
         </tr>
     </tbody>
 </table>
+
+<h2>Cross-Hardware Evidence Matrix</h2>
+
+<p>A kernel is not "CPU optimized" because it performed well on one host. CKE uses several hardware lanes to separate
+portable mathematics from ISA-specific implementation quality, heterogeneous scheduling, memory topology, and
+server-scale behavior.</p>
+
+<table class="phase-table">
+    <thead>
+        <tr>
+            <th>Hardware Lane</th>
+            <th>Primary Question</th>
+            <th>Tools and Evidence</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Intel Core i7, multiple generations</td>
+            <td>Do FP32 and quantized generated runtimes remain useful on commodity x86 systems?</td>
+            <td>Practical E2E, fixed-token throughput, parity, compiler and ISA inspection.</td>
+            <td>Active</td>
+        </tr>
+        <tr>
+            <td>Core i7-14700T</td>
+            <td>How close can AVX2/FMA/AVX-VNNI FP32 and Q4/Q5/Q6/Q8 kernels get to the useful roofline on a hybrid 8P + 12E CPU? Native BF16 is not claimed.</td>
+            <td>VTune hotspots/uarch/memory/threading, Advisor roofline, perf, flamegraphs, assembly, frequency and utilization.</td>
+            <td>Dedicated profiling node</td>
+        </tr>
+        <tr>
+            <td>TI TDA4VM ARM</td>
+            <td>Are FP32 and quantized contracts and kernels portable to ARM NEON and realistic embedded constraints?</td>
+            <td>Build and kernel parity, NEON path inspection, constrained-memory and practical runtime checks.</td>
+            <td>Active portability lane</td>
+        </tr>
+        <tr>
+            <td>Intel Xeon, 2nd/3rd/5th Gen</td>
+            <td>How do FP32/quantized AVX-512/VNNI and host-gated native BF16/AMX availability affect parity and throughput across generations?</td>
+            <td>ISA-appropriate kernel tests, model parity, larger artifacts, profiler summaries, and cross-generation comparisons.</td>
+            <td>External validation lanes</td>
+        </tr>
+        <tr>
+            <td>Intel Xeon 6</td>
+            <td>What do native AMX BF16, AVX-512/VNNI, wider memory systems, NUMA placement, sustained power, and multiple nodes enable?</td>
+            <td>Planned VTune/Advisor, native BF16, memory-channel roofline, NUMA, power, and distributed CKU experiments.</td>
+            <td>Planned; not measured</td>
+        </tr>
+    </tbody>
+</table>
+
+<div class="alert alert-warning">
+    <strong>Coverage is workload-specific.</strong> A platform row does not certify every model, dtype, quantization, or
+    context length. Publish the host, CPU and detected ISA flags, storage/compute dtype, memory topology, compiler, CKE commit, model hash, quantization,
+    prompt or tensor shape, thread/affinity policy, warmup/repeats, power/frequency state, raw command, and artifact path.
+</div>
+
+<h3>Publication Contract</h3>
+<ul class="check-list">
+    <li>Label the hardware lane as active, external, or planned; planned hardware has no benchmark result.</li>
+    <li>Separate portable numerical evidence from ISA-specific throughput evidence.</li>
+    <li>Compare before/after and reference runtimes on the same host with equivalent model and workload settings.</li>
+    <li>Link raw commands, logs, profiler output, and the CKE commit behind every published performance table.</li>
+    <li>Do not extrapolate one Core, Xeon, or ARM result to another generation without running that lane.</li>
+</ul>
 
 <h2>How To Read The Signals</h2>
 
@@ -1563,7 +1630,8 @@ tie one profiler dot back to one function, one tensor layout, and one source pat
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1571,13 +1639,14 @@ tie one profiler dot back to one function, one tensor layout, and one source pat
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/kernels.html
+++ b/docs/site/kernels.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1393,7 +1396,8 @@ out     = S_new^T * q_hat</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1401,13 +1405,14 @@ out     = S_new^T * q_hat</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-reality.html
+++ b/docs/site/memory-reality.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1705,7 +1708,8 @@ CPU (2TB server): FITS with 1.8TB headroom
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1713,13 +1717,14 @@ CPU (2TB server): FITS with 1.8TB headroom
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/memory-safety.html
+++ b/docs/site/memory-safety.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1912,7 +1915,8 @@ echo "=== All memory safety checks passed ==="</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1920,13 +1924,14 @@ echo "=== All memory safety checks passed ==="</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/model-kernel-matrix.html
+++ b/docs/site/model-kernel-matrix.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2415,7 +2418,8 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2423,13 +2427,14 @@ python3 version/v7/scripts/test_kv_cache_batch_copy_call_ir_v7.py \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/page_metadata.json
+++ b/docs/site/page_metadata.json
@@ -73,6 +73,10 @@
       "title": "Getting Started",
       "description": "Quickstart guide for building and running C-Kernel-Engine, including the current v7 runtime path plus the v8 text-inference and Qwen3-VL multimodal bring-up surfaces."
     },
+    "contributing.html": {
+      "title": "Contributor Path: Start Small and Build Evidence",
+      "description": "Five contribution levels for C-Kernel-Engine, from Linux compatibility and profiling through numerical fixtures, CPU kernels, compiler work, multimodal parity, and distributed execution."
+    },
     "pytorch-parity.html": {
       "title": "PyTorch Parity and Numerical Validation",
       "description": "How C-Kernel-Engine validates kernel and training behavior against PyTorch with deterministic parity gates and numerical checks."

--- a/docs/site/prefill-performance-roadmap.html
+++ b/docs/site/prefill-performance-roadmap.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1347,7 +1350,8 @@ make profile-v8-prefill-perf-stat</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1355,13 +1359,14 @@ make profile-v8-prefill-perf-stat</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/profiling.html
+++ b/docs/site/profiling.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1624,7 +1627,8 @@ make flamegraph       # Generate SVG flamegraph</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1632,13 +1636,14 @@ make flamegraph       # Generate SVG flamegraph</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/pytorch-parity.html
+++ b/docs/site/pytorch-parity.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -921,7 +924,7 @@
                     </div>
                 </div>
             </div>
-            <a href="pytorch-parity.html" class="">PyTorch Parity</a>
+            <a href="pytorch-parity.html" class="active">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
             <a href="research.html" class="">Research</a>
@@ -1326,7 +1329,8 @@ make litmus</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1334,13 +1338,14 @@ make litmus</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/q6-prefill-roofline.html
+++ b/docs/site/q6-prefill-roofline.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1284,7 +1287,8 @@ CK_NUM_THREADS=12 OMP_NUM_THREADS=1 CK_Q6K_Q8K_SIMD=1 \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1292,13 +1296,14 @@ CK_NUM_THREADS=12 OMP_NUM_THREADS=1 CK_Q6K_Q8K_SIMD=1 \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quant-formats.html
+++ b/docs/site/quant-formats.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1606,7 +1609,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1614,13 +1618,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-math-temp.html
+++ b/docs/site/quantization-math-temp.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1370,7 +1373,8 @@ for (int ib = 0; ib < nb; ib++) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1378,13 +1382,14 @@ for (int ib = 0; ib < nb; ib++) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization-visuals.html
+++ b/docs/site/quantization-visuals.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1502,7 +1505,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1510,13 +1514,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quantization.html
+++ b/docs/site/quantization.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2380,7 +2383,8 @@ void matmul_q4(float* out, const float* x, const tensor* W) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2388,13 +2392,14 @@ void matmul_q4(float* out, const float* x, const tensor* W) {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1670,7 +1673,8 @@ firefox build/flamegraph.svg</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1678,13 +1682,14 @@ firefox build/flamegraph.svg</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/research.html
+++ b/docs/site/research.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -924,7 +927,7 @@
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
-            <a href="research.html" class="">Research</a>
+            <a href="research.html" class="active">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
@@ -1618,7 +1621,8 @@ K = [K_rope (with position), K_nope (from latent)]</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1626,13 +1630,14 @@ K = [K_rope (with position), K_nope (from latent)]</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
-            <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="contributing.html" class="">Contribute</a>
+            <a href="scaling.html" class="active">Scaling</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -3379,7 +3382,8 @@ That's it. For any model size.
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -3387,13 +3391,14 @@ That's it. For any model size.
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sentencepiece.html
+++ b/docs/site/sentencepiece.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1862,7 +1865,8 @@ ck_tokenizer_free(tok);</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1870,13 +1874,14 @@ ck_tokenizer_free(tok);</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/simd-architecture.html
+++ b/docs/site/simd-architecture.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2355,7 +2358,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2363,13 +2367,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -2,278 +2,286 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/api.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture-links.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/architecture.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/bf16-amx-performance-study.html</loc>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/cke-throughput-unit.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/codegen.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/concepts.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/contributing.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions-dynamic.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/decisions.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deltanet-deep-dive.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/deterministic-memory.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/developer-guide.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/divergence-harness.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/flash_attention.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-memory-layout.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemm-optimization.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gemma4-speculative-pair.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-bump.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/gguf-conversion.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-pipeline.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/ir-v2.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/iteration-philosophy.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernel-tuning-methodology.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/kernels.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/mega_fusion.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-reality.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/memory-safety.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/model-kernel-matrix.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/prefill-performance-roadmap.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/profiling.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/pytorch-parity.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/q6-prefill-roofline.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quant-formats.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization-visuals.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quantization.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/quickstart.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/research.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/sentencepiece.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/simd-architecture.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-method.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec-training-results.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec17-curriculum-blueprint.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spec19-textbook-routing-mixture.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/spectrum.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
+  </url>
+  <url>
+    <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/support-hardware.html</loc>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/test-report.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/testing.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/threadpool.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/tokenizer.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-curriculum.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-intuition.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/training-lessons-learned.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-backprop-ir.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-cross-entropy-parity.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-grad-accum-windows.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-parity-checklist.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-profiling.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-python-authoring.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-runbook.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-svg-dataset-runbook.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-training-progression-playbook.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v7-visualizer-test-runbook.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-mla-kimi.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-numerical-contracts.html</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-runbook.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/v8-vision-encoder.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/version-history.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
   <url>
     <loc>https://c-kernel-engine.github.io/C-Kernel-Engine/vision-encoder-parity.html</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-14</lastmod>
   </url>
 </urlset>

--- a/docs/site/spec-training-method.html
+++ b/docs/site/spec-training-method.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -3764,7 +3767,8 @@ Next run:</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -3772,13 +3776,14 @@ Next run:</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1102,7 +1105,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-05 03:36 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-12 21:48 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>
@@ -1406,7 +1409,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1414,13 +1418,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec-training-results.html
+++ b/docs/site/spec-training-results.html
@@ -1105,7 +1105,7 @@
     <div class="results-card">
         <div class="metric-label">Specs With Probe Data</div>
         <div class="metric-value">19</div>
-        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-12 21:48 UTC.</p>
+        <p class="results-note">Generated from 2 source roots and refreshed at 2026-07-05 03:36 UTC.</p>
     </div>
     <div class="results-card">
         <div class="metric-label">Run Directories</div>

--- a/docs/site/spec17-curriculum-blueprint.html
+++ b/docs/site/spec17-curriculum-blueprint.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1462,7 +1465,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1470,13 +1474,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spec19-textbook-routing-mixture.html
+++ b/docs/site/spec19-textbook-routing-mixture.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1575,7 +1578,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1583,13 +1587,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/spectrum.html
+++ b/docs/site/spectrum.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -859,11 +860,13 @@
         </button>
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
-            <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
+            <a href="spectrum.html" class="active" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1753,7 +1756,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1761,13 +1765,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/support-hardware.html
+++ b/docs/site/support-hardware.html
@@ -1000,10 +1000,6 @@ body { overflow-x: hidden; }
 .support-milestone { padding: .7rem .45rem; border-top: 4px solid var(--grey-light); background: rgba(255,255,255,.025); text-align: center; }
 .support-milestone strong { display: block; color: var(--orange); font-family: 'JetBrains Mono', monospace; }
 .support-milestone span { color: var(--text-muted); font-size: .72rem; }
-.support-investment { margin: 1.5rem 0 2rem; padding: 1.5rem; border: 1px solid rgba(7,173,248,.32); border-radius: 12px; background: linear-gradient(135deg, rgba(7,173,248,.08), rgba(71,180,117,.04)); }
-.support-investment-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; flex-wrap: wrap; margin-bottom: .8rem; }
-.support-investment-total { color: var(--blue); font: 800 1.7rem 'JetBrains Mono', monospace; }
-.support-funded { color: var(--green); font: 700 .72rem 'JetBrains Mono', monospace; letter-spacing: .08em; text-transform: uppercase; }
 @media (max-width: 850px) { .support-grid { grid-template-columns: minmax(0, 1fr); } .support-hero { padding: 2.2rem 1.25rem; } .support-actions, .support-button { box-sizing: border-box; width: 100%; } .support-table { display: block; max-width: 100%; overflow-x: auto; } }
 @media (max-width: 700px) { .support-milestones { grid-template-columns: repeat(2, minmax(0,1fr)); } }
 </style>
@@ -1035,22 +1031,6 @@ body { overflow-x: hidden; }
     <div class="support-milestone"><strong>$30K</strong><span>full evidence program</span></div>
   </div>
   <p style="margin-top:1rem"><strong>Current funding must be reported manually.</strong> Until GitHub Sponsors and in-kind contributions are reconciled into a public ledger, these markers describe capability gates rather than claiming money raised.</p>
-</section>
-
-<section class="support-investment">
-  <div class="support-investment-head">
-    <div><div class="support-kicker">Personal investment so far</div><h2 style="margin:.35rem 0 0">Founder-funded hardware already supporting CKE</h2></div>
-    <div class="support-investment-total">CAD $1,650</div>
-  </div>
-  <p>This is money personally spent on hardware now used for CKE development and evidence generation. It is separate from sponsor funding, donated or loaned equipment, and the future CAD $30,000 laboratory ceiling.</p>
-  <table class="support-table">
-    <thead><tr><th>Hardware</th><th>Personal cost</th><th>Research role</th><th>Funding status</th></tr></thead>
-    <tbody>
-      <tr><td>Used Lenovo ThinkPad, purchased through Craigslist</td><td>CAD $600</td><td>Portable CKE development, AVX2 testing, documentation, and content production</td><td><span class="support-funded">Personally funded</span></td></tr>
-      <tr><td>Lenovo P3 Tiny, Core i7, 32 GB RAM</td><td>CAD $1,050</td><td>Dedicated minimal Ubuntu Server node for repeatable CKE execution, profiling, and unattended experiments</td><td><span class="support-funded">Personally funded</span></td></tr>
-    </tbody>
-  </table>
-  <p><strong>Ledger scope:</strong> this total includes only the two confirmed hardware purchases above. It excludes electricity, storage or memory upgrades, warranties already included with a purchase, personal labor, and planned Xeon nodes. Future entries will separate personally funded, sponsor funded, donated, loaned, and discounted hardware.</p>
 </section>
 
 <h2>The Immediate Goal</h2>

--- a/docs/site/support-hardware.html
+++ b/docs/site/support-hardware.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,9 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="active" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -998,6 +1000,10 @@ body { overflow-x: hidden; }
 .support-milestone { padding: .7rem .45rem; border-top: 4px solid var(--grey-light); background: rgba(255,255,255,.025); text-align: center; }
 .support-milestone strong { display: block; color: var(--orange); font-family: 'JetBrains Mono', monospace; }
 .support-milestone span { color: var(--text-muted); font-size: .72rem; }
+.support-investment { margin: 1.5rem 0 2rem; padding: 1.5rem; border: 1px solid rgba(7,173,248,.32); border-radius: 12px; background: linear-gradient(135deg, rgba(7,173,248,.08), rgba(71,180,117,.04)); }
+.support-investment-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; flex-wrap: wrap; margin-bottom: .8rem; }
+.support-investment-total { color: var(--blue); font: 800 1.7rem 'JetBrains Mono', monospace; }
+.support-funded { color: var(--green); font: 700 .72rem 'JetBrains Mono', monospace; letter-spacing: .08em; text-transform: uppercase; }
 @media (max-width: 850px) { .support-grid { grid-template-columns: minmax(0, 1fr); } .support-hero { padding: 2.2rem 1.25rem; } .support-actions, .support-button { box-sizing: border-box; width: 100%; } .support-table { display: block; max-width: 100%; overflow-x: auto; } }
 @media (max-width: 700px) { .support-milestones { grid-template-columns: repeat(2, minmax(0,1fr)); } }
 </style>
@@ -1029,6 +1035,22 @@ body { overflow-x: hidden; }
     <div class="support-milestone"><strong>$30K</strong><span>full evidence program</span></div>
   </div>
   <p style="margin-top:1rem"><strong>Current funding must be reported manually.</strong> Until GitHub Sponsors and in-kind contributions are reconciled into a public ledger, these markers describe capability gates rather than claiming money raised.</p>
+</section>
+
+<section class="support-investment">
+  <div class="support-investment-head">
+    <div><div class="support-kicker">Personal investment so far</div><h2 style="margin:.35rem 0 0">Founder-funded hardware already supporting CKE</h2></div>
+    <div class="support-investment-total">CAD $1,650</div>
+  </div>
+  <p>This is money personally spent on hardware now used for CKE development and evidence generation. It is separate from sponsor funding, donated or loaned equipment, and the future CAD $30,000 laboratory ceiling.</p>
+  <table class="support-table">
+    <thead><tr><th>Hardware</th><th>Personal cost</th><th>Research role</th><th>Funding status</th></tr></thead>
+    <tbody>
+      <tr><td>Used Lenovo ThinkPad, purchased through Craigslist</td><td>CAD $600</td><td>Portable CKE development, AVX2 testing, documentation, and content production</td><td><span class="support-funded">Personally funded</span></td></tr>
+      <tr><td>Lenovo P3 Tiny, Core i7, 32 GB RAM</td><td>CAD $1,050</td><td>Dedicated minimal Ubuntu Server node for repeatable CKE execution, profiling, and unattended experiments</td><td><span class="support-funded">Personally funded</span></td></tr>
+    </tbody>
+  </table>
+  <p><strong>Ledger scope:</strong> this total includes only the two confirmed hardware purchases above. It excludes electricity, storage or memory upgrades, warranties already included with a purchase, personal labor, and planned Xeon nodes. Future entries will separate personally funded, sponsor funded, donated, loaned, and discounted hardware.</p>
 </section>
 
 <h2>The Immediate Goal</h2>
@@ -1332,6 +1354,7 @@ body { overflow-x: hidden; }
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
                     <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1346,7 +1369,7 @@ body { overflow-x: hidden; }
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-12</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-report.html
+++ b/docs/site/test-report.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1774,7 +1777,7 @@
       (<code>make v7-visualizer-health</code>)</li>
     <li><strong>v8 Inference Regression</strong>: Family bring-up gate for Gemma3, Qwen2, Qwen3, Qwen3.5, and Nanbeige with build/smoke/coherence/contract checks
       (<code>make regression-fast</code>, aliasing the promoted <code>make v8-regression-fast</code> lane)</li>
-    <li><strong>Architecture Contract Dashboard</strong>: v8 circuit, lowered IR dataflow, generated-C preservation, runtime-path equivalence, and model contract coverage summary
+    <li><strong>Architecture Contract Dashboard</strong>: v8 template/circuit, lowered IR dataflow, generated-C preservation, runtime-path equivalence, and model contract coverage summary
       (<code>make test-architecture-contracts</code>)</li>
     <li><strong>v8 Qwen3-VL Vision Smoke</strong>: Cached image → mmproj → decoder smoke for the 8B multimodal path; skips cleanly when the runner does not have the large artifacts
       (<code>make test-v8-qwen3vl-e2e-smoke</code>)</li>
@@ -2388,6 +2391,31 @@ function renderArchitectureContracts(data) {
 }
 
 function renderContractRows(sectionId, rows) {
+  if (sectionId === 'numerical_kernel_capabilities') {
+    return `
+      <div class="contract-table-wrap">
+        <table class="results-table">
+          <thead><tr><th>Family</th><th>Capability</th><th>Status</th><th>Input</th><th>Compute</th><th>Reduction</th><th>Output</th><th>Oracle</th><th>Shape</th><th>Threads</th><th>Max Abs</th></tr></thead>
+          <tbody>
+            ${rows.map(row => `
+              <tr>
+                <td><code>${escapeHtml(row.kernel_family || '-')}</code></td>
+                <td><code>${escapeHtml(row.capability || '-')}</code></td>
+                <td>${contractBadge(row.status)}</td>
+                <td>${escapeHtml(row.input_storage || '-')}</td>
+                <td>${escapeHtml(row.compute || '-')}</td>
+                <td>${escapeHtml(row.reduction || '-')}</td>
+                <td>${escapeHtml(row.output_storage || '-')}</td>
+                <td>${escapeHtml(row.oracle || '-')}</td>
+                <td><code>D=${escapeHtml(row.head_dim ?? '-')}</code></td>
+                <td>${escapeHtml(row.threads || '-')}</td>
+                <td><code>${escapeHtml(row.max_abs ?? '-')}</code></td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>`;
+  }
   if (sectionId === 'model_contract_coverage') {
     return `
       <div class="contract-table-wrap">
@@ -2858,7 +2886,8 @@ document.addEventListener('DOMContentLoaded', loadResults);
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2866,13 +2895,14 @@ document.addEventListener('DOMContentLoaded', loadResults);
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/test-viewer.html
+++ b/docs/site/test-viewer.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1376,7 +1379,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1384,13 +1388,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/testing.html
+++ b/docs/site/testing.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1879,7 +1882,8 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1887,13 +1891,14 @@ Both are mathematically valid RoPE, but weights are trained for one convention.
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/threadpool.html
+++ b/docs/site/threadpool.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2817,7 +2820,8 @@ make test-threadpool-parity-verbose
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2825,13 +2829,14 @@ make test-threadpool-parity-verbose
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/tokenizer.html
+++ b/docs/site/tokenizer.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -2304,7 +2307,8 @@ True BPE (merge rules applied in order):
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2312,13 +2316,14 @@ True BPE (merge rules applied in order):
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-curriculum.html
+++ b/docs/site/training-curriculum.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1837,7 +1840,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1845,13 +1849,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-intuition.html
+++ b/docs/site/training-intuition.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -924,7 +927,7 @@
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
-            <a href="research.html" class="">Research</a>
+            <a href="research.html" class="active">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
@@ -2244,7 +2247,8 @@ report:    version/v7/tools/ir_visualizer.html (or generated ir_report*.html)</c
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2252,13 +2256,14 @@ report:    version/v7/tools/ir_visualizer.html (or generated ir_report*.html)</c
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/training-lessons-learned.html
+++ b/docs/site/training-lessons-learned.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -924,7 +927,7 @@
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
-            <a href="research.html" class="">Research</a>
+            <a href="research.html" class="active">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
@@ -1830,7 +1833,8 @@ AFTER TRAINING:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1838,13 +1842,14 @@ AFTER TRAINING:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-backprop-ir.html
+++ b/docs/site/v7-backprop-ir.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -924,7 +927,7 @@
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
-            <a href="research.html" class="">Research</a>
+            <a href="research.html" class="active">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
@@ -1999,7 +2002,8 @@ version/v7/scripts/cks-v7-run init \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2007,13 +2011,14 @@ version/v7/scripts/cks-v7-run init \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-cross-entropy-parity.html
+++ b/docs/site/v7-cross-entropy-parity.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -924,7 +927,7 @@
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
-            <a href="research.html" class="">Research</a>
+            <a href="research.html" class="active">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
@@ -1386,7 +1389,8 @@ CK_NUM_THREADS=8 python version/v7/scripts/train_parity_epochs_v7.py \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1394,13 +1398,14 @@ CK_NUM_THREADS=8 python version/v7/scripts/train_parity_epochs_v7.py \
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-grad-accum-windows.html
+++ b/docs/site/v7-grad-accum-windows.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -924,7 +927,7 @@
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
-            <a href="research.html" class="">Research</a>
+            <a href="research.html" class="active">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
@@ -1316,7 +1319,8 @@ at accumulation boundary:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1324,13 +1328,14 @@ at accumulation boundary:
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-parity-checklist.html
+++ b/docs/site/v7-parity-checklist.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1515,7 +1518,8 @@ PY</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1523,13 +1527,14 @@ PY</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-profiling.html
+++ b/docs/site/v7-profiling.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -924,7 +927,7 @@
             <a href="pytorch-parity.html" class="">PyTorch Parity</a>
             <a href="test-report.html" class="">Test Report</a>
             <a href="version-history.html" class="">Versions</a>
-            <a href="research.html" class="">Research</a>
+            <a href="research.html" class="active">Research</a>
             <a href="decisions.html" class="">ADR</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">API & Docs</span>
@@ -1434,7 +1437,8 @@ python3 version/v7/tools/open_ir_visualizer.py --generate --run /tmp/v7_ht_threa
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1442,13 +1446,14 @@ python3 version/v7/tools/open_ir_visualizer.py --generate --run /tmp/v7_ht_threa
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-python-authoring.html
+++ b/docs/site/v7-python-authoring.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1587,7 +1590,8 @@ python3 version/v7/examples/python_module_api_tiny_lm_v7.py --run-name py-module
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1595,13 +1599,14 @@ python3 version/v7/examples/python_module_api_tiny_lm_v7.py --run-name py-module
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-runbook.html
+++ b/docs/site/v7-runbook.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -5597,7 +5600,8 @@ python3 scripts/ck_chat.py --help</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -5605,13 +5609,14 @@ python3 scripts/ck_chat.py --help</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-svg-dataset-runbook.html
+++ b/docs/site/v7-svg-dataset-runbook.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1645,7 +1648,8 @@ tail -n 20 "$RUN/autopilot/summary.jsonl"</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1653,13 +1657,14 @@ tail -n 20 "$RUN/autopilot/summary.jsonl"</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-training-progression-playbook.html
+++ b/docs/site/v7-training-progression-playbook.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1565,7 +1568,8 @@ jq -r '.status, (.stages // [])' "$RUN/training_parity_regimen_latest.json" 2>/d
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1573,13 +1577,14 @@ jq -r '.status, (.stages // [])' "$RUN/training_parity_regimen_latest.json" 2>/d
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v7-visualizer-test-runbook.html
+++ b/docs/site/v7-visualizer-test-runbook.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1916,7 +1919,8 @@ document.querySelectorAll('.copy-btn').forEach(btn => {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1924,13 +1928,14 @@ document.querySelectorAll('.copy-btn').forEach(btn => {
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-mla-kimi.html
+++ b/docs/site/v8-mla-kimi.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1389,7 +1392,8 @@ make build/libckernel_engine.so
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1397,13 +1401,14 @@ make build/libckernel_engine.so
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-numerical-contracts.html
+++ b/docs/site/v8-numerical-contracts.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1045,6 +1048,41 @@
 
 <p>The two legacy binding registries remain only for uncontracted compatibility helpers while migration continues. They are not authoritative inputs for attention reductions, BF16 storage boundaries, vision M-RoPE, or Q4/Q6 numerical execution contracts.</p>
 
+<h2>Compiler Policy Gate</h2>
+
+<p><code>make v8-regression-fast</code> begins with an AST-based DSL policy audit. Generic compiler and code-generation entry points may branch on exact operation IDs, resolved kernel IDs, tensor metadata, and declared capability fields. They may not branch on model, architecture, or family names. Aliasing a family value through local variables does not bypass the audit.</p>
+
+<p>The builder also treats operation families as exact inputs. A missing <code>attention_sliding</code> implementation cannot silently resolve to ordinary <code>attention</code>; missing and ambiguous routes fail with an instruction to fix the circuit or kernel map. Per-layer dimensions are validated arrays, circuit weight policies own aliases and intentionally unused tensors, and unknown policy fields fail schema validation.</p>
+
+<p>The same policy now protects v7 training and backprop through <code>make test-v7-dsl-policy</code>, which is part of <code>make v7-regression-fast</code>. This does not make v7 and v8 share one graph, but it enforces the same ownership rule: the training IR owns backward ordering and the emitter may not acquire model-family behavior.</p>
+
+<pre><code>make test-v8-dsl
+make v8-regression-fast
+make test-v7-dsl-policy
+make v7-regression-fast</code></pre>
+
+<h3>Remaining Migration Debt</h3>
+
+<table>
+  <thead><tr><th>Measured category</th><th>Before this PR</th><th>Current</th><th>Meaning</th></tr></thead>
+  <tbody>
+    <tr><td>Executable model-literal AST sites</td><td>78</td><td>76</td><td>A checked-in per-file ceiling now fails on any increase. Reductions must lower the ceiling.</td></tr>
+    <tr><td>Build and IR model-literal sites</td><td>39</td><td>37</td><td>Lower 1 no longer reselects decode attention from model-specific defaults or function-name patterns.</td></tr>
+    <tr><td>Code-generation model-literal sites</td><td>39</td><td>39</td><td>Bridge, tokenizer, debug, and specialized emission remain the largest migration area.</td></tr>
+    <tr><td>Lower-1 decode-attention reselection branches</td><td>7</td><td>0</td><td>Lower 1 validates the exact IR1 kernel and resolved contract, then only wires KV-cache inputs.</td></tr>
+    <tr><td>Compiler functions governed by the no-family-dispatch policy</td><td>8</td><td>9</td><td>The authoritative decode-attention validator is now covered directly.</td></tr>
+    <tr><td>Forbidden family dispatch in governed generic paths</td><td>0</td><td>0</td><td>Direct and aliased model/family dispatch continues to hard-fail.</td></tr>
+  </tbody>
+</table>
+
+<p>The 76-site inventory is deliberately broader than the previous 41-site estimate: it counts executable module-level and function-level string literals containing model-family names across the four principal compiler and code-generation modules, while excluding comments, docstrings, and standalone documentation strings. Not every site selects mathematics, but every site is visible debt that cannot increase silently. The audit reports a per-function inventory so cleanup can proceed in bounded groups instead of relying on an informal grep count.</p>
+
+<p>The next priority is Qwen3-VL bridge generation: multimodal fallback injection, deepstack handling, M-RoPE calls, and position advancement should be explicit call-IR operations. Kimi/DeepSeek MLA decode and prefill selection follows after both phases have exact kernel-map providers. Tokenizer adapters may retain family knowledge only while hydrating external metadata into canonical configuration.</p>
+
+<p>This refactor prevents four concrete failure classes: model names silently changing tensor dimensions, undeclared weights being ignored by family branches, unavailable sliding attention falling back to ordinary attention, and generated runtimes enabling multimodal or quantized behavior from a family-name test instead of a hydrated capability.</p>
+
+<p>Tokenizer and format adapters may identify an external model family while translating source metadata into the canonical circuit/config representation. That knowledge must stop at hydration. It is not permission for GraphIR construction, lowering, memory planning, or codegen to select mathematics from a family name.</p>
+
 <h2>Threading Is an Execution Contract</h2>
 
 <p>Kernel maps also declare ISA dispatch, threading runtime, possible work partitions, dispatch mechanisms, and whether scheduling can alter reduction order. Q4/Q6 GEMM and GEMV maps therefore expose serial, row, column, or output-tile policies instead of hiding threadpool behavior in generated wrappers. GraphIR records this as <code>resolved_execution</code>, and LoweredIR plus call-ready IR hard-fail if the kernel ID changes. When partitioning changes arithmetic order, the numerical contract must define the corresponding reduction and merge behavior.</p>
@@ -1068,6 +1106,39 @@
 <div class="contract-note">
   <strong>Migration policy:</strong> add one operator family at a time. Record current semantics, add leaf and public-route tests, declare circuit requirements, enrich real kernel maps, prove generated artifact equivalence, run stitched parity, then promote the route.
 </div>
+
+<h2>X-Ray Fix Progression</h2>
+
+<p>Every X-ray failure follows the same additive progression. The report embeds these steps so another agent does not repeat an already diagnosed numerical bug.</p>
+
+<ol>
+  <li>Stop at the first divergent semantic edge and classify its storage, compute, reduction, position, layout, circuit, binding, and threading contract.</li>
+  <li>Resolve an exact compatible kernel-map capability. Zero or multiple providers hard-fail.</li>
+  <li>Fix the existing implementation or add one new additive variant. Do not alter unrelated numerical variants.</li>
+  <li>Extend the kernel-family matrix across input storage, compute and accumulator precision, reduction and merge order, rounding points, output storage, and threading semantics.</li>
+  <li>Test the leaf kernel against an independent formula and the requested PyTorch or llama.cpp backend oracle.</li>
+  <li>Register the exact validated function in the kernel map, then run isolated, contract-resolution, stitched-checkpoint, mixed-prefill, and teacher-forced gates.</li>
+  <li>Rerun X-ray from the last passing checkpoint. The accepted fix must move the first divergence to a later semantic edge.</li>
+  <li>Publish the capability evidence in the test-report accordion and nightly artifacts before promoting the route.</li>
+</ol>
+
+<h2>Measured BF16 Vision Progression</h2>
+
+<p>The Qwen3-VL BF16 investigation demonstrates the closure rule on a real 1152&times;896 form image with 4,032 visual tokens. Each row was reached through the normal compiler and exact kernel-map resolution; no generated C was edited by hand.</p>
+
+<table>
+  <thead><tr><th>Semantic edge</th><th>Before relative RMSE</th><th>After relative RMSE</th><th>Resolved capability</th></tr></thead>
+  <tbody>
+    <tr><td>Frontend position output</td><td>1.899e-2</td><td>2.361e-5</td><td>BF16 align-corners position storage</td></tr>
+    <tr><td>Layer 0 norm1</td><td>1.225e-2</td><td>5.538e-5</td><td>BF16 storage with matched FP32 reduction</td></tr>
+    <tr><td>Packed QKV projection</td><td>Not yet isolated</td><td>7.129e-5</td><td>BF16 input/weight, FP32 dot, BF16 output</td></tr>
+    <tr><td>Q after M-RoPE</td><td>Wrong generated sections</td><td>7.811e-5</td><td>Full-width multi-section BF16 output</td></tr>
+    <tr><td>Attention context</td><td>1.744e-3</td><td>9.258e-4</td><td>BF16 Q/K/V, FP32 online reduction, BF16 output</td></tr>
+    <tr><td>Output projection</td><td>Not yet isolated</td><td>6.059e-4</td><td>BF16 input/weight, FP32 dot, BF16 output</td></tr>
+  </tbody>
+</table>
+
+<p>The next edge is always explicit. After output projection the resolver selects the BF16 residual capability, then X-ray continues through norm2, MLP, spatial merge, projector, final prefix, mixed-prefill logits, and teacher-forced generation. A green leaf test without this forward movement is evidence for a kernel only, not closure of the model bug.</p>
 
 <h2>Validation Commands</h2>
 
@@ -1307,7 +1378,8 @@ make v8-regression-fast</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1315,13 +1387,14 @@ make v8-regression-fast</code></pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-numerical-contracts.html
+++ b/docs/site/v8-numerical-contracts.html
@@ -1112,6 +1112,9 @@ make v7-regression-fast</code></pre>
 <p>Every X-ray failure follows the same additive progression. The report embeds these steps so another agent does not repeat an already diagnosed numerical bug.</p>
 
 <ol>
+  <li>Compare execution policy first: prefill segmentation, kernel batch shapes, position progression, cache reset/append behavior, and cache strides. A combined 1,307-row prefill is not numerically equivalent evidence for a backend that executes 33, 1,008, and 266-row segments.</li>
+  <li>For incremental decode, prove cache state before attention math: compare append index, current post-RoPE K/V, stored-row readback, the previous row, and hashes for every valid cache row.</li>
+  <li>Only when query and valid cache bytes agree, compare attention providers, split thresholds, worker partitions, probability/value rounding, and merge order.</li>
   <li>Stop at the first divergent semantic edge and classify its storage, compute, reduction, position, layout, circuit, binding, and threading contract.</li>
   <li>Resolve an exact compatible kernel-map capability. Zero or multiple providers hard-fail.</li>
   <li>Fix the existing implementation or add one new additive variant. Do not alter unrelated numerical variants.</li>
@@ -1121,6 +1124,15 @@ make v7-regression-fast</code></pre>
   <li>Rerun X-ray from the last passing checkpoint. The accepted fix must move the first divergence to a later semantic edge.</li>
   <li>Publish the capability evidence in the test-report accordion and nightly artifacts before promoting the route.</li>
 </ol>
+
+<p>The bounded execution-state comparator preserves this order in a machine-readable report:</p>
+
+<pre><code>python version/v8/scripts/xray_execution_state_v8.py \
+  --subject-trace build/xray/ck-execution-trace.json \
+  --oracle-trace build/xray/llama-execution-trace.json \
+  --output build/xray/execution-state-report.json</code></pre>
+
+<p>It stops at one of four useful boundaries: execution-policy mismatch, cache metadata/content mismatch, attention-input mismatch, or attention-arithmetic mismatch. Tensor bisection begins only after the execution and state contracts agree.</p>
 
 <h2>Measured BF16 Vision Progression</h2>
 
@@ -1139,6 +1151,26 @@ make v7-regression-fast</code></pre>
 </table>
 
 <p>The next edge is always explicit. After output projection the resolver selects the BF16 residual capability, then X-ray continues through norm2, MLP, spatial merge, projector, final prefix, mixed-prefill logits, and teacher-forced generation. A green leaf test without this forward movement is evidence for a kernel only, not closure of the model bug.</p>
+
+<h2>Execution-Contract X-Ray</h2>
+
+<p>Tensor parity cannot diagnose a backend that executes the same mixed prefix with a different schedule. X-ray therefore records prefill segmentation, cache transitions, position transitions, exact shared-library identity, and the manifest-map identity alongside numerical checkpoints.</p>
+
+<table>
+  <thead><tr><th>Mixed-prefix contract</th><th>Required behavior</th><th>Failure meaning</th></tr></thead>
+  <tbody>
+    <tr><td>Segments</td><td><code>text_before -&gt; visual -&gt; text_after</code></td><td>A combined prefix changes projection reduction shape and rounding.</td></tr>
+    <tr><td>Cache transition</td><td><code>append_preserve</code></td><td>A segment must retain all prior K/V rows and append at the physical token offset.</td></tr>
+    <tr><td>Position transition</td><td><code>segment_defined</code></td><td>Physical cache position and semantic M-RoPE text position must not be conflated.</td></tr>
+    <tr><td>Runtime evidence</td><td>Exact generated library and manifest-map hashes</td><td>A stale converted manifest or rebuilt runtime invalidates attribution.</td></tr>
+  </tbody>
+</table>
+
+<p>On the 1,008-token Qwen3-VL form cases, the old single-call path diverged from llama.cpp as early as generated step 4. Circuit-driven segmented append removed the cache-state failure, but a later close-ranking flip remained. X-ray then showed that the visual M-RoPE cache was exact while only the rotated second half differed. Basis-vector replay isolated two compiler-visible rounding points: llama.cpp rounds the partner product before each <code>fmaf</code>, and its frequency recurrence uses the system <code>powf</code>, <code>sinf</code>, and <code>cosf</code> behavior. CK now names that evaluation order in the numerical contract and implements it explicitly.</p>
+
+<p>The resulting production gate is exact for both canonical OCR forms: each full <code>1008 x 16384</code> decoder-facing visual prefix matches llama.cpp across all 16,515,072 FP32 values, and both 128-token greedy runs match 128/128 top-1 tokens. Minimum logits cosine was 0.98892 and 0.99168 respectively, with at least 14/16 top-k overlap. This closes these two fixtures, not the unexecuted 40-image sweep or every multimodal family.</p>
+
+<p>The investigation also invalidated an earlier packed Q4_K&times;Q8_K diagnosis. The apparent packed-reduction failure was downstream of the M-RoPE ULP and a report that recorded the generated decoder library but not its dynamically loaded engine library. X-ray now defaults the raw llama.cpp oracle to one thread, rejects multi-threaded exact capture without an explicit opt-in, and records the engine, generated model, llama shim, and manifest identities. A downstream kernel is not blamed until exact-input replay and complete runtime provenance both pass.</p>
 
 <h2>Validation Commands</h2>
 

--- a/docs/site/v8-runbook.html
+++ b/docs/site/v8-runbook.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -860,10 +861,12 @@
         <nav class="site-nav">
             <a href="index.html" class="">Home</a>
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
-            <a href="quickstart.html" class="">Getting Started</a>
+            <a href="quickstart.html" class="active">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1730,7 +1733,8 @@ make v8-visualizer-vision-artifacts</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1738,13 +1742,14 @@ make v8-visualizer-vision-artifacts</pre>
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/v8-vision-encoder.html
+++ b/docs/site/v8-vision-encoder.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1147,7 +1150,7 @@
     <div class="v8-vision-panel">
         <h2>Validated Components</h2>
         <ul>
-            <li><strong>Template:</strong> <code>version/v8/circuits/qwen3_vl_vision.json</code></li>
+            <li><strong>Circuit:</strong> <code>version/v8/circuits/qwen3_vl_vision.json</code></li>
             <li><strong>Converter:</strong> <code>version/v8/scripts/convert_gguf_to_bump_v8.py</code></li>
             <li><strong>Lowering:</strong> <code>version/v8/scripts/build_ir_v8.py</code></li>
             <li><strong>Host bridge:</strong> <code>version/v8/scripts/run_multimodal_bridge_v8.py</code></li>
@@ -1931,7 +1934,8 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1939,13 +1943,14 @@
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/version-history.html
+++ b/docs/site/version-history.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1193,7 +1196,7 @@
       <div class="arch-node-dot"></div>
     </div>
     <div class="arch-arrow-right">→</div>
-    <div class="arch-node">
+    <div class="arch-node current">
       <div class="arch-node-badge arch-v8">v8-9</div>
       <div class="arch-node-label">Vision</div>
       <div class="arch-node-dot"></div>
@@ -1757,6 +1760,49 @@
     }
   </script>
 
+  <h2>Current Execution Order</h2>
+  <p style="color: var(--text-secondary);">
+    New model families are added only after their mathematical requirements can be expressed by circuits and
+    resolved exactly through kernel capabilities. The compiler emits the resolved decision; it does not infer a
+    model-specific fallback. This keeps correctness work reusable across text, vision, and audio.
+  </p>
+  <table class="roadmap-table">
+    <thead>
+      <tr>
+        <th>Order</th>
+        <th>Workstream</th>
+        <th>Exit Gate</th>
+        <th>State</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td><strong>v8 compiler and numerical hardening</strong><br>Circuits, kernel maps, exact resolution, bounded X-ray attribution, and zero model-family dispatch in protected compiler paths.</td>
+        <td>Supported text and vision circuits compile deterministically; incompatible or ambiguous capabilities hard-fail; stitched and end-to-end regressions remain clean.</td>
+        <td><span class="version-status status-building">Active</span></td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td><strong>Qwen3-VL parity closure</strong><br>Encoder checkpoints, mixed prefill, teacher-forced decode, and persistent decode against llama.cpp and PyTorch references.</td>
+        <td>First-divergence reports advance through every remaining boundary and each fix is retained by a numerical contract plus nightly coverage.</td>
+        <td><span class="version-status status-building">Active</span></td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td><strong>Whisper tiny/base inference</strong><br>PCM/WAV, resampling, STFT, log-Mel, Conv1D encoder stem, bidirectional encoder attention, decoder cross-attention, and audio token semantics.</td>
+        <td>Fixed public audio fixtures match PyTorch and whisper.cpp at frontend, encoder, mixed-prefill, and transcript boundaries before quantized optimization.</td>
+        <td><span class="version-status status-planned">Next</span></td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td><strong>Audio performance and FP32 training</strong><br>Encoder tiling/threading, cached cross-attention K/V, then Conv1D and cross-attention backward in v7.</td>
+        <td>Inference parity is stable; performance evidence separates frontend, encoder, and autoregressive decode; FP32 backward matches PyTorch.</td>
+        <td><span class="version-status status-planned">Gated</span></td>
+      </tr>
+    </tbody>
+  </table>
+
   <!-- Detailed Roadmap Table -->
   <h2>Detailed Roadmap</h2>
   <table class="roadmap-table">
@@ -1800,30 +1846,30 @@
       </tr>
       <tr>
         <td><strong>v8.0</strong></td>
-        <td>Vision Encoder</td>
-        <td>Patch embedding lowering, image positional encoding, ViT support, and block-local multimodal stitching groundwork</td>
+        <td>Inference Compiler + Vision Encoder</td>
+        <td>Circuit-owned topology and weight policy, fail-closed kernel capability resolution, explicit numerical and threading contracts, GraphIR-to-call-IR decision preservation, bounded X-ray attribution, patch embedding, resized position encoding, M-RoPE, deepstack, and multimodal stitching</td>
         <td>v7.x training</td>
         <td><span class="version-status status-building">Building</span></td>
       </tr>
       <tr>
         <td><strong>v9.0</strong></td>
-        <td>Vision Training</td>
-        <td>Backward through vision encoder, image classification fine-tuning</td>
+        <td>Vision Parity + Training</td>
+        <td>Qwen3-VL encoder, mixed-prefill, teacher-forced and persistent-decode parity; then FP32 backward through vision encoder and image fine-tuning</td>
         <td>v8.0</td>
         <td><span class="version-status status-planned">Planned</span></td>
       </tr>
       <tr>
         <td><strong>v10.0</strong></td>
-        <td>Audio Encoder</td>
-        <td>Conformer/Whisper-style encoder, spectrogram preprocessing</td>
-        <td>v7.x training</td>
+        <td>Audio Inference</td>
+        <td>Whisper tiny/base first: PCM/WAV ingestion, resampling, STFT and log-Mel preprocessing, Conv1D stem, bidirectional encoder, cached encoder-decoder cross-attention, and transcript parity</td>
+        <td>v8 exact resolution + X-ray gates</td>
         <td><span class="version-status status-planned">Planned</span></td>
       </tr>
       <tr>
         <td><strong>v11.0</strong></td>
         <td>Audio Training</td>
-        <td>Backward through audio encoder, speech recognition training</td>
-        <td>v10.0</td>
+        <td>FP32 Conv1D, encoder-attention and cross-attention backward; speech recognition training after inference parity. Log-Mel remains fixed preprocessing initially.</td>
+        <td>v10.0 inference parity</td>
         <td><span class="version-status status-planned">Planned</span></td>
       </tr>
       <tr>
@@ -2395,11 +2441,11 @@
     Version numbers follow this convention:
   </p>
   <ul style="color: var(--text-secondary);">
-    <li><strong>Current priority (2026):</strong> Complete v7.x training sign-off while actively bringing up v8.x vision inference foundations before opening v15 implementation</li>
+    <li><strong>Current priority (2026):</strong> Keep v7 FP32 training parity stable, finish v8 fail-closed compiler and Qwen3-VL numerical hardening, then bring up Whisper tiny/base inference through the same circuit and kernel-contract path</li>
     <li><strong>v6.x:</strong> Inference-only (forward pass)</li>
     <li><strong>v7.x:</strong> Training foundation (forward + backward)</li>
-    <li><strong>v8.x:</strong> Vision encoding and image training foundations, now in active bring-up</li>
-    <li><strong>v10.x:</strong> Audio encoding and audio training foundations</li>
+    <li><strong>v8.x:</strong> Deterministic inference compiler, numerical contracts, X-ray attribution, and vision encoding, now in active hardening</li>
+    <li><strong>v10.x:</strong> Whisper-style audio inference after v8 contract and parity gates; FP32 audio training follows in v11</li>
     <li><strong>v12.x:</strong> MoE architecture (efficient large models)</li>
     <li><strong>v14.x:</strong> Parameter-efficient fine-tuning (LoRA)</li>
     <li><strong>v15.x:</strong> Embedded AI inference on constrained hardware (enabled by v1-v14 groundwork)</li>
@@ -2670,7 +2716,8 @@ console.log('Roadmap: ' + versionData.roadmap.map(v => 'v' + v.major).join(' →
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -2678,13 +2725,14 @@ console.log('Roadmap: ' + versionData.roadmap.map(v => 'v' + v.major).join(' →
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-10</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -265,6 +265,7 @@
 
         /* Main Content */
         main {
+            box-sizing: border-box;
             max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
@@ -862,8 +863,10 @@
             <a href="spectrum.html" class="" style="color:var(--orange)">⚡ Spectrum</a>
             <a href="quickstart.html" class="">Getting Started</a>
             <a href="developer-guide.html" class="">Developer Guide</a>
+            <a href="contributing.html" class="">Contribute</a>
             <a href="scaling.html" class="">Scaling</a>
-            <a href="cke-throughput-unit.html" class="{{NAV_CKU}}" style="color:var(--orange)">CKU</a>
+            <a href="support-hardware.html" class="" style="color:var(--green)">Support Lab</a>
+            <a href="cke-throughput-unit.html" class="" style="color:var(--orange)">CKU</a>
             <div class="nav-dropdown">
                 <span class="nav-trigger">Architecture</span>
                 <div class="nav-dropdown-menu mega-menu">
@@ -1062,7 +1065,7 @@ permalink: /vision-encoder-parity/
     The Qwen3-VL encoder path is driven by:
   </p>
   <ul>
-    <li>the template in <code>version/v8/circuits/qwen3_vl_vision.json</code></li>
+    <li>the circuit in <code>version/v8/circuits/qwen3_vl_vision.json</code></li>
     <li>kernel maps in <code>version/v8/kernel_maps/*.json</code></li>
     <li>kernel-map-owned <code>call_abi</code> declarations for every contract-governed provider</li>
   </ul>
@@ -1317,7 +1320,8 @@ permalink: /vision-encoder-parity/
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Resources</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/antshiv/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://github.com/C-Kernel-Engine/C-Kernel-Engine" style="color: #909090; text-decoration: none; font-size: 0.875rem;">GitHub</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="contributing.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Contributor Path</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="architecture.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Architecture</a></li>
                     <li style="margin-bottom: 0.5rem;"><a href="api.html" style="color: #909090; text-decoration: none; font-size: 0.875rem;">API Reference</a></li>
                 </ul>
@@ -1325,13 +1329,14 @@ permalink: /vision-encoder-parity/
             <div>
                 <h4 style="color: #ffb400; margin-bottom: 0.75rem; font-size: 1rem;">Related</h4>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="margin-bottom: 0.5rem;"><a href="https://pytorch.org" style="color: #909090; text-decoration: none; font-size: 0.875rem;">PyTorch</a></li>
-                    <li style="margin-bottom: 0.5rem;"><a href="https://antsand.com" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antsand.com</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">ShivasNotes</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://www.shivasnotes.com/work-with-us" style="color: #909090; text-decoration: none; font-size: 0.875rem;">Work With Us</a></li>
+                    <li style="margin-bottom: 0.5rem;"><a href="https://antshiv.com/" style="color: #909090; text-decoration: none; font-size: 0.875rem;">antshiv.com</a></li>
                 </ul>
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-11</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
             </div>
         </div>
     </footer>

--- a/docs/site/vision-encoder-parity.html
+++ b/docs/site/vision-encoder-parity.html
@@ -951,159 +951,280 @@
     <main>
 ---
 layout: default
-title: Vision Encoder Parity
+title: Qwen3-VL Numerical Parity
 permalink: /vision-encoder-parity/
 ---
 
 <div class="container">
-  <h1>Vision Encoder Parity</h1>
+  <h1>Qwen3-VL Numerical Parity</h1>
   <p class="lead">
-    Qwen3-VL vision encoder parity was closed on March 30, 2026.
-    The generated C runtime now matches local llama.cpp end to end in native strict mode.
-  </p>
-
-  <div class="alert alert-success">
-    <strong>Current Result:</strong>
-    Native strict parity for the generated v8 Qwen3-VL encoder is exact:
-    <code>max_abs=0.0</code>,
-    <code>mean_abs=0.0</code>,
-    <code>rmse=0.0</code>,
-    <code>cosine=1.0</code>.
-    This is not the temporary mtmd-oracle shortcut.
-  </div>
-
-  <h2>What Was Actually Wrong</h2>
-  <p>
-    The final blocker was not patching, not deepstack stitching, and not a missing attention op.
-    We initially localized the drift to full attention because that was the first place tiny errors became visible.
-    The real remaining seed was later in the layer:
-    <strong>the GGML fp16-table GELU path was not bit-identical to llama.cpp</strong>.
-  </p>
-  <p>
-    Once layer-0 attention became exact, the first remaining mismatch showed up at
-    <code>ffn_gelu</code>, then propagated through <code>ffn_out</code>, residual addition,
-    and the remaining encoder stack.
-  </p>
-
-  <h2>Why This Took Time</h2>
-  <div class="card">
-    <h3 style="margin-top: 0;">Encoder Parity Is Not Just "Correct Math"</h3>
-    <p>
-      For decoder bring-up, mathematically correct kernels were often enough to converge quickly.
-      For this vision encoder, the target was <strong>ggml-exact graph behavior</strong>.
-      Tiny <code>fp32</code> or <code>fp16</code> rounding differences that look harmless in one row
-      compound across full attention, MLP, and 27 layers of residual accumulation.
-    </p>
-    <p>
-      The painful lesson is simple:
-      <strong>if a model is loaded from GGUF and the reference is llama.cpp, "close" is not done.</strong>
-    </p>
-  </div>
-
-  <h2>Method That Worked</h2>
-  <ol>
-    <li>Get end-to-end parity metrics first, so the failure is measurable.</li>
-    <li>Dump per-activation tensors for both CK and llama.cpp.</li>
-    <li>Find the first layer and first tensor that diverges.</li>
-    <li>Replay that tensor boundary in isolation until the drift is explained.</li>
-    <li>Fix the exact seed error, then rerun end-to-end because later layers amplify tiny misses.</li>
-  </ol>
-
-  <div class="alert alert-info">
-    <strong>Do not skip the first-divergence step.</strong>
-    Large final embedding drift does not imply a large bug.
-    In this case, a tiny fp16-table activation mismatch was enough to poison later layers.
-  </div>
-
-  <h2>Major Issues To Watch For On Future Encoder Ports</h2>
-  <div class="grid grid-2">
-    <div class="card">
-      <h3 style="margin-top: 0;">1. GGML-Exact Activation Tables</h3>
-      <p>
-        If the reference path uses lookup-table math, especially fp16 tables,
-        do not assume a "same formula" implementation is enough.
-        The exact table and the exact fp32→fp16 conversion path matter.
-      </p>
-    </div>
-    <div class="card">
-      <h3 style="margin-top: 0;">2. Full Attention Is Less Forgiving</h3>
-      <p>
-        Full bidirectional attention spreads tiny row-level differences across the entire layer.
-        Decoder-style causal paths tend to localize drift much more naturally.
-      </p>
-    </div>
-    <div class="card">
-      <h3 style="margin-top: 0;">3. Mixed Dtype Boundaries Matter</h3>
-      <p>
-        Even when most activations are <code>fp32</code>, the decisive mismatch may come from an fp16 lookup,
-        quantized projection boundary, or a reference-only conversion convention.
-      </p>
-    </div>
-    <div class="card">
-      <h3 style="margin-top: 0;">4. Standalone Test Builds Must Track Runtime Splits</h3>
-      <p>
-        Splitting production code into new helper files is safe, but standalone libs and generated harnesses
-        must be updated too. Otherwise the main engine passes while test-only link targets fail.
-      </p>
-    </div>
-  </div>
-
-  <h2>What To Check First On The Next Encoder</h2>
-  <ul>
-    <li>Template contract: make sure the model path is expressed in the template, not hidden in lowering code.</li>
-    <li>Kernel map coverage: verify every required op resolves to a concrete kernel id before codegen.</li>
-    <li>Layer-0 first divergence: do not start with layer 12 or final embeddings.</li>
-    <li>Reference activations: dump both sides and replay isolated seams before editing kernels broadly.</li>
-    <li>Activation-table parity: GELU, RoPE tables, and any special lookup path deserve direct standalone checks.</li>
-  </ul>
-
-  <h2>Is The v8 IR Builder Hard-Coded?</h2>
-  <p>
-    Mostly no, but not perfectly no.
-  </p>
-  <p>
-    The Qwen3-VL encoder path is driven by:
-  </p>
-  <ul>
-    <li>the circuit in <code>version/v8/circuits/qwen3_vl_vision.json</code></li>
-    <li>kernel maps in <code>version/v8/kernel_maps/*.json</code></li>
-    <li>kernel-map-owned <code>call_abi</code> declarations for every contract-governed provider</li>
-  </ul>
-  <p>
-    That is the required ownership: model structure in the circuit, exact kernel identity and call ABI in kernel maps, and deterministic stitching in the compiler. Legacy binding registries are compatibility-only and cannot satisfy a resolved numerical contract.
-  </p>
-  <p>
-    But <code>build_ir_v8.py</code> still contains real lowering policy:
-    buffer contracts, generic attention selection, fallback rules, and parameter shaping for vision operators.
-    That policy is mostly <strong>generic vision lowering</strong>, not Qwen3-VL-specific hardcoding,
-    but it is still code, not pure data.
+    Qwen3-VL forced CKE to treat numerical behavior, execution schedules, cache transitions,
+    and position semantics as explicit compiler contracts. This page records what failed,
+    how X-ray attribution evolved, what is proven, and what remains open.
   </p>
 
   <div class="alert alert-warning">
-    <strong>The honest architectural answer:</strong>
-    the system is <strong>template-driven and kernel-driven</strong>, but not yet <strong>100% declarative</strong>.
-    The builder still owns some generic lowering intelligence.
+    <strong>Status on July 14, 2026:</strong> the Q8_0 vision encoder is byte-exact against
+    llama.cpp on the inspected 1008 x 16384 prefixes. Fresh, source-fingerprinted production
+    runs pass 128 generated tokens for the second OCR fixture and the public Fake 2 fixture.
+    The first OCR fixture reproducibly diverges at decoder step 20. Full replay fails at the same
+    step, isolating shared decoder arithmetic rather than persistent cache state. The 5-, 10-,
+    and 40-image gates are intentionally paused until that defect is fixed.
   </div>
 
-  <h2>Regression Gates That Matter</h2>
+  <h2>Evidence, Not A Single Parity Label</h2>
+  <p>Qwen3-VL parity has several independent levels. Passing one does not imply the next.</p>
+  <table>
+    <thead>
+      <tr><th>Level</th><th>Question</th><th>Required evidence</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Vision geometry</td><td>Are the same patches and visual rows produced?</td><td>Grid, prefix rows, embedding width, patch order</td></tr>
+      <tr><td>Encoder values</td><td>Is every visual-prefix value identical?</td><td>Elementwise comparison and byte hash</td></tr>
+      <tr><td>Mixed prefill</td><td>Are visual and text segments executed with the same positions and cache transitions?</td><td>Segment trace, cache metadata, logits</td></tr>
+      <tr><td>Full replay</td><td>Does recomputing the complete prefix produce the same next token?</td><td>Teacher-forced ranking and logits</td></tr>
+      <tr><td>Persistent decode</td><td>Does incremental KV-cache execution stay aligned?</td><td>Token trace through EOS plus cache-state attribution</td></tr>
+      <tr><td>Application</td><td>Does OCR behavior remain aligned across varied images?</td><td>Multi-image output and accuracy sweep</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Current Multi-Image Sweep</h2>
+  <table>
+    <thead>
+      <tr><th>Fixture</th><th>Geometry</th><th>Encoder</th><th>Decoder result</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>OCR fixture 1</td><td>28 x 36, 1008 rows</td><td>Inspected prefix exact</td><td>First top-1 mismatch at step 20; full replay also fails</td></tr>
+      <tr><td>OCR fixture 2</td><td>36 x 28, 1008 rows</td><td>Inspected prefix exact</td><td>128 / 128 top-1 tokens</td></tr>
+      <tr><td>Public Fake 2 fixture</td><td>36 x 28, 1008 rows</td><td>Inspected prefix exact</td><td>128 / 128 top-1 tokens</td></tr>
+      <tr><td>Remaining OCR corpus</td><td>Varied</td><td>Not promoted</td><td>5-, 10-, and 40-image gates pending</td></tr>
+    </tbody>
+  </table>
+  <p>
+    Top-1 equality is a behavioral gate, not a claim that every decoder logit is byte-exact.
+    The landscape run matched all 128 selected tokens while its minimum logits cosine was
+    approximately 0.9504. Close rankings can hide numerical drift until a later prompt or image
+    changes the margin. For that reason the gate records cosine, RMSE, top-k overlap, margins,
+    full replay, and the generated token trace.
+  </p>
+
+  <h2>Why An Ordinary Qwen3 Decoder Was Not Enough</h2>
+  <p>
+    Qwen3-VL reuses a Qwen-like text transformer, but its runtime contract is not simply
+    <code>vision_encoder -&gt; ordinary_Qwen3_decode</code>. The decoder must consume and preserve
+    multimodal state that a text-only Qwen3 path does not have.
+  </p>
   <ul>
-    <li><code>make test-v8-qwen3vl</code></li>
-    <li><code>make test-v8-vision-kernels</code></li>
-    <li><code>make llamacpp-parity-full</code></li>
-    <li><code>make test</code></li>
+    <li>The visual prefix contains projected embeddings, not token IDs that can be passed through the normal embedding lookup.</li>
+    <li>Deepstack streams are injected at specific decoder layers in addition to the base visual embedding.</li>
+    <li>Multimodal M-RoPE uses text, row, and column position semantics instead of ordinary one-dimensional text positions.</li>
+    <li>Physical KV-cache indices and semantic M-RoPE positions are related but not interchangeable.</li>
+    <li>llama.cpp executes <code>text_before -&gt; visual -&gt; text_after</code> as cache-preserving prefill segments.</li>
+    <li>Incremental decode must append one K/V row without modifying any previous row and must advance all position state correctly.</li>
+  </ul>
+  <p>
+    The core decoder weights may be Qwen3-shaped, but the bridge, execution schedule, position
+    contract, deepstack injection, and cache lifecycle make Qwen3-VL a distinct stitched circuit.
+  </p>
+
+  <h2>What Actually Failed</h2>
+  <div class="grid grid-2">
+    <div class="card">
+      <h3 style="margin-top: 0;">Frontend And Geometry</h3>
+      <p>Resize policy, patch order, tiled position interpolation, and floating-point evaluation order all had to match the reference.</p>
+    </div>
+    <div class="card">
+      <h3 style="margin-top: 0;">Vision M-RoPE</h3>
+      <p>Rotary width, pair count, split-half partner indexing, axis sections, recurrence, and rounding points were initially conflated.</p>
+    </div>
+    <div class="card">
+      <h3 style="margin-top: 0;">Reference Math</h3>
+      <p>GGML fp16-table GELU, Q8 activation thresholds, FP16 K/V storage, online softmax, split thresholds, and merge order exposed differences hidden by formula-level tests.</p>
+    </div>
+    <div class="card">
+      <h3 style="margin-top: 0;">Capability Identity</h3>
+      <p>A legacy FP32 decode function incorrectly advertised the FP16 online/FP32 merge capability. Resolution was deterministic but followed false metadata until the explicit contract provider became authoritative.</p>
+    </div>
+    <div class="card">
+      <h3 style="margin-top: 0;">Bridge And Decoder State</h3>
+      <p>Combined versus segmented prefill, deepstack placement, semantic versus physical positions, append indices, cache strides, and persistent state all affected the result.</p>
+    </div>
+    <div class="card">
+      <h3 style="margin-top: 0;">Diagnostic Artifacts</h3>
+      <p>Some Q/K/V dumps used different layouts. Internal llama.cpp dumps disabled flash attention. Stale generated libraries and incomplete runtime hashes produced misleading comparisons.</p>
+    </div>
+    <div class="card">
+      <h3 style="margin-top: 0;">Harness Semantics</h3>
+      <p>Comparing after both runtimes emitted EOS created a false divergence. Segmented full replay produced multiple valid checkpoint files, and unsupported checkpoint aliases previously triggered long runs that emitted nothing.</p>
+    </div>
+  </div>
+
+  <h2>Bug Stages And Fix Ownership</h2>
+  <table>
+    <thead>
+      <tr><th>Stage</th><th>Failure class</th><th>Observed example</th><th>Correct owner</th><th>Regression evidence</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Reference harness</td><td>Invalid comparison window</td><td>Tokens were compared after both runtimes emitted EOS.</td><td>Parity runner and bridge stop-token metadata</td><td>EOS-aware multitoken tests</td></tr>
+      <tr><td>Reference adapter</td><td>Wrong tensor or backend mode</td><td>Segmented replay selected the wrong Q/K occurrence; internal llama.cpp dumps could change flash mode.</td><td>llama.cpp/PyTorch adapter and parity profile</td><td>Occurrence, alias, layout, and mode-metadata tests</td></tr>
+      <tr><td>Generated artifact</td><td>Stale or uninstrumented runtime</td><td>A cached library omitted imported compiler sources from its fingerprint or lacked <code>CK_PARITY_DUMP</code>.</td><td>Runtime builder and capture preflight</td><td>Source-set fingerprint and instrumentation rejection tests</td></tr>
+      <tr><td>Circuit</td><td>Wrong execution semantics</td><td>Combined prefill did not express <code>text_before -&gt; visual -&gt; text_after</code> cache-preserving execution.</td><td>Circuit schedule, bridge contract, and semantic positions</td><td>Segmented-prefill and call-IR tests</td></tr>
+      <tr><td>Kernel map</td><td>False capability advertisement</td><td>A legacy FP32 decode function claimed an FP16 online-softmax/FP32-merge contract.</td><td>Exact provider capability and resolver</td><td>Zero/ambiguous provider failures and resolved-function assertions</td></tr>
+      <tr><td>Kernel</td><td>Missing numerical implementation</td><td>RMSNorm/QK normalization needed an explicit ascending FP64 row-sum provider.</td><td>Leaf kernel with exact storage, arithmetic, reduction, and threading contract</td><td>Concrete scalar oracle and production-shape tests</td></tr>
+      <tr><td>Stateful execution</td><td>Cache or position mismatch</td><td>Persistent decode can differ from full replay through append index, stride, M-RoPE position, or prior-row corruption.</td><td>Execution-state X-ray and runtime state API</td><td>Bounded cache metadata, row-hash, and replay classification tests</td></tr>
+      <tr><td>Remaining arithmetic</td><td>Small seed amplified later</td><td>At image-1 step 20, Q/K first differ near 1.79e-7; post-RoPE K reaches 4.58e-5 and attention first materially fails near 1.47e-4.</td><td>Same-input primitive oracle, then kernel or capability selected by evidence</td><td>Not closed; no tolerance relaxation permitted</td></tr>
+    </tbody>
+  </table>
+  <p>
+    The harness is part of the correctness architecture, not disposable test scaffolding. A faulty
+    adapter can falsely accuse a correct kernel, while a permissive harness can conceal a real
+    circuit or reduction defect. Every diagnosed harness failure therefore receives a regression
+    test and enters the same nightly report as kernel and compiler contracts.
+  </p>
+
+  <h2>Rejected Hypotheses And Negative Results</h2>
+  <p>
+    A rejected experiment is retained as bounded evidence, not treated as wasted work. Its conclusion
+    applies only to the recorded model, tensor boundary, compiler, ISA, and execution mode.
+  </p>
+  <table>
+    <thead>
+      <tr><th>Hypothesis or intervention</th><th>Observed result</th><th>Conclusion for this failure</th><th>Where it may still matter</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Disable AVX-512 VNNI</td><td>Native VNNI and native no-VNNI layer-0 MLP boundaries were identical; forced AVX2 still differed.</td><td>VNNI was not the source of that encoder drift.</td><td>Other quant formats, compiler versions, or kernels with different VNNI implementations.</td></tr>
+      <tr><td>Change the simple AVX2 Q8 dot-product accumulation wrapper</td><td>The layer-0 MLP-up metrics did not move.</td><td>The wrapper was not the first cause; activation quantization or the batched GEMM path remained stronger suspects.</td><td>Shapes routed directly through the wrapper rather than the batched path.</td></tr>
+      <tr><td>Force scalar/reference Q4 projection at image-1 step 20</td><td>The token mismatch and granular metrics were unchanged.</td><td>The selected Q4 SIMD provider was not responsible for the current step-20 seed.</td><td>Other layers, shapes, weight formats, ISAs, or exact-input projection failures.</td></tr>
+      <tr><td>Force reference Q6 projection</td><td>The step-20 result was unchanged.</td><td>The V projection/Q6 provider was not the current first cause.</td><td>Later Q6 MLP-down boundaries and different natural inputs.</td></tr>
+      <tr><td>Force exact M-RoPE, alone and with reference projections</td><td>The step-20 result was unchanged.</td><td>The tested M-RoPE implementation was not the remaining top-1 cause.</td><td>Different position grids, partial rotary widths, section patterns, or BF16 storage contracts.</td></tr>
+      <tr><td>Attribute the mismatch to persistent KV state</td><td>Full replay failed at the same generated step as persistent decode.</td><td>The remaining failure is shared arithmetic after the replay inputs are reconstructed.</td><td>Other images and steps where persistent decode fails but full replay matches.</td></tr>
+      <tr><td>Trust an older strict-mode pass</td><td>Source-set fingerprinting rebuilt the runtime and reproduced the failure.</td><td>The earlier pass was stale-artifact evidence and cannot support a parity claim.</td><td>Strict mode remains useful when explicitly labeled and built from the same source identity.</td></tr>
+      <tr><td>Compare production logits with an internal-dump reference run without mode metadata</td><td>Some llama.cpp internal captures can disable flash attention.</td><td>That comparison changes the oracle execution mode and cannot attribute production-flash arithmetic.</td><td>Unfused-to-unfused diagnostic comparisons when both sides declare the mode explicitly.</td></tr>
+    </tbody>
+  </table>
+  <p>
+    Future agents should rerun a rejected path only when at least one recorded condition changes.
+    A new ISA, compiler, model shape, storage dtype, backend mode, or first-divergence boundary is a
+    valid reason. Repeating the same intervention on the same evidence is not.
+  </p>
+
+  <h2>Why Small Differences Became Large Failures</h2>
+  <p>
+    The difficult bugs were rarely grossly incorrect matrix multiplication. They were differences
+    in when values were rounded, how reductions were partitioned, and which state was reused.
+    A one-ULP input change can cross a Q8 scale or code threshold. The following projection expands
+    that changed code across many outputs, residual layers accumulate it, and a close token ranking
+    can eventually flip even when cosine similarity remains high.
+  </p>
+  <p>
+    Sequence length and threading also change algorithms. At a KV threshold, a reference can move
+    from one online-softmax reduction to worker-local partials and an ordered merge. Diagnostic
+    capture can disable a production flash path. A test is valid only when backend mode, dtype,
+    thread count, partitioning, runtime libraries, positions, and input bytes are recorded together.
+    CKE's global strict flag is also an execution mode, not proof of correctness: it can select
+    diagnostic implementations that differ from the circuit-resolved production providers.
+  </p>
+
+  <h2>Three Numerical Lanes</h2>
+  <table>
+    <thead>
+      <tr><th>Lane</th><th>Reference</th><th>Primary risks</th><th>Current claim</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>AVX2 GGUF</td><td>llama.cpp</td><td>Q8 quantization, AVX2 reduction order, FP16 cache attention, persistent state</td><td>Encoder exact on tested fixtures; decoder sweep still open</td></tr>
+      <tr><td>AVX-512 GGUF</td><td>llama.cpp</td><td>ISA dispatch, VNNI/non-VNNI routing, reduction and cache contracts</td><td>Separate Xeon validation is required; results are not inferred from AVX2</td></tr>
+      <tr><td>BF16 / AMX</td><td>PyTorch</td><td>BF16 storage boundaries, SDPA tiling, LayerNorm/GEMM rounding, M-RoPE</td><td>Leaf and practical contracts are strong; full BF16 encoder and generation are not byte-exact</td></tr>
+    </tbody>
+  </table>
+
+  <h2>How X-Ray Had To Evolve</h2>
+  <p>
+    The first X-ray implementation compared named tensors and found the first divergent layer or op.
+    That was necessary but insufficient for a stateful multimodal decoder. The current workflow checks
+    execution state before expensive tensor capture.
+  </p>
+  <ol>
+    <li>Verify runtime, model, engine, shim, manifest, compiler, ISA, thread, and attention-mode identity.</li>
+    <li>Compare prefill segmentation and the actual kernel batch shapes.</li>
+    <li>Compare physical cache count, append index, strides, and semantic positions.</li>
+    <li>Verify the newly appended FP16 K/V row round-trips and every previous row remains unchanged.</li>
+    <li>Hash and compare every valid cache row, reporting the first and worst logical coordinates.</li>
+    <li>Use full replay at the failing token to classify persistent-state versus shared arithmetic failures.</li>
+    <li>Bisect sparse layers, then every layer in the failing interval, then internal op checkpoints.</li>
+    <li>Replay identical input bytes through the suspected quantizer or kernel before changing production math.</li>
+  </ol>
+  <div class="alert alert-info">
+    <strong>Current varied-image classification:</strong> exact encoder prefixes were established for
+    four inspected fixtures. Fresh, fingerprinted production runs pass 128 tokens for the second OCR
+    image and the public Fake 2 fixture. The first OCR image has a reproducible shared-arithmetic
+    mismatch at generated step 20: persistent and full replay agree with each other but not llama.cpp.
+    An older strict-mode pass was invalidated after source-set hashing forced the stale decoder runtime
+    to regenerate. Granular replay now shows Q/K/V projection, Q/K normalization, and post-RoPE values
+    remain close, with attention output the first material amplification. Production, strict/debug,
+    flash, and diagnostic unfused results are recorded as distinct modes and are never combined into
+    one parity claim.
+  </div>
+
+  <h3>Capture Adapter Guardrails</h3>
+  <ul>
+    <li>Discover checkpoint names from the exact generated decoder source paired with the runtime.</li>
+    <li>Hard-fail unknown names, unavailable layers, or missing replay variants before model initialization.</li>
+    <li>Capture a bounded comma-separated checkpoint set in one persistent run and one replay run.</li>
+    <li>Build or reuse a dedicated parity-instrumented runtime; never expect a production library compiled without <code>CK_PARITY_DUMP</code> to emit tensors.</li>
+    <li>Select segmented files by final physical position and reject unresolved duplicates.</li>
+    <li>Fingerprint imported compiler, circuit, kernel-map, and schema sources so stale generated libraries cannot masquerade as current results.</li>
+    <li>Record strict/debug, flash, repack, threading, model, engine, generated library, and manifest identity in the report.</li>
   </ul>
 
+  <h2>Architecture Hardened By The Investigation</h2>
+  <p>The accepted ownership model is now explicit:</p>
+  <ul>
+    <li><strong>Circuits</strong> own topology, dataflow, execution phases, segmented schedules, semantic positions, required numerical contracts, and checkpoints.</li>
+    <li><strong>Kernel maps</strong> own exact function identity, call ABI, storage and compute dtype, rounding points, reduction order, threading arithmetic, ISA eligibility, and implementation metadata. Distinct functions cannot claim one contract unless both pass its numerical oracle.</li>
+    <li><strong>The resolver</strong> selects exactly one semantically compatible provider and hard-fails on zero, multiple, or incomplete matches.</li>
+    <li><strong>IR and code generation</strong> carry the resolved decision forward. They must not infer model families from function names or inject a model-specific fallback.</li>
+    <li><strong>Parity profiles</strong> own backend tensor mappings, canonical layouts, tolerances, and bounded attribution plans.</li>
+  </ul>
   <p>
-    These four are the minimum confidence set for future encoder compatibility work.
-    If a parity fix only passes one of them, it is not ready.
+    A fix belongs in the circuit when the model requires different graph or schedule semantics, in
+    the kernel map when an existing implementation has a distinct numerical capability, and in a
+    kernel when the required capability does not exist. The DSL should change only to express a
+    generic missing concept, never to special-case Qwen3-VL.
   </p>
+
+  <h2>Regression Gates</h2>
+  <pre><code>make test-v8-dsl
+make test-v8-qwen3vl
+make test-qwen3vl-methodical-parity
+make test-v8-vision-kernels
+make test-numerical-contracts
+make test-attention-f16-split-kv
+make llamacpp-parity-full</code></pre>
+  <p>
+    Artifact-backed encoder, mixed-prefill, teacher-forced, persistent decode, and OCR sweeps remain
+    resource-gated. Missing models or unsupported BF16 hardware must report <code>SKIP</code>, not
+    <code>PASS</code>. Numerical failures are hard failures; performance regressions are reported
+    separately because machine topology and thermal state affect timing.
+  </p>
+
+  <h2>What Happens Next</h2>
+  <ol>
+    <li>Close the first OCR fixture's shared layer-0 attention/reduction mismatch with a same-input production-flash oracle.</li>
+    <li>Rerun the first five fixtures through at least 128 tokens and EOS where bounded.</li>
+    <li>Expand to ten images only after the five-image gate is clean.</li>
+    <li>Run the full 40-image encoder, mixed-prefill, persistent-decode, and OCR sweep.</li>
+    <li>Publish exact artifacts, negative results, compiler and ISA identity, and application accuracy.</li>
+    <li>Resume performance tuning only after correctness remains green.</li>
+  </ol>
 
   <h2>Bottom Line</h2>
   <p>
-    The engine did not need a special-case Qwen3-VL runtime.
-    It needed one more round of exactness at the seam where GGML conventions still mattered.
-    That is a good outcome:
-    the path remained template- and kernel-driven, and the final fix improved the shared exactness story instead of adding one-off model glue.
+    Qwen3-VL was difficult because correctness spans more than kernels and more than a tensor graph.
+    It spans image geometry, dtype boundaries, evaluation order, execution schedules, position spaces,
+    cache transitions, backend modes, and persistent state. X-ray made those contracts observable and
+    converted repeated manual debugging into a bounded first-divergence process. The encoder evidence
+    is now strong, but the project will not call end-to-end parity complete until the varied-image
+    persistent-decode and OCR gates pass.
   </p>
 </div>
     </main>


### PR DESCRIPTION
## Why

CKE's hardest active work includes multimodal numerical parity, ISA-specific reduction behavior, compiler ownership, and distributed execution. Presenting those Level-5 problems without a visible entry path makes useful first-time contributors believe they must understand the entire engine before helping. The documentation site also had inconsistent generated navigation behavior: the CKU token remained unresolved and active navigation state was cleared before it could be applied.

## What changed

- Replaced the old contributor page with a five-level evidence-based contribution ladder, from documentation and Linux distribution compatibility through profiling, numerical fixtures, kernel optimization, compiler/DSL ownership, multimodal parity, and distributed execution.
- Added bounded first-contribution paths, including Arch/CachyOS `flamegraph-rs` integration, reproducible benchmark capture, and reference-test work.
- Added Discord onboarding guidance while keeping GitHub issues and draft pull requests as the durable engineering record.
- Added an original contributor-ladder SVG and linked the contributor path from the README, shared header, and shared footer.
- Fixed static generation so CKU navigation placeholders are resolved and the current page receives its active state before unused navigation placeholders are cleared.
- Regenerated and committed all 74 root documentation pages against current `main`, including the previously ungenerated BF16/AMX study.

## Evidence

- All 74 generated root pages contain the contributor navigation route and footer link.
- No generated page contains unresolved `NAV`, `PAGE_TITLE`, or `CURRENT_DATE` template tokens.
- The contributor page has no missing local links or image assets.
- Desktop and 390 px mobile renders were inspected; the mobile document and body scroll widths both equal the 390 px viewport.
- The CKU page and contributor page each receive the correct active navigation class.

## Validation

- `CK_SITE_SKIP_SPEC_TRAINING_REFRESH=1 bash docs/site/build.sh` completed successfully on current `origin/main`.
- `python3 -m json.tool docs/site/page_metadata.json` passed.
- `docs/site/assets/contributor-ladder.svg` and `docs/site/sitemap.xml` parsed successfully as XML.
- `bash -n docs/site/build.sh` passed.
- `git diff --check` passed.
- Repository pre-push build, submodule validation, visualizer health, 109 visualizer JavaScript tests, and v7 training contract smoke passed.
- The full pre-push hook could not complete v8 inference contracts or v7 training-kernel parity in the clean worktree because Python packages including `torch` and `jsonschema` were unavailable. No runtime files are changed by this PR.

## Regression coverage

The full static documentation build is the regression guard for shared header/footer propagation. Automated scans cover all 74 generated pages for contributor routes and unresolved template tokens. Existing repository pre-commit metadata validation passed for both commits. Runtime regression suites were not required by the pre-commit hook because this change is confined to README and documentation files; dependency-bound pre-push limitations are disclosed above.

## Documentation

The change is documentation-first. Primary source is `docs/site/_pages/contributing.html`, with generated output in `docs/site/contributing.html`. Supporting changes are in `README.md`, `docs/site/assets/contributor-ladder.svg`, shared header/footer partials, page metadata, and the static-site builder. The complete generated site is committed so global navigation does not vary between pages.

## Content handoff

- Audience: New CKE contributors, Linux distribution maintainers, performance engineers, numerical-testing contributors, and experienced kernel/compiler engineers.
- Angle: CKE exposes a contribution ladder where useful work begins with one reproducible boundary; multimodal parity and compiler research are advanced destinations, not entrance requirements.
- Claims: The site defines five contribution levels, provides bounded Arch/CachyOS and profiling entry paths, links contributor onboarding from every generated page, and removes unresolved CKU navigation metadata across all 74 root pages.
- Caveats: No public Discord invite was found in repository sources, so the page directs existing members to introduce themselves and new contributors to request onboarding through a focused GitHub issue. Runtime parity was not requalified because this PR changes documentation only, and dependency-bound pre-push gates lacked `torch` and `jsonschema` in the clean worktree.
- Sources: Commits `94c7b65c` and `a1e686a0`; `README.md`; `docs/site/_pages/contributing.html`; `docs/site/assets/contributor-ladder.svg`; `docs/site/_partials/header.html`; `docs/site/_partials/footer.html`; `docs/site/build.sh`; `docs/site/page_metadata.json`; generated `docs/site/contributing.html` and the 74-page root documentation build.
