### PR TITLE
fix(v8): match llama padded KV reduction schedule

### DIFF
--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -1651,8 +1651,10 @@ ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16
     ck_attention_reduction_t reduction);
 
 // Deterministic llama.cpp-style FP16 split-KV oracle. The explicit chunk count
-// makes diagnostics independent of the host's available core count. Production
-// routing must be accepted separately by stitched model parity.
+// makes diagnostics independent of the host's available core count. At and
+// above KV=512, worker boundaries use a 256-row padded scheduling extent while
+// storage reads remain bounded by kv_tokens. Production routing must be
+// accepted separately by stitched model parity.
 void attention_forward_decode_head_major_gqa_flash_f16cache_split(const float *q_token,
                                                                   const uint16_t *k_cache,
                                                                   const uint16_t *v_cache,

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -4858,6 +4858,7 @@ typedef struct {
     int head_dim;
     int aligned_head_dim;
     int split_chunks;
+    int partition_tokens;
 } ck_attention_f16_split_args_t;
 
 static inline float ck_attention_dot_f16_llama(const uint16_t *x,
@@ -4968,7 +4969,8 @@ static void ck_attention_f16_split_work(int ith, int nth, void *opaque)
     ck_attention_f16_split_args_t *args = (ck_attention_f16_split_args_t *) opaque;
     const int partial_stride = args->aligned_head_dim + 2;
     const int total_jobs = args->num_heads * args->split_chunks;
-    const int chunk_size = (args->kv_tokens + args->split_chunks - 1) / args->split_chunks;
+    const int chunk_size =
+        (args->partition_tokens + args->split_chunks - 1) / args->split_chunks;
     const size_t head_stride = (size_t) args->cache_capacity * (size_t) args->aligned_head_dim;
     const float scale = ck_attention_strict_scale_f32(args->head_dim);
     uint16_t *q_half = (uint16_t *) alloca((size_t) args->aligned_head_dim * sizeof(uint16_t));
@@ -4980,9 +4982,9 @@ static void ck_attention_f16_split_work(int ith, int nth, void *opaque)
         const int kv_head = (int) ((long long) h * (long long) args->num_kv_heads /
                                    (long long) args->num_heads);
         const int begin = chunk * chunk_size;
-        const int end = begin + chunk_size < args->kv_tokens
-            ? begin + chunk_size
-            : args->kv_tokens;
+        const int end = begin < args->kv_tokens
+            ? (begin + chunk_size < args->kv_tokens ? begin + chunk_size : args->kv_tokens)
+            : begin;
         const float *q_head = args->q_token + (size_t) h * (size_t) args->aligned_head_dim;
         const uint16_t *k_head = args->k_cache + (size_t) kv_head * head_stride;
         const uint16_t *v_head = args->v_cache + (size_t) kv_head * head_stride;
@@ -5070,6 +5072,17 @@ void attention_forward_decode_head_major_gqa_flash_f16cache_split(const float *q
 
     const size_t resolved_count = (size_t) num_heads * (size_t) split_chunks * (size_t) partial_stride;
     float *partials = (float *) alloca(resolved_count * sizeof(float));
+    /*
+     * llama.cpp keeps decode graphs reusable by padding the KV scheduling
+     * extent to at least 256 rows. Masked rows do not contribute values, but
+     * the padded extent still determines worker chunk boundaries and therefore
+     * the FP16 partial-reduction order. Keep valid storage separate from that
+     * scheduling contract: this kernel never reads rows >= kv_tokens.
+     */
+    const int partition_alignment = 256;
+    const int partition_tokens = kv_tokens >= 512
+        ? ((kv_tokens + partition_alignment - 1) / partition_alignment) * partition_alignment
+        : kv_tokens;
     ck_attention_f16_split_args_t args = {
         .q_token = q_token,
         .k_cache = k_cache,
@@ -5082,6 +5095,7 @@ void attention_forward_decode_head_major_gqa_flash_f16cache_split(const float *q
         .head_dim = head_dim,
         .aligned_head_dim = aligned_head_dim,
         .split_chunks = split_chunks,
+        .partition_tokens = partition_tokens,
     };
 
     ck_threadpool_t *pool = ck_threadpool_global();

--- a/tests/test_v8_attention_contracts.py
+++ b/tests/test_v8_attention_contracts.py
@@ -46,6 +46,12 @@ class AttentionContractV8Tests(unittest.TestCase):
     def test_registry_defines_complete_semantics(self) -> None:
         resolver.validate_contract_registry(copy.deepcopy(self.contracts))
 
+    def test_f16_split_contract_declares_padded_scheduling_extent(self) -> None:
+        contract = self.contracts["contracts"]["f16_online_fp32_merge"]
+        self.assertEqual(contract["partition"]["kind"], "kv_chunks_by_workers")
+        self.assertEqual(contract["partition"]["threshold"], 512)
+        self.assertEqual(contract["partition"]["extent_alignment"], 256)
+
     def test_kernel_overlay_matches_v8_kernel_maps(self) -> None:
         resolver.validate_kernel_overlay(copy.deepcopy(self.kernels))
 

--- a/unittest/test_attention_f16_split_kv.py
+++ b/unittest/test_attention_f16_split_kv.py
@@ -88,8 +88,8 @@ static size_t tensor_offset(const ggml_tensor * t, int i0, int i1, int i2, int i
 }
 
 int main(int argc, char ** argv) {
-    if (argc != 10) {
-        fprintf(stderr, "usage: %s q.f32 k.f16 v.f16 out.f32 H Hkv KV D threads\n", argv[0]);
+    if (argc != 10 && argc != 11) {
+        fprintf(stderr, "usage: %s q.f32 k.f16 v.f16 out.f32 H Hkv KV D threads [valid_KV]\n", argv[0]);
         return 2;
     }
     const int H = atoi(argv[5]);
@@ -97,12 +97,15 @@ int main(int argc, char ** argv) {
     const int KV = atoi(argv[7]);
     const int D = atoi(argv[8]);
     const int threads = atoi(argv[9]);
-    if (H <= 0 || Hkv <= 0 || KV <= 0 || D <= 0 || threads <= 0 || H % Hkv != 0) return 2;
+    const int valid_KV = argc == 11 ? atoi(argv[10]) : KV;
+    if (H <= 0 || Hkv <= 0 || KV <= 0 || valid_KV <= 0 || valid_KV > KV ||
+        D <= 0 || threads <= 0 || H % Hkv != 0) return 2;
 
     const size_t q_count = (size_t) H * (size_t) D;
     const size_t kv_count = (size_t) Hkv * (size_t) KV * (size_t) D;
     const size_t memory = 64u * 1024u * 1024u +
-                          q_count * sizeof(float) + 2u * kv_count * sizeof(ggml_fp16_t);
+                          q_count * sizeof(float) +
+                          (2u * kv_count + (size_t) KV) * sizeof(ggml_fp16_t);
     ggml_init_params init = { memory, nullptr, false };
     ggml_context * ctx = ggml_init(init);
     if (!ctx) return 3;
@@ -118,8 +121,16 @@ int main(int argc, char ** argv) {
         return 4;
     }
 
+    ggml_tensor * mask = nullptr;
+    if (valid_KV != KV) {
+        mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, KV, 1);
+        ggml_fp16_t * mask_data = (ggml_fp16_t *) mask->data;
+        for (int i = 0; i < KV; ++i) {
+            mask_data[i] = ggml_fp32_to_fp16(i < valid_KV ? 0.0f : -INFINITY);
+        }
+    }
     ggml_tensor * out = ggml_flash_attn_ext(
-        ctx, q, k, v, nullptr, 1.0f / sqrtf((float) D), 0.0f, 0.0f);
+        ctx, q, k, v, mask, 1.0f / sqrtf((float) D), 0.0f, 0.0f);
     ggml_flash_attn_ext_set_prec(out, GGML_PREC_F32);
     ggml_cgraph * graph = ggml_new_graph(ctx);
     ggml_build_forward_expand(graph, out);
@@ -181,13 +192,18 @@ def _ensure_llama_helper():
     return binary, bin_dir
 
 
-def _llama_split_output(q, k_bits, v_bits, head_dim, threads):
+def _llama_split_output(q, k_bits, v_bits, head_dim, threads, padded_kv_tokens=None):
     helper, bin_dir = _ensure_llama_helper()
     heads, _ = q.shape
     kv_heads, kv_tokens, _ = k_bits.shape
+    padded_kv_tokens = int(padded_kv_tokens or kv_tokens)
+    if padded_kv_tokens < kv_tokens:
+        raise ValueError("padded_kv_tokens cannot be smaller than the valid KV count")
     q_compact = np.ascontiguousarray(q[:, :head_dim], dtype=np.float32)
-    k_compact = np.ascontiguousarray(k_bits[:, :, :head_dim], dtype=np.uint16)
-    v_compact = np.ascontiguousarray(v_bits[:, :, :head_dim], dtype=np.uint16)
+    k_compact = np.zeros((kv_heads, padded_kv_tokens, head_dim), dtype=np.uint16)
+    v_compact = np.zeros((kv_heads, padded_kv_tokens, head_dim), dtype=np.uint16)
+    k_compact[:, :kv_tokens, :] = np.ascontiguousarray(k_bits[:, :, :head_dim], dtype=np.uint16)
+    v_compact[:, :kv_tokens, :] = np.ascontiguousarray(v_bits[:, :, :head_dim], dtype=np.uint16)
     with tempfile.TemporaryDirectory(prefix="ck_f16_split_kv_") as tmp:
         tmp = Path(tmp)
         q_path, k_path, v_path, out_path = [tmp / name for name in ("q.f32", "k.f16", "v.f16", "out.f32")]
@@ -196,7 +212,8 @@ def _llama_split_output(q, k_bits, v_bits, head_dim, threads):
         v_compact.tofile(v_path)
         command = [
             str(helper), str(q_path), str(k_path), str(v_path), str(out_path),
-            str(heads), str(kv_heads), str(kv_tokens), str(head_dim), str(threads),
+            str(heads), str(kv_heads), str(padded_kv_tokens), str(head_dim), str(threads),
+            str(kv_tokens),
         ]
         env = os.environ.copy()
         env["LD_LIBRARY_PATH"] = f"{bin_dir}:{env.get('LD_LIBRARY_PATH', '')}"
@@ -206,6 +223,12 @@ def _llama_split_output(q, k_bits, v_bits, head_dim, threads):
                 f"llama.cpp split-KV helper failed ({completed.returncode}):\n{completed.stderr}"
             )
         return np.fromfile(out_path, dtype=np.float32).reshape(heads, head_dim)
+
+
+def _llama_kv_partition_extent(kv_tokens):
+    """Match llama.cpp's reusable decode-graph KV scheduling extent."""
+    kv_tokens = int(kv_tokens)
+    return ((kv_tokens + 255) // 256) * 256 if kv_tokens >= 512 else kv_tokens
 
 
 def _f32_ptr(a):
@@ -492,7 +515,9 @@ def _case(name, seed, heads, kv_heads, kv_tokens, head_dim, aligned, chunks, tol
     # contract, but its dot traversal models one ISA and is not authoritative
     # across AVX2, AVX-512, and NEON. Gate the production entry point against
     # GGML using the same worker/chunk count instead.
-    expected = _llama_split_output(q, k, v, head_dim, chunks)
+    expected = _llama_split_output(
+        q, k, v, head_dim, chunks, _llama_kv_partition_extent(kv_tokens)
+    )
     active_diff = float(np.max(np.abs(actual[:, :head_dim] - expected)))
     padding_diff = (
         float(np.max(np.abs(actual[:, head_dim:])))
@@ -520,6 +545,11 @@ def main():
         1058, 32, 8, 1058, 128, 128, 20, 2.0e-5,
     )
     results.append(qwen)
+    qwen_step20, qwen_step20_data = _case(
+        "f16_split_qwen3vl_step20(KV=1047,P=1280,H=32,D=128,C=20)",
+        1047, 32, 8, 1047, 128, 128, 20, 2.0e-5,
+    )
+    results.append(qwen_step20)
     qwen_long, qwen_long_data = _case(
         "f16_split_qwen3vl_long(KV=1609,H=32,D=128,C=20)",
         1609, 32, 8, 1609, 128, 128, 20, 2.0e-5,
@@ -536,6 +566,7 @@ def main():
         ("explicit_contract_route_below(KV=511)", below_data),
         ("explicit_contract_route_threshold(KV=512)", threshold_data),
         ("explicit_contract_route_qwen3vl(KV=1058)", qwen_data),
+        ("explicit_contract_route_qwen3vl_step20(KV=1047,P=1280)", qwen_step20_data),
         ("explicit_contract_route_qwen3vl_long(KV=1609)", qwen_long_data),
     ):
         q, k, v, _ = data
@@ -572,11 +603,14 @@ def main():
             ("llama_oracle_below(KV=511)", below_data, 1),
             ("llama_oracle_threshold(KV=512)", threshold_data, threads),
             ("llama_oracle_qwen3vl(KV=1058)", qwen_data, threads),
+            ("llama_oracle_qwen3vl_step20(KV=1047,P=1280)", qwen_step20_data, threads),
             ("llama_oracle_qwen3vl_long(KV=1609)", qwen_long_data, threads),
         ):
             q, k, v, _ = data
             ck = _run_explicit(q, k, v, q.shape[1], chunks)
-            llama = _llama_split_output(q, k, v, q.shape[1], threads)
+            llama = _llama_split_output(
+                q, k, v, q.shape[1], threads, _llama_kv_partition_extent(k.shape[1])
+            )
             diff = float(np.max(np.abs(ck[:, :q.shape[1]] - llama)))
             results.append(Result(name, diff, 2.0e-5, diff <= 2.0e-5))
     except RuntimeError as exc:

--- a/version/v8/contracts/attention_reductions.json
+++ b/version/v8/contracts/attention_reductions.json
@@ -106,13 +106,14 @@
       "partition": {
         "kind": "kv_chunks_by_workers",
         "threshold": 512,
+        "extent_alignment": 256,
         "below_threshold_chunks": 1,
         "at_or_above_threshold_chunks": "runtime_worker_count"
       },
-      "description": "FP16-rounded online-softmax partials with deterministic FP32 chunk-order merge.",
+      "description": "FP16-rounded online-softmax partials with a 256-row padded scheduling extent and deterministic FP32 chunk-order merge.",
       "validation": {
         "test": "unittest/test_attention_f16_split_kv.py",
-        "cases": ["KV=511", "KV=512", "KV=1058", "padded GQA"],
+        "cases": ["KV=511", "KV=512", "Qwen3-VL KV=1047->1280", "KV=1058->1280", "KV=1609->1792", "padded GQA"],
         "reference": "llama.cpp GGML flash attention"
       }
     }

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -2185,7 +2185,7 @@
           "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
           "explicit_selector": true,
           "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
-          "notes": "Cache-preserving segmented causal prefill using the validated FP16 decode reduction contract for each query row."
+          "notes": "Cache-preserving segmented causal prefill using the validated 256-row-padded FP16 decode reduction contract for each query row."
         }
       },
       "implementation": {
@@ -2635,7 +2635,7 @@
           "function": "attention_forward_decode_head_major_gqa_flash_f16cache_contract",
           "explicit_selector": true,
           "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
-          "notes": "FP16 Q/K and partial-value storage with worker-chunk online softmax and ordered FP32 merge."
+          "notes": "FP16 Q/K and partial-value storage with a 256-row padded KV scheduling extent, worker-chunk online softmax, and ordered FP32 merge."
         }
       },
       "implementation": {

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.json
@@ -18,7 +18,7 @@
       "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
       "explicit_selector": true,
       "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
-      "notes": "Cache-preserving segmented causal prefill using the validated FP16 decode reduction contract for each query row."
+      "notes": "Cache-preserving segmented causal prefill using the validated 256-row-padded FP16 decode reduction contract for each query row."
     }
   },
   "implementation": {

--- a/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_f16cache_contract.json
+++ b/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_f16cache_contract.json
@@ -17,7 +17,7 @@
       "function": "attention_forward_decode_head_major_gqa_flash_f16cache_contract",
       "explicit_selector": true,
       "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
-      "notes": "FP16 Q/K and partial-value storage with worker-chunk online softmax and ordered FP32 merge."
+      "notes": "FP16 Q/K and partial-value storage with a 256-row padded KV scheduling extent, worker-chunk online softmax, and ordered FP32 merge."
     }
   },
   "implementation": {

--- a/version/v8/schemas/attention_reduction_registry.schema.json
+++ b/version/v8/schemas/attention_reduction_registry.schema.json
@@ -61,6 +61,7 @@
           "properties": {
             "kind": {"enum": ["single_range", "kv_chunks_by_workers", "query_key_tiles"]},
             "threshold": {"type": "integer", "minimum": 1},
+            "extent_alignment": {"type": "integer", "minimum": 1},
             "below_threshold_chunks": {"type": "integer", "minimum": 1},
             "at_or_above_threshold_chunks": {"enum": ["runtime_worker_count"]},
             "query_tile_size": {"type": "integer", "minimum": 1},


### PR DESCRIPTION
## Why

llama.cpp pads the scheduled decode KV extent to 256-row boundaries so decode graphs can be reused. CK partitioned only the valid rows. At Qwen3-VL OCR fixture 1 step 20, llama scheduled 1047 valid rows over an extent of 1280, while CK split 1047 directly. Masked rows contributed no values, but the different worker boundaries changed FP16 partial-reduction order and eventually changed token ranking.

## What changed

- Separate valid KV storage rows from the padded attention scheduling extent.
- Align the split-KV scheduling extent to 256 rows at and above the existing KV=512 split threshold.
- Keep all cache reads bounded by the valid KV count.
- Record `extent_alignment=256` in the attention numerical contract and schema.
- Propagate the semantic through both exact kernel maps and the generated kernel registry.
- Document the public provider behavior without changing its ABI.
- Add a production-shaped llama/GGML oracle case for KV=1047 -> 1280, H=32, D=128, and 20 workers.
- Assert the partition kind, threshold, and alignment in resolver tests.

No model-family or codegen branch was added.

## Evidence

Identical post-RoPE Q and FP16 K/V bytes matched GGML when both sides used the unpadded extent, ruling out the leaf dot product and online-softmax implementation. Padding the GGML graph to 1280 rows with an FP16 negative-infinity mask reproduced llama.cpp's saved layer-0 attention output byte-for-byte.

With the corrected provider:

- Production-shaped primitive maximum difference: `1.49e-8`.
- OCR fixture 1: `128/128` generated tokens match llama.cpp; former step-20 failure is closed.
- OCR fixture 2: `128/128` generated tokens match llama.cpp.
- Existing threshold, long-context, padded-GQA, explicit-route, and rejection cases pass.

This proves two canonical fixtures through 128 tokens. It does not establish the five-, ten-, or forty-image promotion gates.

## Validation

- `make test-attention-f16-split-kv`: 21/21 PASS.
- `make test-numerical-contracts`: PASS.
- `make test-v8-qwen3vl`: PASS.
- `make test-v8-dsl`: PASS.
- `v7-regression-fast` staged pre-commit lane: PASS.
- `v8-regression-fast` staged pre-commit lane: PASS.
- Pre-push build, v8 E2E text smoke, v8 inference contracts, and v7 training smoke: PASS with ICX and GCC.
- Python compile, JSON parse, and `git diff --check`: PASS.

The full pre-push v7 matrix is currently blocked by Gemma/Qwen2 first-token and Nanbeige coherence/first-token failures. An untouched `origin/main` worktree reproduced the identical matrix under GCC, proving it is pre-existing and unrelated to this attention contract.

## Regression coverage

Nightly's existing FP16 attention and v8 numerical-contract lanes now include the observed KV=1047 -> 1280 graph-shape case. Resolver coverage fails if the 512 threshold or 256-row alignment disappears. The test also verifies explicit provider routing, unsupported-contract rejection, padded GQA, long context, and valid-row read bounds.

## Documentation

The public API comment, numerical contract registry, kernel-map capability notes, and generated registry document the scheduling semantic. The broader investigation method remains documented in `docs/site/_pages/vision-encoder-parity.html` from PR #173.

## Content handoff

- Audience: CPU inference engineers, compiler/runtime developers, and numerical-parity researchers.
- Angle: Masked padding can change model output even when padded rows contribute no values, because graph shape controls FP16 parallel reduction partitions.
- Claims: The corrected primitive reaches `1.49e-8` error against the production-shaped GGML oracle and closes two 128-token Qwen3-VL OCR parity runs.
- Caveats: Only two fixtures are proven through 128 tokens; the 5/10/40-image gates remain to be run, and unrelated v7 baseline failures remain open.
- Sources: Commit `729a8937`, `unittest/test_attention_f16_split_kv.py`, the attention numerical contract, parity sweep reports, and PR #173's investigation documentation.
