### PR TITLE
docs(scaling): preserve and harden the CPU frontier-model thesis

### DIFF
--- a/docs/site/_pages/scaling.html
+++ b/docs/site/_pages/scaling.html
@@ -1,357 +1,2224 @@
-<!-- TITLE: Scaling Thesis -->
+<!-- TITLE: Scaling Philosophy -->
 <!-- NAV: scaling -->
 
-<h1>Scaling Thesis</h1>
+<h1>Scaling Philosophy</h1>
 
-<div class="card card-accent">
-    <h2 style="margin-top: 0;">The Bet, Not the Verdict</h2>
+<div class="card card-accent" style="border: 2px solid #ffb400; padding: 2rem; margin-bottom: 2rem;">
+    <h2 style="margin-top: 0; color: #ffb400;">The Bet Behind This Project</h2>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        C-Kernel-Engine is testing whether explicit numerical contracts, generated C, optimized CPU kernels,
-        and ordinary Linux nodes can make locally owned CPU infrastructure practical for selected AI workloads.
-        The thesis is not that CPUs universally beat accelerators. There is no universal hardware winner.
+        The bet here is simple: AI will not stay locked inside premium proprietary boxes forever.
+        C-Kernel-Engine takes a different path:
+        <strong>Linux-only, CPU-only, server-grade hardware, open software, and standard data-center parts.</strong>
+        If the software gets good enough, ordinary servers become practical AI machines.
     </p>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        The narrower bet is that model execution can be reduced to measurable contracts: arithmetic, bytes moved,
-        synchronization, latency, accuracy, power, and operating cost. For workloads whose constraints match CPU
-        systems, better kernels and better orchestration may turn hardware organizations can procure and control
-        into useful AI infrastructure.
+        This is a long-horizon commodity compute bet.
+        The underlying workload is still math, memory movement, and systems software.
+        If CPUs keep gaining cores, SIMD and matrix units, memory channels, NUMA controls, and fast interconnects,
+        then a generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly valuable.
     </p>
-    <p style="font-size: 1.15em; line-height: 1.7; margin-bottom: 0;">
-        This page defines how that bet will be tested. Single-node execution has evidence today.
-        Multi-node scaling remains a research thesis until matched-node measurements close the communication,
-        synchronization, and efficiency questions.
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        This is not a claim that CPUs always beat GPU systems on raw peak throughput.
+        That is not the point.
+        The real question is whether CPU-only Linux systems can become
+        <strong>good enough, cheap enough, and accessible enough</strong>
+        to handle serious inference and eventually serious training.
+        That is the thesis being tested here.
     </p>
-</div>
-
-<div style="margin: 2.5rem 0; text-align: center;">
-    <img src="assets/engineering-compass.svg"
-         alt="CKE engineering loop: profile, identify the bottleneck, fix one kernel, and measure again"
-         style="width: 100%; max-width: 1200px; border-radius: 16px;" />
-</div>
-
-<h2>What CKE Is Betting On</h2>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">The workload is inspectable</h3>
-        <p>
-            A model becomes circuits, tensors, kernels, memory traffic, and synchronization. CKE exposes those
-            boundaries so correctness and performance can be attributed instead of hidden behind a framework call.
-        </p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">CPU systems keep changing</h3>
-        <p>
-            Vector and matrix instructions, memory-channel counts, NUMA controls, core counts, and data-center
-            networking continue to improve. CKE asks what modern CPU systems can do when software is designed for
-            their actual topology rather than treated as a fallback target.
-        </p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Ownership can be a requirement</h3>
-        <p>
-            Privacy, data residency, predictable capacity, embedded deployment, long-lived services, and operational
-            control can matter as much as peak throughput. These constraints create workloads worth evaluating on
-            locally controlled hardware.
-        </p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">The result must remain falsifiable</h3>
-        <p>
-            A CPU deployment is useful only when it meets a stated accuracy, latency, concurrency, memory, power,
-            reliability, and total-cost envelope. A failed envelope narrows the thesis; it is not a reason to move
-            the goalposts.
-        </p>
-    </div>
-</div>
-
-<h2>The Feasibility Gates</h2>
-
-<p>
-    Scaling begins only after one node is correct, fits the workload, and has a measured bottleneck. Capacity is the
-    first gate:
-</p>
-
-<pre>M_weights + M_KV + M_workspace + M_runtime &lt;= M_usable</pre>
-
-<p>
-    Once the workload fits, single-node execution time is bounded by the slower of useful arithmetic and memory
-    movement, plus software overhead:
-</p>
-
-<pre>T_node = max(T_compute, T_memory) + T_overhead</pre>
-
-<p>
-    Adding nodes introduces costs that do not exist in the single-node result:
-</p>
-
-<pre>T_N = T_compute,N
-    + T_communication,N
-    + T_synchronization,N
-    + T_imbalance,N</pre>
-
-<p>
-    Speedup and parallel efficiency are therefore measured results, not consequences of owning more machines:
-</p>
-
-<pre>S(N) = T(1) / T(N)          E(N) = S(N) / N</pre>
-
-<div class="alert alert-info">
-    <div class="alert-icon">i</div>
-    <div>
-        <strong>Memory capacity is necessary, not sufficient.</strong>
-        A model that does not fit cannot run, but a model that fits can still be too slow, too expensive, or too
-        difficult to operate. CKE treats capacity, bandwidth, compute, communication, and user-visible behavior as
-        separate gates.
-    </div>
-</div>
-
-<h2>What One Node Must Prove</h2>
-
-<div class="table-container" style="max-width: 100%; overflow-x: auto;">
-<table>
-    <thead>
-        <tr><th>Question</th><th>Required evidence</th><th>Failure means</th></tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>Is it numerically acceptable?</td>
-            <td>Reference parity, first-divergence attribution, task-level output, and explicit tolerance</td>
-            <td>Performance results are not yet promotable</td>
-        </tr>
-        <tr>
-            <td>Does it fit?</td>
-            <td>Peak RSS, mapped weights, KV state, workspace, and allocator behavior</td>
-            <td>The model, precision, context, or memory plan must change</td>
-        </tr>
-        <tr>
-            <td>What limits it?</td>
-            <td>Roofline position, effective bandwidth, vector utilization, cache behavior, and hot kernels</td>
-            <td>Optimization is speculation</td>
-        </tr>
-        <tr>
-            <td>Is it useful to a person or service?</td>
-            <td>Time to first token, prefill, decode, concurrency, tail latency, and sustained operation</td>
-            <td>A peak token rate is not enough</td>
-        </tr>
-        <tr>
-            <td>Is it operationally credible?</td>
-            <td>Power, thermals, repeatability, failure behavior, deployment steps, and total system assumptions</td>
-            <td>The benchmark does not describe a deployable system</td>
-        </tr>
-    </tbody>
-</table>
-</div>
-
-<p>
-    Every published result should identify the CPU, memory channels and population, NUMA topology, firmware or
-    microcode where relevant, compiler, CKE commit, model and input hashes, precision, context, batch, thread count,
-    commands, repetitions, and known limitations.
-</p>
-
-<h2>Distributed Scaling Is a Cost Equation</h2>
-
-<p>
-    CKE does not claim infinite scaling. A network makes remote memory and remote computation available, but every
-    boundary adds transfer time, synchronization, queueing, and imbalance. The transfer floor is approximately:
-</p>
-
-<pre>T_transfer &gt;= bytes_transferred / effective_bandwidth + network_latency</pre>
-
-<p>
-    Amdahl's law still applies. If <code>f_s</code> is the serial or effectively non-parallel fraction, ideal speedup
-    cannot exceed:
-</p>
-
-<pre>S(N) &lt;= 1 / (f_s + (1 - f_s) / N)</pre>
-
-<p>
-    Ten, 25, or 100 gigabit Ethernet, RDMA, NUMA placement, transport implementation, message size, and overlap are
-    experiment variables. They are not interchangeable labels. Internet-connected laptops may support independent or
-    delay-tolerant work, but they are not a low-latency tensor fabric and should not be described as one.
-</p>
-
-<h3>Parallelism must match the boundary</h3>
-
-<div class="table-container" style="max-width: 100%; overflow-x: auto;">
-<table>
-    <thead>
-        <tr><th>Strategy</th><th>What crosses nodes</th><th>Where it may fit</th><th>Primary risk</th></tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>Data parallelism</td>
-            <td>Gradients, optimizer state, or independent results</td>
-            <td>Independent requests and sufficiently large training batches</td>
-            <td>Reduction cost and duplicated model memory</td>
-        </tr>
-        <tr>
-            <td>Pipeline parallelism</td>
-            <td>Boundary activations</td>
-            <td>Large stages with enough work to amortize transfers</td>
-            <td>Pipeline bubbles and uneven stages</td>
-        </tr>
-        <tr>
-            <td>Tensor parallelism</td>
-            <td>Partial activations and frequent collective results</td>
-            <td>Fast, predictable fabrics and large kernels</td>
-            <td>Communication frequency dominates useful work</td>
-        </tr>
-        <tr>
-            <td>Expert parallelism</td>
-            <td>Routed tokens and expert outputs</td>
-            <td>Stable routing, useful locality, and balanced expert load</td>
-            <td>Dispatch overhead, hotspots, and remote weight traffic</td>
-        </tr>
-    </tbody>
-</table>
-</div>
-
-<h2>MoE Caveat: Routing Does Not Remove Memory Traffic</h2>
-
-<p>
-    Conditional routing is natural to express on a CPU, but that fact alone does not establish a performance
-    advantage. Active expert weights still have to reach the cores. At small batches, an expert may be used too
-    briefly to amortize its weight traffic. At larger batches, routing imbalance and token dispatch can dominate.
-    Total parameter storage also remains large even when only a subset of experts is active for each token.
-</p>
-
-<p>
-    CKE should claim an MoE benefit only after measuring active bytes per token, effective memory bandwidth, expert
-    cache locality, routing distribution, dispatch cost, concurrency, and the routed model's task quality against a
-    dense or established reference. Branch support is an implementation property; system throughput is the result.
-</p>
-
-<h2>Model Architecture Is Shaped by Constraints</h2>
-
-<p>
-    Many important model techniques can be understood as responses to memory, compute, or communication pressure.
-    That is useful systems context, but it is not evidence that the techniques are merely workarounds or that they
-    belong to one hardware class.
-</p>
-
-<div class="table-container" style="max-width: 100%; overflow-x: auto;">
-<table>
-    <thead>
-        <tr><th>Technique</th><th>Constraint reduced</th><th>New cost or contract</th></tr>
-    </thead>
-    <tbody>
-        <tr><td>GQA and MQA</td><td>KV-cache capacity and bandwidth</td><td>Shared key/value semantics and possible quality trade-offs</td></tr>
-        <tr><td>Fused or tiled attention</td><td>Intermediate storage and external memory traffic</td><td>Tiling, reduction order, precision, and backend-specific kernels</td></tr>
-        <tr><td>KV paging and quantization</td><td>Long-context capacity and allocation pressure</td><td>State management, conversion cost, and numerical error</td></tr>
-        <tr><td>Mixture of experts</td><td>Active compute per token relative to total model capacity</td><td>Routing, load balance, expert storage, and dispatch</td></tr>
-        <tr><td>Recurrent or state-space layers</td><td>Explicit long-sequence state growth</td><td>Compressed-state semantics, scan kernels, and training complexity</td></tr>
-        <tr><td>Weight and activation quantization</td><td>Capacity, bandwidth, and arithmetic cost</td><td>Calibration, scale handling, kernel coverage, and quality validation</td></tr>
-    </tbody>
-</table>
-</div>
-
-<h2>The CKE Experiment Ladder</h2>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">1. Numerical closure</h3>
-        <p>Establish model-specific parity against PyTorch or another declared reference before promoting speed.</p>
-        <p><strong>Status:</strong> active, with supported model paths and known multimodal gaps.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">2. Single-node performance</h3>
-        <p>Measure kernels, memory topology, prefill, decode, concurrency, power, and sustained behavior.</p>
-        <p><strong>Status:</strong> active across consumer, server, and selected embedded CPU targets.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">3. NUMA and topology</h3>
-        <p>Make placement, replication, thread ownership, and cross-socket traffic explicit and reproducible.</p>
-        <p><strong>Status:</strong> being hardened; results remain hardware-specific.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">4. Two-node transport</h3>
-        <p>Measure serialization, transfer, synchronization, overlap, and failure behavior on matched nodes.</p>
-        <p><strong>Status:</strong> planned research; no general scaling claim yet.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">5. Parallel execution</h3>
-        <p>Select data, pipeline, tensor, or expert boundaries from measured compute-to-communication ratios.</p>
-        <p><strong>Status:</strong> research roadmap.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">6. Distributed training</h3>
-        <p>Extend forward and backward contracts only after single-node training and transport behavior are closed.</p>
-        <p><strong>Status:</strong> long-horizon thesis, not a demonstrated capability.</p>
-    </div>
-</div>
-
-<h2>Decision Rule</h2>
-
-<div class="card card-accent">
-    <p style="font-size: 1.1em; margin-top: 0;">
-        <strong>Use an established runtime and hardware platform when it already meets the requirement.</strong>
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        The early numbers already show that CPU-only inference is practical.
+        A quantized 0.6B model on a 12th-gen Intel Alder Lake machine has reached
+        <strong>about 100 tokens/sec</strong> when the system is otherwise idle.
+        On an older 4-core machine, the same model still runs at
+        <strong>about 20&ndash;25 tokens/sec</strong>.
+        No GPU. No CUDA. No special hardware. Just common x86 instructions and Linux.
     </p>
-    <p>
-        CKE becomes relevant when a model is unsupported, numerically wrong, unexpectedly slow, difficult to
-        validate, or constrained to owned CPU or embedded infrastructure. Its value is not that every deployment
-        needs generated C. Its value is that the execution boundary can be made explicit when the normal abstraction
-        is no longer enough.
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        The bigger target is server-grade CPU infrastructure.
+        Testing is underway on 5th-gen Intel Xeon Scalable systems with AVX-512 and AMX &mdash;
+        the same class of machines already sitting in real data centers.
+        The bet is that these machines will be cheaper, easier to procure, easier to operate, and more broadly deployable than proprietary accelerator-heavy stacks.
     </p>
-    <p style="margin-bottom: 0;">
-        Hardware selection should follow the workload envelope. The same investigation may conclude that a CPU,
-        accelerator, embedded target, or mixed system is the correct answer.
+    <p style="font-size: 1.15em; line-height: 1.7; border-top: 1px solid #333; padding-top: 1.5rem; margin-bottom: 0;">
+        The method is straightforward: profile, find the real bottleneck, fix one kernel at a time, and measure again.
+        C-Kernel-Engine uses VTune, FlameGraph, Intel Advisor, <code>perf stat</code>, and roofline analysis to do exactly that.
+        <strong>The point of this page is not hype. It is to state the engineering bet clearly and then earn it with measurements.</strong>
     </p>
 </div>
 
-<h2>What Would Narrow or Falsify the Thesis?</h2>
+<!-- ── Engineering Compass SVG ── -->
+<div style="margin: 2.5rem 0 0.5rem 0; text-align: center;">
+    <img src="assets/engineering-compass.svg" alt="Engineering Compass — Profile, Find Bottleneck, Fix Kernel, Measure, Repeat" style="width: 100%; max-width: 1200px; border-radius: 16px; box-shadow: 0 8px 32px rgba(0,0,0,0.4);" />
+</div>
 
-<ul>
-    <li>Communication and synchronization erase useful speedup beyond one node.</li>
-    <li>Memory bandwidth prevents acceptable latency or concurrency on the target model family.</li>
-    <li>Measured power and total cost are worse than practical alternatives under the same workload.</li>
-    <li>Maintaining numerical parity consumes more complexity than the generated runtime removes.</li>
-    <li>Scheduling, deployment, and operations overwhelm the portability benefit.</li>
-    <li>The useful workload set remains too narrow to justify distributed infrastructure.</li>
-</ul>
-
-<p>
-    Negative results are useful. They identify where CPU execution is practical, where a different architecture is
-    required, and which CKE abstractions survive contact with real systems.
-</p>
-
-<h2>Current Evidence Boundary</h2>
+<!-- ── Engineering Compass ── -->
+<div style="background: linear-gradient(135deg, #1a2332 0%, #1a1a2e 100%); border: 1px solid #334; border-left: 4px solid #07adf8; border-radius: 12px; padding: 2rem 2.5rem; margin: 0.5rem 0 2rem 0;">
+    <h3 style="margin-top: 0; color: #07adf8; font-size: 1.3em;">
+        🧭 Engineering Compass &mdash; What This Page Is Really For
+    </h3>
+    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc;">
+        This page is the reminder to stay focused on the real thesis:
+        make CPU-only Linux systems useful for modern AI by improving the software until commodity server hardware becomes practical.
+        The scaling story is a direction, not a marketing slogan.
+    </p>
+    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc; margin-bottom: 0.5rem;">
+        The engineering discipline is simple and repeatable:
+    </p>
+    <ol style="font-size: 1.05em; line-height: 2; color: #ddd; padding-left: 1.5rem;">
+        <li><strong style="color: #47b475;">Find the slowest-moving part.</strong> Profile it. Understand <em>why</em> it's slow.</li>
+        <li><strong style="color: #47b475;">Find the fastest-moving part.</strong> Understand what makes it fast. Replicate the pattern.</li>
+        <li><strong style="color: #47b475;">Get more RAM, more cores.</strong> Test on bigger hardware. See if the architecture holds.</li>
+        <li><strong style="color: #47b475;">Keep profiling.</strong> VTune, perf stat, roofline, FlameGraph &mdash; every run, every change.</li>
+        <li><strong style="color: #47b475;">Fix one kernel at a time.</strong> Don't boil the ocean. One bottleneck, one fix, one measurement.</li>
+    </ol>
+    <p style="font-size: 1.1em; line-height: 1.7; color: #999; border-top: 1px solid #333; padding-top: 1rem; margin-bottom: 0;">
+        People will disagree with the thesis, and that is fine.
+        The only useful answer is better measurement, better kernels, and clearer system design.
+        Follow the data, not the hype.
+    </p>
+</div>
 
 <div class="alert alert-warning">
-    <div class="alert-icon">!</div>
-    <div>
-        CKE currently demonstrates model-specific single-node CPU inference and selected embedded paths. Numerical
-        parity, multimodal execution, training contracts, and performance coverage continue to be hardened.
-        Multi-node execution, distributed efficiency, and distributed training are roadmap items until reproducible
-        measurements are published. This page states the experiment, not its predetermined outcome.
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
     </div>
+    <div>
+        <strong>TL;DR — Two First Principles</strong><br>
+        1) <strong>0 × ∞ = 0:</strong> If the model doesn't fit in memory, FLOPS don't matter.<br>
+        2) <strong>Theory of Constraints:</strong> At the Ethernet boundary, CPUs and GPUs face the same bottleneck.
+    </div>
+</div>
+
+<h2>The Two First Principles</h2>
+
+<div class="img-container svg-viewer" data-title="Two First Principles: Memory Gate + Theory of Constraints">
+    <img src="assets/two-principles.svg" alt="Principle 1: 0 × ∞ = 0 — memory gates everything. Principle 2: Theory of Constraints — Ethernet equalizes GPUs and CPUs at cluster scale.">
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>CPU Horizontal Scaling Can Stay Simpler</strong><br>
+        Adding CPU servers still requires sharding, scheduling, networking, and NUMA discipline. But it avoids vendor-specific programming models, specialized accelerator fabrics, and the assumption that serious AI must depend on external accelerators from the start. The bet here is that standard Linux servers on Ethernet remain a simpler operational path for many real deployments.
+    </div>
+</div>
+
+<h2>The Computation Is Not Exotic</h2>
+
+<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
+    AI training and inference reduce to five operations: matrix multiply, attention, softmax, layer normalization, and backpropagation.
+    These are linear algebra and calculus — mathematics developed in the 17th through 19th centuries, long before the first computer.
+    <strong>Nothing about the computation requires physically exotic hardware.</strong> A CPU with SIMD instructions executes every one of these operations natively.
+    If the math isn't exotic, the hardware requirement isn't permanent — it's a market condition.
+    And market conditions change.
+</p>
+
+<div class="img-container svg-viewer" data-title="AI Is Standard Math — Commodity Hardware Always Wins">
+    <img src="assets/commodity-hardware-pattern.svg" alt="Left: AI operations are standard linear algebra and calculus. Right: hardware displacement pattern showing proprietary always loses to commodity.">
+</div>
+
+<div class="alert alert-warning" style="margin-top: 1.5rem;">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The same pattern, repeating</strong><br>
+        In 1995, "You can't run serious workloads on cheap PCs" was conventional wisdom.<br>
+        In 2025, "You can't run serious AI on cheap CPUs" is conventional wisdom.<br>
+        <strong>One of these beliefs aged very poorly. The pattern suggests which way this one goes.</strong>
+    </div>
+</div>
+
+<details style="margin-top: 1rem;">
+    <summary style="cursor: pointer; color: #a0a0a0; font-size: 0.9em; padding: 0.5rem 0;">Historical reference</summary>
+    <div class="table-container" style="margin-top: 0.75rem;">
+        <table>
+            <thead>
+                <tr><th>Era</th><th>Proprietary Incumbent</th><th>Commodity Disruptor</th><th>Result</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>1990s</strong></td>
+                    <td>SPARC, Alpha, PA-RISC</td>
+                    <td>x86 commodity chips</td>
+                    <td style="color: #4ade80;">Proprietary RISC faded</td>
+                </tr>
+                <tr>
+                    <td><strong>1998</strong></td>
+                    <td>Sun/SGI servers (&#36;500K+)</td>
+                    <td>x86 PCs + MapReduce/GFS</td>
+                    <td style="color: #4ade80;">Sun bankrupt (2010)</td>
+                </tr>
+                <tr>
+                    <td><strong>2009</strong></td>
+                    <td>Teradata, Netezza (&#36;1M+)</td>
+                    <td>Hadoop on commodity clusters</td>
+                    <td style="color: #4ade80;">Big data democratized</td>
+                </tr>
+                <tr style="opacity: 0.7; border-top: 1px dashed #333;">
+                    <td><strong>Now</strong></td>
+                    <td>GPU clusters ($M+)</td>
+                    <td>CPU clusters + software</td>
+                    <td style="color: #ffb400;">→ ?</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</details>
+
+<h2>Principle 1: The Cost of 0 × ∞ = 0</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The GPU Memory Trap</h3>
+    <p>Yes, you CAN fit a 70B model on GPUs using tensor/pipeline parallelism. That's not the point.</p>
+    <p><strong>The point is: you're now FORCED to buy 8+ GPUs in a cluster.</strong></p>
+    <p><strong>And GPUs are:</strong></p>
+    <ul>
+        <li><strong>Proprietary</strong> — locked to NVIDIA (CUDA), no open ecosystem</li>
+        <li><strong>Export-controlled</strong> — H100/H200 blocked in many countries, supply constrained</li>
+        <li><strong>Cluster-required</strong> — single GPUs can't handle large models, need NVLink infrastructure</li>
+        <li><strong>Expensive</strong> — &#36;40K+ per GPU, &#36;200K+ for NVLink switches</li>
+    </ul>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Math That Matters</h3>
+    <pre>
+GPU Path:
+  Model doesn't fit in 80GB → Buy 8 GPUs → $320K for GPUs alone
+  Need NVLink for fast communication → Another $50K+
+  Need DGX chassis → Another $80K+
+  Total: $450K+ just to START
+
+CPU Path:
+  Model fits in 4TB RAM → Buy 1-2 servers → $30K each
+  Standard Ethernet networking → $2K
+  Total: $60K and you're running
+    </pre>
+    <p><strong>The "0 × ∞ = 0" principle forces GPU users into expensive multi-GPU setups. CPUs avoid this entirely.</strong></p>
+</div>
+
+<h2>Target Platform</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Server-Grade Hardware by Instruction Set</h3>
+    <p>C-Kernel-Engine uses <code>ck_features.h</code> for feature detection. We target by SIMD capability, not CPU model:</p>
+</div>
+
+<div class="grid grid-3">
+    <div class="card">
+        <h3 style="margin-top: 0;">Instruction Set Priority</h3>
+        <ul>
+            <li><strong>AMX</strong> - 512-bit tile ops (Intel Sapphire Rapids+)</li>
+            <li><strong>AVX-512</strong> - 512-bit vector (Intel Skylake-X+, AMD Zen 4)</li>
+            <li><strong>AVX2+FMA</strong> - 256-bit with FMA (Intel Haswell+, AMD Zen 2+)</li>
+            <li><strong>AVX</strong> - 256-bit vector (Intel Sandy Bridge+, AMD Zen 1)</li>
+            <li><strong>NEON</strong> - 128-bit (ARM64, Apple Silicon)</li>
+        </ul>
+        <p><strong>Auto-detection:</strong> The engine selects the best kernel at build time with runtime dispatch for optional extensions.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">CPU Requirements</h3>
+        <ul>
+            <li><strong>High core count</strong> - 64-128+ cores per socket</li>
+            <li><strong>Large L3 cache</strong> - Good core-to-cache ratio (1-2MB/core)</li>
+            <li><strong>Vector width</strong> - 256-bit minimum (AVX)</li>
+            <li><strong>FMA</strong> - Recommended for 2x throughput</li>
+            <li><strong>Multiple sockets</strong> - NUMA-aware memory access</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Memory Requirements</h3>
+        <ul>
+            <li><strong>DDR5</strong> - Higher bandwidth, lower latency</li>
+            <li><strong>Multi-channel</strong> - 8-12 channels per socket</li>
+            <li><strong>Large capacity</strong> - 512GB - 2TB+ per node</li>
+            <li><strong>ECC</strong> - Error correction for reliability</li>
+            <li><strong>NUMA-local</strong> - Pin threads to local memory</li>
+        </ul>
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Accelerators</h3>
+        <ul>
+            <li><strong>Intel DSA</strong> - Data Streaming Accelerator for memory copies</li>
+            <li><strong>Intel IAA</strong> - Analytics Accelerator for compression</li>
+            <li><strong>Intel QAT</strong> - QuickAssist for crypto (if needed)</li>
+            <li><strong>CXL</strong> - Memory expansion and pooling (future)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Networking</h3>
+        <ul>
+            <li><strong>RDMA</strong> - InfiniBand or RoCEv2</li>
+            <li><strong>100-400 Gbps</strong> - High bandwidth interconnect</li>
+            <li><strong>Low latency</strong> - 1-2 μs for RDMA operations</li>
+            <li><strong>Kernel bypass</strong> - Zero-copy transfers</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Operating System</h3>
+    <p><strong>Linux-only.</strong> We use Linux-specific features:</p>
+    <ul>
+        <li><code>mmap()</code> with <code>MAP_HUGETLB</code> for huge pages</li>
+        <li><code>madvise(MADV_HUGEPAGE)</code> for transparent huge pages</li>
+        <li><code>numactl</code> / <code>set_mempolicy()</code> for NUMA binding</li>
+        <li><code>sched_setaffinity()</code> for core pinning</li>
+        <li><code>perf</code> for profiling</li>
+        <li><code>io_uring</code> for async I/O (weight loading)</li>
+        <li>Intel DSA via <code>libaccel-config</code> / <code>idxd</code> driver</li>
+    </ul>
+</div>
+
+<div class="card card-green">
+    <p>C-Kernel-Engine targets by <strong>instruction set capability</strong>, not CPU model. Any server-grade CPU with AVX2+FMA or better is a valid target — specific models change, the instruction sets don't. See <code>include/ck_features.h</code> for detection logic.</p>
+</div>
+
+<h2>Why CPU-Only?</h2>
+
+<div class="card card-accent" style="margin-bottom: 1.5rem;">
+    <p><strong>GPUs dominate when you can keep them highly utilized.</strong> Large batches, dense GEMMs, and well-packed workloads that fit comfortably in VRAM let GPUs exercise their theoretical FLOPS advantage. C-Kernel-Engine isn't anti-GPU—we're anti-waste: wasted money on unused capacity, wasted energy at low utilization, and wasted coordination overhead at scale.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Advantages</h3>
+        <ul>
+            <li><strong>No vendor lock-in</strong> - Works on any x86/ARM CPU</li>
+            <li><strong>Commodity hardware</strong> - Standard servers, not &#36;40K GPUs</li>
+            <li><strong>Larger memory</strong> - 2TB RAM per node, no 80GB VRAM limit</li>
+            <li><strong>Better debugging</strong> - GDB, Valgrind, perf all work</li>
+            <li><strong>Simpler deployment</strong> - No CUDA, no driver hell</li>
+            <li><strong>Open ecosystem</strong> - GCC, Linux, standard tools</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">The Trade-off</h3>
+        <ul>
+            <li>GPUs have higher peak FLOPS</li>
+            <li>But: memory bandwidth often bottlenecks anyway</li>
+            <li>But: PCIe transfer overhead for large models</li>
+            <li>But: multi-GPU coordination is complex</li>
+            <li>But: CPU memory is 10-100x larger and cheaper</li>
+        </ul>
+        <p><strong>For inference:</strong> CPUs are often faster for batch=1</p>
+        <p><strong>For training:</strong> Scale horizontally with RDMA</p>
+    </div>
+</div>
+
+<h2>The Fundamental Math: 0 × ∞ = 0</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Memory Constraint</strong><br>
+        It doesn't matter how fast your compute is if your model won't fit in memory. Being 10x faster at computing doesn't help if you're limited by 0 × ∞ = 0.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU: Memory Wins</h3>
+        <ul>
+            <li><strong>Dual-socket server:</strong> 4-6TB DDR5</li>
+            <li><strong>Can train:</strong> 1TB model in BF16</li>
+            <li><strong>Math:</strong> 4-6TB × dual socket = non-zero, model loads</li>
+            <li><strong>Result:</strong> Actually trains the model</li>
+        </ul>
+    </div>
+    <div class="card card-blue">
+        <h3 style="margin-top: 0;">GPU: Compute Fast, Memory Fails</h3>
+        <ul>
+            <li><strong>Single GPU VRAM:</strong> tops out well below what large models need</li>
+            <li><strong>Each GPU generation:</strong> more HBM — at exponentially higher price per unit</li>
+            <li><strong>The constraint:</strong> 1TB model ÷ per-GPU VRAM = many GPUs, minimum, just for weights</li>
+            <li><strong>Math:</strong> 0 utility per GPU (model won't fit alone) × fast FLOPS = 0 — compute speed doesn't solve a memory problem</li>
+            <li><strong>Result:</strong> You buy more GPUs. Cost compounds. Complexity compounds. Memory is still the bottleneck.</li>
+        </ul>
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="CPU vs GPU Memory Analysis">
+    <img src="assets/cpu-gpu-analysis.svg" alt="CPU vs GPU Memory Analysis">
+</div>
+
+<h2>The GPU Cluster Reality</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">GPUs Require Clusters</h3>
+    <p>Here's the fundamental problem: no single GPU can handle large models. You need a cluster.</p>
+    <ul>
+        <li><strong>Even the biggest GPU:</strong> 80GB VRAM max—can't fit 70B+ models</li>
+        <li><strong>Multi-GPU needed:</strong> 8-32 GPUs for practical workloads</li>
+        <li><strong>NVLink required:</strong> &#36;200K+ in interconnects for fast GPU-to-GPU communication</li>
+        <li><strong>DGX systems:</strong> Pre-configured clusters start at &#36;250K+</li>
+    </ul>
+</div>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    </div>
+    <div>
+        <strong>The VRAM Wall</strong><br>
+        Every GPU hits the same VRAM wall. Whether 24GB or 80GB per GPU, large models require massive GPU counts in coordinated clusters. This is the fundamental constraint that CPU-only architecture bypasses entirely.
+    </div>
+</div>
+
+<h2>Energy Efficiency: The CPU Advantage at Realistic Utilization</h2>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg>
+    </div>
+    <div>
+        <strong>"CPUs burn too much power per token"</strong><br>
+        This is the final argument GPU advocates use. But the math changes dramatically when we look at <strong>realistic utilization</strong>, not theoretical peak FLOPS.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The Utilization Problem</h3>
+    <p>GPU efficiency claims assume <strong>100% compute utilization</strong>. Real inference doesn't work that way:</p>
+    <ul>
+        <li><strong>Batch=1 latency:</strong> Most production inference is single-request</li>
+        <li><strong>Memory-bound:</strong> KV cache and weight loading dominate</li>
+        <li><strong>Token-to-token:</strong> 90%+ of time is waiting for next token</li>
+        <li><strong>I/O bound:</strong> Network, disk, and tokenization overhead</li>
+    </ul>
+    <p><strong>The dirty secret:</strong> GPUs spend most of their time <em>idle</em>, still drawing full power.</p>
+</div>
+
+<h3>The Idle Power Reality</h3>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: Always Hungry</h3>
+        <ul>
+            <li><strong>High-end GPU at idle:</strong> ~150W (just sitting there)</li>
+            <li><strong>High-end GPU at compute:</strong> ~700W</li>
+            <li><strong>PCIe overhead:</strong> +50W for data transfer</li>
+            <li><strong>VRAM stays powered:</strong> Weights must remain loaded</li>
+        </ul>
+        <p><strong>Real-world:</strong> If your GPU is only computing 20% of the time, you're wasting 80% of that 700W.</p>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU: Scales Down</h3>
+        <ul>
+            <li><strong>Dual Xeon at idle:</strong> ~100-150W (bare OS, minimal load)</li>
+            <li><strong>Dual Xeon at compute:</strong> ~800-1000W (full load)</li>
+            <li><strong>DVFS:</strong> Scales from 0.8GHz to 3.5GHz dynamically</li>
+            <li><strong>C-states:</strong> Deep sleep cores when waiting for I/O</li>
+        </ul>
+        <p><strong>Real-world:</strong> Enterprise server with 2TB RAM typically draws 200-400W average for inference workloads.</p>
+    </div>
+</div>
+
+<h3>Power-Per-Token Analysis</h3>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Scenario</th><th>GPU Power</th><th>CPU Power</th><th>Winner</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>Theoretical peak FLOPS</strong></td>
+                <td>700W / 989 TFLOPS = 0.71 W/TFLOPS</td>
+                <td>1000W / 6 TFLOPS = 167 W/TFLOPS</td>
+                <td style="color: #ff6b6b;">GPU (theoretical)</td>
+            </tr>
+            <tr>
+                <td><strong>Memory-bound (typical inference)</strong></td>
+                <td>700W (can't scale down)</td>
+                <td>200-400W (scales with load)</td>
+                <td style="color: #47b475;">CPU (2-3.5x less)</td>
+            </tr>
+            <tr>
+                <td><strong>Batch=1, high I/O wait</strong></td>
+                <td>300W average (60% idle)</td>
+                <td>150-200W average (70% idle)</td>
+                <td style="color: #47b475;">CPU (1.5-2x less)</td>
+            </tr>
+            <tr>
+                <td><strong>Multi-tenant (6 models)</strong></td>
+                <td>6 × 700W = 4,200W (all active)</td>
+                <td>800-1000W (all on one server)</td>
+                <td style="color: #47b475;">CPU (4-5x less)</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Utilization Math</h3>
+    <pre>
+GPU Cluster (6× high-end GPUs) for 6-department enterprise:
+  6 departments × 1 GPU each = 4,200W continuous
+  Even when only 1-2 departments are active.
+  Plus: $240,000+ in hardware, NVLink complexity.
+
+CPU (1× Dual Xeon Platinum) for 6-department enterprise:
+  All 6 models resident in 2TB RAM = ~1000W max
+  Each department waits its turn = efficient time-sharing
+  Scales power with actual compute load (not fixed at max)
+
+Net difference: 4-5x less power, 10x lower hardware cost
+    </pre>
+</div>
+
+<h3>Watts Per Token: The Real Numbers</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Enterprise Deployment Comparison</h3>
+    <pre>
+Scenario: 6 models, 24/7 operation, mixed workload
+
+GPU Cluster (6× high-end GPUs):
+  Idle power: 6 × 150W = 900W
+  Compute power: 6 × 700W = 4,200W (when all busy)
+  Average (typical 20% compute): ~1,500W
+  Power/24hr: 36 kWh
+  Power/year: 13,140 kWh
+  @ $0.10/kWh: $1,314/year
+
+CPU Server (1× Dual Xeon Platinum, 2TB RAM):
+  Idle power: ~150W (bare OS, all models in RAM)
+  Compute power: ~1000W (all models active)
+  Average (typical 20% compute): ~320W
+  Power/24hr: 7.7 kWh
+  Power/year: 2,800 kWh
+  @ $0.10/kWh: $280/year
+
+Net difference: 4-5x less power = ~$1,000+/year savings
+    </pre>
+</div>
+
+<h3>Carbon Footprint: Real-World Impact</h3>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU Advantage</h3>
+        <ul>
+            <li><strong>4-5x less electricity</strong> for multi-tenant inference</li>
+            <li><strong>No GPU manufacturing impact</strong> (TSMC 4nm vs 5nm)</li>
+            <li><strong>Lower cooling</strong> due to lower heat output</li>
+            <li><strong>Uses existing infrastructure</strong> - no new hardware needed</li>
+            <li><strong>10x lower hardware cost</strong> (&#36;60K vs &#36;600K+)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">When GPUs Make Sense</h3>
+        <ul>
+            <li><strong>Training large models</strong> (100B+) at 100% utilization</li>
+            <li><strong>Very high throughput</strong> with batching</li>
+            <li><strong>Research</strong> where peak FLOPS matter more than efficiency</li>
+        </ul>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Bottom Line</strong><br>
+        GPU efficiency claims assume 100% compute utilization. Real inference workloads are typically 10-30% compute-bound. At realistic utilization, CPUs consume 3-5x less power for multi-tenant inference. Plus: 10x lower hardware cost. This isn't theory - it's simple thermodynamics based on how often your hardware is actually doing work.
+    </div>
+</div>
+
+<h3>The Hidden Cost: Power Delivery and Signal Integrity</h3>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Nobody Talks About This</strong><br>
+        GPU marketing quotes peak TFLOPS. What they don't mention is the electrical engineering nightmare required to actually deliver those peaks.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The GPU Power Profile: Burst-Idle-Burst</h3>
+    <p>GPUs don't draw steady power. They spike to peak compute (hundreds of watts), then drop when waiting for data transfer, then spike again. This <strong>burst-idle-burst</strong> pattern creates massive di/dt (rate of current change) that cascades into real electrical engineering problems:</p>
+    <ul>
+        <li><strong>di/dt spikes</strong> &mdash; Rapid current transitions from idle to peak compute stress every component in the power delivery path</li>
+        <li><strong>Signal reflections</strong> &mdash; High-speed switching creates signal integrity issues on PCB traces and interconnects</li>
+        <li><strong>Crosstalk</strong> &mdash; Adjacent high-speed signal lines interfere with each other at GPU clock speeds</li>
+        <li><strong>Ground bounce</strong> &mdash; Simultaneous switching of thousands of CUDA cores causes ground plane voltage fluctuation</li>
+        <li><strong>Power supply design</strong> &mdash; PSUs must handle massive transient spikes, requiring expensive voltage regulation and capacitor banks</li>
+    </ul>
+    <p><strong>Result:</strong> Data centers running GPU clusters need specialized power infrastructure &mdash; substations, high-capacity PDUs, and overprovisioned power delivery &mdash; to handle these peak bursts that occur for fractions of a second.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: Spiky, Unpredictable Power</h3>
+        <pre>
+Power draw over time:
+  ████████░░░░████████░░████████░░░░
+  700W     150W  700W  150W 700W  150W
+  compute  wait  compute wait compute wait
+
+Peak-to-idle ratio: ~5:1
+di/dt: Extreme
+Infrastructure: Substation-grade power delivery
+        </pre>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU: Steady, Predictable Power</h3>
+        <pre>
+Power draw over time:
+  ████████████████████████████████
+  200-400W consistent draw
+
+Peak-to-idle ratio: ~2:1
+di/dt: Minimal (DVFS transitions are gradual)
+Infrastructure: Standard data center power
+        </pre>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Theory of Constraints Applied to Power</h3>
+    <p>The fastest moving part and the slowest moving part of a system should be as close together as possible. GPUs violate this principle at the electrical level:</p>
+    <ul>
+        <li><strong>Fastest part:</strong> GPU peak compute at 700W+ burst</li>
+        <li><strong>Slowest part:</strong> Data transfer at 150W idle</li>
+        <li><strong>Gap:</strong> 5:1 ratio &mdash; massive mismatch that the power infrastructure must absorb</li>
+    </ul>
+    <p>CPUs don't have GPU-level peak FLOPS, but they also <strong>don't need substation-grade power infrastructure</strong> to handle those peaks. The power draw is consistent and predictable. Standard, well-designed data center power delivery handles it without complication. No specialized substations. No overprovisioned PDUs. No capacitor banks for transient spikes.</p>
+    <p><strong>The peak FLOPS that GPUs advertise are real &mdash; but the cost of actually delivering that power is hidden from every benchmark and every marketing slide.</strong></p>
+</div>
+
+<div class="img-container svg-viewer" data-title="Power Delivery Reality: GPU Spikes vs CPU Steady State">
+    <img src="assets/power-delivery-infographic.svg" alt="Power Delivery Reality - GPU burst-idle-burst spikes vs CPU steady state power draw, showing signal integrity problems, Theory of Constraints applied to power, and hidden infrastructure costs">
+</div>
+
+<h2>Principle 2: The Ethernet Equalizer</h2>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    </div>
+    <div>
+        <strong>NVLink Doesn't Scale Infinitely</strong><br>
+        NVLink is 900 GB/s <em>within a single node</em>. But you can only fit 8 GPUs per node. Go beyond that? You hit Ethernet. And at the Ethernet boundary, CPUs and GPUs face the exact same constraint.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The Bandwidth Reality</h3>
+    <p>Let's be precise about the numbers:</p>
+</div>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Connection Type</th><th>Bandwidth</th><th>Where It Applies</th><th>Scales To</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>NVLink 4.0</td>
+                <td>900 GB/s</td>
+                <td>GPU-to-GPU within 1 node</td>
+                <td>8 GPUs max</td>
+            </tr>
+            <tr>
+                <td>DDR5 (12-channel)</td>
+                <td>460 GB/s</td>
+                <td>CPU-to-RAM within 1 socket</td>
+                <td>Per socket</td>
+            </tr>
+            <tr>
+                <td>400GbE Ethernet</td>
+                <td>50 GB/s</td>
+                <td>Node-to-node</td>
+                <td>Infinite nodes</td>
+            </tr>
+            <tr>
+                <td>100GbE Ethernet</td>
+                <td>12.5 GB/s</td>
+                <td>Node-to-node</td>
+                <td>Infinite nodes</td>
+            </tr>
+            <tr>
+                <td>InfiniBand HDR</td>
+                <td>25 GB/s</td>
+                <td>Node-to-node</td>
+                <td>Thousands of nodes</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Theory of Constraints Applied</h3>
+    <pre>
+GPU Cluster at Scale:
+  Within node:  NVLink 900 GB/s (fast!)
+  Between nodes: Ethernet 50 GB/s (constraint!)
+  System speed = 50 GB/s (bottleneck)
+
+CPU Cluster at Scale:
+  Within node:  DDR5 460 GB/s
+  Between nodes: Ethernet 50 GB/s (same constraint!)
+  System speed = 50 GB/s (same bottleneck)
+
+AT SCALE, THEY HIT THE SAME WALL.
+    </pre>
+</div>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Without NVLink, GPUs Are Often Slower</strong><br>
+        If you can't afford NVLink switches (&#36;200K+), your GPUs communicate over PCIe → Ethernet. That's 12.5-50 GB/s. A server-grade CPU with DDR5 has 460 GB/s to its own memory. For memory-bound workloads, the CPU wins.
+    </div>
+</div>
+
+<h2>The Compute-to-Bandwidth Chasm</h2>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    </div>
+    <div>
+        <strong>The Ethernet Equalizer Shows Both Hit the Same Wall &mdash; But the Pain Is Wildly Different</strong><br>
+        Every system has a fastest thing (compute) and a slowest thing (cross-node data movement). C-Kernel-Engine's entire goal is to bring these two into sync. On CPUs, they're close enough that software can bridge the gap. On GPUs, they're orders of magnitude apart &mdash; no software fixes that.
+    </div>
+</div>
+
+<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
+    On CPUs, the gap between the fastest thing the system can do (compute) and the slowest thing it must do (move data across the network) is <strong>close</strong>.
+    Peak FLOPS and Ethernet bandwidth live in the same neighborhood.
+    That means the remaining optimization work is pure engineering &mdash; tiling, prefetching, computation-communication overlap &mdash; real techniques that bring compute and data movement closer to sync.
+    <strong>That's what C-Kernel-Engine is built to do.</strong>
+</p>
+<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
+    On GPUs, the fastest and slowest are worlds apart. GPU peak compute is orders of magnitude faster than the Ethernet pipe that feeds it at cluster scale.
+    It's the difference between the summit of <strong>Mt. Everest</strong> and the floor of the <strong>Mariana Trench</strong>.
+    Most of that compute sits permanently idle, burning power, waiting for data that will never arrive fast enough. No amount of software engineering changes the physics.
+</p>
+
+<div class="img-container svg-viewer" data-title="The Compute-to-Bandwidth Chasm: CPU Rolling Hills vs GPU Everest-to-Mariana">
+    <img src="assets/compute-bandwidth-chasm.svg" alt="On CPUs the gap between compute speed and network speed is small — C-Kernel-Engine bridges it. On GPUs the gap is orders of magnitude — unbridgeable at scale.">
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU: Rolling Hills &mdash; Bridgeable</h3>
+        <ul>
+            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are close</li>
+            <li><strong>Local memory bandwidth</strong> sits in between &mdash; a smooth gradient, not a cliff</li>
+            <li><strong>Software can bridge the remaining gap:</strong> tiling, prefetch, overlap</li>
+            <li><strong>Every hardware generation</strong> makes the gap smaller (more bandwidth, same physics)</li>
+        </ul>
+        <p>The terrain is gentle enough to walk. C-Kernel-Engine's job is to build the bridge: bring compute throughput and data movement into sync through aggressive kernel engineering.</p>
+    </div>
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: Everest to Mariana &mdash; Unbridgeable</h3>
+        <ul>
+            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are orders of magnitude apart</li>
+            <li><strong>Intra-node interconnects</strong> are fast, but only reach a handful of GPUs</li>
+            <li><strong>At cluster scale</strong>, everything hits the same Ethernet wall</li>
+            <li><strong>Most compute capacity</strong> sits permanently idle, starved for data</li>
+        </ul>
+        <p>The terrain is a cliff face. No bridge spans from the peak of Everest to the bottom of the Mariana Trench. The gap is structural &mdash; physics, not engineering.</p>
+    </div>
+</div>
+
+<div class="alert alert-success" style="margin-top: 1.5rem;">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>C-Kernel-Engine's Optimization Thesis</strong><br>
+        The goal is straightforward: bring the fastest-moving thing and the slowest-moving thing as close to sync as possible. On CPUs, they're already neighbors &mdash; the remaining work is tiling, cache management, prefetching, and overlapping computation with communication. That is a solvable engineering problem, and it's exactly what this project is built to solve. On GPUs at cluster scale, the gap between compute and data movement is structural. No kernel optimization closes it.
+    </div>
+</div>
+
+<h2>Designing Your Ethernet Network</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Ethernet Switch Topology for ML Clusters</h3>
+    <p>Since Ethernet is the equalizer at scale, designing it well is critical.</p>
+</div>
+
+<h3>Leaf-Spine Architecture</h3>
+
+<div class="card">
+    <pre>
+                    ┌─────────────┐     ┌─────────────┐
+                    │  Spine 1    │     │  Spine 2    │
+                    │ 400GbE      │     │ 400GbE      │
+                    └──────┬──────┘     └──────┬──────┘
+                           │                   │
+         ┌─────────────────┼───────────────────┼─────────────────┐
+         │                 │                   │                 │
+    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
+    │ Leaf 1  │       │ Leaf 2  │       │ Leaf 3  │       │ Leaf 4  │
+    │ 100GbE  │       │ 100GbE  │       │ 100GbE  │       │ 100GbE  │
+    └────┬────┘       └────┬────┘       └────┬────┘       └────┴────┘
+         │                 │                 │                 │
+    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
+    │Server 1 │       │Server 3 │       │Server 5 │       │Server 7 │
+    │Server 2 │       │Server 4 │       │Server 6 │       │Server 8 │
+    └─────────┘       └─────────┘       └─────────┘       └─────────┘
+    </pre>
+</div>
+
+<h3>Switch Sizing Calculator</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Bandwidth Requirements</h3>
+    <pre>
+For distributed training with data parallelism:
+  Gradient size = Model parameters × bytes per param
+  70B model in FP16 = 70B × 2 bytes = 140 GB
+
+All-reduce bandwidth needed:
+  Per iteration: 2 × gradient size (reduce-scatter + all-gather)
+  70B model: 2 × 140 GB = 280 GB per iteration
+
+With 100GbE (12.5 GB/s):
+  All-reduce time = 280 GB ÷ 12.5 GB/s = 22.4 seconds
+
+With 400GbE (50 GB/s):
+  All-reduce time = 280 GB ÷ 50 GB/s = 5.6 seconds
+    </pre>
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Small Cluster (8-16 servers)</h3>
+        <ul>
+            <li><strong>Topology:</strong> Single 400GbE switch</li>
+            <li><strong>Switch:</strong> Arista 7060X5 or similar</li>
+            <li><strong>Ports:</strong> 32× 400GbE</li>
+            <li><strong>Cost:</strong> ~$30,000</li>
+            <li><strong>Bisection BW:</strong> 12.8 Tbps</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Medium Cluster (32-64 servers)</h3>
+        <ul>
+            <li><strong>Topology:</strong> Leaf-spine (2 spine, 4 leaf)</li>
+            <li><strong>Spine:</strong> 2× 400GbE switches</li>
+            <li><strong>Leaf:</strong> 4× 100GbE switches</li>
+            <li><strong>Cost:</strong> ~$120,000</li>
+            <li><strong>Bisection BW:</strong> 25.6 Tbps</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Large Cluster (100+ servers)</h3>
+    <ul>
+        <li><strong>Topology:</strong> 3-tier Clos or fat-tree</li>
+        <li><strong>Consider:</strong> InfiniBand for lower latency</li>
+        <li><strong>RDMA:</strong> RoCEv2 over Ethernet or native IB</li>
+        <li><strong>Cost:</strong> $500K-2M depending on scale</li>
+    </ul>
+    <p><strong>Key insight:</strong> A GPU cluster at this scale needs the SAME network infrastructure. The Ethernet cost is equal. But CPUs don't need the $2M+ in NVLink switches.</p>
+</div>
+
+<h3>RDMA Configuration</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">RoCEv2 Setup</h3>
+    <pre>
+# Enable RDMA over Converged Ethernet v2
+# On each server with Mellanox/NVIDIA ConnectX NICs:
+
+# 1. Enable PFC (Priority Flow Control) on switch
+#    Required for lossless Ethernet
+
+# 2. Configure ECN (Explicit Congestion Notification)
+mlnx_qos -i eth0 --pfc 0,0,0,1,0,0,0,0  # Enable PFC on priority 3
+mlnx_qos -i eth0 --trust=dscp
+
+# 3. Set up RDMA
+modprobe rdma_ucm
+modprobe rdma_cm
+
+# 4. Verify RDMA is working
+ibv_devinfo
+rdma link show
+    </pre>
+</div>
+
+<div class="img-container svg-viewer" data-title="Ethernet Switch Topology">
+    <img src="assets/ethernet-topology.svg" alt="Ethernet Switch Topology for ML Clusters">
+</div>
+
+<h2>Scale Economics: The Real Comparison</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Why CPU-Only Wins at Scale</h3>
+</div>
+
+<div class="img-container svg-viewer" data-title="Scale Economics Comparison">
+    <img src="assets/scale-economics.svg" alt="Scale Economics Comparison">
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-blue">
+        <h3 style="margin-top: 0;">GPU Cluster at Scale</h3>
+        <ul>
+            <li><strong>For 1TB model:</strong> 100 GPUs minimum</li>
+            <li><strong>Total cost:</strong> $4 Billion</li>
+            <li><strong>Who can afford:</strong> 5 companies globally</li>
+            <li><strong>Result:</strong> Elite-only access</li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU Cluster at Scale</h3>
+        <ul>
+            <li><strong>For same scale:</strong> 80 servers</li>
+            <li><strong>Total cost:</strong> $240 Million</li>
+            <li><strong>Who can afford:</strong> 1000+ companies</li>
+            <li><strong>Result:</strong> Accessible to everyone</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Economics: 16x Cheaper, 200x More Accessible</h3>
+    <p>While GPU costs stay high and GPU access remains limited, CPU clusters deliver the same scale at a fraction of the cost. This makes large-scale ML accessible to 1000+ companies instead of just 5.</p>
+</div>
+
+<h2>The Hybrid Trap: CPU+GPU = CPU-Bound</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    </div>
+    <div>
+        <strong>Common Question:</strong><br>
+        "Why not use CPU for memory and GPU for compute? Get the best of both!"<br><br>
+        <strong>Answer:</strong> You're then AS FAST AS THE CPU anyway! You get the complexity of both with the performance of neither.
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="Hybrid CPU+GPU Bottleneck">
+    <img src="assets/hybrid-bottleneck.svg" alt="Hybrid CPU+GPU Bottleneck">
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Hybrid Bottleneck</h3>
+    <p>When CPU holds weights and transfers to GPU for compute:</p>
+    <ul>
+        <li><strong>Transfer bottleneck:</strong> 100 GB/s limits throughput</li>
+        <li><strong>GPU idle time:</strong> Waits for data from CPU</li>
+        <li><strong>You get:</strong> GPU performance = CPU performance</li>
+        <li><strong>Plus:</strong> Double the code complexity, double the cost</li>
+    </ul>
+    <p><strong>Conclusion:</strong> If the GPU is limited by the CPU anyway, just use CPUs! Simpler, faster, cheaper.</p>
+</div>
+
+<h2>The GPU Workaround Stack: "Innovations" That Are Actually Patches</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Uncomfortable Truth</strong><br>
+        The entire field has been optimizing around a hardware constraint and mistaking the workarounds for progress. Every major "breakthrough" in LLM architecture is actually compensating for GPU memory limitations.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Every "Innovation" Maps to a GPU Constraint</h3>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>"Innovation"</th><th>What It Actually Does</th><th>The GPU Constraint It Patches</th><th>Needed on CPU with 2-4TB RAM?</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>GQA (Grouped Query Attention)</strong></td>
+                    <td>Shares KV heads across query heads</td>
+                    <td>KV cache blows up GPU VRAM</td>
+                    <td style="color: #4ade80;">No &mdash; KV cache fits</td>
+                </tr>
+                <tr>
+                    <td><strong>MoE (Mixture of Experts)</strong></td>
+                    <td>Activates sparse subset of parameters</td>
+                    <td>Dense model won't fit on one GPU</td>
+                    <td style="color: #4ade80;">No &mdash; dense model fits</td>
+                </tr>
+                <tr>
+                    <td><strong>KV Caching</strong></td>
+                    <td>Stores past attention keys/values &mdash; literally a key-value database in every layer</td>
+                    <td>GPU VRAM limits cache size, forces eviction strategies</td>
+                    <td style="color: #4ade80;">CPU home turf &mdash; this is literally how databases work. CPUs have been running key-value stores for decades.</td>
+                </tr>
+                <tr>
+                    <td><strong>Gradient Checkpointing</strong></td>
+                    <td>Recomputes activations instead of storing them</td>
+                    <td>Training activations don't fit in GPU VRAM</td>
+                    <td style="color: #4ade80;">No &mdash; store everything</td>
+                </tr>
+                <tr>
+                    <td><strong>Tensor Parallelism</strong></td>
+                    <td>Shards weight matrices across GPUs</td>
+                    <td>Single GPU can't hold the full matrix</td>
+                    <td style="color: #4ade80;">No &mdash; full matrix fits in RAM</td>
+                </tr>
+                <tr>
+                    <td><strong>Pipeline Parallelism</strong></td>
+                    <td>Distributes layers across GPUs</td>
+                    <td>All layers don't fit on one GPU</td>
+                    <td style="color: #4ade80;">No &mdash; all layers fit</td>
+                </tr>
+                <tr>
+                    <td><strong>Flash Attention</strong></td>
+                    <td>Online softmax with tiled computation &mdash; streams through attention in blocks</td>
+                    <td>Full attention matrix doesn't fit in GPU SRAM/VRAM</td>
+                    <td style="color: #4ade80;">Brilliant for CPU &mdash; tiling maps naturally to CPU cache hierarchies. CPUs process data in cache-line-sized tiles inherently.</td>
+                </tr>
+                <tr>
+                    <td><strong>Quantization Research</strong></td>
+                    <td>Compresses model weights (Q4, Q8, etc.)</td>
+                    <td>Model doesn't fit in GPU VRAM at full precision</td>
+                    <td style="color: #fbbf24;">Optional &mdash; use for bandwidth, not capacity</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Punchline</strong><br>
+        On a CPU with 2-4TB RAM, <strong>half of these become unnecessary, and the other half become simpler.</strong> The entire research direction has been shaped by GPU limitations, and people have confused "optimizations forced by GPU memory walls" with "fundamental advances in model architecture."
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="GPU Workaround Convergence: All Roads Lead Back to CPU">
+    <img src="assets/gpu-workaround-convergence.svg" alt="GPU Workaround Convergence - Every GPU innovation (GQA, MoE, KV Caching, Flash Attention, Gradient Checkpointing, Tensor/Pipeline Parallelism, Quantization) converges toward capabilities CPUs have had natively for decades">
+</div>
+
+<h3>The Sequential Reality: GPUs Were Never Designed for This</h3>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Transformers Are Sequential. Period.</h3>
+    <p>A transformer forward pass is:</p>
+    <pre>Layer 1 &rarr; Layer 2 &rarr; Layer 3 &rarr; ... &rarr; Layer 80</pre>
+    <p>You <strong>cannot</strong> compute layer 10 without the output of layer 9. That is the <em>definition</em> of sequential dependency. There is no debate here &mdash; it's mathematical fact.</p>
+    <p>What people mean when they say "LLMs are parallel" is that <em>within</em> a single layer, the matrix multiplication can be parallelized across rows and columns. But that's not the model being parallel &mdash; that's a single operation within a sequential pipeline being decomposable. Every CPU has been decomposing matmuls across SIMD lanes and cores for decades.</p>
+</div>
+
+<h3>Amdahl's Law: Why Parallel Hardware Still Hits a Ceiling</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Strong-Scaling Limit</h3>
+    <p>Amdahl's Law is the simplest way to say what the sequential transformer argument implies in practice:</p>
+    <pre>speedup(N) = 1 / (S + (1 - S) / N)</pre>
+    <p>Where <code>S</code> is the fraction of work that stays effectively serial or synchronization-bound. Even with infinite parallel hardware, the maximum speedup is still:</p>
+    <pre>max_speedup = 1 / S</pre>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Serial / sync fraction</th><th>Theoretical max speedup</th><th>What it means</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>10%</td><td>10&times;</td><td>A surprisingly hard wall for giant clusters</td></tr>
+                <tr><td>5%</td><td>20&times;</td><td>Still not "infinite scaling"</td></tr>
+                <tr><td>2%</td><td>50&times;</td><td>Requires extraordinary system design</td></tr>
+                <tr><td>1%</td><td>100&times;</td><td>Already very difficult in real distributed systems</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <p>For LLMs, that serial fraction is not just "the next token depends on the previous token." It also includes layer boundaries, synchronization, collective communication, optimizer steps, routing decisions, and all the places where the system must wait for the slowest participant.</p>
+    <p><strong>CKE takeaway:</strong> do not optimize only for peak FLOPS. Reduce the effective serial fraction, reduce synchronization pressure, and keep compute, memory, and network in the same performance neighborhood.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">What GPUs Were Designed For</h3>
+        <p><strong>Independent pixel computation.</strong></p>
+        <p>Millions of pixels with <em>zero</em> data dependency on each other. Pixel (0,0) doesn't need the result of pixel (1920,1080) to compute its color. That IS embarrassingly parallel.</p>
+        <pre>
+pixel(0,0)   &rarr; compute color &rarr; done
+pixel(0,1)   &rarr; compute color &rarr; done
+pixel(1,0)   &rarr; compute color &rarr; done
+...
+pixel(1920,1080) &rarr; compute color &rarr; done
+(all independent, all simultaneous)</pre>
+    </div>
+    <div class="card" style="border-left: 4px solid #fbbf24;">
+        <h3 style="margin-top: 0;">What LLM Inference Actually Is</h3>
+        <p><strong>Sequential token generation on a sequential layer stack.</strong></p>
+        <p>Token N+1 depends on the attention computation over ALL previous tokens. The autoregressive decode loop is the opposite of pixel independence.</p>
+        <pre>
+token 1 &rarr; 80 layers &rarr; token 2
+token 2 &rarr; 80 layers &rarr; token 3
+token 3 &rarr; 80 layers &rarr; token 4
+...
+(each waits for the previous)</pre>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Vocabulary of Mismatch</h3>
+    <p>The fact that the industry bolted LLM training onto hardware designed for independent pixel shading and then invented an entire vocabulary to work around the mismatch should tell you something is wrong with the foundational assumption:</p>
+    <ul>
+        <li><strong>Tensor parallelism</strong> &mdash; because one GPU can't hold the weights</li>
+        <li><strong>Pipeline parallelism</strong> &mdash; because one GPU can't hold the layers</li>
+        <li><strong>Model parallelism</strong> &mdash; because the model doesn't fit</li>
+        <li><strong>Gradient checkpointing</strong> &mdash; because activations don't fit</li>
+        <li><strong>Flash Attention</strong> &mdash; because attention intermediates don't fit</li>
+        <li><strong>Activation recomputation</strong> &mdash; because you ran out of memory</li>
+    </ul>
+    <p><strong>Every one of these is a workaround for the same problem:</strong> you're running a sequential, memory-hungry workload on hardware designed for embarrassingly parallel, compute-bound pixel shading.</p>
+</div>
+
+<h3>MoE: The Right Hardware for Dynamic Routing</h3>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Native Fit vs. Forced Workaround</h3>
+    <p>Yes, MoE runs on GPUs — frontier models do it at scale. But <em>runs on</em> is not the same as <em>naturally fits</em>. The same argument made against CPUs for AI ("it works, but it's not the right tool") applies equally to GPUs for MoE.</p>
+    <p>MoE routing is conditional: for each token, a gating function decides which experts activate. GPUs — designed for dense, predictable, lockstep computation — handle this through software workarounds: load balancing losses, capacity factors, expert dropout, and auxiliary training objectives just to keep GPU utilization from collapsing under sparse activation patterns.</p>
+    <p>Consider fixed-function inference chips. They prefer dense computation above all else. The minute you introduce dynamic routing — conditional branching, variable expert selection — they require architectural hacks. GPUs face the same underlying tension, just with more memory headroom to absorb it.</p>
+    <p>CPUs have handled conditional branching natively since the beginning: branch prediction, out-of-order execution, speculative paths. The hardware was built for exactly this. <strong>AVX-512 computes 16 FP32 multiply-accumulates per cycle per core</strong> — across 128 cores that's 2048 parallel operations — and the dynamic routing overhead that GPUs must paper over in software is just normal control flow on a CPU.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Why MoE All-to-All Makes Topology Matter</h3>
+    <p>Jensen Huang's point about MoE is not that "one expert equals one GPU" in a literal one-expert-per-device sense. Real deployments usually place <strong>multiple experts per GPU</strong>, or shard very large experts across several GPUs. But the core communication pattern is the same:</p>
+    <pre>tokens on many GPUs
+   &darr; route top-k experts
+dispatch token states to expert owners (all-to-all)
+   &darr;
+run expert MLPs
+   &darr;
+send expert outputs back / combine (all-to-all again)</pre>
+    <p>That happens at every MoE layer. If the interconnect is a one-hop switched fabric, the communication cost is painful but bounded. If the topology is multi-hop, ring-like, torus-like, or otherwise forces traffic through several devices before reaching the destination, the waiting and queueing add up quickly.</p>
+    <p><strong>This is where Amdahl's Law shows up in systems form:</strong> the expert GEMMs may parallelize beautifully, but the dispatch, synchronization, and combine phases become the part you cannot hide. The more often the model must do all-to-all, the more the communication fraction dominates the ceiling on real speedup.</p>
+</div>
+
+<h3>Training: Batch Size Is Not What You Think</h3>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>"But GPUs need large batches for efficiency!"</strong><br>
+        This is true &mdash; and that's a GPU problem, not a training requirement. Training does not <em>need</em> batch size greater than 1. There are many ways to simulate larger effective batch sizes without holding multiple sequences in memory simultaneously.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: The Batch Balancing Act</h3>
+        <p>On a GPU, you must balance three competing constraints:</p>
+        <ul>
+            <li><strong>Model size</strong> &mdash; weights consume VRAM</li>
+            <li><strong>Context length</strong> &mdash; KV cache consumes VRAM</li>
+            <li><strong>Batch size</strong> &mdash; activations consume VRAM</li>
+        </ul>
+        <p>Increase any one, and you must decrease the others. Want longer context? Reduce batch size. Want larger batch? Reduce context. Want a bigger model? Reduce both.</p>
+        <pre>
+GPU VRAM budget (80GB):
+  Model weights:    40GB (fixed)
+  KV cache:         20GB (varies with context)
+  Activations:      20GB (varies with batch)
+
+  Longer context = less batch
+  Larger batch   = less context
+  ALWAYS a tradeoff.
+        </pre>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU: No Tradeoff Required</h3>
+        <p>With 2-4TB of RAM, all three fit simultaneously:</p>
+        <ul>
+            <li><strong>Model size</strong> &mdash; even 400B+ models fit (800GB+ in FP16)</li>
+            <li><strong>Context length</strong> &mdash; variable, up to 1M+ tokens</li>
+            <li><strong>Batch size</strong> &mdash; whatever you need</li>
+        </ul>
+        <p>You can have <strong>variable context length AND batch greater than one</strong> at the same time. No balancing act required.</p>
+        <pre>
+CPU RAM budget (4TB):
+  Model weights:    810GB (400B+ FP16)
+  KV cache:         500GB (long context)
+  Activations:      200GB (large batch)
+  Remaining:        2,538GB (room to spare)
+
+  Variable context + variable batch
+  NO tradeoffs.
+        </pre>
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">You Don't Need Large Batches &mdash; You Can Simulate Them</h3>
+    <p>Training with batch=1 works. The gradient is noisier, but there are well-established techniques to get the benefits of large batches without the memory cost:</p>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Technique</th><th>How It Works</th><th>GPU Benefit</th><th>CPU Benefit</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>Gradient Accumulation</strong></td>
+                    <td>Accumulate gradients over N forward passes, update once</td>
+                    <td>Simulates batch=N with batch=1 memory</td>
+                    <td>Same, but can also do actual batch=N</td>
+                </tr>
+                <tr>
+                    <td><strong>Micro-batching</strong></td>
+                    <td>Process small sub-batches, aggregate gradients</td>
+                    <td>Fits in VRAM per micro-batch</td>
+                    <td>Can use larger micro-batches</td>
+                </tr>
+                <tr>
+                    <td><strong>Online Learning</strong></td>
+                    <td>Update after every single example (batch=1)</td>
+                    <td>Works but GPU underutilized</td>
+                    <td>Natural fit for CPU sequential processing</td>
+                </tr>
+                <tr>
+                    <td><strong>Data Parallelism</strong></td>
+                    <td>Each node processes different batch, average gradients</td>
+                    <td>Requires NVLink/IB for gradient sync</td>
+                    <td>RDMA gradient sync, same principle</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The C-Kernel-Engine is actively being developed to prove this.</strong><br>
+        Our kernel architecture supports variable context lengths and flexible batch sizes natively. The quantized GEMV/GEMM kernels (Q4_K, Q5_0, Q5_1, Q5_K, Q6_K, Q8_0) are designed from the ground up for CPU-native inference and training &mdash; not as ports of GPU code. We're building the evidence that CPU-only training and inference at scale isn't theoretical &mdash; it's practical, and the kernel-level work is happening now.
+    </div>
+</div>
+
+<h2>Why CPU-Only is the Future</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The Strategic Advantage</h3>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Technical Wins</h3>
+        <ul>
+            <li><strong>Memory capacity:</strong> 4-6TB per node vs 80GB VRAM</li>
+            <li><strong>No transfer bottleneck:</strong> CPU memory + CPU compute</li>
+            <li><strong>Optimize interconnect:</strong> RDMA, core pinning, cache</li>
+            <li><strong>Get close to theoretical FLOPS</strong></li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Market Wins</h3>
+        <ul>
+            <li><strong>16x cheaper</strong> at scale</li>
+            <li><strong>200x more accessible</strong> to companies</li>
+            <li><strong>Commodity hardware</strong> - no special requirements</li>
+            <li><strong>Open ecosystem</strong> - standard Linux tools</li>
+        </ul>
+    </div>
+</div>
+
+<h2>Commodity Economics: The CPU Trajectory</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">CPUs Follow Commodity Price Curves</h3>
+    <p>Unlike GPUs which are supply-constrained and vendor-controlled, CPUs are commodity hardware. Every improvement happens automatically, at scale, with competition driving prices down.</p>
+</div>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Component</th><th>2023</th><th>2025</th><th>2027 (projected)</th><th>Trend</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Memory Standard</td>
+                <td>DDR5-4800</td>
+                <td>DDR5-6400</td>
+                <td>DDR6</td>
+                <td>+33% bandwidth per gen</td>
+            </tr>
+            <tr>
+                <td>Channels per Socket</td>
+                <td>8</td>
+                <td>12</td>
+                <td>16</td>
+                <td>+50% channels</td>
+            </tr>
+            <tr>
+                <td>Max RAM per Server</td>
+                <td>4TB</td>
+                <td>8TB</td>
+                <td>16TB+</td>
+                <td>2x per generation</td>
+            </tr>
+            <tr>
+                <td>Cores per Socket</td>
+                <td>64 (Genoa)</td>
+                <td>128 (Turin)</td>
+                <td>192+</td>
+                <td>+50% per gen</td>
+            </tr>
+            <tr>
+                <td>L3 Cache</td>
+                <td>256MB</td>
+                <td>384MB</td>
+                <td>512MB+</td>
+                <td>Growing</td>
+            </tr>
+            <tr>
+                <td>Ethernet Speed</td>
+                <td>100GbE</td>
+                <td>400GbE</td>
+                <td>800GbE</td>
+                <td>4x per 3 years</td>
+            </tr>
+            <tr>
+                <td>$/TFLOP (CPU)</td>
+                <td>$500</td>
+                <td>$300</td>
+                <td>$150</td>
+                <td>-50% per 2 years</td>
+            </tr>
+            <tr>
+                <td>$/TFLOP (GPU)</td>
+                <td>$50</td>
+                <td>$40</td>
+                <td>$35</td>
+                <td>-15% per 2 years</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Crossover Point</strong><br>
+        GPUs will always have higher peak FLOPS per dollar for raw compute. But for memory-bound ML inference (which is most real-world LLM usage), CPUs are already competitive. And the gap closes every year because CPU economics follow commodity curves.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Why CPU Economics Win</h3>
+        <ul>
+            <li><strong>Competition:</strong> Intel vs AMD vs ARM</li>
+            <li><strong>Volume:</strong> Billions of CPUs vs millions of GPUs</li>
+            <li><strong>Supply:</strong> Multiple fabs, no bottlenecks</li>
+            <li><strong>Standards:</strong> DDR5 is an industry standard, not proprietary</li>
+            <li><strong>Software:</strong> Linux, GCC, standard tools (free)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Why GPU Economics Struggle</h3>
+        <ul>
+            <li><strong>Monopoly:</strong> NVIDIA dominates (~90% market)</li>
+            <li><strong>Supply-constrained:</strong> Artificial scarcity</li>
+            <li><strong>Proprietary:</strong> CUDA lock-in, HBM limited fabs</li>
+            <li><strong>High margins:</strong> No price competition pressure</li>
+            <li><strong>Lead times:</strong> 12-24 month waits</li>
+        </ul>
+    </div>
+</div>
+
+<h2>Infinite CPU Scaling: The Internet Proof</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">CPUs Scale to Infinity</h3>
+    <p>Unlike GPUs, which hit cost and availability ceilings, CPUs scale infinitely through distributed computing across the internet. Your computer is part of that infinity!</p>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Insight</strong><br>
+        Want more FLOPs? Add more CPUs + RDMA! Get your 100 PFLOPS while your friends on the other side keep bragging about their limited GPU clusters. FLOPs is just an accumulation problem that CPUs solve through clever distributed training.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">∞ Infinite Scaling</h3>
+        <ul>
+            <li><strong>Internet-scale distributed computing</strong></li>
+            <li><strong>No ceiling:</strong> Add 10, 100, 1000 CPUs</li>
+            <li><strong>Your computer contributes:</strong> Every device matters</li>
+            <li><strong>Result:</strong> Unlimited FLOP accumulation</li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU Improvements Track</h3>
+        <ul>
+            <li><strong>Cores:</strong> Increasing year over year</li>
+            <li><strong>Cache:</strong> Growing bigger</li>
+            <li><strong>Efficiency:</strong> Getting better</li>
+            <li><strong>Cost:</strong> Decreasing over time</li>
+        </ul>
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Memory Scaling</h3>
+        <ul>
+            <li><strong>DDR5 → DDR6:</strong> 2400 GB/s → higher bandwidth</li>
+            <li><strong>Memory slots:</strong> 8 → 12 → 16 slots per node</li>
+            <li><strong>Total per node:</strong> 4TB → 8TB → 16TB RAM</li>
+            <li><strong>Cost/GB:</strong> Constantly decreasing</li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Model Efficiency</h3>
+        <ul>
+            <li><strong>Smaller models:</strong> Getting more efficient</li>
+            <li><strong>Better quantization:</strong> Q4, Q8, hybrid methods</li>
+            <li><strong>Architecture improvements:</strong> MoE, mixture of experts</li>
+            <li><strong>Training optimization:</strong> Better algorithms</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The C-Kernel Engine Goal</h3>
+    <p>Exploit this infinite CPU scaling on server-grade CPUs. As models get smaller and CPUs get more powerful, the combination becomes unbeatable:</p>
+    <ul>
+        <li><strong>No GPU dependency:</strong> Commodity hardware only</li>
+        <li><strong>Accessible to everyone:</strong> Your laptop contributes to the cluster</li>
+        <li><strong>Sustainable scaling:</strong> Economics favor CPU-only approach</li>
+        <li><strong>Future-proof:</strong> CPU improvements continue while GPU costs stay high</li>
+    </ul>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Multi-Model Parallelism: Enterprise Real Workload</h3>
+    <p>Unlike GPUs which are designed for single-model throughput, CPUs excel at running <strong>multiple models simultaneously</strong> on the same system.</p>
+</div>
+
+<h2>Enterprise & Government: The Multi-Model Reality</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Real Enterprise Scenario</strong><br>
+        In government ministries, large enterprises, and multi-department organizations, different teams need to run different models simultaneously. This is where GPUs become a nightmare.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Government Ministry Example</h3>
+        <ul>
+            <li><strong>Health Dept:</strong> Medical document analysis model</li>
+            <li><strong>Finance Dept:</strong> Fraud detection model</li>
+            <li><strong>Education Dept:</strong> Student assessment model</li>
+            <li><strong>Transport Dept:</strong> Traffic prediction model</li>
+            <li><strong>HR Dept:</strong> Resume screening model</li>
+            <li><strong>Legal Dept:</strong> Contract analysis model</li>
+        </ul>
+        <p><strong>Reality:</strong> 6 departments, 6 different models, all need to run simultaneously.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Enterprise Example</h3>
+        <ul>
+            <li><strong>Sales:</strong> Lead scoring + CRM assistant</li>
+            <li><strong>Support:</strong> Customer chatbot + ticket routing</li>
+            <li><strong>Engineering:</strong> Code review + documentation</li>
+            <li><strong>Marketing:</strong> Content generation + analytics</li>
+            <li><strong>Security:</strong> Threat detection + log analysis</li>
+            <li><strong>Finance:</strong> Expense analysis + forecasting</li>
+        </ul>
+        <p><strong>Reality:</strong> Each department has specialized models for their domain.</p>
+    </div>
+</div>
+
+<h3>The GPU Context-Switching Nightmare</h3>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">GPU Model Switching: Slow and Expensive</h3>
+    <pre>
+GPU Workflow for Multi-Model Serving:
+  1. Load Model A weights into VRAM (80GB)     → 30-60 seconds
+  2. Run inference for Department A            → fast
+  3. Unload Model A from VRAM                  → 10 seconds
+  4. Load Model B weights into VRAM            → 30-60 seconds
+  5. Run inference for Department B            → fast
+  6. Repeat for each model...
+
+Problem: Each context switch = 40-70 seconds of GPU sitting idle!
+With 6 departments cycling through: most of the time is loading/unloading.
+    </pre>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU Multi-Model Issues</h3>
+        <ul>
+            <li><strong>VRAM limit:</strong> 80GB can only hold 1-2 large models</li>
+            <li><strong>Context switching:</strong> Load/unload weights takes 30-60s per model</li>
+            <li><strong>No sharing:</strong> GPU can't easily share between containers</li>
+            <li><strong>MIG complexity:</strong> Multi-Instance GPU splits VRAM, reduces per-model capacity</li>
+            <li><strong>Kubernetes pain:</strong> GPU scheduling requires special plugins, node affinity</li>
+            <li><strong>Cost:</strong> Need dedicated GPU per department = $40K × 6 = $240K</li>
+        </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU Multi-Model Solution</h3>
+        <ul>
+            <li><strong>RAM abundance:</strong> 4TB holds ALL models simultaneously</li>
+            <li><strong>No context switching:</strong> All models resident in RAM, instant access</li>
+            <li><strong>Native sharing:</strong> Standard Linux process isolation works</li>
+            <li><strong>Docker native:</strong> Just containers, no special GPU passthrough</li>
+            <li><strong>Kubernetes native:</strong> Standard pod scheduling, no GPU plugins</li>
+            <li><strong>Cost:</strong> One $60K server runs all 6 departments</li>
+        </ul>
+    </div>
+</div>
+
+<h3>Kubernetes & Docker: CPUs Are First-Class Citizens</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Container Orchestration Reality</h3>
+    <pre>
+GPU Kubernetes Deployment:
+  - Install NVIDIA device plugin
+  - Configure GPU node pools
+  - Set resource limits: nvidia.com/gpu: 1
+  - Deal with GPU memory fragmentation
+  - Handle driver version mismatches
+  - Manage MIG partitioning (if sharing)
+  - Debug CUDA OOM errors in production
+
+CPU Kubernetes Deployment:
+  - Just deploy your container
+  - Set resource limits: cpu: "32", memory: "64Gi"
+  - Done. Standard k8s scheduling handles the rest.
+    </pre>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">CPU Multi-Model Architecture</h3>
+    <pre>
+┌─────────────────────────────────────────────────────────────────┐
+│                    Single CPU Server (4TB RAM)                   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │ Container 1  │  │ Container 2  │  │ Container 3  │           │
+│  │ Health Model │  │ Finance Model│  │ Education    │           │
+│  │ 70B (140GB)  │  │ 13B (26GB)   │  │ 7B (14GB)    │           │
+│  │ 32 cores     │  │ 16 cores     │  │ 8 cores      │           │
+│  └──────────────┘  └──────────────┘  └──────────────┘           │
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │ Container 4  │  │ Container 5  │  │ Container 6  │           │
+│  │ Transport    │  │ HR Model     │  │ Legal Model  │           │
+│  │ 7B (14GB)    │  │ 3B (6GB)     │  │ 13B (26GB)   │           │
+│  │ 8 cores      │  │ 4 cores      │  │ 16 cores     │           │
+│  └──────────────┘  └──────────────┘  └──────────────┘           │
+│                                                                  │
+│  Total: 226GB used / 4TB available = 5.6% RAM utilization       │
+│  All 6 models running simultaneously, no context switching      │
+└─────────────────────────────────────────────────────────────────┘
+    </pre>
+    <p><strong>Key insight:</strong> 6 models totaling 226GB fit easily in 4TB RAM. All running 24/7, no loading/unloading, instant response for any department.</p>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>Enterprise Reality Check</strong><br>
+        Most enterprise/government deployments need to run 5-20 different models for different use cases. CPUs handle this natively with standard containers. GPUs require expensive, complex multi-GPU setups with painful orchestration. This alone makes CPUs the practical choice for most real-world deployments.
+    </div>
+</div>
+
+<h2>CPU-Only: Complete Solution for All Model Sizes</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">One Architecture, All Scales</h3>
+    <p>CPU-only isn't just for large models. It's the complete solution for <strong>every model size</strong>, for <strong>both training and inference</strong>.</p>
+</div>
+
+<div class="grid grid-3">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Small Models (1-7B)</h3>
+        <ul>
+            <li><strong>Training:</strong> Single CPU server</li>
+            <li><strong>Inference:</strong> Laptop or edge device</li>
+            <li><strong>Latency:</strong> Sub-millisecond</li>
+            <li><strong>Cost:</strong> < $100/month</li>
+        </ul>
+        <p><strong>Use cases:</strong> Chatbots, code completion, mobile AI</p>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Medium Models (7-70B)</h3>
+        <ul>
+            <li><strong>Training:</strong> 2-8 CPU servers</li>
+            <li><strong>Inference:</strong> Single CPU server</li>
+            <li><strong>Throughput:</strong> High batch processing</li>
+            <li><strong>Cost:</strong> $500-2000/month</li>
+        </ul>
+        <p><strong>Use cases:</strong> Enterprise AI, content generation, analysis</p>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Large Models (70B+)</h3>
+        <ul>
+            <li><strong>Training:</strong> 10-100 CPU servers</li>
+            <li><strong>Inference:</strong> 2-20 CPU servers</li>
+            <li><strong>Scale:</strong> Distributed across RDMA</li>
+            <li><strong>Cost:</strong> $5000-50000/month</li>
+        </ul>
+        <p><strong>Use cases:</strong> Foundation models, research, large-scale analytics</p>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Unified Approach</strong><br>
+        Same CPU-only architecture scales from your laptop (1B model) to global clusters (1T+ parameters). No architecture changes, no GPU lock-in, no complexity multiplication.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Training at Every Scale</h3>
+        <ul>
+            <li><strong>Small:</strong> Fine-tune on laptop (1-7B)</li>
+            <li><strong>Medium:</strong> Train on workstation (7-70B)</li>
+            <li><strong>Large:</strong> Distributed training (70B+)</li>
+            <li><strong>Methodology:</strong> Same principles, same tools</li>
+        </ul>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Inference at Every Scale</h3>
+        <ul>
+            <li><strong>Small:</strong> Edge deployment (1-7B)</li>
+            <li><strong>Medium:</strong> Server deployment (7-70B)</li>
+            <li><strong>Large:</strong> Distributed inference (70B+)</li>
+            <li><strong>Performance:</strong> Optimized for each tier</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Why This Matters</h3>
+    <p>Organizations can start small and scale infinitely without ever switching architectures:</p>
+    <ol>
+        <li><strong>Start:</strong> Train small model on laptop (fine-tuning)</li>
+        <li><strong>Grow:</strong> Move to server as model size increases</li>
+        <li><strong>Scale:</strong> Add more servers when needed (distributed training)</li>
+        <li><strong>Enterprise:</strong> Run multiple models on same hardware</li>
+    </ol>
+    <p><strong>No lock-in. No architecture migrations. No GPU dependency. Just scale as you grow.</strong></p>
+</div>
+
+<h2>Memory Reality: What NVIDIA Marketing Won't Tell You</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Hidden Truth About LLM Memory</strong><br>
+        GPU marketing focuses on FLOPS. Real-world LLM inference is dominated by <strong>memory bandwidth and capacity</strong>. Here are the actual numbers.
+    </div>
+</div>
+
+<h3>Activation Memory Per Token (Decode)</h3>
+
+<div class="card">
+    <h4 style="margin-top: 0;">Memory Writes Per Token</h4>
+    <p>For a typical 0.5B parameter model (hidden=896, intermediate=4864, 24 layers):</p>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Operation</th><th>Per Layer</th><th>24 Layers</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>RMSNorm output</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>Q, K, V projections</td><td>10.5 KB</td><td>252 KB</td></tr>
+                <tr><td>Attention output</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>O projection</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>MLP gate + up</td><td>38 KB</td><td>912 KB</td></tr>
+                <tr><td>MLP down</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>KV cache (new token)</td><td>1 KB</td><td>24 KB</td></tr>
+                <tr><td>Final logits (once)</td><td>-</td><td>600 KB</td></tr>
+                <tr style="font-weight: bold; background: rgba(255,180,0,0.1);"><td>Total per token</td><td>~63 KB</td><td>~2.1 MB</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <p style="color: #888; font-size: 0.9em;">This is memory bandwidth consumed per generated token. Reducing this is key for decode performance.</p>
+</div>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Real-world profile (0.6B model, Q8_0 quantization, AVX-only CPU):</strong> decode time is dominated by memory-moving kernels --
+        ~48% MLP (gate/up + down), ~21% logits, ~29% attention projections (q/k/v + out), and ~2% attention core. This matches the
+        bandwidth thesis: most time is spent streaming weights/activations, not math.
+    </div>
+</div>
+
+<h3>Context Length: The Memory Multiplier</h3>
+
+<div class="card card-accent">
+    <h4 style="margin-top: 0;">KV Cache Formula</h4>
+    <pre>KV Cache = 2 × n_layers × n_kv_heads × head_dim × context_length × bytes_per_element
+           ↑
+         (K and V)</pre>
+</div>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Context</th><th>KV Cache (FP16)</th><th>+ Model (140GB)</th><th>Fits 80GB GPU?</th><th>Fits 2TB Server?</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>8K</td>
+                <td>2.6 GB</td>
+                <td>143 GB</td>
+                <td style="color: #ff6b6b;">No (need 2×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+            <tr>
+                <td>32K</td>
+                <td>10 GB</td>
+                <td>150 GB</td>
+                <td style="color: #ff6b6b;">No (need 2×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+            <tr>
+                <td>128K</td>
+                <td>41 GB</td>
+                <td>181 GB</td>
+                <td style="color: #ff6b6b;">No (need 3×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+            <tr>
+                <td>1M</td>
+                <td>320 GB</td>
+                <td>460 GB</td>
+                <td style="color: #ff6b6b;">No (need 6×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<!-- Accordion: Show the Math -->
+<details style="margin: 20px 0; background: #1a1a2e; border-radius: 8px; border: 1px solid #333;">
+    <summary style="padding: 15px 20px; cursor: pointer; font-weight: bold; color: #fbbf24;">
+        📐 Show the Math: How We Calculated This
+    </summary>
+    <div style="padding: 0 20px 20px 20px;">
+        <h4 style="color: #4ade80; margin-top: 15px;">Model Architecture (70B Dense Model)</h4>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>Parameter</th><th>Value</th><th>Explanation</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td><code>n_layers</code></td><td>80</td><td>Number of transformer layers</td></tr>
+                    <tr><td><code>n_attention_heads</code></td><td>64</td><td>Query heads per layer</td></tr>
+                    <tr><td><code>n_kv_heads</code></td><td>8</td><td>KV heads (GQA: 8 groups, each serves 8 Q heads)</td></tr>
+                    <tr><td><code>hidden_dim</code></td><td>8192</td><td>Model hidden dimension</td></tr>
+                    <tr><td><code>head_dim</code></td><td>128</td><td>= hidden_dim / n_attention_heads = 8192/64</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h4 style="color: #4ade80;">Step 1: KV Cache Per Token</h4>
+        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
+<span style="color: #888;">// FP16 = 2 bytes per element</span>
+KV_per_token = 2 × n_layers × n_kv_heads × head_dim × bytes
+             = 2 × 80 × 8 × 128 × 2
+             = 327,680 bytes
+             = <span style="color: #4ade80; font-weight: bold;">320 KB per token</span></pre>
+
+        <h4 style="color: #4ade80;">Step 2: Scale by Context Length</h4>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>Context</th><th>Calculation</th><th>KV Cache</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>8K</td>
+                        <td><code>8,192 × 320 KB</code></td>
+                        <td>2.62 GB</td>
+                    </tr>
+                    <tr>
+                        <td>32K</td>
+                        <td><code>32,768 × 320 KB</code></td>
+                        <td>10.5 GB</td>
+                    </tr>
+                    <tr>
+                        <td>128K</td>
+                        <td><code>131,072 × 320 KB</code></td>
+                        <td>41.9 GB</td>
+                    </tr>
+                    <tr>
+                        <td>1M</td>
+                        <td><code>1,048,576 × 320 KB</code></td>
+                        <td>335 GB</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h4 style="color: #4ade80;">Step 3: Add Model Weights</h4>
+        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
+Model weights (70B params × 2 bytes FP16) = <span style="color: #fbbf24; font-weight: bold;">140 GB</span>
+
+Total Memory = Model Weights + KV Cache
+  8K context:   140 + 2.6  = 143 GB  → need 2× 80GB GPUs
+  32K context:  140 + 10.5 = 150 GB  → need 2× 80GB GPUs
+  128K context: 140 + 42   = 182 GB  → need 3× 80GB GPUs
+  1M context:   140 + 335  = 475 GB  → need 6× 80GB GPUs</pre>
+
+        <h4 style="color: #4ade80;">Why GQA Matters</h4>
+        <p style="color: #a0a0b0;">Grouped Query Attention (GQA) reduces KV cache by sharing KV heads across Q heads:</p>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>Attention Type</th><th>KV Heads</th><th>KV per Token</th><th>128K KV Cache</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Multi-Head (MHA)</td>
+                        <td>64</td>
+                        <td>2.56 MB</td>
+                        <td style="color: #ff6b6b;">335 GB</td>
+                    </tr>
+                    <tr>
+                        <td>Grouped Query (GQA-8)</td>
+                        <td>8</td>
+                        <td>320 KB</td>
+                        <td style="color: #4ade80;">42 GB</td>
+                    </tr>
+                    <tr>
+                        <td>Multi-Query (MQA)</td>
+                        <td>1</td>
+                        <td>40 KB</td>
+                        <td style="color: #4ade80;">5.2 GB</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <p style="color: #888; font-size: 0.9em;">GQA-8 gives 8× memory savings over MHA with minimal quality loss.</p>
+    </div>
+</details>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Long Context Reality</strong><br>
+        70B model + 1M context needs ~475 GB. That's 6× 80GB GPUs (&#36;240K+) vs one 2TB CPU server (&#36;30K). This isn't about FLOPS - it's about <strong>where the data can physically exist</strong>.
+    </div>
+</div>
+
+<h3>Prefill Memory Scaling</h3>
+
+<div class="card">
+    <p>Prefill (processing the input prompt) requires storing activations for ALL tokens simultaneously:</p>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Prefill Length</th><th>Activation Memory</th><th>+ KV Cache</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>256 tokens</td><td>~400 MB</td><td>~6 MB</td></tr>
+                <tr><td>1K tokens</td><td>~1.5 GB</td><td>~24 MB</td></tr>
+                <tr><td>4K tokens</td><td>~6 GB</td><td>~96 MB</td></tr>
+                <tr><td>16K tokens</td><td>~24 GB</td><td>~384 MB</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <p style="color: #888; font-size: 0.9em;">Prefill is compute-bound but still needs memory for activations. Long prompts can exceed GPU VRAM.</p>
+</div>
+
+<h3>Visual Guide</h3>
+
+<div class="card" style="max-width: 800px;">
+    <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
+    <p>GPU vs CPU memory comparison for LLM inference:</p>
+    <a href="assets/memory-reality-infographic.svg" target="_blank">
+        <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
+    </a>
+    <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
+</div>
+
+<h2>Training Advantages: Where CPUs Dominate</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Critical Training Scenarios</h3>
+    <p>CPU-only architecture solves training problems that GPU-only simply can't handle.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">1. Long Context Training: KV Cache Explosion</h3>
+        <p><strong>The Problem:</strong> Long context windows create quadratic KV cache growth</p>
+        <ul>
+            <li><strong>4K context:</strong> ~32GB KV cache</li>
+            <li><strong>32K context:</strong> ~256GB KV cache</li>
+            <li><strong>128K context:</strong> ~4TB KV cache</li>
+            <li><strong>1M context:</strong> ~128TB KV cache</li>
+        </ul>
+        <p><strong>CPU Advantage:</strong></p>
+        <ul>
+            <li><strong>4-16TB RAM:</strong> Fits massive KV caches</li>
+            <li><strong>No transfer bottleneck:</strong> Everything in memory</li>
+            <li><strong>GPU Reality:</strong> KV cache doesn't fit = can't train</li>
+        </ul>
+        <div class="alert alert-warning">
+            <strong>Result:</strong> GPU training hits memory wall at 32K context. CPUs handle 1M+ context natively.
+        </div>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">2. Massive Batch Training</h3>
+        <p><strong>The Need:</strong> Large batch sizes improve convergence and throughput</p>
+        <ul>
+            <li><strong>Standard batch:</strong> 32-128 samples</li>
+            <li><strong>Large batch:</strong> 512-2048 samples</li>
+            <li><strong>Massive batch:</strong> 8192+ samples</li>
+            <li><strong>Enterprise batch:</strong> 100K+ samples</li>
+        </ul>
+        <p><strong>CPU Scaling Strategy:</strong></p>
+        <ul>
+            <li><strong>32 CPUs:</strong> 32 batches in parallel</li>
+            <li><strong>Each batch:</strong> 1-10TB RAM available</li>
+            <li><strong>Total effective batch:</strong> 32x larger</li>
+            <li><strong>No communication overhead:</strong> Each CPU independent</li>
+        </ul>
+        <div class="alert alert-success">
+            <strong>Result:</strong> Scale to any batch size by adding more CPUs. No GPU memory constraints!
+        </div>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Training Reality Check</h3>
+    <div class="grid grid-2">
+        <div>
+            <h4>GPU Training Limits</h4>
+            <ul>
+                <li>❌ KV cache fits → max context ~32K</li>
+                <li>❌ Batch size limited by VRAM</li>
+                <li>❌ Large batches require model parallelism</li>
+                <li>❌ Complex coordination across GPUs</li>
+                <li>❌ Expensive hardware (NVLink required)</li>
+            </ul>
+        </div>
+        <div>
+            <h4>CPU Training Advantages</h4>
+            <ul>
+                <li>✅ KV cache fits → context up to 1M+</li>
+                <li>✅ Batch size scales with CPUs</li>
+                <li>✅ Data parallelism = simple scaling</li>
+                <li>✅ RDMA for necessary communication</li>
+                <li>✅ Commodity hardware (Ethernet)</li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>Why This Matters</strong><br>
+        Real-world training needs long context (RAG, document analysis) and large batches (throughput, convergence). CPU-only architecture handles both naturally. GPU-only hits walls that require expensive workarounds.
+    </div>
+</div>
+
+<h2>Distributed Architecture</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">RDMA-Connected CPU Cluster</h3>
+    <pre>
+┌─────────────────────────────────────────────────────────────────┐
+│                     RDMA Fabric (100Gbps+)                      │
+├─────────────────┬─────────────────┬─────────────────────────────┤
+│                 │                 │                             │
+▼                 ▼                 ▼                             │
+┌─────────┐   ┌─────────┐   ┌─────────┐                          │
+│ Node 0  │   │ Node 1  │   │ Node 2  │  ...  Node N             │
+│ 128 cores│   │ 128 cores│   │ 128 cores│                        │
+│ 2TB RAM │   │ 2TB RAM │   │ 2TB RAM │                          │
+│         │   │         │   │         │                          │
+│ Layers  │   │ Layers  │   │ Layers  │                          │
+│ 0-15    │   │ 16-31   │   │ 32-47   │                          │
+└─────────┘   └─────────┘   └─────────┘                          │
+    </pre>
+</div>
+
+<h3>Parallelism Strategies</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">1. Pipeline Parallelism</h3>
+    <p>Different layers on different nodes. Activations flow through the pipeline.</p>
+    <pre>Node 0: Layers 0-15   →  activations  →  Node 1: Layers 16-31  →  ...
+        (forward)           (RDMA)              (forward)</pre>
+    <p><strong>Communication:</strong> Send activations between pipeline stages via RDMA.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">2. Tensor Parallelism</h3>
+    <p>Large matrices split across nodes. Each node computes a shard.</p>
+    <pre>// 16384 x 16384 weight matrix split across 4 nodes
+Node 0: W[0:4096, :]      // Shard 0
+Node 1: W[4096:8192, :]   // Shard 1
+Node 2: W[8192:12288, :]  // Shard 2
+Node 3: W[12288:16384, :] // Shard 3
+
+// After local GEMM, all-reduce to combine</pre>
+    <p><strong>Communication:</strong> RDMA all-reduce after each sharded operation.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">3. Data Parallelism</h3>
+    <p>Same model replicated. Different batches. Gradient averaging.</p>
+    <pre>Node 0: Model copy, Batch 0  →  gradients  ─┐
+Node 1: Model copy, Batch 1  →  gradients  ─┼→  All-reduce  →  Update all
+Node 2: Model copy, Batch 2  →  gradients  ─┤
+Node 3: Model copy, Batch 3  →  gradients  ─┘</pre>
+</div>
+
+<h2>RDMA: The Key Enabler</h2>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Why RDMA?</h3>
+    <p><strong>Remote Direct Memory Access</strong> - Zero-copy, kernel-bypass networking.</p>
+    <div class="table-container">
+        <table class="table">
+        <thead>
+            <tr><th>Metric</th><th>TCP/IP</th><th>RDMA</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>Latency</td><td>~50-100 μs</td><td>~1-2 μs</td></tr>
+            <tr><td>Bandwidth</td><td>10-25 Gbps</td><td>100-400 Gbps</td></tr>
+            <tr><td>CPU overhead</td><td>High (kernel, copies)</td><td>Near zero</td></tr>
+            <tr><td>Memory copies</td><td>Multiple</td><td>Zero (DMA)</td></tr>
+        </tbody>
+    </table>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">RDMA Primitives We Need</h3>
+    <pre>// One-sided operations (no remote CPU involvement)
+rdma_write(remote_addr, local_buf, size);  // Write to remote memory
+rdma_read(local_buf, remote_addr, size);   // Read from remote memory
+
+// Collective operations (built on one-sided)
+rdma_allreduce(buf, size, SUM);  // Gradient averaging
+rdma_broadcast(buf, size, root); // Weight distribution
+rdma_barrier();                   // Synchronization</pre>
+</div>
+
+<h2>Implementation Roadmap</h2>
+
+<div class="card">
+    <div class="table-container">
+        <table class="table">
+        <thead>
+            <tr><th>Phase</th><th>Feature</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>1</td>
+                <td>Single-node training (current)</td>
+                <td><span class="badge badge-green">Done</span></td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>Multi-core parallelism (OpenMP)</td>
+                <td><span class="badge badge-green">Done</span></td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>RDMA communication primitives</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>4</td>
+                <td>Pipeline parallelism</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>5</td>
+                <td>Tensor parallelism (sharded GEMM)</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>6</td>
+                <td>Encoder + cross-attention</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>7</td>
+                <td>600B+ training</td>
+                <td><span class="badge" style="background:#666;color:#ccc;">Future</span></td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</div>
+
+<h2>The Math Doesn't Change</h2>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">From Tiny to Massive: Same Operations</h3>
+    <pre>
+Forward pass (any size model):
+1. embed_tokens()           // Lookup: tokens → vectors
+2. for each layer:
+   a. rmsnorm()             // Normalize
+   b. linear() × 3          // Q, K, V projections
+   c. rope()                // Rotary embeddings
+   d. attention()           // Softmax(QK^T)V
+   e. linear()              // Output projection
+   f. residual_add()        // Skip connection
+   g. rmsnorm()             // Normalize
+   h. mlp_swiglu()          // FFN with gating
+   i. residual_add()        // Skip connection
+3. rmsnorm()                // Final norm
+4. lm_head()                // Logits
+
+Backward pass: Same operations in reverse.
+SGD: weights -= lr * gradients
+
+That's it. For any model size.
+    </pre>
+</div>
+
+<h2>Hardware Recommendations</h2>
+
+<div class="card">
+    <h3 style="margin-top: 0;">For Different Scales</h3>
+    <div class="table-container">
+        <table class="table">
+        <thead>
+            <tr><th>Model Size</th><th>Recommended Setup</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>< 7B</td>
+                <td>Single server, 32+ cores, 128GB+ RAM</td>
+            </tr>
+            <tr>
+                <td>7B - 70B</td>
+                <td>Single server, 128 cores, 512GB-2TB RAM</td>
+            </tr>
+            <tr>
+                <td>70B - 200B</td>
+                <td>2-4 nodes, RDMA interconnect, 2TB RAM each</td>
+            </tr>
+            <tr>
+                <td>200B - 600B</td>
+                <td>8-16 nodes, 100Gbps+ RDMA fabric</td>
+            </tr>
+            <tr>
+                <td>600B+</td>
+                <td>32+ nodes, 400Gbps RDMA, pipeline + tensor parallel</td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Recommended CPUs by Instruction Set</h3>
+    <ul>
+        <li><strong>AMD EPYC 9004/9005 (Genoa/Turin)</strong> - Up to 192 cores, AVX-512 (512-bit), 12-channel DDR5</li>
+        <li><strong>Intel Xeon Sapphire Rapids/Granite Rapids</strong> - Up to 128 cores, AVX-512 + AMX (512-bit tile)</li>
+        <li><strong>Ampere Altra Max</strong> - 128 ARM cores, NEON (128-bit), good perf/watt</li>
+        <li><strong>AWS Graviton3/4</strong> - Cost-effective ARM, NEON + SVE2</li>
+    </ul>
+    <p><strong>Minimum requirement:</strong> AVX (256-bit) or NEON (128-bit). For best performance, AVX-512 or AMX.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">RDMA Options</h3>
+    <ul>
+        <li><strong>Mellanox/NVIDIA ConnectX-7</strong> - 400Gbps InfiniBand</li>
+        <li><strong>Intel E810</strong> - 100Gbps RoCE (RDMA over Ethernet)</li>
+        <li><strong>AWS EFA</strong> - Cloud RDMA for EC2 instances</li>
+    </ul>
+</div>
+
+<h2>Why Not GPU?</h2>
+
+<div class="card">
+    <blockquote style="border-left: 4px solid var(--orange); padding-left: 1rem; margin: 1rem 0; font-style: italic;">
+        "Nvidia, f**k you."<br>
+        <small>— Linus Torvalds, 2012 (<a href="https://www.youtube.com/watch?v=iYWzMvlj2RQ" target="_blank" rel="noopener" style="color: inherit;">video source</a>) regarding their closed-source Linux drivers</small>
+    </blockquote>
+    <p>Beyond the open-source concerns:</p>
+    <ul>
+        <li><strong>Cost</strong> - High-end GPU cluster = $200K+. EPYC server with 2TB RAM = $15,000</li>
+        <li><strong>Memory</strong> - 80GB VRAM vs 2TB+ system RAM</li>
+        <li><strong>Availability</strong> - Export-controlled, supply constrained vs commodity CPUs</li>
+        <li><strong>Flexibility</strong> - Run anywhere: cloud, on-prem, edge, embedded</li>
+        <li><strong>Debugging</strong> - printf works. GDB works. Valgrind works.</li>
+        <li><strong>Longevity</strong> - C code compiles forever. CUDA versions break.</li>
+    </ul>
 </div>
 
 <h2>Further Reading</h2>
 
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="architecture.html">Architecture</a></h3>
-        <p>How circuits, contracts, GraphIR, lowering, generated C, and promotion gates fit together.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="v8-numerical-contracts.html">Numerical Contracts</a></h3>
-        <p>Why mathematically similar kernels can still produce materially different model behavior.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="profiling.html">Profiling</a></h3>
-        <p>The measurement workflow used to identify actual CPU bottlenecks.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a></h3>
-        <p>How a bottleneck moves from attribution to implementation and regression evidence.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="support-hardware.html">Support the Hardware Lab</a></h3>
-        <p>The staged hardware programme and evidence obligations attached to contributed equipment.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="contributing.html">Contribute</a></h3>
-        <p>Start with a bounded build, profiling, numerical, kernel, or compiler contribution.</p>
-    </div>
-</div>
+<ul>
+    <li><a href="memory-reality.html">Memory Reality</a> - What NVIDIA marketing won't tell you about LLM memory</li>
+    <li><a href="developer-guide.html">Developer Guide</a> - How the engine works</li>
+    <li><a href="memory-safety.html">Memory Safety</a> - Bump allocator design</li>
+    <li><a href="profiling.html">Profiling Guide</a> - Performance optimization</li>
+</ul>
+    </main>

--- a/docs/site/_pages/scaling.html
+++ b/docs/site/_pages/scaling.html
@@ -1,2224 +1,357 @@
-<!-- TITLE: Scaling Philosophy -->
+<!-- TITLE: Scaling Thesis -->
 <!-- NAV: scaling -->
 
-<h1>Scaling Philosophy</h1>
+<h1>Scaling Thesis</h1>
 
-<div class="card card-accent" style="border: 2px solid #ffb400; padding: 2rem; margin-bottom: 2rem;">
-    <h2 style="margin-top: 0; color: #ffb400;">The Bet Behind This Project</h2>
+<div class="card card-accent">
+    <h2 style="margin-top: 0;">The Bet, Not the Verdict</h2>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        The bet here is simple: AI will not stay locked inside premium proprietary boxes forever.
-        C-Kernel-Engine takes a different path:
-        <strong>Linux-only, CPU-only, server-grade hardware, open software, and standard data-center parts.</strong>
-        If the software gets good enough, ordinary servers become practical AI machines.
+        C-Kernel-Engine is testing whether explicit numerical contracts, generated C, optimized CPU kernels,
+        and ordinary Linux nodes can make locally owned CPU infrastructure practical for selected AI workloads.
+        The thesis is not that CPUs universally beat accelerators. There is no universal hardware winner.
     </p>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        This is a long-horizon commodity compute bet.
-        The underlying workload is still math, memory movement, and systems software.
-        If CPUs keep gaining cores, SIMD and matrix units, memory channels, NUMA controls, and fast interconnects,
-        then a generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly valuable.
+        The narrower bet is that model execution can be reduced to measurable contracts: arithmetic, bytes moved,
+        synchronization, latency, accuracy, power, and operating cost. For workloads whose constraints match CPU
+        systems, better kernels and better orchestration may turn hardware organizations can procure and control
+        into useful AI infrastructure.
     </p>
-    <p style="font-size: 1.15em; line-height: 1.7;">
-        This is not a claim that CPUs always beat GPU systems on raw peak throughput.
-        That is not the point.
-        The real question is whether CPU-only Linux systems can become
-        <strong>good enough, cheap enough, and accessible enough</strong>
-        to handle serious inference and eventually serious training.
-        That is the thesis being tested here.
-    </p>
-    <p style="font-size: 1.15em; line-height: 1.7;">
-        The early numbers already show that CPU-only inference is practical.
-        A quantized 0.6B model on a 12th-gen Intel Alder Lake machine has reached
-        <strong>about 100 tokens/sec</strong> when the system is otherwise idle.
-        On an older 4-core machine, the same model still runs at
-        <strong>about 20&ndash;25 tokens/sec</strong>.
-        No GPU. No CUDA. No special hardware. Just common x86 instructions and Linux.
-    </p>
-    <p style="font-size: 1.15em; line-height: 1.7;">
-        The bigger target is server-grade CPU infrastructure.
-        Testing is underway on 5th-gen Intel Xeon Scalable systems with AVX-512 and AMX &mdash;
-        the same class of machines already sitting in real data centers.
-        The bet is that these machines will be cheaper, easier to procure, easier to operate, and more broadly deployable than proprietary accelerator-heavy stacks.
-    </p>
-    <p style="font-size: 1.15em; line-height: 1.7; border-top: 1px solid #333; padding-top: 1.5rem; margin-bottom: 0;">
-        The method is straightforward: profile, find the real bottleneck, fix one kernel at a time, and measure again.
-        C-Kernel-Engine uses VTune, FlameGraph, Intel Advisor, <code>perf stat</code>, and roofline analysis to do exactly that.
-        <strong>The point of this page is not hype. It is to state the engineering bet clearly and then earn it with measurements.</strong>
+    <p style="font-size: 1.15em; line-height: 1.7; margin-bottom: 0;">
+        This page defines how that bet will be tested. Single-node execution has evidence today.
+        Multi-node scaling remains a research thesis until matched-node measurements close the communication,
+        synchronization, and efficiency questions.
     </p>
 </div>
 
-<!-- ── Engineering Compass SVG ── -->
-<div style="margin: 2.5rem 0 0.5rem 0; text-align: center;">
-    <img src="assets/engineering-compass.svg" alt="Engineering Compass — Profile, Find Bottleneck, Fix Kernel, Measure, Repeat" style="width: 100%; max-width: 1200px; border-radius: 16px; box-shadow: 0 8px 32px rgba(0,0,0,0.4);" />
+<div style="margin: 2.5rem 0; text-align: center;">
+    <img src="assets/engineering-compass.svg"
+         alt="CKE engineering loop: profile, identify the bottleneck, fix one kernel, and measure again"
+         style="width: 100%; max-width: 1200px; border-radius: 16px;" />
 </div>
 
-<!-- ── Engineering Compass ── -->
-<div style="background: linear-gradient(135deg, #1a2332 0%, #1a1a2e 100%); border: 1px solid #334; border-left: 4px solid #07adf8; border-radius: 12px; padding: 2rem 2.5rem; margin: 0.5rem 0 2rem 0;">
-    <h3 style="margin-top: 0; color: #07adf8; font-size: 1.3em;">
-        🧭 Engineering Compass &mdash; What This Page Is Really For
-    </h3>
-    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc;">
-        This page is the reminder to stay focused on the real thesis:
-        make CPU-only Linux systems useful for modern AI by improving the software until commodity server hardware becomes practical.
-        The scaling story is a direction, not a marketing slogan.
-    </p>
-    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc; margin-bottom: 0.5rem;">
-        The engineering discipline is simple and repeatable:
-    </p>
-    <ol style="font-size: 1.05em; line-height: 2; color: #ddd; padding-left: 1.5rem;">
-        <li><strong style="color: #47b475;">Find the slowest-moving part.</strong> Profile it. Understand <em>why</em> it's slow.</li>
-        <li><strong style="color: #47b475;">Find the fastest-moving part.</strong> Understand what makes it fast. Replicate the pattern.</li>
-        <li><strong style="color: #47b475;">Get more RAM, more cores.</strong> Test on bigger hardware. See if the architecture holds.</li>
-        <li><strong style="color: #47b475;">Keep profiling.</strong> VTune, perf stat, roofline, FlameGraph &mdash; every run, every change.</li>
-        <li><strong style="color: #47b475;">Fix one kernel at a time.</strong> Don't boil the ocean. One bottleneck, one fix, one measurement.</li>
-    </ol>
-    <p style="font-size: 1.1em; line-height: 1.7; color: #999; border-top: 1px solid #333; padding-top: 1rem; margin-bottom: 0;">
-        People will disagree with the thesis, and that is fine.
-        The only useful answer is better measurement, better kernels, and clearer system design.
-        Follow the data, not the hype.
-    </p>
-</div>
+<h2>What CKE Is Betting On</h2>
 
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">The workload is inspectable</h3>
+        <p>
+            A model becomes circuits, tensors, kernels, memory traffic, and synchronization. CKE exposes those
+            boundaries so correctness and performance can be attributed instead of hidden behind a framework call.
+        </p>
     </div>
-    <div>
-        <strong>TL;DR — Two First Principles</strong><br>
-        1) <strong>0 × ∞ = 0:</strong> If the model doesn't fit in memory, FLOPS don't matter.<br>
-        2) <strong>Theory of Constraints:</strong> At the Ethernet boundary, CPUs and GPUs face the same bottleneck.
+    <div class="card">
+        <h3 style="margin-top: 0;">CPU systems keep changing</h3>
+        <p>
+            Vector and matrix instructions, memory-channel counts, NUMA controls, core counts, and data-center
+            networking continue to improve. CKE asks what modern CPU systems can do when software is designed for
+            their actual topology rather than treated as a fallback target.
+        </p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Ownership can be a requirement</h3>
+        <p>
+            Privacy, data residency, predictable capacity, embedded deployment, long-lived services, and operational
+            control can matter as much as peak throughput. These constraints create workloads worth evaluating on
+            locally controlled hardware.
+        </p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">The result must remain falsifiable</h3>
+        <p>
+            A CPU deployment is useful only when it meets a stated accuracy, latency, concurrency, memory, power,
+            reliability, and total-cost envelope. A failed envelope narrows the thesis; it is not a reason to move
+            the goalposts.
+        </p>
     </div>
 </div>
 
-<h2>The Two First Principles</h2>
+<h2>The Feasibility Gates</h2>
 
-<div class="img-container svg-viewer" data-title="Two First Principles: Memory Gate + Theory of Constraints">
-    <img src="assets/two-principles.svg" alt="Principle 1: 0 × ∞ = 0 — memory gates everything. Principle 2: Theory of Constraints — Ethernet equalizes GPUs and CPUs at cluster scale.">
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>CPU Horizontal Scaling Can Stay Simpler</strong><br>
-        Adding CPU servers still requires sharding, scheduling, networking, and NUMA discipline. But it avoids vendor-specific programming models, specialized accelerator fabrics, and the assumption that serious AI must depend on external accelerators from the start. The bet here is that standard Linux servers on Ethernet remain a simpler operational path for many real deployments.
-    </div>
-</div>
-
-<h2>The Computation Is Not Exotic</h2>
-
-<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
-    AI training and inference reduce to five operations: matrix multiply, attention, softmax, layer normalization, and backpropagation.
-    These are linear algebra and calculus — mathematics developed in the 17th through 19th centuries, long before the first computer.
-    <strong>Nothing about the computation requires physically exotic hardware.</strong> A CPU with SIMD instructions executes every one of these operations natively.
-    If the math isn't exotic, the hardware requirement isn't permanent — it's a market condition.
-    And market conditions change.
+<p>
+    Scaling begins only after one node is correct, fits the workload, and has a measured bottleneck. Capacity is the
+    first gate:
 </p>
 
-<div class="img-container svg-viewer" data-title="AI Is Standard Math — Commodity Hardware Always Wins">
-    <img src="assets/commodity-hardware-pattern.svg" alt="Left: AI operations are standard linear algebra and calculus. Right: hardware displacement pattern showing proprietary always loses to commodity.">
-</div>
+<pre>M_weights + M_KV + M_workspace + M_runtime &lt;= M_usable</pre>
 
-<div class="alert alert-warning" style="margin-top: 1.5rem;">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The same pattern, repeating</strong><br>
-        In 1995, "You can't run serious workloads on cheap PCs" was conventional wisdom.<br>
-        In 2025, "You can't run serious AI on cheap CPUs" is conventional wisdom.<br>
-        <strong>One of these beliefs aged very poorly. The pattern suggests which way this one goes.</strong>
-    </div>
-</div>
-
-<details style="margin-top: 1rem;">
-    <summary style="cursor: pointer; color: #a0a0a0; font-size: 0.9em; padding: 0.5rem 0;">Historical reference</summary>
-    <div class="table-container" style="margin-top: 0.75rem;">
-        <table>
-            <thead>
-                <tr><th>Era</th><th>Proprietary Incumbent</th><th>Commodity Disruptor</th><th>Result</th></tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><strong>1990s</strong></td>
-                    <td>SPARC, Alpha, PA-RISC</td>
-                    <td>x86 commodity chips</td>
-                    <td style="color: #4ade80;">Proprietary RISC faded</td>
-                </tr>
-                <tr>
-                    <td><strong>1998</strong></td>
-                    <td>Sun/SGI servers (&#36;500K+)</td>
-                    <td>x86 PCs + MapReduce/GFS</td>
-                    <td style="color: #4ade80;">Sun bankrupt (2010)</td>
-                </tr>
-                <tr>
-                    <td><strong>2009</strong></td>
-                    <td>Teradata, Netezza (&#36;1M+)</td>
-                    <td>Hadoop on commodity clusters</td>
-                    <td style="color: #4ade80;">Big data democratized</td>
-                </tr>
-                <tr style="opacity: 0.7; border-top: 1px dashed #333;">
-                    <td><strong>Now</strong></td>
-                    <td>GPU clusters ($M+)</td>
-                    <td>CPU clusters + software</td>
-                    <td style="color: #ffb400;">→ ?</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</details>
-
-<h2>Principle 1: The Cost of 0 × ∞ = 0</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The GPU Memory Trap</h3>
-    <p>Yes, you CAN fit a 70B model on GPUs using tensor/pipeline parallelism. That's not the point.</p>
-    <p><strong>The point is: you're now FORCED to buy 8+ GPUs in a cluster.</strong></p>
-    <p><strong>And GPUs are:</strong></p>
-    <ul>
-        <li><strong>Proprietary</strong> — locked to NVIDIA (CUDA), no open ecosystem</li>
-        <li><strong>Export-controlled</strong> — H100/H200 blocked in many countries, supply constrained</li>
-        <li><strong>Cluster-required</strong> — single GPUs can't handle large models, need NVLink infrastructure</li>
-        <li><strong>Expensive</strong> — &#36;40K+ per GPU, &#36;200K+ for NVLink switches</li>
-    </ul>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Math That Matters</h3>
-    <pre>
-GPU Path:
-  Model doesn't fit in 80GB → Buy 8 GPUs → $320K for GPUs alone
-  Need NVLink for fast communication → Another $50K+
-  Need DGX chassis → Another $80K+
-  Total: $450K+ just to START
-
-CPU Path:
-  Model fits in 4TB RAM → Buy 1-2 servers → $30K each
-  Standard Ethernet networking → $2K
-  Total: $60K and you're running
-    </pre>
-    <p><strong>The "0 × ∞ = 0" principle forces GPU users into expensive multi-GPU setups. CPUs avoid this entirely.</strong></p>
-</div>
-
-<h2>Target Platform</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Server-Grade Hardware by Instruction Set</h3>
-    <p>C-Kernel-Engine uses <code>ck_features.h</code> for feature detection. We target by SIMD capability, not CPU model:</p>
-</div>
-
-<div class="grid grid-3">
-    <div class="card">
-        <h3 style="margin-top: 0;">Instruction Set Priority</h3>
-        <ul>
-            <li><strong>AMX</strong> - 512-bit tile ops (Intel Sapphire Rapids+)</li>
-            <li><strong>AVX-512</strong> - 512-bit vector (Intel Skylake-X+, AMD Zen 4)</li>
-            <li><strong>AVX2+FMA</strong> - 256-bit with FMA (Intel Haswell+, AMD Zen 2+)</li>
-            <li><strong>AVX</strong> - 256-bit vector (Intel Sandy Bridge+, AMD Zen 1)</li>
-            <li><strong>NEON</strong> - 128-bit (ARM64, Apple Silicon)</li>
-        </ul>
-        <p><strong>Auto-detection:</strong> The engine selects the best kernel at build time with runtime dispatch for optional extensions.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">CPU Requirements</h3>
-        <ul>
-            <li><strong>High core count</strong> - 64-128+ cores per socket</li>
-            <li><strong>Large L3 cache</strong> - Good core-to-cache ratio (1-2MB/core)</li>
-            <li><strong>Vector width</strong> - 256-bit minimum (AVX)</li>
-            <li><strong>FMA</strong> - Recommended for 2x throughput</li>
-            <li><strong>Multiple sockets</strong> - NUMA-aware memory access</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Memory Requirements</h3>
-        <ul>
-            <li><strong>DDR5</strong> - Higher bandwidth, lower latency</li>
-            <li><strong>Multi-channel</strong> - 8-12 channels per socket</li>
-            <li><strong>Large capacity</strong> - 512GB - 2TB+ per node</li>
-            <li><strong>ECC</strong> - Error correction for reliability</li>
-            <li><strong>NUMA-local</strong> - Pin threads to local memory</li>
-        </ul>
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">Accelerators</h3>
-        <ul>
-            <li><strong>Intel DSA</strong> - Data Streaming Accelerator for memory copies</li>
-            <li><strong>Intel IAA</strong> - Analytics Accelerator for compression</li>
-            <li><strong>Intel QAT</strong> - QuickAssist for crypto (if needed)</li>
-            <li><strong>CXL</strong> - Memory expansion and pooling (future)</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Networking</h3>
-        <ul>
-            <li><strong>RDMA</strong> - InfiniBand or RoCEv2</li>
-            <li><strong>100-400 Gbps</strong> - High bandwidth interconnect</li>
-            <li><strong>Low latency</strong> - 1-2 μs for RDMA operations</li>
-            <li><strong>Kernel bypass</strong> - Zero-copy transfers</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Operating System</h3>
-    <p><strong>Linux-only.</strong> We use Linux-specific features:</p>
-    <ul>
-        <li><code>mmap()</code> with <code>MAP_HUGETLB</code> for huge pages</li>
-        <li><code>madvise(MADV_HUGEPAGE)</code> for transparent huge pages</li>
-        <li><code>numactl</code> / <code>set_mempolicy()</code> for NUMA binding</li>
-        <li><code>sched_setaffinity()</code> for core pinning</li>
-        <li><code>perf</code> for profiling</li>
-        <li><code>io_uring</code> for async I/O (weight loading)</li>
-        <li>Intel DSA via <code>libaccel-config</code> / <code>idxd</code> driver</li>
-    </ul>
-</div>
-
-<div class="card card-green">
-    <p>C-Kernel-Engine targets by <strong>instruction set capability</strong>, not CPU model. Any server-grade CPU with AVX2+FMA or better is a valid target — specific models change, the instruction sets don't. See <code>include/ck_features.h</code> for detection logic.</p>
-</div>
-
-<h2>Why CPU-Only?</h2>
-
-<div class="card card-accent" style="margin-bottom: 1.5rem;">
-    <p><strong>GPUs dominate when you can keep them highly utilized.</strong> Large batches, dense GEMMs, and well-packed workloads that fit comfortably in VRAM let GPUs exercise their theoretical FLOPS advantage. C-Kernel-Engine isn't anti-GPU—we're anti-waste: wasted money on unused capacity, wasted energy at low utilization, and wasted coordination overhead at scale.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Advantages</h3>
-        <ul>
-            <li><strong>No vendor lock-in</strong> - Works on any x86/ARM CPU</li>
-            <li><strong>Commodity hardware</strong> - Standard servers, not &#36;40K GPUs</li>
-            <li><strong>Larger memory</strong> - 2TB RAM per node, no 80GB VRAM limit</li>
-            <li><strong>Better debugging</strong> - GDB, Valgrind, perf all work</li>
-            <li><strong>Simpler deployment</strong> - No CUDA, no driver hell</li>
-            <li><strong>Open ecosystem</strong> - GCC, Linux, standard tools</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">The Trade-off</h3>
-        <ul>
-            <li>GPUs have higher peak FLOPS</li>
-            <li>But: memory bandwidth often bottlenecks anyway</li>
-            <li>But: PCIe transfer overhead for large models</li>
-            <li>But: multi-GPU coordination is complex</li>
-            <li>But: CPU memory is 10-100x larger and cheaper</li>
-        </ul>
-        <p><strong>For inference:</strong> CPUs are often faster for batch=1</p>
-        <p><strong>For training:</strong> Scale horizontally with RDMA</p>
-    </div>
-</div>
-
-<h2>The Fundamental Math: 0 × ∞ = 0</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The Memory Constraint</strong><br>
-        It doesn't matter how fast your compute is if your model won't fit in memory. Being 10x faster at computing doesn't help if you're limited by 0 × ∞ = 0.
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU: Memory Wins</h3>
-        <ul>
-            <li><strong>Dual-socket server:</strong> 4-6TB DDR5</li>
-            <li><strong>Can train:</strong> 1TB model in BF16</li>
-            <li><strong>Math:</strong> 4-6TB × dual socket = non-zero, model loads</li>
-            <li><strong>Result:</strong> Actually trains the model</li>
-        </ul>
-    </div>
-    <div class="card card-blue">
-        <h3 style="margin-top: 0;">GPU: Compute Fast, Memory Fails</h3>
-        <ul>
-            <li><strong>Single GPU VRAM:</strong> tops out well below what large models need</li>
-            <li><strong>Each GPU generation:</strong> more HBM — at exponentially higher price per unit</li>
-            <li><strong>The constraint:</strong> 1TB model ÷ per-GPU VRAM = many GPUs, minimum, just for weights</li>
-            <li><strong>Math:</strong> 0 utility per GPU (model won't fit alone) × fast FLOPS = 0 — compute speed doesn't solve a memory problem</li>
-            <li><strong>Result:</strong> You buy more GPUs. Cost compounds. Complexity compounds. Memory is still the bottleneck.</li>
-        </ul>
-    </div>
-</div>
-
-<div class="img-container svg-viewer" data-title="CPU vs GPU Memory Analysis">
-    <img src="assets/cpu-gpu-analysis.svg" alt="CPU vs GPU Memory Analysis">
-</div>
-
-<h2>The GPU Cluster Reality</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">GPUs Require Clusters</h3>
-    <p>Here's the fundamental problem: no single GPU can handle large models. You need a cluster.</p>
-    <ul>
-        <li><strong>Even the biggest GPU:</strong> 80GB VRAM max—can't fit 70B+ models</li>
-        <li><strong>Multi-GPU needed:</strong> 8-32 GPUs for practical workloads</li>
-        <li><strong>NVLink required:</strong> &#36;200K+ in interconnects for fast GPU-to-GPU communication</li>
-        <li><strong>DGX systems:</strong> Pre-configured clusters start at &#36;250K+</li>
-    </ul>
-</div>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-    </div>
-    <div>
-        <strong>The VRAM Wall</strong><br>
-        Every GPU hits the same VRAM wall. Whether 24GB or 80GB per GPU, large models require massive GPU counts in coordinated clusters. This is the fundamental constraint that CPU-only architecture bypasses entirely.
-    </div>
-</div>
-
-<h2>Energy Efficiency: The CPU Advantage at Realistic Utilization</h2>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg>
-    </div>
-    <div>
-        <strong>"CPUs burn too much power per token"</strong><br>
-        This is the final argument GPU advocates use. But the math changes dramatically when we look at <strong>realistic utilization</strong>, not theoretical peak FLOPS.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The Utilization Problem</h3>
-    <p>GPU efficiency claims assume <strong>100% compute utilization</strong>. Real inference doesn't work that way:</p>
-    <ul>
-        <li><strong>Batch=1 latency:</strong> Most production inference is single-request</li>
-        <li><strong>Memory-bound:</strong> KV cache and weight loading dominate</li>
-        <li><strong>Token-to-token:</strong> 90%+ of time is waiting for next token</li>
-        <li><strong>I/O bound:</strong> Network, disk, and tokenization overhead</li>
-    </ul>
-    <p><strong>The dirty secret:</strong> GPUs spend most of their time <em>idle</em>, still drawing full power.</p>
-</div>
-
-<h3>The Idle Power Reality</h3>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: Always Hungry</h3>
-        <ul>
-            <li><strong>High-end GPU at idle:</strong> ~150W (just sitting there)</li>
-            <li><strong>High-end GPU at compute:</strong> ~700W</li>
-            <li><strong>PCIe overhead:</strong> +50W for data transfer</li>
-            <li><strong>VRAM stays powered:</strong> Weights must remain loaded</li>
-        </ul>
-        <p><strong>Real-world:</strong> If your GPU is only computing 20% of the time, you're wasting 80% of that 700W.</p>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU: Scales Down</h3>
-        <ul>
-            <li><strong>Dual Xeon at idle:</strong> ~100-150W (bare OS, minimal load)</li>
-            <li><strong>Dual Xeon at compute:</strong> ~800-1000W (full load)</li>
-            <li><strong>DVFS:</strong> Scales from 0.8GHz to 3.5GHz dynamically</li>
-            <li><strong>C-states:</strong> Deep sleep cores when waiting for I/O</li>
-        </ul>
-        <p><strong>Real-world:</strong> Enterprise server with 2TB RAM typically draws 200-400W average for inference workloads.</p>
-    </div>
-</div>
-
-<h3>Power-Per-Token Analysis</h3>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Scenario</th><th>GPU Power</th><th>CPU Power</th><th>Winner</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><strong>Theoretical peak FLOPS</strong></td>
-                <td>700W / 989 TFLOPS = 0.71 W/TFLOPS</td>
-                <td>1000W / 6 TFLOPS = 167 W/TFLOPS</td>
-                <td style="color: #ff6b6b;">GPU (theoretical)</td>
-            </tr>
-            <tr>
-                <td><strong>Memory-bound (typical inference)</strong></td>
-                <td>700W (can't scale down)</td>
-                <td>200-400W (scales with load)</td>
-                <td style="color: #47b475;">CPU (2-3.5x less)</td>
-            </tr>
-            <tr>
-                <td><strong>Batch=1, high I/O wait</strong></td>
-                <td>300W average (60% idle)</td>
-                <td>150-200W average (70% idle)</td>
-                <td style="color: #47b475;">CPU (1.5-2x less)</td>
-            </tr>
-            <tr>
-                <td><strong>Multi-tenant (6 models)</strong></td>
-                <td>6 × 700W = 4,200W (all active)</td>
-                <td>800-1000W (all on one server)</td>
-                <td style="color: #47b475;">CPU (4-5x less)</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Utilization Math</h3>
-    <pre>
-GPU Cluster (6× high-end GPUs) for 6-department enterprise:
-  6 departments × 1 GPU each = 4,200W continuous
-  Even when only 1-2 departments are active.
-  Plus: $240,000+ in hardware, NVLink complexity.
-
-CPU (1× Dual Xeon Platinum) for 6-department enterprise:
-  All 6 models resident in 2TB RAM = ~1000W max
-  Each department waits its turn = efficient time-sharing
-  Scales power with actual compute load (not fixed at max)
-
-Net difference: 4-5x less power, 10x lower hardware cost
-    </pre>
-</div>
-
-<h3>Watts Per Token: The Real Numbers</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Enterprise Deployment Comparison</h3>
-    <pre>
-Scenario: 6 models, 24/7 operation, mixed workload
-
-GPU Cluster (6× high-end GPUs):
-  Idle power: 6 × 150W = 900W
-  Compute power: 6 × 700W = 4,200W (when all busy)
-  Average (typical 20% compute): ~1,500W
-  Power/24hr: 36 kWh
-  Power/year: 13,140 kWh
-  @ $0.10/kWh: $1,314/year
-
-CPU Server (1× Dual Xeon Platinum, 2TB RAM):
-  Idle power: ~150W (bare OS, all models in RAM)
-  Compute power: ~1000W (all models active)
-  Average (typical 20% compute): ~320W
-  Power/24hr: 7.7 kWh
-  Power/year: 2,800 kWh
-  @ $0.10/kWh: $280/year
-
-Net difference: 4-5x less power = ~$1,000+/year savings
-    </pre>
-</div>
-
-<h3>Carbon Footprint: Real-World Impact</h3>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU Advantage</h3>
-        <ul>
-            <li><strong>4-5x less electricity</strong> for multi-tenant inference</li>
-            <li><strong>No GPU manufacturing impact</strong> (TSMC 4nm vs 5nm)</li>
-            <li><strong>Lower cooling</strong> due to lower heat output</li>
-            <li><strong>Uses existing infrastructure</strong> - no new hardware needed</li>
-            <li><strong>10x lower hardware cost</strong> (&#36;60K vs &#36;600K+)</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">When GPUs Make Sense</h3>
-        <ul>
-            <li><strong>Training large models</strong> (100B+) at 100% utilization</li>
-            <li><strong>Very high throughput</strong> with batching</li>
-            <li><strong>Research</strong> where peak FLOPS matter more than efficiency</li>
-        </ul>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Bottom Line</strong><br>
-        GPU efficiency claims assume 100% compute utilization. Real inference workloads are typically 10-30% compute-bound. At realistic utilization, CPUs consume 3-5x less power for multi-tenant inference. Plus: 10x lower hardware cost. This isn't theory - it's simple thermodynamics based on how often your hardware is actually doing work.
-    </div>
-</div>
-
-<h3>The Hidden Cost: Power Delivery and Signal Integrity</h3>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Nobody Talks About This</strong><br>
-        GPU marketing quotes peak TFLOPS. What they don't mention is the electrical engineering nightmare required to actually deliver those peaks.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The GPU Power Profile: Burst-Idle-Burst</h3>
-    <p>GPUs don't draw steady power. They spike to peak compute (hundreds of watts), then drop when waiting for data transfer, then spike again. This <strong>burst-idle-burst</strong> pattern creates massive di/dt (rate of current change) that cascades into real electrical engineering problems:</p>
-    <ul>
-        <li><strong>di/dt spikes</strong> &mdash; Rapid current transitions from idle to peak compute stress every component in the power delivery path</li>
-        <li><strong>Signal reflections</strong> &mdash; High-speed switching creates signal integrity issues on PCB traces and interconnects</li>
-        <li><strong>Crosstalk</strong> &mdash; Adjacent high-speed signal lines interfere with each other at GPU clock speeds</li>
-        <li><strong>Ground bounce</strong> &mdash; Simultaneous switching of thousands of CUDA cores causes ground plane voltage fluctuation</li>
-        <li><strong>Power supply design</strong> &mdash; PSUs must handle massive transient spikes, requiring expensive voltage regulation and capacitor banks</li>
-    </ul>
-    <p><strong>Result:</strong> Data centers running GPU clusters need specialized power infrastructure &mdash; substations, high-capacity PDUs, and overprovisioned power delivery &mdash; to handle these peak bursts that occur for fractions of a second.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: Spiky, Unpredictable Power</h3>
-        <pre>
-Power draw over time:
-  ████████░░░░████████░░████████░░░░
-  700W     150W  700W  150W 700W  150W
-  compute  wait  compute wait compute wait
-
-Peak-to-idle ratio: ~5:1
-di/dt: Extreme
-Infrastructure: Substation-grade power delivery
-        </pre>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU: Steady, Predictable Power</h3>
-        <pre>
-Power draw over time:
-  ████████████████████████████████
-  200-400W consistent draw
-
-Peak-to-idle ratio: ~2:1
-di/dt: Minimal (DVFS transitions are gradual)
-Infrastructure: Standard data center power
-        </pre>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Theory of Constraints Applied to Power</h3>
-    <p>The fastest moving part and the slowest moving part of a system should be as close together as possible. GPUs violate this principle at the electrical level:</p>
-    <ul>
-        <li><strong>Fastest part:</strong> GPU peak compute at 700W+ burst</li>
-        <li><strong>Slowest part:</strong> Data transfer at 150W idle</li>
-        <li><strong>Gap:</strong> 5:1 ratio &mdash; massive mismatch that the power infrastructure must absorb</li>
-    </ul>
-    <p>CPUs don't have GPU-level peak FLOPS, but they also <strong>don't need substation-grade power infrastructure</strong> to handle those peaks. The power draw is consistent and predictable. Standard, well-designed data center power delivery handles it without complication. No specialized substations. No overprovisioned PDUs. No capacitor banks for transient spikes.</p>
-    <p><strong>The peak FLOPS that GPUs advertise are real &mdash; but the cost of actually delivering that power is hidden from every benchmark and every marketing slide.</strong></p>
-</div>
-
-<div class="img-container svg-viewer" data-title="Power Delivery Reality: GPU Spikes vs CPU Steady State">
-    <img src="assets/power-delivery-infographic.svg" alt="Power Delivery Reality - GPU burst-idle-burst spikes vs CPU steady state power draw, showing signal integrity problems, Theory of Constraints applied to power, and hidden infrastructure costs">
-</div>
-
-<h2>Principle 2: The Ethernet Equalizer</h2>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-    </div>
-    <div>
-        <strong>NVLink Doesn't Scale Infinitely</strong><br>
-        NVLink is 900 GB/s <em>within a single node</em>. But you can only fit 8 GPUs per node. Go beyond that? You hit Ethernet. And at the Ethernet boundary, CPUs and GPUs face the exact same constraint.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The Bandwidth Reality</h3>
-    <p>Let's be precise about the numbers:</p>
-</div>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Connection Type</th><th>Bandwidth</th><th>Where It Applies</th><th>Scales To</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>NVLink 4.0</td>
-                <td>900 GB/s</td>
-                <td>GPU-to-GPU within 1 node</td>
-                <td>8 GPUs max</td>
-            </tr>
-            <tr>
-                <td>DDR5 (12-channel)</td>
-                <td>460 GB/s</td>
-                <td>CPU-to-RAM within 1 socket</td>
-                <td>Per socket</td>
-            </tr>
-            <tr>
-                <td>400GbE Ethernet</td>
-                <td>50 GB/s</td>
-                <td>Node-to-node</td>
-                <td>Infinite nodes</td>
-            </tr>
-            <tr>
-                <td>100GbE Ethernet</td>
-                <td>12.5 GB/s</td>
-                <td>Node-to-node</td>
-                <td>Infinite nodes</td>
-            </tr>
-            <tr>
-                <td>InfiniBand HDR</td>
-                <td>25 GB/s</td>
-                <td>Node-to-node</td>
-                <td>Thousands of nodes</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Theory of Constraints Applied</h3>
-    <pre>
-GPU Cluster at Scale:
-  Within node:  NVLink 900 GB/s (fast!)
-  Between nodes: Ethernet 50 GB/s (constraint!)
-  System speed = 50 GB/s (bottleneck)
-
-CPU Cluster at Scale:
-  Within node:  DDR5 460 GB/s
-  Between nodes: Ethernet 50 GB/s (same constraint!)
-  System speed = 50 GB/s (same bottleneck)
-
-AT SCALE, THEY HIT THE SAME WALL.
-    </pre>
-</div>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Without NVLink, GPUs Are Often Slower</strong><br>
-        If you can't afford NVLink switches (&#36;200K+), your GPUs communicate over PCIe → Ethernet. That's 12.5-50 GB/s. A server-grade CPU with DDR5 has 460 GB/s to its own memory. For memory-bound workloads, the CPU wins.
-    </div>
-</div>
-
-<h2>The Compute-to-Bandwidth Chasm</h2>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-    </div>
-    <div>
-        <strong>The Ethernet Equalizer Shows Both Hit the Same Wall &mdash; But the Pain Is Wildly Different</strong><br>
-        Every system has a fastest thing (compute) and a slowest thing (cross-node data movement). C-Kernel-Engine's entire goal is to bring these two into sync. On CPUs, they're close enough that software can bridge the gap. On GPUs, they're orders of magnitude apart &mdash; no software fixes that.
-    </div>
-</div>
-
-<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
-    On CPUs, the gap between the fastest thing the system can do (compute) and the slowest thing it must do (move data across the network) is <strong>close</strong>.
-    Peak FLOPS and Ethernet bandwidth live in the same neighborhood.
-    That means the remaining optimization work is pure engineering &mdash; tiling, prefetching, computation-communication overlap &mdash; real techniques that bring compute and data movement closer to sync.
-    <strong>That's what C-Kernel-Engine is built to do.</strong>
-</p>
-<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
-    On GPUs, the fastest and slowest are worlds apart. GPU peak compute is orders of magnitude faster than the Ethernet pipe that feeds it at cluster scale.
-    It's the difference between the summit of <strong>Mt. Everest</strong> and the floor of the <strong>Mariana Trench</strong>.
-    Most of that compute sits permanently idle, burning power, waiting for data that will never arrive fast enough. No amount of software engineering changes the physics.
+<p>
+    Once the workload fits, single-node execution time is bounded by the slower of useful arithmetic and memory
+    movement, plus software overhead:
 </p>
 
-<div class="img-container svg-viewer" data-title="The Compute-to-Bandwidth Chasm: CPU Rolling Hills vs GPU Everest-to-Mariana">
-    <img src="assets/compute-bandwidth-chasm.svg" alt="On CPUs the gap between compute speed and network speed is small — C-Kernel-Engine bridges it. On GPUs the gap is orders of magnitude — unbridgeable at scale.">
-</div>
+<pre>T_node = max(T_compute, T_memory) + T_overhead</pre>
 
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU: Rolling Hills &mdash; Bridgeable</h3>
-        <ul>
-            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are close</li>
-            <li><strong>Local memory bandwidth</strong> sits in between &mdash; a smooth gradient, not a cliff</li>
-            <li><strong>Software can bridge the remaining gap:</strong> tiling, prefetch, overlap</li>
-            <li><strong>Every hardware generation</strong> makes the gap smaller (more bandwidth, same physics)</li>
-        </ul>
-        <p>The terrain is gentle enough to walk. C-Kernel-Engine's job is to build the bridge: bring compute throughput and data movement into sync through aggressive kernel engineering.</p>
-    </div>
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: Everest to Mariana &mdash; Unbridgeable</h3>
-        <ul>
-            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are orders of magnitude apart</li>
-            <li><strong>Intra-node interconnects</strong> are fast, but only reach a handful of GPUs</li>
-            <li><strong>At cluster scale</strong>, everything hits the same Ethernet wall</li>
-            <li><strong>Most compute capacity</strong> sits permanently idle, starved for data</li>
-        </ul>
-        <p>The terrain is a cliff face. No bridge spans from the peak of Everest to the bottom of the Mariana Trench. The gap is structural &mdash; physics, not engineering.</p>
-    </div>
-</div>
+<p>
+    Adding nodes introduces costs that do not exist in the single-node result:
+</p>
 
-<div class="alert alert-success" style="margin-top: 1.5rem;">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>C-Kernel-Engine's Optimization Thesis</strong><br>
-        The goal is straightforward: bring the fastest-moving thing and the slowest-moving thing as close to sync as possible. On CPUs, they're already neighbors &mdash; the remaining work is tiling, cache management, prefetching, and overlapping computation with communication. That is a solvable engineering problem, and it's exactly what this project is built to solve. On GPUs at cluster scale, the gap between compute and data movement is structural. No kernel optimization closes it.
-    </div>
-</div>
+<pre>T_N = T_compute,N
+    + T_communication,N
+    + T_synchronization,N
+    + T_imbalance,N</pre>
 
-<h2>Designing Your Ethernet Network</h2>
+<p>
+    Speedup and parallel efficiency are therefore measured results, not consequences of owning more machines:
+</p>
 
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Ethernet Switch Topology for ML Clusters</h3>
-    <p>Since Ethernet is the equalizer at scale, designing it well is critical.</p>
-</div>
-
-<h3>Leaf-Spine Architecture</h3>
-
-<div class="card">
-    <pre>
-                    ┌─────────────┐     ┌─────────────┐
-                    │  Spine 1    │     │  Spine 2    │
-                    │ 400GbE      │     │ 400GbE      │
-                    └──────┬──────┘     └──────┬──────┘
-                           │                   │
-         ┌─────────────────┼───────────────────┼─────────────────┐
-         │                 │                   │                 │
-    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
-    │ Leaf 1  │       │ Leaf 2  │       │ Leaf 3  │       │ Leaf 4  │
-    │ 100GbE  │       │ 100GbE  │       │ 100GbE  │       │ 100GbE  │
-    └────┬────┘       └────┬────┘       └────┬────┘       └────┴────┘
-         │                 │                 │                 │
-    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
-    │Server 1 │       │Server 3 │       │Server 5 │       │Server 7 │
-    │Server 2 │       │Server 4 │       │Server 6 │       │Server 8 │
-    └─────────┘       └─────────┘       └─────────┘       └─────────┘
-    </pre>
-</div>
-
-<h3>Switch Sizing Calculator</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Bandwidth Requirements</h3>
-    <pre>
-For distributed training with data parallelism:
-  Gradient size = Model parameters × bytes per param
-  70B model in FP16 = 70B × 2 bytes = 140 GB
-
-All-reduce bandwidth needed:
-  Per iteration: 2 × gradient size (reduce-scatter + all-gather)
-  70B model: 2 × 140 GB = 280 GB per iteration
-
-With 100GbE (12.5 GB/s):
-  All-reduce time = 280 GB ÷ 12.5 GB/s = 22.4 seconds
-
-With 400GbE (50 GB/s):
-  All-reduce time = 280 GB ÷ 50 GB/s = 5.6 seconds
-    </pre>
-</div>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">Small Cluster (8-16 servers)</h3>
-        <ul>
-            <li><strong>Topology:</strong> Single 400GbE switch</li>
-            <li><strong>Switch:</strong> Arista 7060X5 or similar</li>
-            <li><strong>Ports:</strong> 32× 400GbE</li>
-            <li><strong>Cost:</strong> ~$30,000</li>
-            <li><strong>Bisection BW:</strong> 12.8 Tbps</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Medium Cluster (32-64 servers)</h3>
-        <ul>
-            <li><strong>Topology:</strong> Leaf-spine (2 spine, 4 leaf)</li>
-            <li><strong>Spine:</strong> 2× 400GbE switches</li>
-            <li><strong>Leaf:</strong> 4× 100GbE switches</li>
-            <li><strong>Cost:</strong> ~$120,000</li>
-            <li><strong>Bisection BW:</strong> 25.6 Tbps</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Large Cluster (100+ servers)</h3>
-    <ul>
-        <li><strong>Topology:</strong> 3-tier Clos or fat-tree</li>
-        <li><strong>Consider:</strong> InfiniBand for lower latency</li>
-        <li><strong>RDMA:</strong> RoCEv2 over Ethernet or native IB</li>
-        <li><strong>Cost:</strong> $500K-2M depending on scale</li>
-    </ul>
-    <p><strong>Key insight:</strong> A GPU cluster at this scale needs the SAME network infrastructure. The Ethernet cost is equal. But CPUs don't need the $2M+ in NVLink switches.</p>
-</div>
-
-<h3>RDMA Configuration</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">RoCEv2 Setup</h3>
-    <pre>
-# Enable RDMA over Converged Ethernet v2
-# On each server with Mellanox/NVIDIA ConnectX NICs:
-
-# 1. Enable PFC (Priority Flow Control) on switch
-#    Required for lossless Ethernet
-
-# 2. Configure ECN (Explicit Congestion Notification)
-mlnx_qos -i eth0 --pfc 0,0,0,1,0,0,0,0  # Enable PFC on priority 3
-mlnx_qos -i eth0 --trust=dscp
-
-# 3. Set up RDMA
-modprobe rdma_ucm
-modprobe rdma_cm
-
-# 4. Verify RDMA is working
-ibv_devinfo
-rdma link show
-    </pre>
-</div>
-
-<div class="img-container svg-viewer" data-title="Ethernet Switch Topology">
-    <img src="assets/ethernet-topology.svg" alt="Ethernet Switch Topology for ML Clusters">
-</div>
-
-<h2>Scale Economics: The Real Comparison</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Why CPU-Only Wins at Scale</h3>
-</div>
-
-<div class="img-container svg-viewer" data-title="Scale Economics Comparison">
-    <img src="assets/scale-economics.svg" alt="Scale Economics Comparison">
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-blue">
-        <h3 style="margin-top: 0;">GPU Cluster at Scale</h3>
-        <ul>
-            <li><strong>For 1TB model:</strong> 100 GPUs minimum</li>
-            <li><strong>Total cost:</strong> $4 Billion</li>
-            <li><strong>Who can afford:</strong> 5 companies globally</li>
-            <li><strong>Result:</strong> Elite-only access</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU Cluster at Scale</h3>
-        <ul>
-            <li><strong>For same scale:</strong> 80 servers</li>
-            <li><strong>Total cost:</strong> $240 Million</li>
-            <li><strong>Who can afford:</strong> 1000+ companies</li>
-            <li><strong>Result:</strong> Accessible to everyone</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Economics: 16x Cheaper, 200x More Accessible</h3>
-    <p>While GPU costs stay high and GPU access remains limited, CPU clusters deliver the same scale at a fraction of the cost. This makes large-scale ML accessible to 1000+ companies instead of just 5.</p>
-</div>
-
-<h2>The Hybrid Trap: CPU+GPU = CPU-Bound</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-    </div>
-    <div>
-        <strong>Common Question:</strong><br>
-        "Why not use CPU for memory and GPU for compute? Get the best of both!"<br><br>
-        <strong>Answer:</strong> You're then AS FAST AS THE CPU anyway! You get the complexity of both with the performance of neither.
-    </div>
-</div>
-
-<div class="img-container svg-viewer" data-title="Hybrid CPU+GPU Bottleneck">
-    <img src="assets/hybrid-bottleneck.svg" alt="Hybrid CPU+GPU Bottleneck">
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Hybrid Bottleneck</h3>
-    <p>When CPU holds weights and transfers to GPU for compute:</p>
-    <ul>
-        <li><strong>Transfer bottleneck:</strong> 100 GB/s limits throughput</li>
-        <li><strong>GPU idle time:</strong> Waits for data from CPU</li>
-        <li><strong>You get:</strong> GPU performance = CPU performance</li>
-        <li><strong>Plus:</strong> Double the code complexity, double the cost</li>
-    </ul>
-    <p><strong>Conclusion:</strong> If the GPU is limited by the CPU anyway, just use CPUs! Simpler, faster, cheaper.</p>
-</div>
-
-<h2>The GPU Workaround Stack: "Innovations" That Are Actually Patches</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The Uncomfortable Truth</strong><br>
-        The entire field has been optimizing around a hardware constraint and mistaking the workarounds for progress. Every major "breakthrough" in LLM architecture is actually compensating for GPU memory limitations.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Every "Innovation" Maps to a GPU Constraint</h3>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>"Innovation"</th><th>What It Actually Does</th><th>The GPU Constraint It Patches</th><th>Needed on CPU with 2-4TB RAM?</th></tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><strong>GQA (Grouped Query Attention)</strong></td>
-                    <td>Shares KV heads across query heads</td>
-                    <td>KV cache blows up GPU VRAM</td>
-                    <td style="color: #4ade80;">No &mdash; KV cache fits</td>
-                </tr>
-                <tr>
-                    <td><strong>MoE (Mixture of Experts)</strong></td>
-                    <td>Activates sparse subset of parameters</td>
-                    <td>Dense model won't fit on one GPU</td>
-                    <td style="color: #4ade80;">No &mdash; dense model fits</td>
-                </tr>
-                <tr>
-                    <td><strong>KV Caching</strong></td>
-                    <td>Stores past attention keys/values &mdash; literally a key-value database in every layer</td>
-                    <td>GPU VRAM limits cache size, forces eviction strategies</td>
-                    <td style="color: #4ade80;">CPU home turf &mdash; this is literally how databases work. CPUs have been running key-value stores for decades.</td>
-                </tr>
-                <tr>
-                    <td><strong>Gradient Checkpointing</strong></td>
-                    <td>Recomputes activations instead of storing them</td>
-                    <td>Training activations don't fit in GPU VRAM</td>
-                    <td style="color: #4ade80;">No &mdash; store everything</td>
-                </tr>
-                <tr>
-                    <td><strong>Tensor Parallelism</strong></td>
-                    <td>Shards weight matrices across GPUs</td>
-                    <td>Single GPU can't hold the full matrix</td>
-                    <td style="color: #4ade80;">No &mdash; full matrix fits in RAM</td>
-                </tr>
-                <tr>
-                    <td><strong>Pipeline Parallelism</strong></td>
-                    <td>Distributes layers across GPUs</td>
-                    <td>All layers don't fit on one GPU</td>
-                    <td style="color: #4ade80;">No &mdash; all layers fit</td>
-                </tr>
-                <tr>
-                    <td><strong>Flash Attention</strong></td>
-                    <td>Online softmax with tiled computation &mdash; streams through attention in blocks</td>
-                    <td>Full attention matrix doesn't fit in GPU SRAM/VRAM</td>
-                    <td style="color: #4ade80;">Brilliant for CPU &mdash; tiling maps naturally to CPU cache hierarchies. CPUs process data in cache-line-sized tiles inherently.</td>
-                </tr>
-                <tr>
-                    <td><strong>Quantization Research</strong></td>
-                    <td>Compresses model weights (Q4, Q8, etc.)</td>
-                    <td>Model doesn't fit in GPU VRAM at full precision</td>
-                    <td style="color: #fbbf24;">Optional &mdash; use for bandwidth, not capacity</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Punchline</strong><br>
-        On a CPU with 2-4TB RAM, <strong>half of these become unnecessary, and the other half become simpler.</strong> The entire research direction has been shaped by GPU limitations, and people have confused "optimizations forced by GPU memory walls" with "fundamental advances in model architecture."
-    </div>
-</div>
-
-<div class="img-container svg-viewer" data-title="GPU Workaround Convergence: All Roads Lead Back to CPU">
-    <img src="assets/gpu-workaround-convergence.svg" alt="GPU Workaround Convergence - Every GPU innovation (GQA, MoE, KV Caching, Flash Attention, Gradient Checkpointing, Tensor/Pipeline Parallelism, Quantization) converges toward capabilities CPUs have had natively for decades">
-</div>
-
-<h3>The Sequential Reality: GPUs Were Never Designed for This</h3>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Transformers Are Sequential. Period.</h3>
-    <p>A transformer forward pass is:</p>
-    <pre>Layer 1 &rarr; Layer 2 &rarr; Layer 3 &rarr; ... &rarr; Layer 80</pre>
-    <p>You <strong>cannot</strong> compute layer 10 without the output of layer 9. That is the <em>definition</em> of sequential dependency. There is no debate here &mdash; it's mathematical fact.</p>
-    <p>What people mean when they say "LLMs are parallel" is that <em>within</em> a single layer, the matrix multiplication can be parallelized across rows and columns. But that's not the model being parallel &mdash; that's a single operation within a sequential pipeline being decomposable. Every CPU has been decomposing matmuls across SIMD lanes and cores for decades.</p>
-</div>
-
-<h3>Amdahl's Law: Why Parallel Hardware Still Hits a Ceiling</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Strong-Scaling Limit</h3>
-    <p>Amdahl's Law is the simplest way to say what the sequential transformer argument implies in practice:</p>
-    <pre>speedup(N) = 1 / (S + (1 - S) / N)</pre>
-    <p>Where <code>S</code> is the fraction of work that stays effectively serial or synchronization-bound. Even with infinite parallel hardware, the maximum speedup is still:</p>
-    <pre>max_speedup = 1 / S</pre>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Serial / sync fraction</th><th>Theoretical max speedup</th><th>What it means</th></tr>
-            </thead>
-            <tbody>
-                <tr><td>10%</td><td>10&times;</td><td>A surprisingly hard wall for giant clusters</td></tr>
-                <tr><td>5%</td><td>20&times;</td><td>Still not "infinite scaling"</td></tr>
-                <tr><td>2%</td><td>50&times;</td><td>Requires extraordinary system design</td></tr>
-                <tr><td>1%</td><td>100&times;</td><td>Already very difficult in real distributed systems</td></tr>
-            </tbody>
-        </table>
-    </div>
-    <p>For LLMs, that serial fraction is not just "the next token depends on the previous token." It also includes layer boundaries, synchronization, collective communication, optimizer steps, routing decisions, and all the places where the system must wait for the slowest participant.</p>
-    <p><strong>CKE takeaway:</strong> do not optimize only for peak FLOPS. Reduce the effective serial fraction, reduce synchronization pressure, and keep compute, memory, and network in the same performance neighborhood.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">What GPUs Were Designed For</h3>
-        <p><strong>Independent pixel computation.</strong></p>
-        <p>Millions of pixels with <em>zero</em> data dependency on each other. Pixel (0,0) doesn't need the result of pixel (1920,1080) to compute its color. That IS embarrassingly parallel.</p>
-        <pre>
-pixel(0,0)   &rarr; compute color &rarr; done
-pixel(0,1)   &rarr; compute color &rarr; done
-pixel(1,0)   &rarr; compute color &rarr; done
-...
-pixel(1920,1080) &rarr; compute color &rarr; done
-(all independent, all simultaneous)</pre>
-    </div>
-    <div class="card" style="border-left: 4px solid #fbbf24;">
-        <h3 style="margin-top: 0;">What LLM Inference Actually Is</h3>
-        <p><strong>Sequential token generation on a sequential layer stack.</strong></p>
-        <p>Token N+1 depends on the attention computation over ALL previous tokens. The autoregressive decode loop is the opposite of pixel independence.</p>
-        <pre>
-token 1 &rarr; 80 layers &rarr; token 2
-token 2 &rarr; 80 layers &rarr; token 3
-token 3 &rarr; 80 layers &rarr; token 4
-...
-(each waits for the previous)</pre>
-    </div>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Vocabulary of Mismatch</h3>
-    <p>The fact that the industry bolted LLM training onto hardware designed for independent pixel shading and then invented an entire vocabulary to work around the mismatch should tell you something is wrong with the foundational assumption:</p>
-    <ul>
-        <li><strong>Tensor parallelism</strong> &mdash; because one GPU can't hold the weights</li>
-        <li><strong>Pipeline parallelism</strong> &mdash; because one GPU can't hold the layers</li>
-        <li><strong>Model parallelism</strong> &mdash; because the model doesn't fit</li>
-        <li><strong>Gradient checkpointing</strong> &mdash; because activations don't fit</li>
-        <li><strong>Flash Attention</strong> &mdash; because attention intermediates don't fit</li>
-        <li><strong>Activation recomputation</strong> &mdash; because you ran out of memory</li>
-    </ul>
-    <p><strong>Every one of these is a workaround for the same problem:</strong> you're running a sequential, memory-hungry workload on hardware designed for embarrassingly parallel, compute-bound pixel shading.</p>
-</div>
-
-<h3>MoE: The Right Hardware for Dynamic Routing</h3>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Native Fit vs. Forced Workaround</h3>
-    <p>Yes, MoE runs on GPUs — frontier models do it at scale. But <em>runs on</em> is not the same as <em>naturally fits</em>. The same argument made against CPUs for AI ("it works, but it's not the right tool") applies equally to GPUs for MoE.</p>
-    <p>MoE routing is conditional: for each token, a gating function decides which experts activate. GPUs — designed for dense, predictable, lockstep computation — handle this through software workarounds: load balancing losses, capacity factors, expert dropout, and auxiliary training objectives just to keep GPU utilization from collapsing under sparse activation patterns.</p>
-    <p>Consider fixed-function inference chips. They prefer dense computation above all else. The minute you introduce dynamic routing — conditional branching, variable expert selection — they require architectural hacks. GPUs face the same underlying tension, just with more memory headroom to absorb it.</p>
-    <p>CPUs have handled conditional branching natively since the beginning: branch prediction, out-of-order execution, speculative paths. The hardware was built for exactly this. <strong>AVX-512 computes 16 FP32 multiply-accumulates per cycle per core</strong> — across 128 cores that's 2048 parallel operations — and the dynamic routing overhead that GPUs must paper over in software is just normal control flow on a CPU.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Why MoE All-to-All Makes Topology Matter</h3>
-    <p>Jensen Huang's point about MoE is not that "one expert equals one GPU" in a literal one-expert-per-device sense. Real deployments usually place <strong>multiple experts per GPU</strong>, or shard very large experts across several GPUs. But the core communication pattern is the same:</p>
-    <pre>tokens on many GPUs
-   &darr; route top-k experts
-dispatch token states to expert owners (all-to-all)
-   &darr;
-run expert MLPs
-   &darr;
-send expert outputs back / combine (all-to-all again)</pre>
-    <p>That happens at every MoE layer. If the interconnect is a one-hop switched fabric, the communication cost is painful but bounded. If the topology is multi-hop, ring-like, torus-like, or otherwise forces traffic through several devices before reaching the destination, the waiting and queueing add up quickly.</p>
-    <p><strong>This is where Amdahl's Law shows up in systems form:</strong> the expert GEMMs may parallelize beautifully, but the dispatch, synchronization, and combine phases become the part you cannot hide. The more often the model must do all-to-all, the more the communication fraction dominates the ceiling on real speedup.</p>
-</div>
-
-<h3>Training: Batch Size Is Not What You Think</h3>
+<pre>S(N) = T(1) / T(N)          E(N) = S(N) / N</pre>
 
 <div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
+    <div class="alert-icon">i</div>
     <div>
-        <strong>"But GPUs need large batches for efficiency!"</strong><br>
-        This is true &mdash; and that's a GPU problem, not a training requirement. Training does not <em>need</em> batch size greater than 1. There are many ways to simulate larger effective batch sizes without holding multiple sequences in memory simultaneously.
+        <strong>Memory capacity is necessary, not sufficient.</strong>
+        A model that does not fit cannot run, but a model that fits can still be too slow, too expensive, or too
+        difficult to operate. CKE treats capacity, bandwidth, compute, communication, and user-visible behavior as
+        separate gates.
     </div>
 </div>
+
+<h2>What One Node Must Prove</h2>
+
+<div class="table-container" style="max-width: 100%; overflow-x: auto;">
+<table>
+    <thead>
+        <tr><th>Question</th><th>Required evidence</th><th>Failure means</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Is it numerically acceptable?</td>
+            <td>Reference parity, first-divergence attribution, task-level output, and explicit tolerance</td>
+            <td>Performance results are not yet promotable</td>
+        </tr>
+        <tr>
+            <td>Does it fit?</td>
+            <td>Peak RSS, mapped weights, KV state, workspace, and allocator behavior</td>
+            <td>The model, precision, context, or memory plan must change</td>
+        </tr>
+        <tr>
+            <td>What limits it?</td>
+            <td>Roofline position, effective bandwidth, vector utilization, cache behavior, and hot kernels</td>
+            <td>Optimization is speculation</td>
+        </tr>
+        <tr>
+            <td>Is it useful to a person or service?</td>
+            <td>Time to first token, prefill, decode, concurrency, tail latency, and sustained operation</td>
+            <td>A peak token rate is not enough</td>
+        </tr>
+        <tr>
+            <td>Is it operationally credible?</td>
+            <td>Power, thermals, repeatability, failure behavior, deployment steps, and total system assumptions</td>
+            <td>The benchmark does not describe a deployable system</td>
+        </tr>
+    </tbody>
+</table>
+</div>
+
+<p>
+    Every published result should identify the CPU, memory channels and population, NUMA topology, firmware or
+    microcode where relevant, compiler, CKE commit, model and input hashes, precision, context, batch, thread count,
+    commands, repetitions, and known limitations.
+</p>
+
+<h2>Distributed Scaling Is a Cost Equation</h2>
+
+<p>
+    CKE does not claim infinite scaling. A network makes remote memory and remote computation available, but every
+    boundary adds transfer time, synchronization, queueing, and imbalance. The transfer floor is approximately:
+</p>
+
+<pre>T_transfer &gt;= bytes_transferred / effective_bandwidth + network_latency</pre>
+
+<p>
+    Amdahl's law still applies. If <code>f_s</code> is the serial or effectively non-parallel fraction, ideal speedup
+    cannot exceed:
+</p>
+
+<pre>S(N) &lt;= 1 / (f_s + (1 - f_s) / N)</pre>
+
+<p>
+    Ten, 25, or 100 gigabit Ethernet, RDMA, NUMA placement, transport implementation, message size, and overlap are
+    experiment variables. They are not interchangeable labels. Internet-connected laptops may support independent or
+    delay-tolerant work, but they are not a low-latency tensor fabric and should not be described as one.
+</p>
+
+<h3>Parallelism must match the boundary</h3>
+
+<div class="table-container" style="max-width: 100%; overflow-x: auto;">
+<table>
+    <thead>
+        <tr><th>Strategy</th><th>What crosses nodes</th><th>Where it may fit</th><th>Primary risk</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Data parallelism</td>
+            <td>Gradients, optimizer state, or independent results</td>
+            <td>Independent requests and sufficiently large training batches</td>
+            <td>Reduction cost and duplicated model memory</td>
+        </tr>
+        <tr>
+            <td>Pipeline parallelism</td>
+            <td>Boundary activations</td>
+            <td>Large stages with enough work to amortize transfers</td>
+            <td>Pipeline bubbles and uneven stages</td>
+        </tr>
+        <tr>
+            <td>Tensor parallelism</td>
+            <td>Partial activations and frequent collective results</td>
+            <td>Fast, predictable fabrics and large kernels</td>
+            <td>Communication frequency dominates useful work</td>
+        </tr>
+        <tr>
+            <td>Expert parallelism</td>
+            <td>Routed tokens and expert outputs</td>
+            <td>Stable routing, useful locality, and balanced expert load</td>
+            <td>Dispatch overhead, hotspots, and remote weight traffic</td>
+        </tr>
+    </tbody>
+</table>
+</div>
+
+<h2>MoE Caveat: Routing Does Not Remove Memory Traffic</h2>
+
+<p>
+    Conditional routing is natural to express on a CPU, but that fact alone does not establish a performance
+    advantage. Active expert weights still have to reach the cores. At small batches, an expert may be used too
+    briefly to amortize its weight traffic. At larger batches, routing imbalance and token dispatch can dominate.
+    Total parameter storage also remains large even when only a subset of experts is active for each token.
+</p>
+
+<p>
+    CKE should claim an MoE benefit only after measuring active bytes per token, effective memory bandwidth, expert
+    cache locality, routing distribution, dispatch cost, concurrency, and the routed model's task quality against a
+    dense or established reference. Branch support is an implementation property; system throughput is the result.
+</p>
+
+<h2>Model Architecture Is Shaped by Constraints</h2>
+
+<p>
+    Many important model techniques can be understood as responses to memory, compute, or communication pressure.
+    That is useful systems context, but it is not evidence that the techniques are merely workarounds or that they
+    belong to one hardware class.
+</p>
+
+<div class="table-container" style="max-width: 100%; overflow-x: auto;">
+<table>
+    <thead>
+        <tr><th>Technique</th><th>Constraint reduced</th><th>New cost or contract</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>GQA and MQA</td><td>KV-cache capacity and bandwidth</td><td>Shared key/value semantics and possible quality trade-offs</td></tr>
+        <tr><td>Fused or tiled attention</td><td>Intermediate storage and external memory traffic</td><td>Tiling, reduction order, precision, and backend-specific kernels</td></tr>
+        <tr><td>KV paging and quantization</td><td>Long-context capacity and allocation pressure</td><td>State management, conversion cost, and numerical error</td></tr>
+        <tr><td>Mixture of experts</td><td>Active compute per token relative to total model capacity</td><td>Routing, load balance, expert storage, and dispatch</td></tr>
+        <tr><td>Recurrent or state-space layers</td><td>Explicit long-sequence state growth</td><td>Compressed-state semantics, scan kernels, and training complexity</td></tr>
+        <tr><td>Weight and activation quantization</td><td>Capacity, bandwidth, and arithmetic cost</td><td>Calibration, scale handling, kernel coverage, and quality validation</td></tr>
+    </tbody>
+</table>
+</div>
+
+<h2>The CKE Experiment Ladder</h2>
 
 <div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: The Batch Balancing Act</h3>
-        <p>On a GPU, you must balance three competing constraints:</p>
-        <ul>
-            <li><strong>Model size</strong> &mdash; weights consume VRAM</li>
-            <li><strong>Context length</strong> &mdash; KV cache consumes VRAM</li>
-            <li><strong>Batch size</strong> &mdash; activations consume VRAM</li>
-        </ul>
-        <p>Increase any one, and you must decrease the others. Want longer context? Reduce batch size. Want larger batch? Reduce context. Want a bigger model? Reduce both.</p>
-        <pre>
-GPU VRAM budget (80GB):
-  Model weights:    40GB (fixed)
-  KV cache:         20GB (varies with context)
-  Activations:      20GB (varies with batch)
-
-  Longer context = less batch
-  Larger batch   = less context
-  ALWAYS a tradeoff.
-        </pre>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU: No Tradeoff Required</h3>
-        <p>With 2-4TB of RAM, all three fit simultaneously:</p>
-        <ul>
-            <li><strong>Model size</strong> &mdash; even 400B+ models fit (800GB+ in FP16)</li>
-            <li><strong>Context length</strong> &mdash; variable, up to 1M+ tokens</li>
-            <li><strong>Batch size</strong> &mdash; whatever you need</li>
-        </ul>
-        <p>You can have <strong>variable context length AND batch greater than one</strong> at the same time. No balancing act required.</p>
-        <pre>
-CPU RAM budget (4TB):
-  Model weights:    810GB (400B+ FP16)
-  KV cache:         500GB (long context)
-  Activations:      200GB (large batch)
-  Remaining:        2,538GB (room to spare)
-
-  Variable context + variable batch
-  NO tradeoffs.
-        </pre>
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">You Don't Need Large Batches &mdash; You Can Simulate Them</h3>
-    <p>Training with batch=1 works. The gradient is noisier, but there are well-established techniques to get the benefits of large batches without the memory cost:</p>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Technique</th><th>How It Works</th><th>GPU Benefit</th><th>CPU Benefit</th></tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><strong>Gradient Accumulation</strong></td>
-                    <td>Accumulate gradients over N forward passes, update once</td>
-                    <td>Simulates batch=N with batch=1 memory</td>
-                    <td>Same, but can also do actual batch=N</td>
-                </tr>
-                <tr>
-                    <td><strong>Micro-batching</strong></td>
-                    <td>Process small sub-batches, aggregate gradients</td>
-                    <td>Fits in VRAM per micro-batch</td>
-                    <td>Can use larger micro-batches</td>
-                </tr>
-                <tr>
-                    <td><strong>Online Learning</strong></td>
-                    <td>Update after every single example (batch=1)</td>
-                    <td>Works but GPU underutilized</td>
-                    <td>Natural fit for CPU sequential processing</td>
-                </tr>
-                <tr>
-                    <td><strong>Data Parallelism</strong></td>
-                    <td>Each node processes different batch, average gradients</td>
-                    <td>Requires NVLink/IB for gradient sync</td>
-                    <td>RDMA gradient sync, same principle</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The C-Kernel-Engine is actively being developed to prove this.</strong><br>
-        Our kernel architecture supports variable context lengths and flexible batch sizes natively. The quantized GEMV/GEMM kernels (Q4_K, Q5_0, Q5_1, Q5_K, Q6_K, Q8_0) are designed from the ground up for CPU-native inference and training &mdash; not as ports of GPU code. We're building the evidence that CPU-only training and inference at scale isn't theoretical &mdash; it's practical, and the kernel-level work is happening now.
-    </div>
-</div>
-
-<h2>Why CPU-Only is the Future</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The Strategic Advantage</h3>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Technical Wins</h3>
-        <ul>
-            <li><strong>Memory capacity:</strong> 4-6TB per node vs 80GB VRAM</li>
-            <li><strong>No transfer bottleneck:</strong> CPU memory + CPU compute</li>
-            <li><strong>Optimize interconnect:</strong> RDMA, core pinning, cache</li>
-            <li><strong>Get close to theoretical FLOPS</strong></li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Market Wins</h3>
-        <ul>
-            <li><strong>16x cheaper</strong> at scale</li>
-            <li><strong>200x more accessible</strong> to companies</li>
-            <li><strong>Commodity hardware</strong> - no special requirements</li>
-            <li><strong>Open ecosystem</strong> - standard Linux tools</li>
-        </ul>
-    </div>
-</div>
-
-<h2>Commodity Economics: The CPU Trajectory</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">CPUs Follow Commodity Price Curves</h3>
-    <p>Unlike GPUs which are supply-constrained and vendor-controlled, CPUs are commodity hardware. Every improvement happens automatically, at scale, with competition driving prices down.</p>
-</div>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Component</th><th>2023</th><th>2025</th><th>2027 (projected)</th><th>Trend</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>Memory Standard</td>
-                <td>DDR5-4800</td>
-                <td>DDR5-6400</td>
-                <td>DDR6</td>
-                <td>+33% bandwidth per gen</td>
-            </tr>
-            <tr>
-                <td>Channels per Socket</td>
-                <td>8</td>
-                <td>12</td>
-                <td>16</td>
-                <td>+50% channels</td>
-            </tr>
-            <tr>
-                <td>Max RAM per Server</td>
-                <td>4TB</td>
-                <td>8TB</td>
-                <td>16TB+</td>
-                <td>2x per generation</td>
-            </tr>
-            <tr>
-                <td>Cores per Socket</td>
-                <td>64 (Genoa)</td>
-                <td>128 (Turin)</td>
-                <td>192+</td>
-                <td>+50% per gen</td>
-            </tr>
-            <tr>
-                <td>L3 Cache</td>
-                <td>256MB</td>
-                <td>384MB</td>
-                <td>512MB+</td>
-                <td>Growing</td>
-            </tr>
-            <tr>
-                <td>Ethernet Speed</td>
-                <td>100GbE</td>
-                <td>400GbE</td>
-                <td>800GbE</td>
-                <td>4x per 3 years</td>
-            </tr>
-            <tr>
-                <td>$/TFLOP (CPU)</td>
-                <td>$500</td>
-                <td>$300</td>
-                <td>$150</td>
-                <td>-50% per 2 years</td>
-            </tr>
-            <tr>
-                <td>$/TFLOP (GPU)</td>
-                <td>$50</td>
-                <td>$40</td>
-                <td>$35</td>
-                <td>-15% per 2 years</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Crossover Point</strong><br>
-        GPUs will always have higher peak FLOPS per dollar for raw compute. But for memory-bound ML inference (which is most real-world LLM usage), CPUs are already competitive. And the gap closes every year because CPU economics follow commodity curves.
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Why CPU Economics Win</h3>
-        <ul>
-            <li><strong>Competition:</strong> Intel vs AMD vs ARM</li>
-            <li><strong>Volume:</strong> Billions of CPUs vs millions of GPUs</li>
-            <li><strong>Supply:</strong> Multiple fabs, no bottlenecks</li>
-            <li><strong>Standards:</strong> DDR5 is an industry standard, not proprietary</li>
-            <li><strong>Software:</strong> Linux, GCC, standard tools (free)</li>
-        </ul>
+    <div class="card">
+        <h3 style="margin-top: 0;">1. Numerical closure</h3>
+        <p>Establish model-specific parity against PyTorch or another declared reference before promoting speed.</p>
+        <p><strong>Status:</strong> active, with supported model paths and known multimodal gaps.</p>
     </div>
     <div class="card">
-        <h3 style="margin-top: 0;">Why GPU Economics Struggle</h3>
-        <ul>
-            <li><strong>Monopoly:</strong> NVIDIA dominates (~90% market)</li>
-            <li><strong>Supply-constrained:</strong> Artificial scarcity</li>
-            <li><strong>Proprietary:</strong> CUDA lock-in, HBM limited fabs</li>
-            <li><strong>High margins:</strong> No price competition pressure</li>
-            <li><strong>Lead times:</strong> 12-24 month waits</li>
-        </ul>
+        <h3 style="margin-top: 0;">2. Single-node performance</h3>
+        <p>Measure kernels, memory topology, prefill, decode, concurrency, power, and sustained behavior.</p>
+        <p><strong>Status:</strong> active across consumer, server, and selected embedded CPU targets.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">3. NUMA and topology</h3>
+        <p>Make placement, replication, thread ownership, and cross-socket traffic explicit and reproducible.</p>
+        <p><strong>Status:</strong> being hardened; results remain hardware-specific.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">4. Two-node transport</h3>
+        <p>Measure serialization, transfer, synchronization, overlap, and failure behavior on matched nodes.</p>
+        <p><strong>Status:</strong> planned research; no general scaling claim yet.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">5. Parallel execution</h3>
+        <p>Select data, pipeline, tensor, or expert boundaries from measured compute-to-communication ratios.</p>
+        <p><strong>Status:</strong> research roadmap.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">6. Distributed training</h3>
+        <p>Extend forward and backward contracts only after single-node training and transport behavior are closed.</p>
+        <p><strong>Status:</strong> long-horizon thesis, not a demonstrated capability.</p>
     </div>
 </div>
 
-<h2>Infinite CPU Scaling: The Internet Proof</h2>
+<h2>Decision Rule</h2>
 
 <div class="card card-accent">
-    <h3 style="margin-top: 0;">CPUs Scale to Infinity</h3>
-    <p>Unlike GPUs, which hit cost and availability ceilings, CPUs scale infinitely through distributed computing across the internet. Your computer is part of that infinity!</p>
+    <p style="font-size: 1.1em; margin-top: 0;">
+        <strong>Use an established runtime and hardware platform when it already meets the requirement.</strong>
+    </p>
+    <p>
+        CKE becomes relevant when a model is unsupported, numerically wrong, unexpectedly slow, difficult to
+        validate, or constrained to owned CPU or embedded infrastructure. Its value is not that every deployment
+        needs generated C. Its value is that the execution boundary can be made explicit when the normal abstraction
+        is no longer enough.
+    </p>
+    <p style="margin-bottom: 0;">
+        Hardware selection should follow the workload envelope. The same investigation may conclude that a CPU,
+        accelerator, embedded target, or mixed system is the correct answer.
+    </p>
 </div>
 
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Insight</strong><br>
-        Want more FLOPs? Add more CPUs + RDMA! Get your 100 PFLOPS while your friends on the other side keep bragging about their limited GPU clusters. FLOPs is just an accumulation problem that CPUs solve through clever distributed training.
-    </div>
-</div>
+<h2>What Would Narrow or Falsify the Thesis?</h2>
 
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">∞ Infinite Scaling</h3>
-        <ul>
-            <li><strong>Internet-scale distributed computing</strong></li>
-            <li><strong>No ceiling:</strong> Add 10, 100, 1000 CPUs</li>
-            <li><strong>Your computer contributes:</strong> Every device matters</li>
-            <li><strong>Result:</strong> Unlimited FLOP accumulation</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU Improvements Track</h3>
-        <ul>
-            <li><strong>Cores:</strong> Increasing year over year</li>
-            <li><strong>Cache:</strong> Growing bigger</li>
-            <li><strong>Efficiency:</strong> Getting better</li>
-            <li><strong>Cost:</strong> Decreasing over time</li>
-        </ul>
-    </div>
-</div>
+<ul>
+    <li>Communication and synchronization erase useful speedup beyond one node.</li>
+    <li>Memory bandwidth prevents acceptable latency or concurrency on the target model family.</li>
+    <li>Measured power and total cost are worse than practical alternatives under the same workload.</li>
+    <li>Maintaining numerical parity consumes more complexity than the generated runtime removes.</li>
+    <li>Scheduling, deployment, and operations overwhelm the portability benefit.</li>
+    <li>The useful workload set remains too narrow to justify distributed infrastructure.</li>
+</ul>
 
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Memory Scaling</h3>
-        <ul>
-            <li><strong>DDR5 → DDR6:</strong> 2400 GB/s → higher bandwidth</li>
-            <li><strong>Memory slots:</strong> 8 → 12 → 16 slots per node</li>
-            <li><strong>Total per node:</strong> 4TB → 8TB → 16TB RAM</li>
-            <li><strong>Cost/GB:</strong> Constantly decreasing</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Model Efficiency</h3>
-        <ul>
-            <li><strong>Smaller models:</strong> Getting more efficient</li>
-            <li><strong>Better quantization:</strong> Q4, Q8, hybrid methods</li>
-            <li><strong>Architecture improvements:</strong> MoE, mixture of experts</li>
-            <li><strong>Training optimization:</strong> Better algorithms</li>
-        </ul>
-    </div>
-</div>
+<p>
+    Negative results are useful. They identify where CPU execution is practical, where a different architecture is
+    required, and which CKE abstractions survive contact with real systems.
+</p>
 
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The C-Kernel Engine Goal</h3>
-    <p>Exploit this infinite CPU scaling on server-grade CPUs. As models get smaller and CPUs get more powerful, the combination becomes unbeatable:</p>
-    <ul>
-        <li><strong>No GPU dependency:</strong> Commodity hardware only</li>
-        <li><strong>Accessible to everyone:</strong> Your laptop contributes to the cluster</li>
-        <li><strong>Sustainable scaling:</strong> Economics favor CPU-only approach</li>
-        <li><strong>Future-proof:</strong> CPU improvements continue while GPU costs stay high</li>
-    </ul>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Multi-Model Parallelism: Enterprise Real Workload</h3>
-    <p>Unlike GPUs which are designed for single-model throughput, CPUs excel at running <strong>multiple models simultaneously</strong> on the same system.</p>
-</div>
-
-<h2>Enterprise & Government: The Multi-Model Reality</h2>
+<h2>Current Evidence Boundary</h2>
 
 <div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
+    <div class="alert-icon">!</div>
     <div>
-        <strong>The Real Enterprise Scenario</strong><br>
-        In government ministries, large enterprises, and multi-department organizations, different teams need to run different models simultaneously. This is where GPUs become a nightmare.
+        CKE currently demonstrates model-specific single-node CPU inference and selected embedded paths. Numerical
+        parity, multimodal execution, training contracts, and performance coverage continue to be hardened.
+        Multi-node execution, distributed efficiency, and distributed training are roadmap items until reproducible
+        measurements are published. This page states the experiment, not its predetermined outcome.
     </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">Government Ministry Example</h3>
-        <ul>
-            <li><strong>Health Dept:</strong> Medical document analysis model</li>
-            <li><strong>Finance Dept:</strong> Fraud detection model</li>
-            <li><strong>Education Dept:</strong> Student assessment model</li>
-            <li><strong>Transport Dept:</strong> Traffic prediction model</li>
-            <li><strong>HR Dept:</strong> Resume screening model</li>
-            <li><strong>Legal Dept:</strong> Contract analysis model</li>
-        </ul>
-        <p><strong>Reality:</strong> 6 departments, 6 different models, all need to run simultaneously.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Enterprise Example</h3>
-        <ul>
-            <li><strong>Sales:</strong> Lead scoring + CRM assistant</li>
-            <li><strong>Support:</strong> Customer chatbot + ticket routing</li>
-            <li><strong>Engineering:</strong> Code review + documentation</li>
-            <li><strong>Marketing:</strong> Content generation + analytics</li>
-            <li><strong>Security:</strong> Threat detection + log analysis</li>
-            <li><strong>Finance:</strong> Expense analysis + forecasting</li>
-        </ul>
-        <p><strong>Reality:</strong> Each department has specialized models for their domain.</p>
-    </div>
-</div>
-
-<h3>The GPU Context-Switching Nightmare</h3>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">GPU Model Switching: Slow and Expensive</h3>
-    <pre>
-GPU Workflow for Multi-Model Serving:
-  1. Load Model A weights into VRAM (80GB)     → 30-60 seconds
-  2. Run inference for Department A            → fast
-  3. Unload Model A from VRAM                  → 10 seconds
-  4. Load Model B weights into VRAM            → 30-60 seconds
-  5. Run inference for Department B            → fast
-  6. Repeat for each model...
-
-Problem: Each context switch = 40-70 seconds of GPU sitting idle!
-With 6 departments cycling through: most of the time is loading/unloading.
-    </pre>
-</div>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU Multi-Model Issues</h3>
-        <ul>
-            <li><strong>VRAM limit:</strong> 80GB can only hold 1-2 large models</li>
-            <li><strong>Context switching:</strong> Load/unload weights takes 30-60s per model</li>
-            <li><strong>No sharing:</strong> GPU can't easily share between containers</li>
-            <li><strong>MIG complexity:</strong> Multi-Instance GPU splits VRAM, reduces per-model capacity</li>
-            <li><strong>Kubernetes pain:</strong> GPU scheduling requires special plugins, node affinity</li>
-            <li><strong>Cost:</strong> Need dedicated GPU per department = $40K × 6 = $240K</li>
-        </ul>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU Multi-Model Solution</h3>
-        <ul>
-            <li><strong>RAM abundance:</strong> 4TB holds ALL models simultaneously</li>
-            <li><strong>No context switching:</strong> All models resident in RAM, instant access</li>
-            <li><strong>Native sharing:</strong> Standard Linux process isolation works</li>
-            <li><strong>Docker native:</strong> Just containers, no special GPU passthrough</li>
-            <li><strong>Kubernetes native:</strong> Standard pod scheduling, no GPU plugins</li>
-            <li><strong>Cost:</strong> One $60K server runs all 6 departments</li>
-        </ul>
-    </div>
-</div>
-
-<h3>Kubernetes & Docker: CPUs Are First-Class Citizens</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Container Orchestration Reality</h3>
-    <pre>
-GPU Kubernetes Deployment:
-  - Install NVIDIA device plugin
-  - Configure GPU node pools
-  - Set resource limits: nvidia.com/gpu: 1
-  - Deal with GPU memory fragmentation
-  - Handle driver version mismatches
-  - Manage MIG partitioning (if sharing)
-  - Debug CUDA OOM errors in production
-
-CPU Kubernetes Deployment:
-  - Just deploy your container
-  - Set resource limits: cpu: "32", memory: "64Gi"
-  - Done. Standard k8s scheduling handles the rest.
-    </pre>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">CPU Multi-Model Architecture</h3>
-    <pre>
-┌─────────────────────────────────────────────────────────────────┐
-│                    Single CPU Server (4TB RAM)                   │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
-│  │ Container 1  │  │ Container 2  │  │ Container 3  │           │
-│  │ Health Model │  │ Finance Model│  │ Education    │           │
-│  │ 70B (140GB)  │  │ 13B (26GB)   │  │ 7B (14GB)    │           │
-│  │ 32 cores     │  │ 16 cores     │  │ 8 cores      │           │
-│  └──────────────┘  └──────────────┘  └──────────────┘           │
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
-│  │ Container 4  │  │ Container 5  │  │ Container 6  │           │
-│  │ Transport    │  │ HR Model     │  │ Legal Model  │           │
-│  │ 7B (14GB)    │  │ 3B (6GB)     │  │ 13B (26GB)   │           │
-│  │ 8 cores      │  │ 4 cores      │  │ 16 cores     │           │
-│  └──────────────┘  └──────────────┘  └──────────────┘           │
-│                                                                  │
-│  Total: 226GB used / 4TB available = 5.6% RAM utilization       │
-│  All 6 models running simultaneously, no context switching      │
-└─────────────────────────────────────────────────────────────────┘
-    </pre>
-    <p><strong>Key insight:</strong> 6 models totaling 226GB fit easily in 4TB RAM. All running 24/7, no loading/unloading, instant response for any department.</p>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>Enterprise Reality Check</strong><br>
-        Most enterprise/government deployments need to run 5-20 different models for different use cases. CPUs handle this natively with standard containers. GPUs require expensive, complex multi-GPU setups with painful orchestration. This alone makes CPUs the practical choice for most real-world deployments.
-    </div>
-</div>
-
-<h2>CPU-Only: Complete Solution for All Model Sizes</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">One Architecture, All Scales</h3>
-    <p>CPU-only isn't just for large models. It's the complete solution for <strong>every model size</strong>, for <strong>both training and inference</strong>.</p>
-</div>
-
-<div class="grid grid-3">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Small Models (1-7B)</h3>
-        <ul>
-            <li><strong>Training:</strong> Single CPU server</li>
-            <li><strong>Inference:</strong> Laptop or edge device</li>
-            <li><strong>Latency:</strong> Sub-millisecond</li>
-            <li><strong>Cost:</strong> < $100/month</li>
-        </ul>
-        <p><strong>Use cases:</strong> Chatbots, code completion, mobile AI</p>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Medium Models (7-70B)</h3>
-        <ul>
-            <li><strong>Training:</strong> 2-8 CPU servers</li>
-            <li><strong>Inference:</strong> Single CPU server</li>
-            <li><strong>Throughput:</strong> High batch processing</li>
-            <li><strong>Cost:</strong> $500-2000/month</li>
-        </ul>
-        <p><strong>Use cases:</strong> Enterprise AI, content generation, analysis</p>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Large Models (70B+)</h3>
-        <ul>
-            <li><strong>Training:</strong> 10-100 CPU servers</li>
-            <li><strong>Inference:</strong> 2-20 CPU servers</li>
-            <li><strong>Scale:</strong> Distributed across RDMA</li>
-            <li><strong>Cost:</strong> $5000-50000/month</li>
-        </ul>
-        <p><strong>Use cases:</strong> Foundation models, research, large-scale analytics</p>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Unified Approach</strong><br>
-        Same CPU-only architecture scales from your laptop (1B model) to global clusters (1T+ parameters). No architecture changes, no GPU lock-in, no complexity multiplication.
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Training at Every Scale</h3>
-        <ul>
-            <li><strong>Small:</strong> Fine-tune on laptop (1-7B)</li>
-            <li><strong>Medium:</strong> Train on workstation (7-70B)</li>
-            <li><strong>Large:</strong> Distributed training (70B+)</li>
-            <li><strong>Methodology:</strong> Same principles, same tools</li>
-        </ul>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Inference at Every Scale</h3>
-        <ul>
-            <li><strong>Small:</strong> Edge deployment (1-7B)</li>
-            <li><strong>Medium:</strong> Server deployment (7-70B)</li>
-            <li><strong>Large:</strong> Distributed inference (70B+)</li>
-            <li><strong>Performance:</strong> Optimized for each tier</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Why This Matters</h3>
-    <p>Organizations can start small and scale infinitely without ever switching architectures:</p>
-    <ol>
-        <li><strong>Start:</strong> Train small model on laptop (fine-tuning)</li>
-        <li><strong>Grow:</strong> Move to server as model size increases</li>
-        <li><strong>Scale:</strong> Add more servers when needed (distributed training)</li>
-        <li><strong>Enterprise:</strong> Run multiple models on same hardware</li>
-    </ol>
-    <p><strong>No lock-in. No architecture migrations. No GPU dependency. Just scale as you grow.</strong></p>
-</div>
-
-<h2>Memory Reality: What NVIDIA Marketing Won't Tell You</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The Hidden Truth About LLM Memory</strong><br>
-        GPU marketing focuses on FLOPS. Real-world LLM inference is dominated by <strong>memory bandwidth and capacity</strong>. Here are the actual numbers.
-    </div>
-</div>
-
-<h3>Activation Memory Per Token (Decode)</h3>
-
-<div class="card">
-    <h4 style="margin-top: 0;">Memory Writes Per Token</h4>
-    <p>For a typical 0.5B parameter model (hidden=896, intermediate=4864, 24 layers):</p>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Operation</th><th>Per Layer</th><th>24 Layers</th></tr>
-            </thead>
-            <tbody>
-                <tr><td>RMSNorm output</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>Q, K, V projections</td><td>10.5 KB</td><td>252 KB</td></tr>
-                <tr><td>Attention output</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>O projection</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>MLP gate + up</td><td>38 KB</td><td>912 KB</td></tr>
-                <tr><td>MLP down</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>KV cache (new token)</td><td>1 KB</td><td>24 KB</td></tr>
-                <tr><td>Final logits (once)</td><td>-</td><td>600 KB</td></tr>
-                <tr style="font-weight: bold; background: rgba(255,180,0,0.1);"><td>Total per token</td><td>~63 KB</td><td>~2.1 MB</td></tr>
-            </tbody>
-        </table>
-    </div>
-    <p style="color: #888; font-size: 0.9em;">This is memory bandwidth consumed per generated token. Reducing this is key for decode performance.</p>
-</div>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Real-world profile (0.6B model, Q8_0 quantization, AVX-only CPU):</strong> decode time is dominated by memory-moving kernels --
-        ~48% MLP (gate/up + down), ~21% logits, ~29% attention projections (q/k/v + out), and ~2% attention core. This matches the
-        bandwidth thesis: most time is spent streaming weights/activations, not math.
-    </div>
-</div>
-
-<h3>Context Length: The Memory Multiplier</h3>
-
-<div class="card card-accent">
-    <h4 style="margin-top: 0;">KV Cache Formula</h4>
-    <pre>KV Cache = 2 × n_layers × n_kv_heads × head_dim × context_length × bytes_per_element
-           ↑
-         (K and V)</pre>
-</div>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Context</th><th>KV Cache (FP16)</th><th>+ Model (140GB)</th><th>Fits 80GB GPU?</th><th>Fits 2TB Server?</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>8K</td>
-                <td>2.6 GB</td>
-                <td>143 GB</td>
-                <td style="color: #ff6b6b;">No (need 2×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-            <tr>
-                <td>32K</td>
-                <td>10 GB</td>
-                <td>150 GB</td>
-                <td style="color: #ff6b6b;">No (need 2×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-            <tr>
-                <td>128K</td>
-                <td>41 GB</td>
-                <td>181 GB</td>
-                <td style="color: #ff6b6b;">No (need 3×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-            <tr>
-                <td>1M</td>
-                <td>320 GB</td>
-                <td>460 GB</td>
-                <td style="color: #ff6b6b;">No (need 6×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<!-- Accordion: Show the Math -->
-<details style="margin: 20px 0; background: #1a1a2e; border-radius: 8px; border: 1px solid #333;">
-    <summary style="padding: 15px 20px; cursor: pointer; font-weight: bold; color: #fbbf24;">
-        📐 Show the Math: How We Calculated This
-    </summary>
-    <div style="padding: 0 20px 20px 20px;">
-        <h4 style="color: #4ade80; margin-top: 15px;">Model Architecture (70B Dense Model)</h4>
-        <div class="table-container">
-            <table>
-                <thead>
-                    <tr><th>Parameter</th><th>Value</th><th>Explanation</th></tr>
-                </thead>
-                <tbody>
-                    <tr><td><code>n_layers</code></td><td>80</td><td>Number of transformer layers</td></tr>
-                    <tr><td><code>n_attention_heads</code></td><td>64</td><td>Query heads per layer</td></tr>
-                    <tr><td><code>n_kv_heads</code></td><td>8</td><td>KV heads (GQA: 8 groups, each serves 8 Q heads)</td></tr>
-                    <tr><td><code>hidden_dim</code></td><td>8192</td><td>Model hidden dimension</td></tr>
-                    <tr><td><code>head_dim</code></td><td>128</td><td>= hidden_dim / n_attention_heads = 8192/64</td></tr>
-                </tbody>
-            </table>
-        </div>
-
-        <h4 style="color: #4ade80;">Step 1: KV Cache Per Token</h4>
-        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
-<span style="color: #888;">// FP16 = 2 bytes per element</span>
-KV_per_token = 2 × n_layers × n_kv_heads × head_dim × bytes
-             = 2 × 80 × 8 × 128 × 2
-             = 327,680 bytes
-             = <span style="color: #4ade80; font-weight: bold;">320 KB per token</span></pre>
-
-        <h4 style="color: #4ade80;">Step 2: Scale by Context Length</h4>
-        <div class="table-container">
-            <table>
-                <thead>
-                    <tr><th>Context</th><th>Calculation</th><th>KV Cache</th></tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>8K</td>
-                        <td><code>8,192 × 320 KB</code></td>
-                        <td>2.62 GB</td>
-                    </tr>
-                    <tr>
-                        <td>32K</td>
-                        <td><code>32,768 × 320 KB</code></td>
-                        <td>10.5 GB</td>
-                    </tr>
-                    <tr>
-                        <td>128K</td>
-                        <td><code>131,072 × 320 KB</code></td>
-                        <td>41.9 GB</td>
-                    </tr>
-                    <tr>
-                        <td>1M</td>
-                        <td><code>1,048,576 × 320 KB</code></td>
-                        <td>335 GB</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-
-        <h4 style="color: #4ade80;">Step 3: Add Model Weights</h4>
-        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
-Model weights (70B params × 2 bytes FP16) = <span style="color: #fbbf24; font-weight: bold;">140 GB</span>
-
-Total Memory = Model Weights + KV Cache
-  8K context:   140 + 2.6  = 143 GB  → need 2× 80GB GPUs
-  32K context:  140 + 10.5 = 150 GB  → need 2× 80GB GPUs
-  128K context: 140 + 42   = 182 GB  → need 3× 80GB GPUs
-  1M context:   140 + 335  = 475 GB  → need 6× 80GB GPUs</pre>
-
-        <h4 style="color: #4ade80;">Why GQA Matters</h4>
-        <p style="color: #a0a0b0;">Grouped Query Attention (GQA) reduces KV cache by sharing KV heads across Q heads:</p>
-        <div class="table-container">
-            <table>
-                <thead>
-                    <tr><th>Attention Type</th><th>KV Heads</th><th>KV per Token</th><th>128K KV Cache</th></tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Multi-Head (MHA)</td>
-                        <td>64</td>
-                        <td>2.56 MB</td>
-                        <td style="color: #ff6b6b;">335 GB</td>
-                    </tr>
-                    <tr>
-                        <td>Grouped Query (GQA-8)</td>
-                        <td>8</td>
-                        <td>320 KB</td>
-                        <td style="color: #4ade80;">42 GB</td>
-                    </tr>
-                    <tr>
-                        <td>Multi-Query (MQA)</td>
-                        <td>1</td>
-                        <td>40 KB</td>
-                        <td style="color: #4ade80;">5.2 GB</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <p style="color: #888; font-size: 0.9em;">GQA-8 gives 8× memory savings over MHA with minimal quality loss.</p>
-    </div>
-</details>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Long Context Reality</strong><br>
-        70B model + 1M context needs ~475 GB. That's 6× 80GB GPUs (&#36;240K+) vs one 2TB CPU server (&#36;30K). This isn't about FLOPS - it's about <strong>where the data can physically exist</strong>.
-    </div>
-</div>
-
-<h3>Prefill Memory Scaling</h3>
-
-<div class="card">
-    <p>Prefill (processing the input prompt) requires storing activations for ALL tokens simultaneously:</p>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Prefill Length</th><th>Activation Memory</th><th>+ KV Cache</th></tr>
-            </thead>
-            <tbody>
-                <tr><td>256 tokens</td><td>~400 MB</td><td>~6 MB</td></tr>
-                <tr><td>1K tokens</td><td>~1.5 GB</td><td>~24 MB</td></tr>
-                <tr><td>4K tokens</td><td>~6 GB</td><td>~96 MB</td></tr>
-                <tr><td>16K tokens</td><td>~24 GB</td><td>~384 MB</td></tr>
-            </tbody>
-        </table>
-    </div>
-    <p style="color: #888; font-size: 0.9em;">Prefill is compute-bound but still needs memory for activations. Long prompts can exceed GPU VRAM.</p>
-</div>
-
-<h3>Visual Guide</h3>
-
-<div class="card" style="max-width: 800px;">
-    <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
-    <p>GPU vs CPU memory comparison for LLM inference:</p>
-    <a href="assets/memory-reality-infographic.svg" target="_blank">
-        <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
-    </a>
-    <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
-</div>
-
-<h2>Training Advantages: Where CPUs Dominate</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Critical Training Scenarios</h3>
-    <p>CPU-only architecture solves training problems that GPU-only simply can't handle.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">1. Long Context Training: KV Cache Explosion</h3>
-        <p><strong>The Problem:</strong> Long context windows create quadratic KV cache growth</p>
-        <ul>
-            <li><strong>4K context:</strong> ~32GB KV cache</li>
-            <li><strong>32K context:</strong> ~256GB KV cache</li>
-            <li><strong>128K context:</strong> ~4TB KV cache</li>
-            <li><strong>1M context:</strong> ~128TB KV cache</li>
-        </ul>
-        <p><strong>CPU Advantage:</strong></p>
-        <ul>
-            <li><strong>4-16TB RAM:</strong> Fits massive KV caches</li>
-            <li><strong>No transfer bottleneck:</strong> Everything in memory</li>
-            <li><strong>GPU Reality:</strong> KV cache doesn't fit = can't train</li>
-        </ul>
-        <div class="alert alert-warning">
-            <strong>Result:</strong> GPU training hits memory wall at 32K context. CPUs handle 1M+ context natively.
-        </div>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">2. Massive Batch Training</h3>
-        <p><strong>The Need:</strong> Large batch sizes improve convergence and throughput</p>
-        <ul>
-            <li><strong>Standard batch:</strong> 32-128 samples</li>
-            <li><strong>Large batch:</strong> 512-2048 samples</li>
-            <li><strong>Massive batch:</strong> 8192+ samples</li>
-            <li><strong>Enterprise batch:</strong> 100K+ samples</li>
-        </ul>
-        <p><strong>CPU Scaling Strategy:</strong></p>
-        <ul>
-            <li><strong>32 CPUs:</strong> 32 batches in parallel</li>
-            <li><strong>Each batch:</strong> 1-10TB RAM available</li>
-            <li><strong>Total effective batch:</strong> 32x larger</li>
-            <li><strong>No communication overhead:</strong> Each CPU independent</li>
-        </ul>
-        <div class="alert alert-success">
-            <strong>Result:</strong> Scale to any batch size by adding more CPUs. No GPU memory constraints!
-        </div>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Training Reality Check</h3>
-    <div class="grid grid-2">
-        <div>
-            <h4>GPU Training Limits</h4>
-            <ul>
-                <li>❌ KV cache fits → max context ~32K</li>
-                <li>❌ Batch size limited by VRAM</li>
-                <li>❌ Large batches require model parallelism</li>
-                <li>❌ Complex coordination across GPUs</li>
-                <li>❌ Expensive hardware (NVLink required)</li>
-            </ul>
-        </div>
-        <div>
-            <h4>CPU Training Advantages</h4>
-            <ul>
-                <li>✅ KV cache fits → context up to 1M+</li>
-                <li>✅ Batch size scales with CPUs</li>
-                <li>✅ Data parallelism = simple scaling</li>
-                <li>✅ RDMA for necessary communication</li>
-                <li>✅ Commodity hardware (Ethernet)</li>
-            </ul>
-        </div>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>Why This Matters</strong><br>
-        Real-world training needs long context (RAG, document analysis) and large batches (throughput, convergence). CPU-only architecture handles both naturally. GPU-only hits walls that require expensive workarounds.
-    </div>
-</div>
-
-<h2>Distributed Architecture</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">RDMA-Connected CPU Cluster</h3>
-    <pre>
-┌─────────────────────────────────────────────────────────────────┐
-│                     RDMA Fabric (100Gbps+)                      │
-├─────────────────┬─────────────────┬─────────────────────────────┤
-│                 │                 │                             │
-▼                 ▼                 ▼                             │
-┌─────────┐   ┌─────────┐   ┌─────────┐                          │
-│ Node 0  │   │ Node 1  │   │ Node 2  │  ...  Node N             │
-│ 128 cores│   │ 128 cores│   │ 128 cores│                        │
-│ 2TB RAM │   │ 2TB RAM │   │ 2TB RAM │                          │
-│         │   │         │   │         │                          │
-│ Layers  │   │ Layers  │   │ Layers  │                          │
-│ 0-15    │   │ 16-31   │   │ 32-47   │                          │
-└─────────┘   └─────────┘   └─────────┘                          │
-    </pre>
-</div>
-
-<h3>Parallelism Strategies</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">1. Pipeline Parallelism</h3>
-    <p>Different layers on different nodes. Activations flow through the pipeline.</p>
-    <pre>Node 0: Layers 0-15   →  activations  →  Node 1: Layers 16-31  →  ...
-        (forward)           (RDMA)              (forward)</pre>
-    <p><strong>Communication:</strong> Send activations between pipeline stages via RDMA.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">2. Tensor Parallelism</h3>
-    <p>Large matrices split across nodes. Each node computes a shard.</p>
-    <pre>// 16384 x 16384 weight matrix split across 4 nodes
-Node 0: W[0:4096, :]      // Shard 0
-Node 1: W[4096:8192, :]   // Shard 1
-Node 2: W[8192:12288, :]  // Shard 2
-Node 3: W[12288:16384, :] // Shard 3
-
-// After local GEMM, all-reduce to combine</pre>
-    <p><strong>Communication:</strong> RDMA all-reduce after each sharded operation.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">3. Data Parallelism</h3>
-    <p>Same model replicated. Different batches. Gradient averaging.</p>
-    <pre>Node 0: Model copy, Batch 0  →  gradients  ─┐
-Node 1: Model copy, Batch 1  →  gradients  ─┼→  All-reduce  →  Update all
-Node 2: Model copy, Batch 2  →  gradients  ─┤
-Node 3: Model copy, Batch 3  →  gradients  ─┘</pre>
-</div>
-
-<h2>RDMA: The Key Enabler</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Why RDMA?</h3>
-    <p><strong>Remote Direct Memory Access</strong> - Zero-copy, kernel-bypass networking.</p>
-    <div class="table-container">
-        <table class="table">
-        <thead>
-            <tr><th>Metric</th><th>TCP/IP</th><th>RDMA</th></tr>
-        </thead>
-        <tbody>
-            <tr><td>Latency</td><td>~50-100 μs</td><td>~1-2 μs</td></tr>
-            <tr><td>Bandwidth</td><td>10-25 Gbps</td><td>100-400 Gbps</td></tr>
-            <tr><td>CPU overhead</td><td>High (kernel, copies)</td><td>Near zero</td></tr>
-            <tr><td>Memory copies</td><td>Multiple</td><td>Zero (DMA)</td></tr>
-        </tbody>
-    </table>
-    </div>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">RDMA Primitives We Need</h3>
-    <pre>// One-sided operations (no remote CPU involvement)
-rdma_write(remote_addr, local_buf, size);  // Write to remote memory
-rdma_read(local_buf, remote_addr, size);   // Read from remote memory
-
-// Collective operations (built on one-sided)
-rdma_allreduce(buf, size, SUM);  // Gradient averaging
-rdma_broadcast(buf, size, root); // Weight distribution
-rdma_barrier();                   // Synchronization</pre>
-</div>
-
-<h2>Implementation Roadmap</h2>
-
-<div class="card">
-    <div class="table-container">
-        <table class="table">
-        <thead>
-            <tr><th>Phase</th><th>Feature</th><th>Status</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>1</td>
-                <td>Single-node training (current)</td>
-                <td><span class="badge badge-green">Done</span></td>
-            </tr>
-            <tr>
-                <td>2</td>
-                <td>Multi-core parallelism (OpenMP)</td>
-                <td><span class="badge badge-green">Done</span></td>
-            </tr>
-            <tr>
-                <td>3</td>
-                <td>RDMA communication primitives</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>4</td>
-                <td>Pipeline parallelism</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>5</td>
-                <td>Tensor parallelism (sharded GEMM)</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>6</td>
-                <td>Encoder + cross-attention</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>7</td>
-                <td>600B+ training</td>
-                <td><span class="badge" style="background:#666;color:#ccc;">Future</span></td>
-            </tr>
-        </tbody>
-    </table>
-    </div>
-</div>
-
-<h2>The Math Doesn't Change</h2>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">From Tiny to Massive: Same Operations</h3>
-    <pre>
-Forward pass (any size model):
-1. embed_tokens()           // Lookup: tokens → vectors
-2. for each layer:
-   a. rmsnorm()             // Normalize
-   b. linear() × 3          // Q, K, V projections
-   c. rope()                // Rotary embeddings
-   d. attention()           // Softmax(QK^T)V
-   e. linear()              // Output projection
-   f. residual_add()        // Skip connection
-   g. rmsnorm()             // Normalize
-   h. mlp_swiglu()          // FFN with gating
-   i. residual_add()        // Skip connection
-3. rmsnorm()                // Final norm
-4. lm_head()                // Logits
-
-Backward pass: Same operations in reverse.
-SGD: weights -= lr * gradients
-
-That's it. For any model size.
-    </pre>
-</div>
-
-<h2>Hardware Recommendations</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">For Different Scales</h3>
-    <div class="table-container">
-        <table class="table">
-        <thead>
-            <tr><th>Model Size</th><th>Recommended Setup</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>< 7B</td>
-                <td>Single server, 32+ cores, 128GB+ RAM</td>
-            </tr>
-            <tr>
-                <td>7B - 70B</td>
-                <td>Single server, 128 cores, 512GB-2TB RAM</td>
-            </tr>
-            <tr>
-                <td>70B - 200B</td>
-                <td>2-4 nodes, RDMA interconnect, 2TB RAM each</td>
-            </tr>
-            <tr>
-                <td>200B - 600B</td>
-                <td>8-16 nodes, 100Gbps+ RDMA fabric</td>
-            </tr>
-            <tr>
-                <td>600B+</td>
-                <td>32+ nodes, 400Gbps RDMA, pipeline + tensor parallel</td>
-            </tr>
-        </tbody>
-    </table>
-    </div>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Recommended CPUs by Instruction Set</h3>
-    <ul>
-        <li><strong>AMD EPYC 9004/9005 (Genoa/Turin)</strong> - Up to 192 cores, AVX-512 (512-bit), 12-channel DDR5</li>
-        <li><strong>Intel Xeon Sapphire Rapids/Granite Rapids</strong> - Up to 128 cores, AVX-512 + AMX (512-bit tile)</li>
-        <li><strong>Ampere Altra Max</strong> - 128 ARM cores, NEON (128-bit), good perf/watt</li>
-        <li><strong>AWS Graviton3/4</strong> - Cost-effective ARM, NEON + SVE2</li>
-    </ul>
-    <p><strong>Minimum requirement:</strong> AVX (256-bit) or NEON (128-bit). For best performance, AVX-512 or AMX.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">RDMA Options</h3>
-    <ul>
-        <li><strong>Mellanox/NVIDIA ConnectX-7</strong> - 400Gbps InfiniBand</li>
-        <li><strong>Intel E810</strong> - 100Gbps RoCE (RDMA over Ethernet)</li>
-        <li><strong>AWS EFA</strong> - Cloud RDMA for EC2 instances</li>
-    </ul>
-</div>
-
-<h2>Why Not GPU?</h2>
-
-<div class="card">
-    <blockquote style="border-left: 4px solid var(--orange); padding-left: 1rem; margin: 1rem 0; font-style: italic;">
-        "Nvidia, f**k you."<br>
-        <small>— Linus Torvalds, 2012 (<a href="https://www.youtube.com/watch?v=iYWzMvlj2RQ" target="_blank" rel="noopener" style="color: inherit;">video source</a>) regarding their closed-source Linux drivers</small>
-    </blockquote>
-    <p>Beyond the open-source concerns:</p>
-    <ul>
-        <li><strong>Cost</strong> - High-end GPU cluster = $200K+. EPYC server with 2TB RAM = $15,000</li>
-        <li><strong>Memory</strong> - 80GB VRAM vs 2TB+ system RAM</li>
-        <li><strong>Availability</strong> - Export-controlled, supply constrained vs commodity CPUs</li>
-        <li><strong>Flexibility</strong> - Run anywhere: cloud, on-prem, edge, embedded</li>
-        <li><strong>Debugging</strong> - printf works. GDB works. Valgrind works.</li>
-        <li><strong>Longevity</strong> - C code compiles forever. CUDA versions break.</li>
-    </ul>
 </div>
 
 <h2>Further Reading</h2>
 
-<ul>
-    <li><a href="memory-reality.html">Memory Reality</a> - What NVIDIA marketing won't tell you about LLM memory</li>
-    <li><a href="developer-guide.html">Developer Guide</a> - How the engine works</li>
-    <li><a href="memory-safety.html">Memory Safety</a> - Bump allocator design</li>
-    <li><a href="profiling.html">Profiling Guide</a> - Performance optimization</li>
-</ul>
-    </main>
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="architecture.html">Architecture</a></h3>
+        <p>How circuits, contracts, GraphIR, lowering, generated C, and promotion gates fit together.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="v8-numerical-contracts.html">Numerical Contracts</a></h3>
+        <p>Why mathematically similar kernels can still produce materially different model behavior.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="profiling.html">Profiling</a></h3>
+        <p>The measurement workflow used to identify actual CPU bottlenecks.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a></h3>
+        <p>How a bottleneck moves from attribution to implementation and regression evidence.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="support-hardware.html">Support the Hardware Lab</a></h3>
+        <p>The staged hardware programme and evidence obligations attached to contributed equipment.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="contributing.html">Contribute</a></h3>
+        <p>Start with a bounded build, profiling, numerical, kernel, or compiler contribution.</p>
+    </div>
+</div>

--- a/docs/site/_pages/scaling.html
+++ b/docs/site/_pages/scaling.html
@@ -18,6 +18,22 @@
         then a generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly valuable.
     </p>
     <p style="font-size: 1.15em; line-height: 1.7;">
+        The asymmetry CKE is testing is that useful model intelligence does not necessarily require total model state
+        to grow as quickly as general-purpose CPU capability and memory capacity. Dense models made parameter count
+        the visible scaling axis. Mixture-of-experts models can increase total stored capacity while activating only
+        part of that capacity for each token. Better data, routing, architecture, and training can also add capability
+        without multiplying inference state at the same rate.
+    </p>
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        That matters differently for inference and training. Inference must keep the model and runtime state
+        addressable, but it may execute only a sparse path through the weights. Large CPU memory domains can make
+        that placement increasingly practical as cores, matrix instructions, channels, and bandwidth improve.
+        Training is harder because gradients, optimizer state, saved activations, and communication multiply the
+        memory and compute requirement. CKE's frontier-model bet is therefore not that training is already solved;
+        it is that inference becomes practical first, and measured CPU training capability expands as kernels,
+        memory systems, and distributed execution improve.
+    </p>
+    <p style="font-size: 1.15em; line-height: 1.7;">
         This is not a claim that CPUs always beat GPU systems on raw peak throughput.
         That is not the point.
         The real question is whether CPU-only Linux systems can become
@@ -168,6 +184,34 @@
     </div>
 </details>
 
+<div class="card card-accent" style="margin-top: 1.5rem;">
+    <h3 style="margin-top: 0;">The Google Precedent: Treat the Fleet as the Computer</h3>
+    <p>
+        Google's early advantage was not a processor that was individually faster than every high-end server CPU.
+        It combined commodity-class machines with fault-tolerant software and optimized the fleet for throughput,
+        price-performance, energy, and service availability. Google's cluster architecture explicitly treated peak
+        processor performance as less important than the price-performance of the complete system.
+    </p>
+    <p>
+        MapReduce then made partitioning, scheduling, data locality, inter-machine communication, and failure recovery
+        part of the runtime contract. The decisive asset was the software that kept broadly available hardware doing
+        useful work, not a benchmark showing that one commodity core was faster than a proprietary server core.
+    </p>
+    <p>
+        That is the precedent CKE follows for AI. The goal is to make circuits, kernels, memory placement, NUMA,
+        communication, and recovery explicit enough that a CPU fleet approaches its useful hardware envelope.
+        If server CPUs continue to add cores, matrix instructions, memory channels, capacity, and bandwidth while
+        frontier-model state grows more slowly, incremental hardware progress compounds into support for more models,
+        longer contexts, and larger active workloads.
+    </p>
+    <p style="margin-bottom: 0; color: #a0a0a0;">
+        Sources:
+        <a href="https://research.google.com/archive/googlecluster.html" target="_blank" rel="noopener">Google cluster architecture</a>,
+        <a href="https://research.google/pubs/mapreduce-simplified-data-processing-on-large-clusters/" target="_blank" rel="noopener">MapReduce</a>, and
+        <a href="https://research.google/pubs/power-provisioning-for-a-warehouse-sized-computer/" target="_blank" rel="noopener">warehouse-scale power provisioning</a>.
+    </p>
+</div>
+
 <h2>Principle 1: The Cost of 0 × ∞ = 0</h2>
 
 <div class="card card-accent">
@@ -177,7 +221,7 @@
     <p><strong>And GPUs are:</strong></p>
     <ul>
         <li><strong>Proprietary</strong> — locked to NVIDIA (CUDA), no open ecosystem</li>
-        <li><strong>Export-controlled</strong> — H100/H200 blocked in many countries, supply constrained</li>
+        <li><strong>Export-controlled</strong> — leading data-center accelerators may be restricted by destination and product class</li>
         <li><strong>Cluster-required</strong> — single GPUs can't handle large models, need NVLink infrastructure</li>
         <li><strong>Expensive</strong> — &#36;40K+ per GPU, &#36;200K+ for NVLink switches</li>
     </ul>
@@ -356,7 +400,7 @@ CPU Path:
     <h3 style="margin-top: 0;">GPUs Require Clusters</h3>
     <p>Here's the fundamental problem: no single GPU can handle large models. You need a cluster.</p>
     <ul>
-        <li><strong>Even the biggest GPU:</strong> 80GB VRAM max—can't fit 70B+ models</li>
+        <li><strong>Per-device memory remains finite:</strong> frontier models and long contexts can still require model and state sharding</li>
         <li><strong>Multi-GPU needed:</strong> 8-32 GPUs for practical workloads</li>
         <li><strong>NVLink required:</strong> &#36;200K+ in interconnects for fast GPU-to-GPU communication</li>
         <li><strong>DGX systems:</strong> Pre-configured clusters start at &#36;250K+</li>
@@ -369,7 +413,9 @@ CPU Path:
     </div>
     <div>
         <strong>The VRAM Wall</strong><br>
-        Every GPU hits the same VRAM wall. Whether 24GB or 80GB per GPU, large models require massive GPU counts in coordinated clusters. This is the fundamental constraint that CPU-only architecture bypasses entirely.
+        Every accelerator has a finite local-memory boundary. As models and context state grow beyond that boundary,
+        execution requires coordinated sharding across devices or nodes. The CPU-cluster thesis is that large,
+        addressable system memory and standard Linux distribution can provide another path through that constraint.
     </div>
 </div>
 
@@ -611,14 +657,17 @@ Infrastructure: Standard data center power
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
     </div>
     <div>
-        <strong>NVLink Doesn't Scale Infinitely</strong><br>
-        NVLink is 900 GB/s <em>within a single node</em>. But you can only fit 8 GPUs per node. Go beyond that? You hit Ethernet. And at the Ethernet boundary, CPUs and GPUs face the exact same constraint.
+        <strong>Local Scale-Up Fabrics Do Not Remove the Scale-Out Boundary</strong><br>
+        NVLink bandwidth and domain size vary substantially by accelerator generation and system topology.
+        Once a workload crosses the local NVLink or NVSwitch domain, it still enters a scale-out network with a
+        different bandwidth, latency, and synchronization contract. CPU and accelerator clusters must both account
+        for that boundary.
     </div>
 </div>
 
 <div class="card card-accent">
     <h3 style="margin-top: 0;">The Bandwidth Reality</h3>
-    <p>Let's be precise about the numbers:</p>
+    <p>Separate topology classes instead of freezing the analysis to one accelerator generation:</p>
 </div>
 
 <div class="table-container">
@@ -628,10 +677,10 @@ Infrastructure: Standard data center power
         </thead>
         <tbody>
             <tr>
-                <td>NVLink 4.0</td>
-                <td>900 GB/s</td>
-                <td>GPU-to-GPU within 1 node</td>
-                <td>8 GPUs max</td>
+                <td>Local accelerator scale-up fabric</td>
+                <td>Generation and topology dependent</td>
+                <td>Device-to-device within the configured NVLink/NVSwitch domain</td>
+                <td>Bounded by the purchased system or rack topology</td>
             </tr>
             <tr>
                 <td>DDR5 (12-channel)</td>
@@ -664,10 +713,10 @@ Infrastructure: Standard data center power
 <div class="card card-green">
     <h3 style="margin-top: 0;">The Theory of Constraints Applied</h3>
     <pre>
-GPU Cluster at Scale:
-  Within node:  NVLink 900 GB/s (fast!)
-  Between nodes: Ethernet 50 GB/s (constraint!)
-  System speed = 50 GB/s (bottleneck)
+Accelerator Cluster at Scale:
+  Local domain:    High-bandwidth scale-up fabric
+  Between domains: Scale-out network (constraint)
+  System speed:    Limited by the active communication boundary
 
 CPU Cluster at Scale:
   Within node:  DDR5 460 GB/s
@@ -683,8 +732,10 @@ AT SCALE, THEY HIT THE SAME WALL.
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
     </div>
     <div>
-        <strong>Without NVLink, GPUs Are Often Slower</strong><br>
-        If you can't afford NVLink switches (&#36;200K+), your GPUs communicate over PCIe → Ethernet. That's 12.5-50 GB/s. A server-grade CPU with DDR5 has 460 GB/s to its own memory. For memory-bound workloads, the CPU wins.
+        <strong>Topology Must Be Included in the Benchmark</strong><br>
+        Accelerator results depend on whether communication stays within local device memory, crosses PCIe, uses a
+        scale-up fabric, or enters the scale-out network. CPU results likewise depend on memory channels, NUMA, and
+        network placement. A comparison that omits these boundaries is not a system comparison.
     </div>
 </div>
 
@@ -869,34 +920,33 @@ rdma link show
     <h3 style="margin-top: 0;">Why CPU-Only Wins at Scale</h3>
 </div>
 
-<div class="img-container svg-viewer" data-title="Scale Economics Comparison">
-    <img src="assets/scale-economics.svg" alt="Scale Economics Comparison">
-</div>
-
 <div class="grid grid-2">
     <div class="card card-blue">
         <h3 style="margin-top: 0;">GPU Cluster at Scale</h3>
         <ul>
-            <li><strong>For 1TB model:</strong> 100 GPUs minimum</li>
-            <li><strong>Total cost:</strong> $4 Billion</li>
-            <li><strong>Who can afford:</strong> 5 companies globally</li>
-            <li><strong>Result:</strong> Elite-only access</li>
+            <li><strong>Capacity:</strong> Model, optimizer, activation, and context state may span many devices</li>
+            <li><strong>Topology:</strong> Scale-up and scale-out domains must be designed together</li>
+            <li><strong>Procurement:</strong> Cost and availability depend on accelerator generation and system configuration</li>
+            <li><strong>Result:</strong> High performance with substantial infrastructure requirements</li>
         </ul>
     </div>
     <div class="card card-green">
         <h3 style="margin-top: 0;">CPU Cluster at Scale</h3>
         <ul>
-            <li><strong>For same scale:</strong> 80 servers</li>
-            <li><strong>Total cost:</strong> $240 Million</li>
-            <li><strong>Who can afford:</strong> 1000+ companies</li>
-            <li><strong>Result:</strong> Accessible to everyone</li>
+            <li><strong>Capacity:</strong> Large system-memory pools reduce the number of mandatory model shards</li>
+            <li><strong>Topology:</strong> NUMA and network boundaries remain explicit engineering constraints</li>
+            <li><strong>Procurement:</strong> Standard server, memory, Linux, and network components provide a broader supply path</li>
+            <li><strong>Result:</strong> A credible frontier-model scaling path if CKE closes kernel and communication efficiency</li>
         </ul>
     </div>
 </div>
 
 <div class="card card-green">
-    <h3 style="margin-top: 0;">The Economics: 16x Cheaper, 200x More Accessible</h3>
-    <p>While GPU costs stay high and GPU access remains limited, CPU clusters deliver the same scale at a fraction of the cost. This makes large-scale ML accessible to 1000+ companies instead of just 5.</p>
+    <h3 style="margin-top: 0;">The Economics Must Be Measured at Purchase Time</h3>
+    <p>Accelerator prices, server prices, memory prices, power, and availability change too quickly for a permanent
+    multiplier. The durable thesis is that CPU clusters use broadly available server components and large memory
+    domains. CKE must prove whether those properties produce competitive frontier-model capability and total cost
+    for a defined workload.</p>
 </div>
 
 <h2>The Hybrid Trap: CPU+GPU = CPU-Bound</h2>
@@ -1236,8 +1286,8 @@ CPU RAM budget (4TB):
     <div class="card card-green">
         <h3 style="margin-top: 0;">Market Wins</h3>
         <ul>
-            <li><strong>16x cheaper</strong> at scale</li>
-            <li><strong>200x more accessible</strong> to companies</li>
+            <li><strong>Potentially lower system cost</strong> for workloads that fit CPU memory and utilization patterns</li>
+            <li><strong>Broader procurement paths</strong> through standard server and networking channels</li>
             <li><strong>Commodity hardware</strong> - no special requirements</li>
             <li><strong>Open ecosystem</strong> - standard Linux tools</li>
         </ul>

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
+        <span class="folder-updated">Updated: 2026-07-14 15:12</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 15:12</span>
+        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/_partials/folder_structure.html
+++ b/docs/site/_partials/folder_structure.html
@@ -2,7 +2,7 @@
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
+        <span class="folder-updated">Updated: 2026-07-14 15:26</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -1291,7 +1291,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 15:12</span>
+        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -1291,7 +1291,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
+        <span class="folder-updated">Updated: 2026-07-14 15:12</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -1291,7 +1291,7 @@ make ck-emit CONFIG=config.json OUT=build/model.c</pre>
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
+        <span class="folder-updated">Updated: 2026-07-14 15:26</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1642,7 +1642,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
+        <span class="folder-updated">Updated: 2026-07-14 15:12</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1642,7 +1642,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 15:12</span>
+        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1642,7 +1642,7 @@ python version/v7/scripts/ck_run_v7.py train \
     <div class="folder-header">
         <span class="folder-title">Focused Source Tree</span>
         <span class="folder-scope">src/kernels · version/v6.6 · version/v7</span>
-        <span class="folder-updated">Updated: 2026-07-14 14:44</span>
+        <span class="folder-updated">Updated: 2026-07-14 15:26</span>
     </div>
     <pre class="tree-output">
 src/kernels

--- a/docs/site/page_metadata.json
+++ b/docs/site/page_metadata.json
@@ -10,8 +10,8 @@
       "description": "C-Kernel-Engine is a CPU-native AI runtime and code generation system for training and inference in pure C, with auditable IR, kernel parity, and Linux-first deployment."
     },
     "scaling.html": {
-      "title": "CKE Scaling Thesis: From One CPU Node to Measured Distributed Systems",
-      "description": "A falsifiable research thesis for scaling C-Kernel-Engine from correct single-node CPU execution to measured multi-node efficiency, with explicit memory, communication, and synchronization gates."
+      "title": "Scaling Philosophy for CPU-Only AI Systems",
+      "description": "Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks."
     },
     "support-hardware.html": {
       "title": "Support the CKE CPU AI Hardware Lab",

--- a/docs/site/page_metadata.json
+++ b/docs/site/page_metadata.json
@@ -10,8 +10,8 @@
       "description": "C-Kernel-Engine is a CPU-native AI runtime and code generation system for training and inference in pure C, with auditable IR, kernel parity, and Linux-first deployment."
     },
     "scaling.html": {
-      "title": "Scaling Philosophy for CPU-Only AI Systems",
-      "description": "Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks."
+      "title": "CKE Scaling Thesis: From One CPU Node to Measured Distributed Systems",
+      "description": "A falsifiable research thesis for scaling C-Kernel-Engine from correct single-node CPU execution to measured multi-node efficiency, with explicit memory, communication, and synchronization gates."
     },
     "support-hardware.html": {
       "title": "Support the CKE CPU AI Hardware Lab",

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -995,6 +995,22 @@
         then a generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly valuable.
     </p>
     <p style="font-size: 1.15em; line-height: 1.7;">
+        The asymmetry CKE is testing is that useful model intelligence does not necessarily require total model state
+        to grow as quickly as general-purpose CPU capability and memory capacity. Dense models made parameter count
+        the visible scaling axis. Mixture-of-experts models can increase total stored capacity while activating only
+        part of that capacity for each token. Better data, routing, architecture, and training can also add capability
+        without multiplying inference state at the same rate.
+    </p>
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        That matters differently for inference and training. Inference must keep the model and runtime state
+        addressable, but it may execute only a sparse path through the weights. Large CPU memory domains can make
+        that placement increasingly practical as cores, matrix instructions, channels, and bandwidth improve.
+        Training is harder because gradients, optimizer state, saved activations, and communication multiply the
+        memory and compute requirement. CKE's frontier-model bet is therefore not that training is already solved;
+        it is that inference becomes practical first, and measured CPU training capability expands as kernels,
+        memory systems, and distributed execution improve.
+    </p>
+    <p style="font-size: 1.15em; line-height: 1.7;">
         This is not a claim that CPUs always beat GPU systems on raw peak throughput.
         That is not the point.
         The real question is whether CPU-only Linux systems can become
@@ -1143,6 +1159,34 @@
     </div>
 </details>
 
+<div class="card card-accent" style="margin-top: 1.5rem;">
+    <h3 style="margin-top: 0;">The Google Precedent: Treat the Fleet as the Computer</h3>
+    <p>
+        Google's early advantage was not a processor that was individually faster than every high-end server CPU.
+        It combined commodity-class machines with fault-tolerant software and optimized the fleet for throughput,
+        price-performance, energy, and service availability. Google's cluster architecture explicitly treated peak
+        processor performance as less important than the price-performance of the complete system.
+    </p>
+    <p>
+        MapReduce then made partitioning, scheduling, data locality, inter-machine communication, and failure recovery
+        part of the runtime contract. The decisive asset was the software that kept broadly available hardware doing
+        useful work, not a benchmark showing that one commodity core was faster than a proprietary server core.
+    </p>
+    <p>
+        That is the precedent CKE follows for AI. The goal is to make circuits, kernels, memory placement, NUMA,
+        communication, and recovery explicit enough that a CPU fleet approaches its useful hardware envelope.
+        If server CPUs continue to add cores, matrix instructions, memory channels, capacity, and bandwidth while
+        frontier-model state grows more slowly, incremental hardware progress compounds into support for more models,
+        longer contexts, and larger active workloads.
+    </p>
+    <p style="margin-bottom: 0; color: #a0a0a0;">
+        Sources:
+        <a href="https://research.google.com/archive/googlecluster.html" target="_blank" rel="noopener">Google cluster architecture</a>,
+        <a href="https://research.google/pubs/mapreduce-simplified-data-processing-on-large-clusters/" target="_blank" rel="noopener">MapReduce</a>, and
+        <a href="https://research.google/pubs/power-provisioning-for-a-warehouse-sized-computer/" target="_blank" rel="noopener">warehouse-scale power provisioning</a>.
+    </p>
+</div>
+
 <h2>Principle 1: The Cost of 0 × ∞ = 0</h2>
 
 <div class="card card-accent">
@@ -1152,7 +1196,7 @@
     <p><strong>And GPUs are:</strong></p>
     <ul>
         <li><strong>Proprietary</strong> — locked to NVIDIA (CUDA), no open ecosystem</li>
-        <li><strong>Export-controlled</strong> — H100/H200 blocked in many countries, supply constrained</li>
+        <li><strong>Export-controlled</strong> — leading data-center accelerators may be restricted by destination and product class</li>
         <li><strong>Cluster-required</strong> — single GPUs can't handle large models, need NVLink infrastructure</li>
         <li><strong>Expensive</strong> — &#36;40K+ per GPU, &#36;200K+ for NVLink switches</li>
     </ul>
@@ -1331,7 +1375,7 @@ CPU Path:
     <h3 style="margin-top: 0;">GPUs Require Clusters</h3>
     <p>Here's the fundamental problem: no single GPU can handle large models. You need a cluster.</p>
     <ul>
-        <li><strong>Even the biggest GPU:</strong> 80GB VRAM max—can't fit 70B+ models</li>
+        <li><strong>Per-device memory remains finite:</strong> frontier models and long contexts can still require model and state sharding</li>
         <li><strong>Multi-GPU needed:</strong> 8-32 GPUs for practical workloads</li>
         <li><strong>NVLink required:</strong> &#36;200K+ in interconnects for fast GPU-to-GPU communication</li>
         <li><strong>DGX systems:</strong> Pre-configured clusters start at &#36;250K+</li>
@@ -1344,7 +1388,9 @@ CPU Path:
     </div>
     <div>
         <strong>The VRAM Wall</strong><br>
-        Every GPU hits the same VRAM wall. Whether 24GB or 80GB per GPU, large models require massive GPU counts in coordinated clusters. This is the fundamental constraint that CPU-only architecture bypasses entirely.
+        Every accelerator has a finite local-memory boundary. As models and context state grow beyond that boundary,
+        execution requires coordinated sharding across devices or nodes. The CPU-cluster thesis is that large,
+        addressable system memory and standard Linux distribution can provide another path through that constraint.
     </div>
 </div>
 
@@ -1586,14 +1632,17 @@ Infrastructure: Standard data center power
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
     </div>
     <div>
-        <strong>NVLink Doesn't Scale Infinitely</strong><br>
-        NVLink is 900 GB/s <em>within a single node</em>. But you can only fit 8 GPUs per node. Go beyond that? You hit Ethernet. And at the Ethernet boundary, CPUs and GPUs face the exact same constraint.
+        <strong>Local Scale-Up Fabrics Do Not Remove the Scale-Out Boundary</strong><br>
+        NVLink bandwidth and domain size vary substantially by accelerator generation and system topology.
+        Once a workload crosses the local NVLink or NVSwitch domain, it still enters a scale-out network with a
+        different bandwidth, latency, and synchronization contract. CPU and accelerator clusters must both account
+        for that boundary.
     </div>
 </div>
 
 <div class="card card-accent">
     <h3 style="margin-top: 0;">The Bandwidth Reality</h3>
-    <p>Let's be precise about the numbers:</p>
+    <p>Separate topology classes instead of freezing the analysis to one accelerator generation:</p>
 </div>
 
 <div class="table-container">
@@ -1603,10 +1652,10 @@ Infrastructure: Standard data center power
         </thead>
         <tbody>
             <tr>
-                <td>NVLink 4.0</td>
-                <td>900 GB/s</td>
-                <td>GPU-to-GPU within 1 node</td>
-                <td>8 GPUs max</td>
+                <td>Local accelerator scale-up fabric</td>
+                <td>Generation and topology dependent</td>
+                <td>Device-to-device within the configured NVLink/NVSwitch domain</td>
+                <td>Bounded by the purchased system or rack topology</td>
             </tr>
             <tr>
                 <td>DDR5 (12-channel)</td>
@@ -1639,10 +1688,10 @@ Infrastructure: Standard data center power
 <div class="card card-green">
     <h3 style="margin-top: 0;">The Theory of Constraints Applied</h3>
     <pre>
-GPU Cluster at Scale:
-  Within node:  NVLink 900 GB/s (fast!)
-  Between nodes: Ethernet 50 GB/s (constraint!)
-  System speed = 50 GB/s (bottleneck)
+Accelerator Cluster at Scale:
+  Local domain:    High-bandwidth scale-up fabric
+  Between domains: Scale-out network (constraint)
+  System speed:    Limited by the active communication boundary
 
 CPU Cluster at Scale:
   Within node:  DDR5 460 GB/s
@@ -1658,8 +1707,10 @@ AT SCALE, THEY HIT THE SAME WALL.
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
     </div>
     <div>
-        <strong>Without NVLink, GPUs Are Often Slower</strong><br>
-        If you can't afford NVLink switches (&#36;200K+), your GPUs communicate over PCIe → Ethernet. That's 12.5-50 GB/s. A server-grade CPU with DDR5 has 460 GB/s to its own memory. For memory-bound workloads, the CPU wins.
+        <strong>Topology Must Be Included in the Benchmark</strong><br>
+        Accelerator results depend on whether communication stays within local device memory, crosses PCIe, uses a
+        scale-up fabric, or enters the scale-out network. CPU results likewise depend on memory channels, NUMA, and
+        network placement. A comparison that omits these boundaries is not a system comparison.
     </div>
 </div>
 
@@ -1844,34 +1895,33 @@ rdma link show
     <h3 style="margin-top: 0;">Why CPU-Only Wins at Scale</h3>
 </div>
 
-<div class="img-container svg-viewer" data-title="Scale Economics Comparison">
-    <img src="assets/scale-economics.svg" alt="Scale Economics Comparison">
-</div>
-
 <div class="grid grid-2">
     <div class="card card-blue">
         <h3 style="margin-top: 0;">GPU Cluster at Scale</h3>
         <ul>
-            <li><strong>For 1TB model:</strong> 100 GPUs minimum</li>
-            <li><strong>Total cost:</strong> $4 Billion</li>
-            <li><strong>Who can afford:</strong> 5 companies globally</li>
-            <li><strong>Result:</strong> Elite-only access</li>
+            <li><strong>Capacity:</strong> Model, optimizer, activation, and context state may span many devices</li>
+            <li><strong>Topology:</strong> Scale-up and scale-out domains must be designed together</li>
+            <li><strong>Procurement:</strong> Cost and availability depend on accelerator generation and system configuration</li>
+            <li><strong>Result:</strong> High performance with substantial infrastructure requirements</li>
         </ul>
     </div>
     <div class="card card-green">
         <h3 style="margin-top: 0;">CPU Cluster at Scale</h3>
         <ul>
-            <li><strong>For same scale:</strong> 80 servers</li>
-            <li><strong>Total cost:</strong> $240 Million</li>
-            <li><strong>Who can afford:</strong> 1000+ companies</li>
-            <li><strong>Result:</strong> Accessible to everyone</li>
+            <li><strong>Capacity:</strong> Large system-memory pools reduce the number of mandatory model shards</li>
+            <li><strong>Topology:</strong> NUMA and network boundaries remain explicit engineering constraints</li>
+            <li><strong>Procurement:</strong> Standard server, memory, Linux, and network components provide a broader supply path</li>
+            <li><strong>Result:</strong> A credible frontier-model scaling path if CKE closes kernel and communication efficiency</li>
         </ul>
     </div>
 </div>
 
 <div class="card card-green">
-    <h3 style="margin-top: 0;">The Economics: 16x Cheaper, 200x More Accessible</h3>
-    <p>While GPU costs stay high and GPU access remains limited, CPU clusters deliver the same scale at a fraction of the cost. This makes large-scale ML accessible to 1000+ companies instead of just 5.</p>
+    <h3 style="margin-top: 0;">The Economics Must Be Measured at Purchase Time</h3>
+    <p>Accelerator prices, server prices, memory prices, power, and availability change too quickly for a permanent
+    multiplier. The durable thesis is that CPU clusters use broadly available server components and large memory
+    domains. CKE must prove whether those properties produce competitive frontier-model capability and total cost
+    for a defined workload.</p>
 </div>
 
 <h2>The Hybrid Trap: CPU+GPU = CPU-Bound</h2>
@@ -2211,8 +2261,8 @@ CPU RAM budget (4TB):
     <div class="card card-green">
         <h3 style="margin-top: 0;">Market Wins</h3>
         <ul>
-            <li><strong>16x cheaper</strong> at scale</li>
-            <li><strong>200x more accessible</strong> to companies</li>
+            <li><strong>Potentially lower system cost</strong> for workloads that fit CPU memory and utilization patterns</li>
+            <li><strong>Broader procurement paths</strong> through standard server and networking channels</li>
             <li><strong>Commodity hardware</strong> - no special requirements</li>
             <li><strong>Open ecosystem</strong> - standard Linux tools</li>
         </ul>

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CKE Scaling Thesis: From One CPU Node to Measured Distributed Systems | C-Kernel-Engine</title>
-    <meta name="description" content="A falsifiable research thesis for scaling C-Kernel-Engine from correct single-node CPU execution to measured multi-node efficiency, with explicit memory, communication, and synchronization gates.">
+    <title>Scaling Philosophy for CPU-Only AI Systems | C-Kernel-Engine</title>
+    <meta name="description" content="Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks.">
     <meta name="robots" content="index,follow">
     <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html">
-    <meta property="og:title" content="CKE Scaling Thesis: From One CPU Node to Measured Distributed Systems | C-Kernel-Engine">
-    <meta property="og:description" content="A falsifiable research thesis for scaling C-Kernel-Engine from correct single-node CPU execution to measured multi-node efficiency, with explicit memory, communication, and synchronization gates.">
+    <meta property="og:title" content="Scaling Philosophy for CPU-Only AI Systems | C-Kernel-Engine">
+    <meta property="og:description" content="Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
@@ -978,360 +978,2224 @@
     </header>
     <main>
 
-<h1>Scaling Thesis</h1>
+<h1>Scaling Philosophy</h1>
 
-<div class="card card-accent">
-    <h2 style="margin-top: 0;">The Bet, Not the Verdict</h2>
+<div class="card card-accent" style="border: 2px solid #ffb400; padding: 2rem; margin-bottom: 2rem;">
+    <h2 style="margin-top: 0; color: #ffb400;">The Bet Behind This Project</h2>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        C-Kernel-Engine is testing whether explicit numerical contracts, generated C, optimized CPU kernels,
-        and ordinary Linux nodes can make locally owned CPU infrastructure practical for selected AI workloads.
-        The thesis is not that CPUs universally beat accelerators. There is no universal hardware winner.
+        The bet here is simple: AI will not stay locked inside premium proprietary boxes forever.
+        C-Kernel-Engine takes a different path:
+        <strong>Linux-only, CPU-only, server-grade hardware, open software, and standard data-center parts.</strong>
+        If the software gets good enough, ordinary servers become practical AI machines.
     </p>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        The narrower bet is that model execution can be reduced to measurable contracts: arithmetic, bytes moved,
-        synchronization, latency, accuracy, power, and operating cost. For workloads whose constraints match CPU
-        systems, better kernels and better orchestration may turn hardware organizations can procure and control
-        into useful AI infrastructure.
+        This is a long-horizon commodity compute bet.
+        The underlying workload is still math, memory movement, and systems software.
+        If CPUs keep gaining cores, SIMD and matrix units, memory channels, NUMA controls, and fast interconnects,
+        then a generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly valuable.
     </p>
-    <p style="font-size: 1.15em; line-height: 1.7; margin-bottom: 0;">
-        This page defines how that bet will be tested. Single-node execution has evidence today.
-        Multi-node scaling remains a research thesis until matched-node measurements close the communication,
-        synchronization, and efficiency questions.
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        This is not a claim that CPUs always beat GPU systems on raw peak throughput.
+        That is not the point.
+        The real question is whether CPU-only Linux systems can become
+        <strong>good enough, cheap enough, and accessible enough</strong>
+        to handle serious inference and eventually serious training.
+        That is the thesis being tested here.
     </p>
-</div>
-
-<div style="margin: 2.5rem 0; text-align: center;">
-    <img src="assets/engineering-compass.svg"
-         alt="CKE engineering loop: profile, identify the bottleneck, fix one kernel, and measure again"
-         style="width: 100%; max-width: 1200px; border-radius: 16px;" />
-</div>
-
-<h2>What CKE Is Betting On</h2>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">The workload is inspectable</h3>
-        <p>
-            A model becomes circuits, tensors, kernels, memory traffic, and synchronization. CKE exposes those
-            boundaries so correctness and performance can be attributed instead of hidden behind a framework call.
-        </p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">CPU systems keep changing</h3>
-        <p>
-            Vector and matrix instructions, memory-channel counts, NUMA controls, core counts, and data-center
-            networking continue to improve. CKE asks what modern CPU systems can do when software is designed for
-            their actual topology rather than treated as a fallback target.
-        </p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Ownership can be a requirement</h3>
-        <p>
-            Privacy, data residency, predictable capacity, embedded deployment, long-lived services, and operational
-            control can matter as much as peak throughput. These constraints create workloads worth evaluating on
-            locally controlled hardware.
-        </p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">The result must remain falsifiable</h3>
-        <p>
-            A CPU deployment is useful only when it meets a stated accuracy, latency, concurrency, memory, power,
-            reliability, and total-cost envelope. A failed envelope narrows the thesis; it is not a reason to move
-            the goalposts.
-        </p>
-    </div>
-</div>
-
-<h2>The Feasibility Gates</h2>
-
-<p>
-    Scaling begins only after one node is correct, fits the workload, and has a measured bottleneck. Capacity is the
-    first gate:
-</p>
-
-<pre>M_weights + M_KV + M_workspace + M_runtime &lt;= M_usable</pre>
-
-<p>
-    Once the workload fits, single-node execution time is bounded by the slower of useful arithmetic and memory
-    movement, plus software overhead:
-</p>
-
-<pre>T_node = max(T_compute, T_memory) + T_overhead</pre>
-
-<p>
-    Adding nodes introduces costs that do not exist in the single-node result:
-</p>
-
-<pre>T_N = T_compute,N
-    + T_communication,N
-    + T_synchronization,N
-    + T_imbalance,N</pre>
-
-<p>
-    Speedup and parallel efficiency are therefore measured results, not consequences of owning more machines:
-</p>
-
-<pre>S(N) = T(1) / T(N)          E(N) = S(N) / N</pre>
-
-<div class="alert alert-info">
-    <div class="alert-icon">i</div>
-    <div>
-        <strong>Memory capacity is necessary, not sufficient.</strong>
-        A model that does not fit cannot run, but a model that fits can still be too slow, too expensive, or too
-        difficult to operate. CKE treats capacity, bandwidth, compute, communication, and user-visible behavior as
-        separate gates.
-    </div>
-</div>
-
-<h2>What One Node Must Prove</h2>
-
-<div class="table-container" style="max-width: 100%; overflow-x: auto;">
-<table>
-    <thead>
-        <tr><th>Question</th><th>Required evidence</th><th>Failure means</th></tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>Is it numerically acceptable?</td>
-            <td>Reference parity, first-divergence attribution, task-level output, and explicit tolerance</td>
-            <td>Performance results are not yet promotable</td>
-        </tr>
-        <tr>
-            <td>Does it fit?</td>
-            <td>Peak RSS, mapped weights, KV state, workspace, and allocator behavior</td>
-            <td>The model, precision, context, or memory plan must change</td>
-        </tr>
-        <tr>
-            <td>What limits it?</td>
-            <td>Roofline position, effective bandwidth, vector utilization, cache behavior, and hot kernels</td>
-            <td>Optimization is speculation</td>
-        </tr>
-        <tr>
-            <td>Is it useful to a person or service?</td>
-            <td>Time to first token, prefill, decode, concurrency, tail latency, and sustained operation</td>
-            <td>A peak token rate is not enough</td>
-        </tr>
-        <tr>
-            <td>Is it operationally credible?</td>
-            <td>Power, thermals, repeatability, failure behavior, deployment steps, and total system assumptions</td>
-            <td>The benchmark does not describe a deployable system</td>
-        </tr>
-    </tbody>
-</table>
-</div>
-
-<p>
-    Every published result should identify the CPU, memory channels and population, NUMA topology, firmware or
-    microcode where relevant, compiler, CKE commit, model and input hashes, precision, context, batch, thread count,
-    commands, repetitions, and known limitations.
-</p>
-
-<h2>Distributed Scaling Is a Cost Equation</h2>
-
-<p>
-    CKE does not claim infinite scaling. A network makes remote memory and remote computation available, but every
-    boundary adds transfer time, synchronization, queueing, and imbalance. The transfer floor is approximately:
-</p>
-
-<pre>T_transfer &gt;= bytes_transferred / effective_bandwidth + network_latency</pre>
-
-<p>
-    Amdahl's law still applies. If <code>f_s</code> is the serial or effectively non-parallel fraction, ideal speedup
-    cannot exceed:
-</p>
-
-<pre>S(N) &lt;= 1 / (f_s + (1 - f_s) / N)</pre>
-
-<p>
-    Ten, 25, or 100 gigabit Ethernet, RDMA, NUMA placement, transport implementation, message size, and overlap are
-    experiment variables. They are not interchangeable labels. Internet-connected laptops may support independent or
-    delay-tolerant work, but they are not a low-latency tensor fabric and should not be described as one.
-</p>
-
-<h3>Parallelism must match the boundary</h3>
-
-<div class="table-container" style="max-width: 100%; overflow-x: auto;">
-<table>
-    <thead>
-        <tr><th>Strategy</th><th>What crosses nodes</th><th>Where it may fit</th><th>Primary risk</th></tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>Data parallelism</td>
-            <td>Gradients, optimizer state, or independent results</td>
-            <td>Independent requests and sufficiently large training batches</td>
-            <td>Reduction cost and duplicated model memory</td>
-        </tr>
-        <tr>
-            <td>Pipeline parallelism</td>
-            <td>Boundary activations</td>
-            <td>Large stages with enough work to amortize transfers</td>
-            <td>Pipeline bubbles and uneven stages</td>
-        </tr>
-        <tr>
-            <td>Tensor parallelism</td>
-            <td>Partial activations and frequent collective results</td>
-            <td>Fast, predictable fabrics and large kernels</td>
-            <td>Communication frequency dominates useful work</td>
-        </tr>
-        <tr>
-            <td>Expert parallelism</td>
-            <td>Routed tokens and expert outputs</td>
-            <td>Stable routing, useful locality, and balanced expert load</td>
-            <td>Dispatch overhead, hotspots, and remote weight traffic</td>
-        </tr>
-    </tbody>
-</table>
-</div>
-
-<h2>MoE Caveat: Routing Does Not Remove Memory Traffic</h2>
-
-<p>
-    Conditional routing is natural to express on a CPU, but that fact alone does not establish a performance
-    advantage. Active expert weights still have to reach the cores. At small batches, an expert may be used too
-    briefly to amortize its weight traffic. At larger batches, routing imbalance and token dispatch can dominate.
-    Total parameter storage also remains large even when only a subset of experts is active for each token.
-</p>
-
-<p>
-    CKE should claim an MoE benefit only after measuring active bytes per token, effective memory bandwidth, expert
-    cache locality, routing distribution, dispatch cost, concurrency, and the routed model's task quality against a
-    dense or established reference. Branch support is an implementation property; system throughput is the result.
-</p>
-
-<h2>Model Architecture Is Shaped by Constraints</h2>
-
-<p>
-    Many important model techniques can be understood as responses to memory, compute, or communication pressure.
-    That is useful systems context, but it is not evidence that the techniques are merely workarounds or that they
-    belong to one hardware class.
-</p>
-
-<div class="table-container" style="max-width: 100%; overflow-x: auto;">
-<table>
-    <thead>
-        <tr><th>Technique</th><th>Constraint reduced</th><th>New cost or contract</th></tr>
-    </thead>
-    <tbody>
-        <tr><td>GQA and MQA</td><td>KV-cache capacity and bandwidth</td><td>Shared key/value semantics and possible quality trade-offs</td></tr>
-        <tr><td>Fused or tiled attention</td><td>Intermediate storage and external memory traffic</td><td>Tiling, reduction order, precision, and backend-specific kernels</td></tr>
-        <tr><td>KV paging and quantization</td><td>Long-context capacity and allocation pressure</td><td>State management, conversion cost, and numerical error</td></tr>
-        <tr><td>Mixture of experts</td><td>Active compute per token relative to total model capacity</td><td>Routing, load balance, expert storage, and dispatch</td></tr>
-        <tr><td>Recurrent or state-space layers</td><td>Explicit long-sequence state growth</td><td>Compressed-state semantics, scan kernels, and training complexity</td></tr>
-        <tr><td>Weight and activation quantization</td><td>Capacity, bandwidth, and arithmetic cost</td><td>Calibration, scale handling, kernel coverage, and quality validation</td></tr>
-    </tbody>
-</table>
-</div>
-
-<h2>The CKE Experiment Ladder</h2>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">1. Numerical closure</h3>
-        <p>Establish model-specific parity against PyTorch or another declared reference before promoting speed.</p>
-        <p><strong>Status:</strong> active, with supported model paths and known multimodal gaps.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">2. Single-node performance</h3>
-        <p>Measure kernels, memory topology, prefill, decode, concurrency, power, and sustained behavior.</p>
-        <p><strong>Status:</strong> active across consumer, server, and selected embedded CPU targets.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">3. NUMA and topology</h3>
-        <p>Make placement, replication, thread ownership, and cross-socket traffic explicit and reproducible.</p>
-        <p><strong>Status:</strong> being hardened; results remain hardware-specific.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">4. Two-node transport</h3>
-        <p>Measure serialization, transfer, synchronization, overlap, and failure behavior on matched nodes.</p>
-        <p><strong>Status:</strong> planned research; no general scaling claim yet.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">5. Parallel execution</h3>
-        <p>Select data, pipeline, tensor, or expert boundaries from measured compute-to-communication ratios.</p>
-        <p><strong>Status:</strong> research roadmap.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">6. Distributed training</h3>
-        <p>Extend forward and backward contracts only after single-node training and transport behavior are closed.</p>
-        <p><strong>Status:</strong> long-horizon thesis, not a demonstrated capability.</p>
-    </div>
-</div>
-
-<h2>Decision Rule</h2>
-
-<div class="card card-accent">
-    <p style="font-size: 1.1em; margin-top: 0;">
-        <strong>Use an established runtime and hardware platform when it already meets the requirement.</strong>
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        The early numbers already show that CPU-only inference is practical.
+        A quantized 0.6B model on a 12th-gen Intel Alder Lake machine has reached
+        <strong>about 100 tokens/sec</strong> when the system is otherwise idle.
+        On an older 4-core machine, the same model still runs at
+        <strong>about 20&ndash;25 tokens/sec</strong>.
+        No GPU. No CUDA. No special hardware. Just common x86 instructions and Linux.
     </p>
-    <p>
-        CKE becomes relevant when a model is unsupported, numerically wrong, unexpectedly slow, difficult to
-        validate, or constrained to owned CPU or embedded infrastructure. Its value is not that every deployment
-        needs generated C. Its value is that the execution boundary can be made explicit when the normal abstraction
-        is no longer enough.
+    <p style="font-size: 1.15em; line-height: 1.7;">
+        The bigger target is server-grade CPU infrastructure.
+        Testing is underway on 5th-gen Intel Xeon Scalable systems with AVX-512 and AMX &mdash;
+        the same class of machines already sitting in real data centers.
+        The bet is that these machines will be cheaper, easier to procure, easier to operate, and more broadly deployable than proprietary accelerator-heavy stacks.
     </p>
-    <p style="margin-bottom: 0;">
-        Hardware selection should follow the workload envelope. The same investigation may conclude that a CPU,
-        accelerator, embedded target, or mixed system is the correct answer.
+    <p style="font-size: 1.15em; line-height: 1.7; border-top: 1px solid #333; padding-top: 1.5rem; margin-bottom: 0;">
+        The method is straightforward: profile, find the real bottleneck, fix one kernel at a time, and measure again.
+        C-Kernel-Engine uses VTune, FlameGraph, Intel Advisor, <code>perf stat</code>, and roofline analysis to do exactly that.
+        <strong>The point of this page is not hype. It is to state the engineering bet clearly and then earn it with measurements.</strong>
     </p>
 </div>
 
-<h2>What Would Narrow or Falsify the Thesis?</h2>
+<div style="margin: 2.5rem 0 0.5rem 0; text-align: center;">
+    <img src="assets/engineering-compass.svg" alt="Engineering Compass — Profile, Find Bottleneck, Fix Kernel, Measure, Repeat" style="width: 100%; max-width: 1200px; border-radius: 16px; box-shadow: 0 8px 32px rgba(0,0,0,0.4);" />
+</div>
 
-<ul>
-    <li>Communication and synchronization erase useful speedup beyond one node.</li>
-    <li>Memory bandwidth prevents acceptable latency or concurrency on the target model family.</li>
-    <li>Measured power and total cost are worse than practical alternatives under the same workload.</li>
-    <li>Maintaining numerical parity consumes more complexity than the generated runtime removes.</li>
-    <li>Scheduling, deployment, and operations overwhelm the portability benefit.</li>
-    <li>The useful workload set remains too narrow to justify distributed infrastructure.</li>
-</ul>
-
-<p>
-    Negative results are useful. They identify where CPU execution is practical, where a different architecture is
-    required, and which CKE abstractions survive contact with real systems.
-</p>
-
-<h2>Current Evidence Boundary</h2>
+<div style="background: linear-gradient(135deg, #1a2332 0%, #1a1a2e 100%); border: 1px solid #334; border-left: 4px solid #07adf8; border-radius: 12px; padding: 2rem 2.5rem; margin: 0.5rem 0 2rem 0;">
+    <h3 style="margin-top: 0; color: #07adf8; font-size: 1.3em;">
+        🧭 Engineering Compass &mdash; What This Page Is Really For
+    </h3>
+    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc;">
+        This page is the reminder to stay focused on the real thesis:
+        make CPU-only Linux systems useful for modern AI by improving the software until commodity server hardware becomes practical.
+        The scaling story is a direction, not a marketing slogan.
+    </p>
+    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc; margin-bottom: 0.5rem;">
+        The engineering discipline is simple and repeatable:
+    </p>
+    <ol style="font-size: 1.05em; line-height: 2; color: #ddd; padding-left: 1.5rem;">
+        <li><strong style="color: #47b475;">Find the slowest-moving part.</strong> Profile it. Understand <em>why</em> it's slow.</li>
+        <li><strong style="color: #47b475;">Find the fastest-moving part.</strong> Understand what makes it fast. Replicate the pattern.</li>
+        <li><strong style="color: #47b475;">Get more RAM, more cores.</strong> Test on bigger hardware. See if the architecture holds.</li>
+        <li><strong style="color: #47b475;">Keep profiling.</strong> VTune, perf stat, roofline, FlameGraph &mdash; every run, every change.</li>
+        <li><strong style="color: #47b475;">Fix one kernel at a time.</strong> Don't boil the ocean. One bottleneck, one fix, one measurement.</li>
+    </ol>
+    <p style="font-size: 1.1em; line-height: 1.7; color: #999; border-top: 1px solid #333; padding-top: 1rem; margin-bottom: 0;">
+        People will disagree with the thesis, and that is fine.
+        The only useful answer is better measurement, better kernels, and clearer system design.
+        Follow the data, not the hype.
+    </p>
+</div>
 
 <div class="alert alert-warning">
-    <div class="alert-icon">!</div>
-    <div>
-        CKE currently demonstrates model-specific single-node CPU inference and selected embedded paths. Numerical
-        parity, multimodal execution, training contracts, and performance coverage continue to be hardened.
-        Multi-node execution, distributed efficiency, and distributed training are roadmap items until reproducible
-        measurements are published. This page states the experiment, not its predetermined outcome.
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
     </div>
+    <div>
+        <strong>TL;DR — Two First Principles</strong><br>
+        1) <strong>0 × ∞ = 0:</strong> If the model doesn't fit in memory, FLOPS don't matter.<br>
+        2) <strong>Theory of Constraints:</strong> At the Ethernet boundary, CPUs and GPUs face the same bottleneck.
+    </div>
+</div>
+
+<h2>The Two First Principles</h2>
+
+<div class="img-container svg-viewer" data-title="Two First Principles: Memory Gate + Theory of Constraints">
+    <img src="assets/two-principles.svg" alt="Principle 1: 0 × ∞ = 0 — memory gates everything. Principle 2: Theory of Constraints — Ethernet equalizes GPUs and CPUs at cluster scale.">
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>CPU Horizontal Scaling Can Stay Simpler</strong><br>
+        Adding CPU servers still requires sharding, scheduling, networking, and NUMA discipline. But it avoids vendor-specific programming models, specialized accelerator fabrics, and the assumption that serious AI must depend on external accelerators from the start. The bet here is that standard Linux servers on Ethernet remain a simpler operational path for many real deployments.
+    </div>
+</div>
+
+<h2>The Computation Is Not Exotic</h2>
+
+<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
+    AI training and inference reduce to five operations: matrix multiply, attention, softmax, layer normalization, and backpropagation.
+    These are linear algebra and calculus — mathematics developed in the 17th through 19th centuries, long before the first computer.
+    <strong>Nothing about the computation requires physically exotic hardware.</strong> A CPU with SIMD instructions executes every one of these operations natively.
+    If the math isn't exotic, the hardware requirement isn't permanent — it's a market condition.
+    And market conditions change.
+</p>
+
+<div class="img-container svg-viewer" data-title="AI Is Standard Math — Commodity Hardware Always Wins">
+    <img src="assets/commodity-hardware-pattern.svg" alt="Left: AI operations are standard linear algebra and calculus. Right: hardware displacement pattern showing proprietary always loses to commodity.">
+</div>
+
+<div class="alert alert-warning" style="margin-top: 1.5rem;">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The same pattern, repeating</strong><br>
+        In 1995, "You can't run serious workloads on cheap PCs" was conventional wisdom.<br>
+        In 2025, "You can't run serious AI on cheap CPUs" is conventional wisdom.<br>
+        <strong>One of these beliefs aged very poorly. The pattern suggests which way this one goes.</strong>
+    </div>
+</div>
+
+<details style="margin-top: 1rem;">
+    <summary style="cursor: pointer; color: #a0a0a0; font-size: 0.9em; padding: 0.5rem 0;">Historical reference</summary>
+    <div class="table-container" style="margin-top: 0.75rem;">
+        <table>
+            <thead>
+                <tr><th>Era</th><th>Proprietary Incumbent</th><th>Commodity Disruptor</th><th>Result</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>1990s</strong></td>
+                    <td>SPARC, Alpha, PA-RISC</td>
+                    <td>x86 commodity chips</td>
+                    <td style="color: #4ade80;">Proprietary RISC faded</td>
+                </tr>
+                <tr>
+                    <td><strong>1998</strong></td>
+                    <td>Sun/SGI servers (&#36;500K+)</td>
+                    <td>x86 PCs + MapReduce/GFS</td>
+                    <td style="color: #4ade80;">Sun bankrupt (2010)</td>
+                </tr>
+                <tr>
+                    <td><strong>2009</strong></td>
+                    <td>Teradata, Netezza (&#36;1M+)</td>
+                    <td>Hadoop on commodity clusters</td>
+                    <td style="color: #4ade80;">Big data democratized</td>
+                </tr>
+                <tr style="opacity: 0.7; border-top: 1px dashed #333;">
+                    <td><strong>Now</strong></td>
+                    <td>GPU clusters ($M+)</td>
+                    <td>CPU clusters + software</td>
+                    <td style="color: #ffb400;">→ ?</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</details>
+
+<h2>Principle 1: The Cost of 0 × ∞ = 0</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The GPU Memory Trap</h3>
+    <p>Yes, you CAN fit a 70B model on GPUs using tensor/pipeline parallelism. That's not the point.</p>
+    <p><strong>The point is: you're now FORCED to buy 8+ GPUs in a cluster.</strong></p>
+    <p><strong>And GPUs are:</strong></p>
+    <ul>
+        <li><strong>Proprietary</strong> — locked to NVIDIA (CUDA), no open ecosystem</li>
+        <li><strong>Export-controlled</strong> — H100/H200 blocked in many countries, supply constrained</li>
+        <li><strong>Cluster-required</strong> — single GPUs can't handle large models, need NVLink infrastructure</li>
+        <li><strong>Expensive</strong> — &#36;40K+ per GPU, &#36;200K+ for NVLink switches</li>
+    </ul>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Math That Matters</h3>
+    <pre>
+GPU Path:
+  Model doesn't fit in 80GB → Buy 8 GPUs → $320K for GPUs alone
+  Need NVLink for fast communication → Another $50K+
+  Need DGX chassis → Another $80K+
+  Total: $450K+ just to START
+
+CPU Path:
+  Model fits in 4TB RAM → Buy 1-2 servers → $30K each
+  Standard Ethernet networking → $2K
+  Total: $60K and you're running
+    </pre>
+    <p><strong>The "0 × ∞ = 0" principle forces GPU users into expensive multi-GPU setups. CPUs avoid this entirely.</strong></p>
+</div>
+
+<h2>Target Platform</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Server-Grade Hardware by Instruction Set</h3>
+    <p>C-Kernel-Engine uses <code>ck_features.h</code> for feature detection. We target by SIMD capability, not CPU model:</p>
+</div>
+
+<div class="grid grid-3">
+    <div class="card">
+        <h3 style="margin-top: 0;">Instruction Set Priority</h3>
+        <ul>
+            <li><strong>AMX</strong> - 512-bit tile ops (Intel Sapphire Rapids+)</li>
+            <li><strong>AVX-512</strong> - 512-bit vector (Intel Skylake-X+, AMD Zen 4)</li>
+            <li><strong>AVX2+FMA</strong> - 256-bit with FMA (Intel Haswell+, AMD Zen 2+)</li>
+            <li><strong>AVX</strong> - 256-bit vector (Intel Sandy Bridge+, AMD Zen 1)</li>
+            <li><strong>NEON</strong> - 128-bit (ARM64, Apple Silicon)</li>
+        </ul>
+        <p><strong>Auto-detection:</strong> The engine selects the best kernel at build time with runtime dispatch for optional extensions.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">CPU Requirements</h3>
+        <ul>
+            <li><strong>High core count</strong> - 64-128+ cores per socket</li>
+            <li><strong>Large L3 cache</strong> - Good core-to-cache ratio (1-2MB/core)</li>
+            <li><strong>Vector width</strong> - 256-bit minimum (AVX)</li>
+            <li><strong>FMA</strong> - Recommended for 2x throughput</li>
+            <li><strong>Multiple sockets</strong> - NUMA-aware memory access</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Memory Requirements</h3>
+        <ul>
+            <li><strong>DDR5</strong> - Higher bandwidth, lower latency</li>
+            <li><strong>Multi-channel</strong> - 8-12 channels per socket</li>
+            <li><strong>Large capacity</strong> - 512GB - 2TB+ per node</li>
+            <li><strong>ECC</strong> - Error correction for reliability</li>
+            <li><strong>NUMA-local</strong> - Pin threads to local memory</li>
+        </ul>
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Accelerators</h3>
+        <ul>
+            <li><strong>Intel DSA</strong> - Data Streaming Accelerator for memory copies</li>
+            <li><strong>Intel IAA</strong> - Analytics Accelerator for compression</li>
+            <li><strong>Intel QAT</strong> - QuickAssist for crypto (if needed)</li>
+            <li><strong>CXL</strong> - Memory expansion and pooling (future)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Networking</h3>
+        <ul>
+            <li><strong>RDMA</strong> - InfiniBand or RoCEv2</li>
+            <li><strong>100-400 Gbps</strong> - High bandwidth interconnect</li>
+            <li><strong>Low latency</strong> - 1-2 μs for RDMA operations</li>
+            <li><strong>Kernel bypass</strong> - Zero-copy transfers</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Operating System</h3>
+    <p><strong>Linux-only.</strong> We use Linux-specific features:</p>
+    <ul>
+        <li><code>mmap()</code> with <code>MAP_HUGETLB</code> for huge pages</li>
+        <li><code>madvise(MADV_HUGEPAGE)</code> for transparent huge pages</li>
+        <li><code>numactl</code> / <code>set_mempolicy()</code> for NUMA binding</li>
+        <li><code>sched_setaffinity()</code> for core pinning</li>
+        <li><code>perf</code> for profiling</li>
+        <li><code>io_uring</code> for async I/O (weight loading)</li>
+        <li>Intel DSA via <code>libaccel-config</code> / <code>idxd</code> driver</li>
+    </ul>
+</div>
+
+<div class="card card-green">
+    <p>C-Kernel-Engine targets by <strong>instruction set capability</strong>, not CPU model. Any server-grade CPU with AVX2+FMA or better is a valid target — specific models change, the instruction sets don't. See <code>include/ck_features.h</code> for detection logic.</p>
+</div>
+
+<h2>Why CPU-Only?</h2>
+
+<div class="card card-accent" style="margin-bottom: 1.5rem;">
+    <p><strong>GPUs dominate when you can keep them highly utilized.</strong> Large batches, dense GEMMs, and well-packed workloads that fit comfortably in VRAM let GPUs exercise their theoretical FLOPS advantage. C-Kernel-Engine isn't anti-GPU—we're anti-waste: wasted money on unused capacity, wasted energy at low utilization, and wasted coordination overhead at scale.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Advantages</h3>
+        <ul>
+            <li><strong>No vendor lock-in</strong> - Works on any x86/ARM CPU</li>
+            <li><strong>Commodity hardware</strong> - Standard servers, not &#36;40K GPUs</li>
+            <li><strong>Larger memory</strong> - 2TB RAM per node, no 80GB VRAM limit</li>
+            <li><strong>Better debugging</strong> - GDB, Valgrind, perf all work</li>
+            <li><strong>Simpler deployment</strong> - No CUDA, no driver hell</li>
+            <li><strong>Open ecosystem</strong> - GCC, Linux, standard tools</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">The Trade-off</h3>
+        <ul>
+            <li>GPUs have higher peak FLOPS</li>
+            <li>But: memory bandwidth often bottlenecks anyway</li>
+            <li>But: PCIe transfer overhead for large models</li>
+            <li>But: multi-GPU coordination is complex</li>
+            <li>But: CPU memory is 10-100x larger and cheaper</li>
+        </ul>
+        <p><strong>For inference:</strong> CPUs are often faster for batch=1</p>
+        <p><strong>For training:</strong> Scale horizontally with RDMA</p>
+    </div>
+</div>
+
+<h2>The Fundamental Math: 0 × ∞ = 0</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Memory Constraint</strong><br>
+        It doesn't matter how fast your compute is if your model won't fit in memory. Being 10x faster at computing doesn't help if you're limited by 0 × ∞ = 0.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU: Memory Wins</h3>
+        <ul>
+            <li><strong>Dual-socket server:</strong> 4-6TB DDR5</li>
+            <li><strong>Can train:</strong> 1TB model in BF16</li>
+            <li><strong>Math:</strong> 4-6TB × dual socket = non-zero, model loads</li>
+            <li><strong>Result:</strong> Actually trains the model</li>
+        </ul>
+    </div>
+    <div class="card card-blue">
+        <h3 style="margin-top: 0;">GPU: Compute Fast, Memory Fails</h3>
+        <ul>
+            <li><strong>Single GPU VRAM:</strong> tops out well below what large models need</li>
+            <li><strong>Each GPU generation:</strong> more HBM — at exponentially higher price per unit</li>
+            <li><strong>The constraint:</strong> 1TB model ÷ per-GPU VRAM = many GPUs, minimum, just for weights</li>
+            <li><strong>Math:</strong> 0 utility per GPU (model won't fit alone) × fast FLOPS = 0 — compute speed doesn't solve a memory problem</li>
+            <li><strong>Result:</strong> You buy more GPUs. Cost compounds. Complexity compounds. Memory is still the bottleneck.</li>
+        </ul>
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="CPU vs GPU Memory Analysis">
+    <img src="assets/cpu-gpu-analysis.svg" alt="CPU vs GPU Memory Analysis">
+</div>
+
+<h2>The GPU Cluster Reality</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">GPUs Require Clusters</h3>
+    <p>Here's the fundamental problem: no single GPU can handle large models. You need a cluster.</p>
+    <ul>
+        <li><strong>Even the biggest GPU:</strong> 80GB VRAM max—can't fit 70B+ models</li>
+        <li><strong>Multi-GPU needed:</strong> 8-32 GPUs for practical workloads</li>
+        <li><strong>NVLink required:</strong> &#36;200K+ in interconnects for fast GPU-to-GPU communication</li>
+        <li><strong>DGX systems:</strong> Pre-configured clusters start at &#36;250K+</li>
+    </ul>
+</div>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    </div>
+    <div>
+        <strong>The VRAM Wall</strong><br>
+        Every GPU hits the same VRAM wall. Whether 24GB or 80GB per GPU, large models require massive GPU counts in coordinated clusters. This is the fundamental constraint that CPU-only architecture bypasses entirely.
+    </div>
+</div>
+
+<h2>Energy Efficiency: The CPU Advantage at Realistic Utilization</h2>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg>
+    </div>
+    <div>
+        <strong>"CPUs burn too much power per token"</strong><br>
+        This is the final argument GPU advocates use. But the math changes dramatically when we look at <strong>realistic utilization</strong>, not theoretical peak FLOPS.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The Utilization Problem</h3>
+    <p>GPU efficiency claims assume <strong>100% compute utilization</strong>. Real inference doesn't work that way:</p>
+    <ul>
+        <li><strong>Batch=1 latency:</strong> Most production inference is single-request</li>
+        <li><strong>Memory-bound:</strong> KV cache and weight loading dominate</li>
+        <li><strong>Token-to-token:</strong> 90%+ of time is waiting for next token</li>
+        <li><strong>I/O bound:</strong> Network, disk, and tokenization overhead</li>
+    </ul>
+    <p><strong>The dirty secret:</strong> GPUs spend most of their time <em>idle</em>, still drawing full power.</p>
+</div>
+
+<h3>The Idle Power Reality</h3>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: Always Hungry</h3>
+        <ul>
+            <li><strong>High-end GPU at idle:</strong> ~150W (just sitting there)</li>
+            <li><strong>High-end GPU at compute:</strong> ~700W</li>
+            <li><strong>PCIe overhead:</strong> +50W for data transfer</li>
+            <li><strong>VRAM stays powered:</strong> Weights must remain loaded</li>
+        </ul>
+        <p><strong>Real-world:</strong> If your GPU is only computing 20% of the time, you're wasting 80% of that 700W.</p>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU: Scales Down</h3>
+        <ul>
+            <li><strong>Dual Xeon at idle:</strong> ~100-150W (bare OS, minimal load)</li>
+            <li><strong>Dual Xeon at compute:</strong> ~800-1000W (full load)</li>
+            <li><strong>DVFS:</strong> Scales from 0.8GHz to 3.5GHz dynamically</li>
+            <li><strong>C-states:</strong> Deep sleep cores when waiting for I/O</li>
+        </ul>
+        <p><strong>Real-world:</strong> Enterprise server with 2TB RAM typically draws 200-400W average for inference workloads.</p>
+    </div>
+</div>
+
+<h3>Power-Per-Token Analysis</h3>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Scenario</th><th>GPU Power</th><th>CPU Power</th><th>Winner</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>Theoretical peak FLOPS</strong></td>
+                <td>700W / 989 TFLOPS = 0.71 W/TFLOPS</td>
+                <td>1000W / 6 TFLOPS = 167 W/TFLOPS</td>
+                <td style="color: #ff6b6b;">GPU (theoretical)</td>
+            </tr>
+            <tr>
+                <td><strong>Memory-bound (typical inference)</strong></td>
+                <td>700W (can't scale down)</td>
+                <td>200-400W (scales with load)</td>
+                <td style="color: #47b475;">CPU (2-3.5x less)</td>
+            </tr>
+            <tr>
+                <td><strong>Batch=1, high I/O wait</strong></td>
+                <td>300W average (60% idle)</td>
+                <td>150-200W average (70% idle)</td>
+                <td style="color: #47b475;">CPU (1.5-2x less)</td>
+            </tr>
+            <tr>
+                <td><strong>Multi-tenant (6 models)</strong></td>
+                <td>6 × 700W = 4,200W (all active)</td>
+                <td>800-1000W (all on one server)</td>
+                <td style="color: #47b475;">CPU (4-5x less)</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Utilization Math</h3>
+    <pre>
+GPU Cluster (6× high-end GPUs) for 6-department enterprise:
+  6 departments × 1 GPU each = 4,200W continuous
+  Even when only 1-2 departments are active.
+  Plus: $240,000+ in hardware, NVLink complexity.
+
+CPU (1× Dual Xeon Platinum) for 6-department enterprise:
+  All 6 models resident in 2TB RAM = ~1000W max
+  Each department waits its turn = efficient time-sharing
+  Scales power with actual compute load (not fixed at max)
+
+Net difference: 4-5x less power, 10x lower hardware cost
+    </pre>
+</div>
+
+<h3>Watts Per Token: The Real Numbers</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Enterprise Deployment Comparison</h3>
+    <pre>
+Scenario: 6 models, 24/7 operation, mixed workload
+
+GPU Cluster (6× high-end GPUs):
+  Idle power: 6 × 150W = 900W
+  Compute power: 6 × 700W = 4,200W (when all busy)
+  Average (typical 20% compute): ~1,500W
+  Power/24hr: 36 kWh
+  Power/year: 13,140 kWh
+  @ $0.10/kWh: $1,314/year
+
+CPU Server (1× Dual Xeon Platinum, 2TB RAM):
+  Idle power: ~150W (bare OS, all models in RAM)
+  Compute power: ~1000W (all models active)
+  Average (typical 20% compute): ~320W
+  Power/24hr: 7.7 kWh
+  Power/year: 2,800 kWh
+  @ $0.10/kWh: $280/year
+
+Net difference: 4-5x less power = ~$1,000+/year savings
+    </pre>
+</div>
+
+<h3>Carbon Footprint: Real-World Impact</h3>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU Advantage</h3>
+        <ul>
+            <li><strong>4-5x less electricity</strong> for multi-tenant inference</li>
+            <li><strong>No GPU manufacturing impact</strong> (TSMC 4nm vs 5nm)</li>
+            <li><strong>Lower cooling</strong> due to lower heat output</li>
+            <li><strong>Uses existing infrastructure</strong> - no new hardware needed</li>
+            <li><strong>10x lower hardware cost</strong> (&#36;60K vs &#36;600K+)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">When GPUs Make Sense</h3>
+        <ul>
+            <li><strong>Training large models</strong> (100B+) at 100% utilization</li>
+            <li><strong>Very high throughput</strong> with batching</li>
+            <li><strong>Research</strong> where peak FLOPS matter more than efficiency</li>
+        </ul>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Bottom Line</strong><br>
+        GPU efficiency claims assume 100% compute utilization. Real inference workloads are typically 10-30% compute-bound. At realistic utilization, CPUs consume 3-5x less power for multi-tenant inference. Plus: 10x lower hardware cost. This isn't theory - it's simple thermodynamics based on how often your hardware is actually doing work.
+    </div>
+</div>
+
+<h3>The Hidden Cost: Power Delivery and Signal Integrity</h3>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Nobody Talks About This</strong><br>
+        GPU marketing quotes peak TFLOPS. What they don't mention is the electrical engineering nightmare required to actually deliver those peaks.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The GPU Power Profile: Burst-Idle-Burst</h3>
+    <p>GPUs don't draw steady power. They spike to peak compute (hundreds of watts), then drop when waiting for data transfer, then spike again. This <strong>burst-idle-burst</strong> pattern creates massive di/dt (rate of current change) that cascades into real electrical engineering problems:</p>
+    <ul>
+        <li><strong>di/dt spikes</strong> &mdash; Rapid current transitions from idle to peak compute stress every component in the power delivery path</li>
+        <li><strong>Signal reflections</strong> &mdash; High-speed switching creates signal integrity issues on PCB traces and interconnects</li>
+        <li><strong>Crosstalk</strong> &mdash; Adjacent high-speed signal lines interfere with each other at GPU clock speeds</li>
+        <li><strong>Ground bounce</strong> &mdash; Simultaneous switching of thousands of CUDA cores causes ground plane voltage fluctuation</li>
+        <li><strong>Power supply design</strong> &mdash; PSUs must handle massive transient spikes, requiring expensive voltage regulation and capacitor banks</li>
+    </ul>
+    <p><strong>Result:</strong> Data centers running GPU clusters need specialized power infrastructure &mdash; substations, high-capacity PDUs, and overprovisioned power delivery &mdash; to handle these peak bursts that occur for fractions of a second.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: Spiky, Unpredictable Power</h3>
+        <pre>
+Power draw over time:
+  ████████░░░░████████░░████████░░░░
+  700W     150W  700W  150W 700W  150W
+  compute  wait  compute wait compute wait
+
+Peak-to-idle ratio: ~5:1
+di/dt: Extreme
+Infrastructure: Substation-grade power delivery
+        </pre>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU: Steady, Predictable Power</h3>
+        <pre>
+Power draw over time:
+  ████████████████████████████████
+  200-400W consistent draw
+
+Peak-to-idle ratio: ~2:1
+di/dt: Minimal (DVFS transitions are gradual)
+Infrastructure: Standard data center power
+        </pre>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Theory of Constraints Applied to Power</h3>
+    <p>The fastest moving part and the slowest moving part of a system should be as close together as possible. GPUs violate this principle at the electrical level:</p>
+    <ul>
+        <li><strong>Fastest part:</strong> GPU peak compute at 700W+ burst</li>
+        <li><strong>Slowest part:</strong> Data transfer at 150W idle</li>
+        <li><strong>Gap:</strong> 5:1 ratio &mdash; massive mismatch that the power infrastructure must absorb</li>
+    </ul>
+    <p>CPUs don't have GPU-level peak FLOPS, but they also <strong>don't need substation-grade power infrastructure</strong> to handle those peaks. The power draw is consistent and predictable. Standard, well-designed data center power delivery handles it without complication. No specialized substations. No overprovisioned PDUs. No capacitor banks for transient spikes.</p>
+    <p><strong>The peak FLOPS that GPUs advertise are real &mdash; but the cost of actually delivering that power is hidden from every benchmark and every marketing slide.</strong></p>
+</div>
+
+<div class="img-container svg-viewer" data-title="Power Delivery Reality: GPU Spikes vs CPU Steady State">
+    <img src="assets/power-delivery-infographic.svg" alt="Power Delivery Reality - GPU burst-idle-burst spikes vs CPU steady state power draw, showing signal integrity problems, Theory of Constraints applied to power, and hidden infrastructure costs">
+</div>
+
+<h2>Principle 2: The Ethernet Equalizer</h2>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    </div>
+    <div>
+        <strong>NVLink Doesn't Scale Infinitely</strong><br>
+        NVLink is 900 GB/s <em>within a single node</em>. But you can only fit 8 GPUs per node. Go beyond that? You hit Ethernet. And at the Ethernet boundary, CPUs and GPUs face the exact same constraint.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The Bandwidth Reality</h3>
+    <p>Let's be precise about the numbers:</p>
+</div>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Connection Type</th><th>Bandwidth</th><th>Where It Applies</th><th>Scales To</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>NVLink 4.0</td>
+                <td>900 GB/s</td>
+                <td>GPU-to-GPU within 1 node</td>
+                <td>8 GPUs max</td>
+            </tr>
+            <tr>
+                <td>DDR5 (12-channel)</td>
+                <td>460 GB/s</td>
+                <td>CPU-to-RAM within 1 socket</td>
+                <td>Per socket</td>
+            </tr>
+            <tr>
+                <td>400GbE Ethernet</td>
+                <td>50 GB/s</td>
+                <td>Node-to-node</td>
+                <td>Infinite nodes</td>
+            </tr>
+            <tr>
+                <td>100GbE Ethernet</td>
+                <td>12.5 GB/s</td>
+                <td>Node-to-node</td>
+                <td>Infinite nodes</td>
+            </tr>
+            <tr>
+                <td>InfiniBand HDR</td>
+                <td>25 GB/s</td>
+                <td>Node-to-node</td>
+                <td>Thousands of nodes</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Theory of Constraints Applied</h3>
+    <pre>
+GPU Cluster at Scale:
+  Within node:  NVLink 900 GB/s (fast!)
+  Between nodes: Ethernet 50 GB/s (constraint!)
+  System speed = 50 GB/s (bottleneck)
+
+CPU Cluster at Scale:
+  Within node:  DDR5 460 GB/s
+  Between nodes: Ethernet 50 GB/s (same constraint!)
+  System speed = 50 GB/s (same bottleneck)
+
+AT SCALE, THEY HIT THE SAME WALL.
+    </pre>
+</div>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Without NVLink, GPUs Are Often Slower</strong><br>
+        If you can't afford NVLink switches (&#36;200K+), your GPUs communicate over PCIe → Ethernet. That's 12.5-50 GB/s. A server-grade CPU with DDR5 has 460 GB/s to its own memory. For memory-bound workloads, the CPU wins.
+    </div>
+</div>
+
+<h2>The Compute-to-Bandwidth Chasm</h2>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    </div>
+    <div>
+        <strong>The Ethernet Equalizer Shows Both Hit the Same Wall &mdash; But the Pain Is Wildly Different</strong><br>
+        Every system has a fastest thing (compute) and a slowest thing (cross-node data movement). C-Kernel-Engine's entire goal is to bring these two into sync. On CPUs, they're close enough that software can bridge the gap. On GPUs, they're orders of magnitude apart &mdash; no software fixes that.
+    </div>
+</div>
+
+<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
+    On CPUs, the gap between the fastest thing the system can do (compute) and the slowest thing it must do (move data across the network) is <strong>close</strong>.
+    Peak FLOPS and Ethernet bandwidth live in the same neighborhood.
+    That means the remaining optimization work is pure engineering &mdash; tiling, prefetching, computation-communication overlap &mdash; real techniques that bring compute and data movement closer to sync.
+    <strong>That's what C-Kernel-Engine is built to do.</strong>
+</p>
+<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
+    On GPUs, the fastest and slowest are worlds apart. GPU peak compute is orders of magnitude faster than the Ethernet pipe that feeds it at cluster scale.
+    It's the difference between the summit of <strong>Mt. Everest</strong> and the floor of the <strong>Mariana Trench</strong>.
+    Most of that compute sits permanently idle, burning power, waiting for data that will never arrive fast enough. No amount of software engineering changes the physics.
+</p>
+
+<div class="img-container svg-viewer" data-title="The Compute-to-Bandwidth Chasm: CPU Rolling Hills vs GPU Everest-to-Mariana">
+    <img src="assets/compute-bandwidth-chasm.svg" alt="On CPUs the gap between compute speed and network speed is small — C-Kernel-Engine bridges it. On GPUs the gap is orders of magnitude — unbridgeable at scale.">
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU: Rolling Hills &mdash; Bridgeable</h3>
+        <ul>
+            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are close</li>
+            <li><strong>Local memory bandwidth</strong> sits in between &mdash; a smooth gradient, not a cliff</li>
+            <li><strong>Software can bridge the remaining gap:</strong> tiling, prefetch, overlap</li>
+            <li><strong>Every hardware generation</strong> makes the gap smaller (more bandwidth, same physics)</li>
+        </ul>
+        <p>The terrain is gentle enough to walk. C-Kernel-Engine's job is to build the bridge: bring compute throughput and data movement into sync through aggressive kernel engineering.</p>
+    </div>
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: Everest to Mariana &mdash; Unbridgeable</h3>
+        <ul>
+            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are orders of magnitude apart</li>
+            <li><strong>Intra-node interconnects</strong> are fast, but only reach a handful of GPUs</li>
+            <li><strong>At cluster scale</strong>, everything hits the same Ethernet wall</li>
+            <li><strong>Most compute capacity</strong> sits permanently idle, starved for data</li>
+        </ul>
+        <p>The terrain is a cliff face. No bridge spans from the peak of Everest to the bottom of the Mariana Trench. The gap is structural &mdash; physics, not engineering.</p>
+    </div>
+</div>
+
+<div class="alert alert-success" style="margin-top: 1.5rem;">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>C-Kernel-Engine's Optimization Thesis</strong><br>
+        The goal is straightforward: bring the fastest-moving thing and the slowest-moving thing as close to sync as possible. On CPUs, they're already neighbors &mdash; the remaining work is tiling, cache management, prefetching, and overlapping computation with communication. That is a solvable engineering problem, and it's exactly what this project is built to solve. On GPUs at cluster scale, the gap between compute and data movement is structural. No kernel optimization closes it.
+    </div>
+</div>
+
+<h2>Designing Your Ethernet Network</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Ethernet Switch Topology for ML Clusters</h3>
+    <p>Since Ethernet is the equalizer at scale, designing it well is critical.</p>
+</div>
+
+<h3>Leaf-Spine Architecture</h3>
+
+<div class="card">
+    <pre>
+                    ┌─────────────┐     ┌─────────────┐
+                    │  Spine 1    │     │  Spine 2    │
+                    │ 400GbE      │     │ 400GbE      │
+                    └──────┬──────┘     └──────┬──────┘
+                           │                   │
+         ┌─────────────────┼───────────────────┼─────────────────┐
+         │                 │                   │                 │
+    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
+    │ Leaf 1  │       │ Leaf 2  │       │ Leaf 3  │       │ Leaf 4  │
+    │ 100GbE  │       │ 100GbE  │       │ 100GbE  │       │ 100GbE  │
+    └────┬────┘       └────┬────┘       └────┬────┘       └────┴────┘
+         │                 │                 │                 │
+    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
+    │Server 1 │       │Server 3 │       │Server 5 │       │Server 7 │
+    │Server 2 │       │Server 4 │       │Server 6 │       │Server 8 │
+    └─────────┘       └─────────┘       └─────────┘       └─────────┘
+    </pre>
+</div>
+
+<h3>Switch Sizing Calculator</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Bandwidth Requirements</h3>
+    <pre>
+For distributed training with data parallelism:
+  Gradient size = Model parameters × bytes per param
+  70B model in FP16 = 70B × 2 bytes = 140 GB
+
+All-reduce bandwidth needed:
+  Per iteration: 2 × gradient size (reduce-scatter + all-gather)
+  70B model: 2 × 140 GB = 280 GB per iteration
+
+With 100GbE (12.5 GB/s):
+  All-reduce time = 280 GB ÷ 12.5 GB/s = 22.4 seconds
+
+With 400GbE (50 GB/s):
+  All-reduce time = 280 GB ÷ 50 GB/s = 5.6 seconds
+    </pre>
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Small Cluster (8-16 servers)</h3>
+        <ul>
+            <li><strong>Topology:</strong> Single 400GbE switch</li>
+            <li><strong>Switch:</strong> Arista 7060X5 or similar</li>
+            <li><strong>Ports:</strong> 32× 400GbE</li>
+            <li><strong>Cost:</strong> ~$30,000</li>
+            <li><strong>Bisection BW:</strong> 12.8 Tbps</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Medium Cluster (32-64 servers)</h3>
+        <ul>
+            <li><strong>Topology:</strong> Leaf-spine (2 spine, 4 leaf)</li>
+            <li><strong>Spine:</strong> 2× 400GbE switches</li>
+            <li><strong>Leaf:</strong> 4× 100GbE switches</li>
+            <li><strong>Cost:</strong> ~$120,000</li>
+            <li><strong>Bisection BW:</strong> 25.6 Tbps</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Large Cluster (100+ servers)</h3>
+    <ul>
+        <li><strong>Topology:</strong> 3-tier Clos or fat-tree</li>
+        <li><strong>Consider:</strong> InfiniBand for lower latency</li>
+        <li><strong>RDMA:</strong> RoCEv2 over Ethernet or native IB</li>
+        <li><strong>Cost:</strong> $500K-2M depending on scale</li>
+    </ul>
+    <p><strong>Key insight:</strong> A GPU cluster at this scale needs the SAME network infrastructure. The Ethernet cost is equal. But CPUs don't need the $2M+ in NVLink switches.</p>
+</div>
+
+<h3>RDMA Configuration</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">RoCEv2 Setup</h3>
+    <pre>
+# Enable RDMA over Converged Ethernet v2
+# On each server with Mellanox/NVIDIA ConnectX NICs:
+
+# 1. Enable PFC (Priority Flow Control) on switch
+#    Required for lossless Ethernet
+
+# 2. Configure ECN (Explicit Congestion Notification)
+mlnx_qos -i eth0 --pfc 0,0,0,1,0,0,0,0  # Enable PFC on priority 3
+mlnx_qos -i eth0 --trust=dscp
+
+# 3. Set up RDMA
+modprobe rdma_ucm
+modprobe rdma_cm
+
+# 4. Verify RDMA is working
+ibv_devinfo
+rdma link show
+    </pre>
+</div>
+
+<div class="img-container svg-viewer" data-title="Ethernet Switch Topology">
+    <img src="assets/ethernet-topology.svg" alt="Ethernet Switch Topology for ML Clusters">
+</div>
+
+<h2>Scale Economics: The Real Comparison</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Why CPU-Only Wins at Scale</h3>
+</div>
+
+<div class="img-container svg-viewer" data-title="Scale Economics Comparison">
+    <img src="assets/scale-economics.svg" alt="Scale Economics Comparison">
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-blue">
+        <h3 style="margin-top: 0;">GPU Cluster at Scale</h3>
+        <ul>
+            <li><strong>For 1TB model:</strong> 100 GPUs minimum</li>
+            <li><strong>Total cost:</strong> $4 Billion</li>
+            <li><strong>Who can afford:</strong> 5 companies globally</li>
+            <li><strong>Result:</strong> Elite-only access</li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU Cluster at Scale</h3>
+        <ul>
+            <li><strong>For same scale:</strong> 80 servers</li>
+            <li><strong>Total cost:</strong> $240 Million</li>
+            <li><strong>Who can afford:</strong> 1000+ companies</li>
+            <li><strong>Result:</strong> Accessible to everyone</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Economics: 16x Cheaper, 200x More Accessible</h3>
+    <p>While GPU costs stay high and GPU access remains limited, CPU clusters deliver the same scale at a fraction of the cost. This makes large-scale ML accessible to 1000+ companies instead of just 5.</p>
+</div>
+
+<h2>The Hybrid Trap: CPU+GPU = CPU-Bound</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    </div>
+    <div>
+        <strong>Common Question:</strong><br>
+        "Why not use CPU for memory and GPU for compute? Get the best of both!"<br><br>
+        <strong>Answer:</strong> You're then AS FAST AS THE CPU anyway! You get the complexity of both with the performance of neither.
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="Hybrid CPU+GPU Bottleneck">
+    <img src="assets/hybrid-bottleneck.svg" alt="Hybrid CPU+GPU Bottleneck">
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Hybrid Bottleneck</h3>
+    <p>When CPU holds weights and transfers to GPU for compute:</p>
+    <ul>
+        <li><strong>Transfer bottleneck:</strong> 100 GB/s limits throughput</li>
+        <li><strong>GPU idle time:</strong> Waits for data from CPU</li>
+        <li><strong>You get:</strong> GPU performance = CPU performance</li>
+        <li><strong>Plus:</strong> Double the code complexity, double the cost</li>
+    </ul>
+    <p><strong>Conclusion:</strong> If the GPU is limited by the CPU anyway, just use CPUs! Simpler, faster, cheaper.</p>
+</div>
+
+<h2>The GPU Workaround Stack: "Innovations" That Are Actually Patches</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Uncomfortable Truth</strong><br>
+        The entire field has been optimizing around a hardware constraint and mistaking the workarounds for progress. Every major "breakthrough" in LLM architecture is actually compensating for GPU memory limitations.
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Every "Innovation" Maps to a GPU Constraint</h3>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>"Innovation"</th><th>What It Actually Does</th><th>The GPU Constraint It Patches</th><th>Needed on CPU with 2-4TB RAM?</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>GQA (Grouped Query Attention)</strong></td>
+                    <td>Shares KV heads across query heads</td>
+                    <td>KV cache blows up GPU VRAM</td>
+                    <td style="color: #4ade80;">No &mdash; KV cache fits</td>
+                </tr>
+                <tr>
+                    <td><strong>MoE (Mixture of Experts)</strong></td>
+                    <td>Activates sparse subset of parameters</td>
+                    <td>Dense model won't fit on one GPU</td>
+                    <td style="color: #4ade80;">No &mdash; dense model fits</td>
+                </tr>
+                <tr>
+                    <td><strong>KV Caching</strong></td>
+                    <td>Stores past attention keys/values &mdash; literally a key-value database in every layer</td>
+                    <td>GPU VRAM limits cache size, forces eviction strategies</td>
+                    <td style="color: #4ade80;">CPU home turf &mdash; this is literally how databases work. CPUs have been running key-value stores for decades.</td>
+                </tr>
+                <tr>
+                    <td><strong>Gradient Checkpointing</strong></td>
+                    <td>Recomputes activations instead of storing them</td>
+                    <td>Training activations don't fit in GPU VRAM</td>
+                    <td style="color: #4ade80;">No &mdash; store everything</td>
+                </tr>
+                <tr>
+                    <td><strong>Tensor Parallelism</strong></td>
+                    <td>Shards weight matrices across GPUs</td>
+                    <td>Single GPU can't hold the full matrix</td>
+                    <td style="color: #4ade80;">No &mdash; full matrix fits in RAM</td>
+                </tr>
+                <tr>
+                    <td><strong>Pipeline Parallelism</strong></td>
+                    <td>Distributes layers across GPUs</td>
+                    <td>All layers don't fit on one GPU</td>
+                    <td style="color: #4ade80;">No &mdash; all layers fit</td>
+                </tr>
+                <tr>
+                    <td><strong>Flash Attention</strong></td>
+                    <td>Online softmax with tiled computation &mdash; streams through attention in blocks</td>
+                    <td>Full attention matrix doesn't fit in GPU SRAM/VRAM</td>
+                    <td style="color: #4ade80;">Brilliant for CPU &mdash; tiling maps naturally to CPU cache hierarchies. CPUs process data in cache-line-sized tiles inherently.</td>
+                </tr>
+                <tr>
+                    <td><strong>Quantization Research</strong></td>
+                    <td>Compresses model weights (Q4, Q8, etc.)</td>
+                    <td>Model doesn't fit in GPU VRAM at full precision</td>
+                    <td style="color: #fbbf24;">Optional &mdash; use for bandwidth, not capacity</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Punchline</strong><br>
+        On a CPU with 2-4TB RAM, <strong>half of these become unnecessary, and the other half become simpler.</strong> The entire research direction has been shaped by GPU limitations, and people have confused "optimizations forced by GPU memory walls" with "fundamental advances in model architecture."
+    </div>
+</div>
+
+<div class="img-container svg-viewer" data-title="GPU Workaround Convergence: All Roads Lead Back to CPU">
+    <img src="assets/gpu-workaround-convergence.svg" alt="GPU Workaround Convergence - Every GPU innovation (GQA, MoE, KV Caching, Flash Attention, Gradient Checkpointing, Tensor/Pipeline Parallelism, Quantization) converges toward capabilities CPUs have had natively for decades">
+</div>
+
+<h3>The Sequential Reality: GPUs Were Never Designed for This</h3>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Transformers Are Sequential. Period.</h3>
+    <p>A transformer forward pass is:</p>
+    <pre>Layer 1 &rarr; Layer 2 &rarr; Layer 3 &rarr; ... &rarr; Layer 80</pre>
+    <p>You <strong>cannot</strong> compute layer 10 without the output of layer 9. That is the <em>definition</em> of sequential dependency. There is no debate here &mdash; it's mathematical fact.</p>
+    <p>What people mean when they say "LLMs are parallel" is that <em>within</em> a single layer, the matrix multiplication can be parallelized across rows and columns. But that's not the model being parallel &mdash; that's a single operation within a sequential pipeline being decomposable. Every CPU has been decomposing matmuls across SIMD lanes and cores for decades.</p>
+</div>
+
+<h3>Amdahl's Law: Why Parallel Hardware Still Hits a Ceiling</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Strong-Scaling Limit</h3>
+    <p>Amdahl's Law is the simplest way to say what the sequential transformer argument implies in practice:</p>
+    <pre>speedup(N) = 1 / (S + (1 - S) / N)</pre>
+    <p>Where <code>S</code> is the fraction of work that stays effectively serial or synchronization-bound. Even with infinite parallel hardware, the maximum speedup is still:</p>
+    <pre>max_speedup = 1 / S</pre>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Serial / sync fraction</th><th>Theoretical max speedup</th><th>What it means</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>10%</td><td>10&times;</td><td>A surprisingly hard wall for giant clusters</td></tr>
+                <tr><td>5%</td><td>20&times;</td><td>Still not "infinite scaling"</td></tr>
+                <tr><td>2%</td><td>50&times;</td><td>Requires extraordinary system design</td></tr>
+                <tr><td>1%</td><td>100&times;</td><td>Already very difficult in real distributed systems</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <p>For LLMs, that serial fraction is not just "the next token depends on the previous token." It also includes layer boundaries, synchronization, collective communication, optimizer steps, routing decisions, and all the places where the system must wait for the slowest participant.</p>
+    <p><strong>CKE takeaway:</strong> do not optimize only for peak FLOPS. Reduce the effective serial fraction, reduce synchronization pressure, and keep compute, memory, and network in the same performance neighborhood.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">What GPUs Were Designed For</h3>
+        <p><strong>Independent pixel computation.</strong></p>
+        <p>Millions of pixels with <em>zero</em> data dependency on each other. Pixel (0,0) doesn't need the result of pixel (1920,1080) to compute its color. That IS embarrassingly parallel.</p>
+        <pre>
+pixel(0,0)   &rarr; compute color &rarr; done
+pixel(0,1)   &rarr; compute color &rarr; done
+pixel(1,0)   &rarr; compute color &rarr; done
+...
+pixel(1920,1080) &rarr; compute color &rarr; done
+(all independent, all simultaneous)</pre>
+    </div>
+    <div class="card" style="border-left: 4px solid #fbbf24;">
+        <h3 style="margin-top: 0;">What LLM Inference Actually Is</h3>
+        <p><strong>Sequential token generation on a sequential layer stack.</strong></p>
+        <p>Token N+1 depends on the attention computation over ALL previous tokens. The autoregressive decode loop is the opposite of pixel independence.</p>
+        <pre>
+token 1 &rarr; 80 layers &rarr; token 2
+token 2 &rarr; 80 layers &rarr; token 3
+token 3 &rarr; 80 layers &rarr; token 4
+...
+(each waits for the previous)</pre>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Vocabulary of Mismatch</h3>
+    <p>The fact that the industry bolted LLM training onto hardware designed for independent pixel shading and then invented an entire vocabulary to work around the mismatch should tell you something is wrong with the foundational assumption:</p>
+    <ul>
+        <li><strong>Tensor parallelism</strong> &mdash; because one GPU can't hold the weights</li>
+        <li><strong>Pipeline parallelism</strong> &mdash; because one GPU can't hold the layers</li>
+        <li><strong>Model parallelism</strong> &mdash; because the model doesn't fit</li>
+        <li><strong>Gradient checkpointing</strong> &mdash; because activations don't fit</li>
+        <li><strong>Flash Attention</strong> &mdash; because attention intermediates don't fit</li>
+        <li><strong>Activation recomputation</strong> &mdash; because you ran out of memory</li>
+    </ul>
+    <p><strong>Every one of these is a workaround for the same problem:</strong> you're running a sequential, memory-hungry workload on hardware designed for embarrassingly parallel, compute-bound pixel shading.</p>
+</div>
+
+<h3>MoE: The Right Hardware for Dynamic Routing</h3>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Native Fit vs. Forced Workaround</h3>
+    <p>Yes, MoE runs on GPUs — frontier models do it at scale. But <em>runs on</em> is not the same as <em>naturally fits</em>. The same argument made against CPUs for AI ("it works, but it's not the right tool") applies equally to GPUs for MoE.</p>
+    <p>MoE routing is conditional: for each token, a gating function decides which experts activate. GPUs — designed for dense, predictable, lockstep computation — handle this through software workarounds: load balancing losses, capacity factors, expert dropout, and auxiliary training objectives just to keep GPU utilization from collapsing under sparse activation patterns.</p>
+    <p>Consider fixed-function inference chips. They prefer dense computation above all else. The minute you introduce dynamic routing — conditional branching, variable expert selection — they require architectural hacks. GPUs face the same underlying tension, just with more memory headroom to absorb it.</p>
+    <p>CPUs have handled conditional branching natively since the beginning: branch prediction, out-of-order execution, speculative paths. The hardware was built for exactly this. <strong>AVX-512 computes 16 FP32 multiply-accumulates per cycle per core</strong> — across 128 cores that's 2048 parallel operations — and the dynamic routing overhead that GPUs must paper over in software is just normal control flow on a CPU.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Why MoE All-to-All Makes Topology Matter</h3>
+    <p>Jensen Huang's point about MoE is not that "one expert equals one GPU" in a literal one-expert-per-device sense. Real deployments usually place <strong>multiple experts per GPU</strong>, or shard very large experts across several GPUs. But the core communication pattern is the same:</p>
+    <pre>tokens on many GPUs
+   &darr; route top-k experts
+dispatch token states to expert owners (all-to-all)
+   &darr;
+run expert MLPs
+   &darr;
+send expert outputs back / combine (all-to-all again)</pre>
+    <p>That happens at every MoE layer. If the interconnect is a one-hop switched fabric, the communication cost is painful but bounded. If the topology is multi-hop, ring-like, torus-like, or otherwise forces traffic through several devices before reaching the destination, the waiting and queueing add up quickly.</p>
+    <p><strong>This is where Amdahl's Law shows up in systems form:</strong> the expert GEMMs may parallelize beautifully, but the dispatch, synchronization, and combine phases become the part you cannot hide. The more often the model must do all-to-all, the more the communication fraction dominates the ceiling on real speedup.</p>
+</div>
+
+<h3>Training: Batch Size Is Not What You Think</h3>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>"But GPUs need large batches for efficiency!"</strong><br>
+        This is true &mdash; and that's a GPU problem, not a training requirement. Training does not <em>need</em> batch size greater than 1. There are many ways to simulate larger effective batch sizes without holding multiple sequences in memory simultaneously.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU: The Batch Balancing Act</h3>
+        <p>On a GPU, you must balance three competing constraints:</p>
+        <ul>
+            <li><strong>Model size</strong> &mdash; weights consume VRAM</li>
+            <li><strong>Context length</strong> &mdash; KV cache consumes VRAM</li>
+            <li><strong>Batch size</strong> &mdash; activations consume VRAM</li>
+        </ul>
+        <p>Increase any one, and you must decrease the others. Want longer context? Reduce batch size. Want larger batch? Reduce context. Want a bigger model? Reduce both.</p>
+        <pre>
+GPU VRAM budget (80GB):
+  Model weights:    40GB (fixed)
+  KV cache:         20GB (varies with context)
+  Activations:      20GB (varies with batch)
+
+  Longer context = less batch
+  Larger batch   = less context
+  ALWAYS a tradeoff.
+        </pre>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU: No Tradeoff Required</h3>
+        <p>With 2-4TB of RAM, all three fit simultaneously:</p>
+        <ul>
+            <li><strong>Model size</strong> &mdash; even 400B+ models fit (800GB+ in FP16)</li>
+            <li><strong>Context length</strong> &mdash; variable, up to 1M+ tokens</li>
+            <li><strong>Batch size</strong> &mdash; whatever you need</li>
+        </ul>
+        <p>You can have <strong>variable context length AND batch greater than one</strong> at the same time. No balancing act required.</p>
+        <pre>
+CPU RAM budget (4TB):
+  Model weights:    810GB (400B+ FP16)
+  KV cache:         500GB (long context)
+  Activations:      200GB (large batch)
+  Remaining:        2,538GB (room to spare)
+
+  Variable context + variable batch
+  NO tradeoffs.
+        </pre>
+    </div>
+</div>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">You Don't Need Large Batches &mdash; You Can Simulate Them</h3>
+    <p>Training with batch=1 works. The gradient is noisier, but there are well-established techniques to get the benefits of large batches without the memory cost:</p>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Technique</th><th>How It Works</th><th>GPU Benefit</th><th>CPU Benefit</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>Gradient Accumulation</strong></td>
+                    <td>Accumulate gradients over N forward passes, update once</td>
+                    <td>Simulates batch=N with batch=1 memory</td>
+                    <td>Same, but can also do actual batch=N</td>
+                </tr>
+                <tr>
+                    <td><strong>Micro-batching</strong></td>
+                    <td>Process small sub-batches, aggregate gradients</td>
+                    <td>Fits in VRAM per micro-batch</td>
+                    <td>Can use larger micro-batches</td>
+                </tr>
+                <tr>
+                    <td><strong>Online Learning</strong></td>
+                    <td>Update after every single example (batch=1)</td>
+                    <td>Works but GPU underutilized</td>
+                    <td>Natural fit for CPU sequential processing</td>
+                </tr>
+                <tr>
+                    <td><strong>Data Parallelism</strong></td>
+                    <td>Each node processes different batch, average gradients</td>
+                    <td>Requires NVLink/IB for gradient sync</td>
+                    <td>RDMA gradient sync, same principle</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The C-Kernel-Engine is actively being developed to prove this.</strong><br>
+        Our kernel architecture supports variable context lengths and flexible batch sizes natively. The quantized GEMV/GEMM kernels (Q4_K, Q5_0, Q5_1, Q5_K, Q6_K, Q8_0) are designed from the ground up for CPU-native inference and training &mdash; not as ports of GPU code. We're building the evidence that CPU-only training and inference at scale isn't theoretical &mdash; it's practical, and the kernel-level work is happening now.
+    </div>
+</div>
+
+<h2>Why CPU-Only is the Future</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">The Strategic Advantage</h3>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Technical Wins</h3>
+        <ul>
+            <li><strong>Memory capacity:</strong> 4-6TB per node vs 80GB VRAM</li>
+            <li><strong>No transfer bottleneck:</strong> CPU memory + CPU compute</li>
+            <li><strong>Optimize interconnect:</strong> RDMA, core pinning, cache</li>
+            <li><strong>Get close to theoretical FLOPS</strong></li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Market Wins</h3>
+        <ul>
+            <li><strong>16x cheaper</strong> at scale</li>
+            <li><strong>200x more accessible</strong> to companies</li>
+            <li><strong>Commodity hardware</strong> - no special requirements</li>
+            <li><strong>Open ecosystem</strong> - standard Linux tools</li>
+        </ul>
+    </div>
+</div>
+
+<h2>Commodity Economics: The CPU Trajectory</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">CPUs Follow Commodity Price Curves</h3>
+    <p>Unlike GPUs which are supply-constrained and vendor-controlled, CPUs are commodity hardware. Every improvement happens automatically, at scale, with competition driving prices down.</p>
+</div>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Component</th><th>2023</th><th>2025</th><th>2027 (projected)</th><th>Trend</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Memory Standard</td>
+                <td>DDR5-4800</td>
+                <td>DDR5-6400</td>
+                <td>DDR6</td>
+                <td>+33% bandwidth per gen</td>
+            </tr>
+            <tr>
+                <td>Channels per Socket</td>
+                <td>8</td>
+                <td>12</td>
+                <td>16</td>
+                <td>+50% channels</td>
+            </tr>
+            <tr>
+                <td>Max RAM per Server</td>
+                <td>4TB</td>
+                <td>8TB</td>
+                <td>16TB+</td>
+                <td>2x per generation</td>
+            </tr>
+            <tr>
+                <td>Cores per Socket</td>
+                <td>64 (Genoa)</td>
+                <td>128 (Turin)</td>
+                <td>192+</td>
+                <td>+50% per gen</td>
+            </tr>
+            <tr>
+                <td>L3 Cache</td>
+                <td>256MB</td>
+                <td>384MB</td>
+                <td>512MB+</td>
+                <td>Growing</td>
+            </tr>
+            <tr>
+                <td>Ethernet Speed</td>
+                <td>100GbE</td>
+                <td>400GbE</td>
+                <td>800GbE</td>
+                <td>4x per 3 years</td>
+            </tr>
+            <tr>
+                <td>$/TFLOP (CPU)</td>
+                <td>$500</td>
+                <td>$300</td>
+                <td>$150</td>
+                <td>-50% per 2 years</td>
+            </tr>
+            <tr>
+                <td>$/TFLOP (GPU)</td>
+                <td>$50</td>
+                <td>$40</td>
+                <td>$35</td>
+                <td>-15% per 2 years</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Crossover Point</strong><br>
+        GPUs will always have higher peak FLOPS per dollar for raw compute. But for memory-bound ML inference (which is most real-world LLM usage), CPUs are already competitive. And the gap closes every year because CPU economics follow commodity curves.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Why CPU Economics Win</h3>
+        <ul>
+            <li><strong>Competition:</strong> Intel vs AMD vs ARM</li>
+            <li><strong>Volume:</strong> Billions of CPUs vs millions of GPUs</li>
+            <li><strong>Supply:</strong> Multiple fabs, no bottlenecks</li>
+            <li><strong>Standards:</strong> DDR5 is an industry standard, not proprietary</li>
+            <li><strong>Software:</strong> Linux, GCC, standard tools (free)</li>
+        </ul>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Why GPU Economics Struggle</h3>
+        <ul>
+            <li><strong>Monopoly:</strong> NVIDIA dominates (~90% market)</li>
+            <li><strong>Supply-constrained:</strong> Artificial scarcity</li>
+            <li><strong>Proprietary:</strong> CUDA lock-in, HBM limited fabs</li>
+            <li><strong>High margins:</strong> No price competition pressure</li>
+            <li><strong>Lead times:</strong> 12-24 month waits</li>
+        </ul>
+    </div>
+</div>
+
+<h2>Infinite CPU Scaling: The Internet Proof</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">CPUs Scale to Infinity</h3>
+    <p>Unlike GPUs, which hit cost and availability ceilings, CPUs scale infinitely through distributed computing across the internet. Your computer is part of that infinity!</p>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Insight</strong><br>
+        Want more FLOPs? Add more CPUs + RDMA! Get your 100 PFLOPS while your friends on the other side keep bragging about their limited GPU clusters. FLOPs is just an accumulation problem that CPUs solve through clever distributed training.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">∞ Infinite Scaling</h3>
+        <ul>
+            <li><strong>Internet-scale distributed computing</strong></li>
+            <li><strong>No ceiling:</strong> Add 10, 100, 1000 CPUs</li>
+            <li><strong>Your computer contributes:</strong> Every device matters</li>
+            <li><strong>Result:</strong> Unlimited FLOP accumulation</li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">CPU Improvements Track</h3>
+        <ul>
+            <li><strong>Cores:</strong> Increasing year over year</li>
+            <li><strong>Cache:</strong> Growing bigger</li>
+            <li><strong>Efficiency:</strong> Getting better</li>
+            <li><strong>Cost:</strong> Decreasing over time</li>
+        </ul>
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Memory Scaling</h3>
+        <ul>
+            <li><strong>DDR5 → DDR6:</strong> 2400 GB/s → higher bandwidth</li>
+            <li><strong>Memory slots:</strong> 8 → 12 → 16 slots per node</li>
+            <li><strong>Total per node:</strong> 4TB → 8TB → 16TB RAM</li>
+            <li><strong>Cost/GB:</strong> Constantly decreasing</li>
+        </ul>
+    </div>
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Model Efficiency</h3>
+        <ul>
+            <li><strong>Smaller models:</strong> Getting more efficient</li>
+            <li><strong>Better quantization:</strong> Q4, Q8, hybrid methods</li>
+            <li><strong>Architecture improvements:</strong> MoE, mixture of experts</li>
+            <li><strong>Training optimization:</strong> Better algorithms</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The C-Kernel Engine Goal</h3>
+    <p>Exploit this infinite CPU scaling on server-grade CPUs. As models get smaller and CPUs get more powerful, the combination becomes unbeatable:</p>
+    <ul>
+        <li><strong>No GPU dependency:</strong> Commodity hardware only</li>
+        <li><strong>Accessible to everyone:</strong> Your laptop contributes to the cluster</li>
+        <li><strong>Sustainable scaling:</strong> Economics favor CPU-only approach</li>
+        <li><strong>Future-proof:</strong> CPU improvements continue while GPU costs stay high</li>
+    </ul>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Multi-Model Parallelism: Enterprise Real Workload</h3>
+    <p>Unlike GPUs which are designed for single-model throughput, CPUs excel at running <strong>multiple models simultaneously</strong> on the same system.</p>
+</div>
+
+<h2>Enterprise & Government: The Multi-Model Reality</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Real Enterprise Scenario</strong><br>
+        In government ministries, large enterprises, and multi-department organizations, different teams need to run different models simultaneously. This is where GPUs become a nightmare.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">Government Ministry Example</h3>
+        <ul>
+            <li><strong>Health Dept:</strong> Medical document analysis model</li>
+            <li><strong>Finance Dept:</strong> Fraud detection model</li>
+            <li><strong>Education Dept:</strong> Student assessment model</li>
+            <li><strong>Transport Dept:</strong> Traffic prediction model</li>
+            <li><strong>HR Dept:</strong> Resume screening model</li>
+            <li><strong>Legal Dept:</strong> Contract analysis model</li>
+        </ul>
+        <p><strong>Reality:</strong> 6 departments, 6 different models, all need to run simultaneously.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Enterprise Example</h3>
+        <ul>
+            <li><strong>Sales:</strong> Lead scoring + CRM assistant</li>
+            <li><strong>Support:</strong> Customer chatbot + ticket routing</li>
+            <li><strong>Engineering:</strong> Code review + documentation</li>
+            <li><strong>Marketing:</strong> Content generation + analytics</li>
+            <li><strong>Security:</strong> Threat detection + log analysis</li>
+            <li><strong>Finance:</strong> Expense analysis + forecasting</li>
+        </ul>
+        <p><strong>Reality:</strong> Each department has specialized models for their domain.</p>
+    </div>
+</div>
+
+<h3>The GPU Context-Switching Nightmare</h3>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">GPU Model Switching: Slow and Expensive</h3>
+    <pre>
+GPU Workflow for Multi-Model Serving:
+  1. Load Model A weights into VRAM (80GB)     → 30-60 seconds
+  2. Run inference for Department A            → fast
+  3. Unload Model A from VRAM                  → 10 seconds
+  4. Load Model B weights into VRAM            → 30-60 seconds
+  5. Run inference for Department B            → fast
+  6. Repeat for each model...
+
+Problem: Each context switch = 40-70 seconds of GPU sitting idle!
+With 6 departments cycling through: most of the time is loading/unloading.
+    </pre>
+</div>
+
+<div class="grid grid-2">
+    <div class="card" style="border-left: 4px solid #ff6b6b;">
+        <h3 style="margin-top: 0;">GPU Multi-Model Issues</h3>
+        <ul>
+            <li><strong>VRAM limit:</strong> 80GB can only hold 1-2 large models</li>
+            <li><strong>Context switching:</strong> Load/unload weights takes 30-60s per model</li>
+            <li><strong>No sharing:</strong> GPU can't easily share between containers</li>
+            <li><strong>MIG complexity:</strong> Multi-Instance GPU splits VRAM, reduces per-model capacity</li>
+            <li><strong>Kubernetes pain:</strong> GPU scheduling requires special plugins, node affinity</li>
+            <li><strong>Cost:</strong> Need dedicated GPU per department = $40K × 6 = $240K</li>
+        </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid #47b475;">
+        <h3 style="margin-top: 0;">CPU Multi-Model Solution</h3>
+        <ul>
+            <li><strong>RAM abundance:</strong> 4TB holds ALL models simultaneously</li>
+            <li><strong>No context switching:</strong> All models resident in RAM, instant access</li>
+            <li><strong>Native sharing:</strong> Standard Linux process isolation works</li>
+            <li><strong>Docker native:</strong> Just containers, no special GPU passthrough</li>
+            <li><strong>Kubernetes native:</strong> Standard pod scheduling, no GPU plugins</li>
+            <li><strong>Cost:</strong> One $60K server runs all 6 departments</li>
+        </ul>
+    </div>
+</div>
+
+<h3>Kubernetes & Docker: CPUs Are First-Class Citizens</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">The Container Orchestration Reality</h3>
+    <pre>
+GPU Kubernetes Deployment:
+  - Install NVIDIA device plugin
+  - Configure GPU node pools
+  - Set resource limits: nvidia.com/gpu: 1
+  - Deal with GPU memory fragmentation
+  - Handle driver version mismatches
+  - Manage MIG partitioning (if sharing)
+  - Debug CUDA OOM errors in production
+
+CPU Kubernetes Deployment:
+  - Just deploy your container
+  - Set resource limits: cpu: "32", memory: "64Gi"
+  - Done. Standard k8s scheduling handles the rest.
+    </pre>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">CPU Multi-Model Architecture</h3>
+    <pre>
+┌─────────────────────────────────────────────────────────────────┐
+│                    Single CPU Server (4TB RAM)                   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │ Container 1  │  │ Container 2  │  │ Container 3  │           │
+│  │ Health Model │  │ Finance Model│  │ Education    │           │
+│  │ 70B (140GB)  │  │ 13B (26GB)   │  │ 7B (14GB)    │           │
+│  │ 32 cores     │  │ 16 cores     │  │ 8 cores      │           │
+│  └──────────────┘  └──────────────┘  └──────────────┘           │
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │ Container 4  │  │ Container 5  │  │ Container 6  │           │
+│  │ Transport    │  │ HR Model     │  │ Legal Model  │           │
+│  │ 7B (14GB)    │  │ 3B (6GB)     │  │ 13B (26GB)   │           │
+│  │ 8 cores      │  │ 4 cores      │  │ 16 cores     │           │
+│  └──────────────┘  └──────────────┘  └──────────────┘           │
+│                                                                  │
+│  Total: 226GB used / 4TB available = 5.6% RAM utilization       │
+│  All 6 models running simultaneously, no context switching      │
+└─────────────────────────────────────────────────────────────────┘
+    </pre>
+    <p><strong>Key insight:</strong> 6 models totaling 226GB fit easily in 4TB RAM. All running 24/7, no loading/unloading, instant response for any department.</p>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>Enterprise Reality Check</strong><br>
+        Most enterprise/government deployments need to run 5-20 different models for different use cases. CPUs handle this natively with standard containers. GPUs require expensive, complex multi-GPU setups with painful orchestration. This alone makes CPUs the practical choice for most real-world deployments.
+    </div>
+</div>
+
+<h2>CPU-Only: Complete Solution for All Model Sizes</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">One Architecture, All Scales</h3>
+    <p>CPU-only isn't just for large models. It's the complete solution for <strong>every model size</strong>, for <strong>both training and inference</strong>.</p>
+</div>
+
+<div class="grid grid-3">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Small Models (1-7B)</h3>
+        <ul>
+            <li><strong>Training:</strong> Single CPU server</li>
+            <li><strong>Inference:</strong> Laptop or edge device</li>
+            <li><strong>Latency:</strong> Sub-millisecond</li>
+            <li><strong>Cost:</strong> < $100/month</li>
+        </ul>
+        <p><strong>Use cases:</strong> Chatbots, code completion, mobile AI</p>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Medium Models (7-70B)</h3>
+        <ul>
+            <li><strong>Training:</strong> 2-8 CPU servers</li>
+            <li><strong>Inference:</strong> Single CPU server</li>
+            <li><strong>Throughput:</strong> High batch processing</li>
+            <li><strong>Cost:</strong> $500-2000/month</li>
+        </ul>
+        <p><strong>Use cases:</strong> Enterprise AI, content generation, analysis</p>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Large Models (70B+)</h3>
+        <ul>
+            <li><strong>Training:</strong> 10-100 CPU servers</li>
+            <li><strong>Inference:</strong> 2-20 CPU servers</li>
+            <li><strong>Scale:</strong> Distributed across RDMA</li>
+            <li><strong>Cost:</strong> $5000-50000/month</li>
+        </ul>
+        <p><strong>Use cases:</strong> Foundation models, research, large-scale analytics</p>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Unified Approach</strong><br>
+        Same CPU-only architecture scales from your laptop (1B model) to global clusters (1T+ parameters). No architecture changes, no GPU lock-in, no complexity multiplication.
+    </div>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Training at Every Scale</h3>
+        <ul>
+            <li><strong>Small:</strong> Fine-tune on laptop (1-7B)</li>
+            <li><strong>Medium:</strong> Train on workstation (7-70B)</li>
+            <li><strong>Large:</strong> Distributed training (70B+)</li>
+            <li><strong>Methodology:</strong> Same principles, same tools</li>
+        </ul>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">Inference at Every Scale</h3>
+        <ul>
+            <li><strong>Small:</strong> Edge deployment (1-7B)</li>
+            <li><strong>Medium:</strong> Server deployment (7-70B)</li>
+            <li><strong>Large:</strong> Distributed inference (70B+)</li>
+            <li><strong>Performance:</strong> Optimized for each tier</li>
+        </ul>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">Why This Matters</h3>
+    <p>Organizations can start small and scale infinitely without ever switching architectures:</p>
+    <ol>
+        <li><strong>Start:</strong> Train small model on laptop (fine-tuning)</li>
+        <li><strong>Grow:</strong> Move to server as model size increases</li>
+        <li><strong>Scale:</strong> Add more servers when needed (distributed training)</li>
+        <li><strong>Enterprise:</strong> Run multiple models on same hardware</li>
+    </ol>
+    <p><strong>No lock-in. No architecture migrations. No GPU dependency. Just scale as you grow.</strong></p>
+</div>
+
+<h2>Memory Reality: What NVIDIA Marketing Won't Tell You</h2>
+
+<div class="alert alert-warning">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>The Hidden Truth About LLM Memory</strong><br>
+        GPU marketing focuses on FLOPS. Real-world LLM inference is dominated by <strong>memory bandwidth and capacity</strong>. Here are the actual numbers.
+    </div>
+</div>
+
+<h3>Activation Memory Per Token (Decode)</h3>
+
+<div class="card">
+    <h4 style="margin-top: 0;">Memory Writes Per Token</h4>
+    <p>For a typical 0.5B parameter model (hidden=896, intermediate=4864, 24 layers):</p>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Operation</th><th>Per Layer</th><th>24 Layers</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>RMSNorm output</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>Q, K, V projections</td><td>10.5 KB</td><td>252 KB</td></tr>
+                <tr><td>Attention output</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>O projection</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>MLP gate + up</td><td>38 KB</td><td>912 KB</td></tr>
+                <tr><td>MLP down</td><td>3.5 KB</td><td>84 KB</td></tr>
+                <tr><td>KV cache (new token)</td><td>1 KB</td><td>24 KB</td></tr>
+                <tr><td>Final logits (once)</td><td>-</td><td>600 KB</td></tr>
+                <tr style="font-weight: bold; background: rgba(255,180,0,0.1);"><td>Total per token</td><td>~63 KB</td><td>~2.1 MB</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <p style="color: #888; font-size: 0.9em;">This is memory bandwidth consumed per generated token. Reducing this is key for decode performance.</p>
+</div>
+
+<div class="alert alert-info">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div>
+        <strong>Real-world profile (0.6B model, Q8_0 quantization, AVX-only CPU):</strong> decode time is dominated by memory-moving kernels --
+        ~48% MLP (gate/up + down), ~21% logits, ~29% attention projections (q/k/v + out), and ~2% attention core. This matches the
+        bandwidth thesis: most time is spent streaming weights/activations, not math.
+    </div>
+</div>
+
+<h3>Context Length: The Memory Multiplier</h3>
+
+<div class="card card-accent">
+    <h4 style="margin-top: 0;">KV Cache Formula</h4>
+    <pre>KV Cache = 2 × n_layers × n_kv_heads × head_dim × context_length × bytes_per_element
+           ↑
+         (K and V)</pre>
+</div>
+
+<div class="table-container">
+    <table>
+        <thead>
+            <tr><th>Context</th><th>KV Cache (FP16)</th><th>+ Model (140GB)</th><th>Fits 80GB GPU?</th><th>Fits 2TB Server?</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>8K</td>
+                <td>2.6 GB</td>
+                <td>143 GB</td>
+                <td style="color: #ff6b6b;">No (need 2×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+            <tr>
+                <td>32K</td>
+                <td>10 GB</td>
+                <td>150 GB</td>
+                <td style="color: #ff6b6b;">No (need 2×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+            <tr>
+                <td>128K</td>
+                <td>41 GB</td>
+                <td>181 GB</td>
+                <td style="color: #ff6b6b;">No (need 3×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+            <tr>
+                <td>1M</td>
+                <td>320 GB</td>
+                <td>460 GB</td>
+                <td style="color: #ff6b6b;">No (need 6×)</td>
+                <td style="color: #47b475;">Yes</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<details style="margin: 20px 0; background: #1a1a2e; border-radius: 8px; border: 1px solid #333;">
+    <summary style="padding: 15px 20px; cursor: pointer; font-weight: bold; color: #fbbf24;">
+        📐 Show the Math: How We Calculated This
+    </summary>
+    <div style="padding: 0 20px 20px 20px;">
+        <h4 style="color: #4ade80; margin-top: 15px;">Model Architecture (70B Dense Model)</h4>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>Parameter</th><th>Value</th><th>Explanation</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td><code>n_layers</code></td><td>80</td><td>Number of transformer layers</td></tr>
+                    <tr><td><code>n_attention_heads</code></td><td>64</td><td>Query heads per layer</td></tr>
+                    <tr><td><code>n_kv_heads</code></td><td>8</td><td>KV heads (GQA: 8 groups, each serves 8 Q heads)</td></tr>
+                    <tr><td><code>hidden_dim</code></td><td>8192</td><td>Model hidden dimension</td></tr>
+                    <tr><td><code>head_dim</code></td><td>128</td><td>= hidden_dim / n_attention_heads = 8192/64</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h4 style="color: #4ade80;">Step 1: KV Cache Per Token</h4>
+        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
+<span style="color: #888;">// FP16 = 2 bytes per element</span>
+KV_per_token = 2 × n_layers × n_kv_heads × head_dim × bytes
+             = 2 × 80 × 8 × 128 × 2
+             = 327,680 bytes
+             = <span style="color: #4ade80; font-weight: bold;">320 KB per token</span></pre>
+
+        <h4 style="color: #4ade80;">Step 2: Scale by Context Length</h4>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>Context</th><th>Calculation</th><th>KV Cache</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>8K</td>
+                        <td><code>8,192 × 320 KB</code></td>
+                        <td>2.62 GB</td>
+                    </tr>
+                    <tr>
+                        <td>32K</td>
+                        <td><code>32,768 × 320 KB</code></td>
+                        <td>10.5 GB</td>
+                    </tr>
+                    <tr>
+                        <td>128K</td>
+                        <td><code>131,072 × 320 KB</code></td>
+                        <td>41.9 GB</td>
+                    </tr>
+                    <tr>
+                        <td>1M</td>
+                        <td><code>1,048,576 × 320 KB</code></td>
+                        <td>335 GB</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h4 style="color: #4ade80;">Step 3: Add Model Weights</h4>
+        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
+Model weights (70B params × 2 bytes FP16) = <span style="color: #fbbf24; font-weight: bold;">140 GB</span>
+
+Total Memory = Model Weights + KV Cache
+  8K context:   140 + 2.6  = 143 GB  → need 2× 80GB GPUs
+  32K context:  140 + 10.5 = 150 GB  → need 2× 80GB GPUs
+  128K context: 140 + 42   = 182 GB  → need 3× 80GB GPUs
+  1M context:   140 + 335  = 475 GB  → need 6× 80GB GPUs</pre>
+
+        <h4 style="color: #4ade80;">Why GQA Matters</h4>
+        <p style="color: #a0a0b0;">Grouped Query Attention (GQA) reduces KV cache by sharing KV heads across Q heads:</p>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>Attention Type</th><th>KV Heads</th><th>KV per Token</th><th>128K KV Cache</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Multi-Head (MHA)</td>
+                        <td>64</td>
+                        <td>2.56 MB</td>
+                        <td style="color: #ff6b6b;">335 GB</td>
+                    </tr>
+                    <tr>
+                        <td>Grouped Query (GQA-8)</td>
+                        <td>8</td>
+                        <td>320 KB</td>
+                        <td style="color: #4ade80;">42 GB</td>
+                    </tr>
+                    <tr>
+                        <td>Multi-Query (MQA)</td>
+                        <td>1</td>
+                        <td>40 KB</td>
+                        <td style="color: #4ade80;">5.2 GB</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <p style="color: #888; font-size: 0.9em;">GQA-8 gives 8× memory savings over MHA with minimal quality loss.</p>
+    </div>
+</details>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>The Long Context Reality</strong><br>
+        70B model + 1M context needs ~475 GB. That's 6× 80GB GPUs (&#36;240K+) vs one 2TB CPU server (&#36;30K). This isn't about FLOPS - it's about <strong>where the data can physically exist</strong>.
+    </div>
+</div>
+
+<h3>Prefill Memory Scaling</h3>
+
+<div class="card">
+    <p>Prefill (processing the input prompt) requires storing activations for ALL tokens simultaneously:</p>
+    <div class="table-container">
+        <table>
+            <thead>
+                <tr><th>Prefill Length</th><th>Activation Memory</th><th>+ KV Cache</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>256 tokens</td><td>~400 MB</td><td>~6 MB</td></tr>
+                <tr><td>1K tokens</td><td>~1.5 GB</td><td>~24 MB</td></tr>
+                <tr><td>4K tokens</td><td>~6 GB</td><td>~96 MB</td></tr>
+                <tr><td>16K tokens</td><td>~24 GB</td><td>~384 MB</td></tr>
+            </tbody>
+        </table>
+    </div>
+    <p style="color: #888; font-size: 0.9em;">Prefill is compute-bound but still needs memory for activations. Long prompts can exceed GPU VRAM.</p>
+</div>
+
+<h3>Visual Guide</h3>
+
+<div class="card" style="max-width: 800px;">
+    <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
+    <p>GPU vs CPU memory comparison for LLM inference:</p>
+    <a href="assets/memory-reality-infographic.svg" target="_blank">
+        <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
+    </a>
+    <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
+</div>
+
+<h2>Training Advantages: Where CPUs Dominate</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">Critical Training Scenarios</h3>
+    <p>CPU-only architecture solves training problems that GPU-only simply can't handle.</p>
+</div>
+
+<div class="grid grid-2">
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">1. Long Context Training: KV Cache Explosion</h3>
+        <p><strong>The Problem:</strong> Long context windows create quadratic KV cache growth</p>
+        <ul>
+            <li><strong>4K context:</strong> ~32GB KV cache</li>
+            <li><strong>32K context:</strong> ~256GB KV cache</li>
+            <li><strong>128K context:</strong> ~4TB KV cache</li>
+            <li><strong>1M context:</strong> ~128TB KV cache</li>
+        </ul>
+        <p><strong>CPU Advantage:</strong></p>
+        <ul>
+            <li><strong>4-16TB RAM:</strong> Fits massive KV caches</li>
+            <li><strong>No transfer bottleneck:</strong> Everything in memory</li>
+            <li><strong>GPU Reality:</strong> KV cache doesn't fit = can't train</li>
+        </ul>
+        <div class="alert alert-warning">
+            <strong>Result:</strong> GPU training hits memory wall at 32K context. CPUs handle 1M+ context natively.
+        </div>
+    </div>
+
+    <div class="card card-green">
+        <h3 style="margin-top: 0;">2. Massive Batch Training</h3>
+        <p><strong>The Need:</strong> Large batch sizes improve convergence and throughput</p>
+        <ul>
+            <li><strong>Standard batch:</strong> 32-128 samples</li>
+            <li><strong>Large batch:</strong> 512-2048 samples</li>
+            <li><strong>Massive batch:</strong> 8192+ samples</li>
+            <li><strong>Enterprise batch:</strong> 100K+ samples</li>
+        </ul>
+        <p><strong>CPU Scaling Strategy:</strong></p>
+        <ul>
+            <li><strong>32 CPUs:</strong> 32 batches in parallel</li>
+            <li><strong>Each batch:</strong> 1-10TB RAM available</li>
+            <li><strong>Total effective batch:</strong> 32x larger</li>
+            <li><strong>No communication overhead:</strong> Each CPU independent</li>
+        </ul>
+        <div class="alert alert-success">
+            <strong>Result:</strong> Scale to any batch size by adding more CPUs. No GPU memory constraints!
+        </div>
+    </div>
+</div>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">The Training Reality Check</h3>
+    <div class="grid grid-2">
+        <div>
+            <h4>GPU Training Limits</h4>
+            <ul>
+                <li>❌ KV cache fits → max context ~32K</li>
+                <li>❌ Batch size limited by VRAM</li>
+                <li>❌ Large batches require model parallelism</li>
+                <li>❌ Complex coordination across GPUs</li>
+                <li>❌ Expensive hardware (NVLink required)</li>
+            </ul>
+        </div>
+        <div>
+            <h4>CPU Training Advantages</h4>
+            <ul>
+                <li>✅ KV cache fits → context up to 1M+</li>
+                <li>✅ Batch size scales with CPUs</li>
+                <li>✅ Data parallelism = simple scaling</li>
+                <li>✅ RDMA for necessary communication</li>
+                <li>✅ Commodity hardware (Ethernet)</li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<div class="alert alert-success">
+    <div class="alert-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
+    </div>
+    <div>
+        <strong>Why This Matters</strong><br>
+        Real-world training needs long context (RAG, document analysis) and large batches (throughput, convergence). CPU-only architecture handles both naturally. GPU-only hits walls that require expensive workarounds.
+    </div>
+</div>
+
+<h2>Distributed Architecture</h2>
+
+<div class="card card-accent">
+    <h3 style="margin-top: 0;">RDMA-Connected CPU Cluster</h3>
+    <pre>
+┌─────────────────────────────────────────────────────────────────┐
+│                     RDMA Fabric (100Gbps+)                      │
+├─────────────────┬─────────────────┬─────────────────────────────┤
+│                 │                 │                             │
+▼                 ▼                 ▼                             │
+┌─────────┐   ┌─────────┐   ┌─────────┐                          │
+│ Node 0  │   │ Node 1  │   │ Node 2  │  ...  Node N             │
+│ 128 cores│   │ 128 cores│   │ 128 cores│                        │
+│ 2TB RAM │   │ 2TB RAM │   │ 2TB RAM │                          │
+│         │   │         │   │         │                          │
+│ Layers  │   │ Layers  │   │ Layers  │                          │
+│ 0-15    │   │ 16-31   │   │ 32-47   │                          │
+└─────────┘   └─────────┘   └─────────┘                          │
+    </pre>
+</div>
+
+<h3>Parallelism Strategies</h3>
+
+<div class="card">
+    <h3 style="margin-top: 0;">1. Pipeline Parallelism</h3>
+    <p>Different layers on different nodes. Activations flow through the pipeline.</p>
+    <pre>Node 0: Layers 0-15   →  activations  →  Node 1: Layers 16-31  →  ...
+        (forward)           (RDMA)              (forward)</pre>
+    <p><strong>Communication:</strong> Send activations between pipeline stages via RDMA.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">2. Tensor Parallelism</h3>
+    <p>Large matrices split across nodes. Each node computes a shard.</p>
+    <pre>// 16384 x 16384 weight matrix split across 4 nodes
+Node 0: W[0:4096, :]      // Shard 0
+Node 1: W[4096:8192, :]   // Shard 1
+Node 2: W[8192:12288, :]  // Shard 2
+Node 3: W[12288:16384, :] // Shard 3
+
+// After local GEMM, all-reduce to combine</pre>
+    <p><strong>Communication:</strong> RDMA all-reduce after each sharded operation.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">3. Data Parallelism</h3>
+    <p>Same model replicated. Different batches. Gradient averaging.</p>
+    <pre>Node 0: Model copy, Batch 0  →  gradients  ─┐
+Node 1: Model copy, Batch 1  →  gradients  ─┼→  All-reduce  →  Update all
+Node 2: Model copy, Batch 2  →  gradients  ─┤
+Node 3: Model copy, Batch 3  →  gradients  ─┘</pre>
+</div>
+
+<h2>RDMA: The Key Enabler</h2>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Why RDMA?</h3>
+    <p><strong>Remote Direct Memory Access</strong> - Zero-copy, kernel-bypass networking.</p>
+    <div class="table-container">
+        <table class="table">
+        <thead>
+            <tr><th>Metric</th><th>TCP/IP</th><th>RDMA</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>Latency</td><td>~50-100 μs</td><td>~1-2 μs</td></tr>
+            <tr><td>Bandwidth</td><td>10-25 Gbps</td><td>100-400 Gbps</td></tr>
+            <tr><td>CPU overhead</td><td>High (kernel, copies)</td><td>Near zero</td></tr>
+            <tr><td>Memory copies</td><td>Multiple</td><td>Zero (DMA)</td></tr>
+        </tbody>
+    </table>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">RDMA Primitives We Need</h3>
+    <pre>// One-sided operations (no remote CPU involvement)
+rdma_write(remote_addr, local_buf, size);  // Write to remote memory
+rdma_read(local_buf, remote_addr, size);   // Read from remote memory
+
+// Collective operations (built on one-sided)
+rdma_allreduce(buf, size, SUM);  // Gradient averaging
+rdma_broadcast(buf, size, root); // Weight distribution
+rdma_barrier();                   // Synchronization</pre>
+</div>
+
+<h2>Implementation Roadmap</h2>
+
+<div class="card">
+    <div class="table-container">
+        <table class="table">
+        <thead>
+            <tr><th>Phase</th><th>Feature</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>1</td>
+                <td>Single-node training (current)</td>
+                <td><span class="badge badge-green">Done</span></td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>Multi-core parallelism (OpenMP)</td>
+                <td><span class="badge badge-green">Done</span></td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>RDMA communication primitives</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>4</td>
+                <td>Pipeline parallelism</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>5</td>
+                <td>Tensor parallelism (sharded GEMM)</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>6</td>
+                <td>Encoder + cross-attention</td>
+                <td><span class="badge badge-orange">Planned</span></td>
+            </tr>
+            <tr>
+                <td>7</td>
+                <td>600B+ training</td>
+                <td><span class="badge" style="background:#666;color:#ccc;">Future</span></td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</div>
+
+<h2>The Math Doesn't Change</h2>
+
+<div class="card card-green">
+    <h3 style="margin-top: 0;">From Tiny to Massive: Same Operations</h3>
+    <pre>
+Forward pass (any size model):
+1. embed_tokens()           // Lookup: tokens → vectors
+2. for each layer:
+   a. rmsnorm()             // Normalize
+   b. linear() × 3          // Q, K, V projections
+   c. rope()                // Rotary embeddings
+   d. attention()           // Softmax(QK^T)V
+   e. linear()              // Output projection
+   f. residual_add()        // Skip connection
+   g. rmsnorm()             // Normalize
+   h. mlp_swiglu()          // FFN with gating
+   i. residual_add()        // Skip connection
+3. rmsnorm()                // Final norm
+4. lm_head()                // Logits
+
+Backward pass: Same operations in reverse.
+SGD: weights -= lr * gradients
+
+That's it. For any model size.
+    </pre>
+</div>
+
+<h2>Hardware Recommendations</h2>
+
+<div class="card">
+    <h3 style="margin-top: 0;">For Different Scales</h3>
+    <div class="table-container">
+        <table class="table">
+        <thead>
+            <tr><th>Model Size</th><th>Recommended Setup</th></tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>< 7B</td>
+                <td>Single server, 32+ cores, 128GB+ RAM</td>
+            </tr>
+            <tr>
+                <td>7B - 70B</td>
+                <td>Single server, 128 cores, 512GB-2TB RAM</td>
+            </tr>
+            <tr>
+                <td>70B - 200B</td>
+                <td>2-4 nodes, RDMA interconnect, 2TB RAM each</td>
+            </tr>
+            <tr>
+                <td>200B - 600B</td>
+                <td>8-16 nodes, 100Gbps+ RDMA fabric</td>
+            </tr>
+            <tr>
+                <td>600B+</td>
+                <td>32+ nodes, 400Gbps RDMA, pipeline + tensor parallel</td>
+            </tr>
+        </tbody>
+    </table>
+    </div>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">Recommended CPUs by Instruction Set</h3>
+    <ul>
+        <li><strong>AMD EPYC 9004/9005 (Genoa/Turin)</strong> - Up to 192 cores, AVX-512 (512-bit), 12-channel DDR5</li>
+        <li><strong>Intel Xeon Sapphire Rapids/Granite Rapids</strong> - Up to 128 cores, AVX-512 + AMX (512-bit tile)</li>
+        <li><strong>Ampere Altra Max</strong> - 128 ARM cores, NEON (128-bit), good perf/watt</li>
+        <li><strong>AWS Graviton3/4</strong> - Cost-effective ARM, NEON + SVE2</li>
+    </ul>
+    <p><strong>Minimum requirement:</strong> AVX (256-bit) or NEON (128-bit). For best performance, AVX-512 or AMX.</p>
+</div>
+
+<div class="card">
+    <h3 style="margin-top: 0;">RDMA Options</h3>
+    <ul>
+        <li><strong>Mellanox/NVIDIA ConnectX-7</strong> - 400Gbps InfiniBand</li>
+        <li><strong>Intel E810</strong> - 100Gbps RoCE (RDMA over Ethernet)</li>
+        <li><strong>AWS EFA</strong> - Cloud RDMA for EC2 instances</li>
+    </ul>
+</div>
+
+<h2>Why Not GPU?</h2>
+
+<div class="card">
+    <blockquote style="border-left: 4px solid var(--orange); padding-left: 1rem; margin: 1rem 0; font-style: italic;">
+        "Nvidia, f**k you."<br>
+        <small>— Linus Torvalds, 2012 (<a href="https://www.youtube.com/watch?v=iYWzMvlj2RQ" target="_blank" rel="noopener" style="color: inherit;">video source</a>) regarding their closed-source Linux drivers</small>
+    </blockquote>
+    <p>Beyond the open-source concerns:</p>
+    <ul>
+        <li><strong>Cost</strong> - High-end GPU cluster = $200K+. EPYC server with 2TB RAM = $15,000</li>
+        <li><strong>Memory</strong> - 80GB VRAM vs 2TB+ system RAM</li>
+        <li><strong>Availability</strong> - Export-controlled, supply constrained vs commodity CPUs</li>
+        <li><strong>Flexibility</strong> - Run anywhere: cloud, on-prem, edge, embedded</li>
+        <li><strong>Debugging</strong> - printf works. GDB works. Valgrind works.</li>
+        <li><strong>Longevity</strong> - C code compiles forever. CUDA versions break.</li>
+    </ul>
 </div>
 
 <h2>Further Reading</h2>
 
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="architecture.html">Architecture</a></h3>
-        <p>How circuits, contracts, GraphIR, lowering, generated C, and promotion gates fit together.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="v8-numerical-contracts.html">Numerical Contracts</a></h3>
-        <p>Why mathematically similar kernels can still produce materially different model behavior.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="profiling.html">Profiling</a></h3>
-        <p>The measurement workflow used to identify actual CPU bottlenecks.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a></h3>
-        <p>How a bottleneck moves from attribution to implementation and regression evidence.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="support-hardware.html">Support the Hardware Lab</a></h3>
-        <p>The staged hardware programme and evidence obligations attached to contributed equipment.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;"><a href="contributing.html">Contribute</a></h3>
-        <p>Start with a bounded build, profiling, numerical, kernel, or compiler contribution.</p>
-    </div>
-</div>
+<ul>
+    <li><a href="memory-reality.html">Memory Reality</a> - What NVIDIA marketing won't tell you about LLM memory</li>
+    <li><a href="developer-guide.html">Developer Guide</a> - How the engine works</li>
+    <li><a href="memory-safety.html">Memory Safety</a> - Bump allocator design</li>
+    <li><a href="profiling.html">Profiling Guide</a> - Performance optimization</li>
+</ul>
+    </main>
     </main>
 
     <!-- SVG Viewer Overlay (shared across all pages) -->

--- a/docs/site/scaling.html
+++ b/docs/site/scaling.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Scaling Philosophy for CPU-Only AI Systems | C-Kernel-Engine</title>
-    <meta name="description" content="Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks.">
+    <title>CKE Scaling Thesis: From One CPU Node to Measured Distributed Systems | C-Kernel-Engine</title>
+    <meta name="description" content="A falsifiable research thesis for scaling C-Kernel-Engine from correct single-node CPU execution to measured multi-node efficiency, with explicit memory, communication, and synchronization gates.">
     <meta name="robots" content="index,follow">
     <link rel="canonical" href="https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html">
-    <meta property="og:title" content="Scaling Philosophy for CPU-Only AI Systems | C-Kernel-Engine">
-    <meta property="og:description" content="Why C-Kernel-Engine bets on Linux-only, CPU-only, server-grade hardware and open software instead of proprietary accelerator-heavy stacks.">
+    <meta property="og:title" content="CKE Scaling Thesis: From One CPU Node to Measured Distributed Systems | C-Kernel-Engine">
+    <meta property="og:description" content="A falsifiable research thesis for scaling C-Kernel-Engine from correct single-node CPU execution to measured multi-node efficiency, with explicit memory, communication, and synchronization gates.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://c-kernel-engine.github.io/C-Kernel-Engine/scaling.html">
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
@@ -978,2224 +978,360 @@
     </header>
     <main>
 
-<h1>Scaling Philosophy</h1>
+<h1>Scaling Thesis</h1>
 
-<div class="card card-accent" style="border: 2px solid #ffb400; padding: 2rem; margin-bottom: 2rem;">
-    <h2 style="margin-top: 0; color: #ffb400;">The Bet Behind This Project</h2>
+<div class="card card-accent">
+    <h2 style="margin-top: 0;">The Bet, Not the Verdict</h2>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        The bet here is simple: AI will not stay locked inside premium proprietary boxes forever.
-        C-Kernel-Engine takes a different path:
-        <strong>Linux-only, CPU-only, server-grade hardware, open software, and standard data-center parts.</strong>
-        If the software gets good enough, ordinary servers become practical AI machines.
+        C-Kernel-Engine is testing whether explicit numerical contracts, generated C, optimized CPU kernels,
+        and ordinary Linux nodes can make locally owned CPU infrastructure practical for selected AI workloads.
+        The thesis is not that CPUs universally beat accelerators. There is no universal hardware winner.
     </p>
     <p style="font-size: 1.15em; line-height: 1.7;">
-        This is a long-horizon commodity compute bet.
-        The underlying workload is still math, memory movement, and systems software.
-        If CPUs keep gaining cores, SIMD and matrix units, memory channels, NUMA controls, and fast interconnects,
-        then a generated-C runtime that can orchestrate many cheap Linux nodes becomes increasingly valuable.
+        The narrower bet is that model execution can be reduced to measurable contracts: arithmetic, bytes moved,
+        synchronization, latency, accuracy, power, and operating cost. For workloads whose constraints match CPU
+        systems, better kernels and better orchestration may turn hardware organizations can procure and control
+        into useful AI infrastructure.
     </p>
-    <p style="font-size: 1.15em; line-height: 1.7;">
-        This is not a claim that CPUs always beat GPU systems on raw peak throughput.
-        That is not the point.
-        The real question is whether CPU-only Linux systems can become
-        <strong>good enough, cheap enough, and accessible enough</strong>
-        to handle serious inference and eventually serious training.
-        That is the thesis being tested here.
-    </p>
-    <p style="font-size: 1.15em; line-height: 1.7;">
-        The early numbers already show that CPU-only inference is practical.
-        A quantized 0.6B model on a 12th-gen Intel Alder Lake machine has reached
-        <strong>about 100 tokens/sec</strong> when the system is otherwise idle.
-        On an older 4-core machine, the same model still runs at
-        <strong>about 20&ndash;25 tokens/sec</strong>.
-        No GPU. No CUDA. No special hardware. Just common x86 instructions and Linux.
-    </p>
-    <p style="font-size: 1.15em; line-height: 1.7;">
-        The bigger target is server-grade CPU infrastructure.
-        Testing is underway on 5th-gen Intel Xeon Scalable systems with AVX-512 and AMX &mdash;
-        the same class of machines already sitting in real data centers.
-        The bet is that these machines will be cheaper, easier to procure, easier to operate, and more broadly deployable than proprietary accelerator-heavy stacks.
-    </p>
-    <p style="font-size: 1.15em; line-height: 1.7; border-top: 1px solid #333; padding-top: 1.5rem; margin-bottom: 0;">
-        The method is straightforward: profile, find the real bottleneck, fix one kernel at a time, and measure again.
-        C-Kernel-Engine uses VTune, FlameGraph, Intel Advisor, <code>perf stat</code>, and roofline analysis to do exactly that.
-        <strong>The point of this page is not hype. It is to state the engineering bet clearly and then earn it with measurements.</strong>
+    <p style="font-size: 1.15em; line-height: 1.7; margin-bottom: 0;">
+        This page defines how that bet will be tested. Single-node execution has evidence today.
+        Multi-node scaling remains a research thesis until matched-node measurements close the communication,
+        synchronization, and efficiency questions.
     </p>
 </div>
 
-<div style="margin: 2.5rem 0 0.5rem 0; text-align: center;">
-    <img src="assets/engineering-compass.svg" alt="Engineering Compass — Profile, Find Bottleneck, Fix Kernel, Measure, Repeat" style="width: 100%; max-width: 1200px; border-radius: 16px; box-shadow: 0 8px 32px rgba(0,0,0,0.4);" />
+<div style="margin: 2.5rem 0; text-align: center;">
+    <img src="assets/engineering-compass.svg"
+         alt="CKE engineering loop: profile, identify the bottleneck, fix one kernel, and measure again"
+         style="width: 100%; max-width: 1200px; border-radius: 16px;" />
 </div>
 
-<div style="background: linear-gradient(135deg, #1a2332 0%, #1a1a2e 100%); border: 1px solid #334; border-left: 4px solid #07adf8; border-radius: 12px; padding: 2rem 2.5rem; margin: 0.5rem 0 2rem 0;">
-    <h3 style="margin-top: 0; color: #07adf8; font-size: 1.3em;">
-        🧭 Engineering Compass &mdash; What This Page Is Really For
-    </h3>
-    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc;">
-        This page is the reminder to stay focused on the real thesis:
-        make CPU-only Linux systems useful for modern AI by improving the software until commodity server hardware becomes practical.
-        The scaling story is a direction, not a marketing slogan.
-    </p>
-    <p style="font-size: 1.1em; line-height: 1.7; color: #ccc; margin-bottom: 0.5rem;">
-        The engineering discipline is simple and repeatable:
-    </p>
-    <ol style="font-size: 1.05em; line-height: 2; color: #ddd; padding-left: 1.5rem;">
-        <li><strong style="color: #47b475;">Find the slowest-moving part.</strong> Profile it. Understand <em>why</em> it's slow.</li>
-        <li><strong style="color: #47b475;">Find the fastest-moving part.</strong> Understand what makes it fast. Replicate the pattern.</li>
-        <li><strong style="color: #47b475;">Get more RAM, more cores.</strong> Test on bigger hardware. See if the architecture holds.</li>
-        <li><strong style="color: #47b475;">Keep profiling.</strong> VTune, perf stat, roofline, FlameGraph &mdash; every run, every change.</li>
-        <li><strong style="color: #47b475;">Fix one kernel at a time.</strong> Don't boil the ocean. One bottleneck, one fix, one measurement.</li>
-    </ol>
-    <p style="font-size: 1.1em; line-height: 1.7; color: #999; border-top: 1px solid #333; padding-top: 1rem; margin-bottom: 0;">
-        People will disagree with the thesis, and that is fine.
-        The only useful answer is better measurement, better kernels, and clearer system design.
-        Follow the data, not the hype.
-    </p>
-</div>
+<h2>What CKE Is Betting On</h2>
 
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;">The workload is inspectable</h3>
+        <p>
+            A model becomes circuits, tensors, kernels, memory traffic, and synchronization. CKE exposes those
+            boundaries so correctness and performance can be attributed instead of hidden behind a framework call.
+        </p>
     </div>
-    <div>
-        <strong>TL;DR — Two First Principles</strong><br>
-        1) <strong>0 × ∞ = 0:</strong> If the model doesn't fit in memory, FLOPS don't matter.<br>
-        2) <strong>Theory of Constraints:</strong> At the Ethernet boundary, CPUs and GPUs face the same bottleneck.
+    <div class="card">
+        <h3 style="margin-top: 0;">CPU systems keep changing</h3>
+        <p>
+            Vector and matrix instructions, memory-channel counts, NUMA controls, core counts, and data-center
+            networking continue to improve. CKE asks what modern CPU systems can do when software is designed for
+            their actual topology rather than treated as a fallback target.
+        </p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">Ownership can be a requirement</h3>
+        <p>
+            Privacy, data residency, predictable capacity, embedded deployment, long-lived services, and operational
+            control can matter as much as peak throughput. These constraints create workloads worth evaluating on
+            locally controlled hardware.
+        </p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">The result must remain falsifiable</h3>
+        <p>
+            A CPU deployment is useful only when it meets a stated accuracy, latency, concurrency, memory, power,
+            reliability, and total-cost envelope. A failed envelope narrows the thesis; it is not a reason to move
+            the goalposts.
+        </p>
     </div>
 </div>
 
-<h2>The Two First Principles</h2>
+<h2>The Feasibility Gates</h2>
 
-<div class="img-container svg-viewer" data-title="Two First Principles: Memory Gate + Theory of Constraints">
-    <img src="assets/two-principles.svg" alt="Principle 1: 0 × ∞ = 0 — memory gates everything. Principle 2: Theory of Constraints — Ethernet equalizes GPUs and CPUs at cluster scale.">
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>CPU Horizontal Scaling Can Stay Simpler</strong><br>
-        Adding CPU servers still requires sharding, scheduling, networking, and NUMA discipline. But it avoids vendor-specific programming models, specialized accelerator fabrics, and the assumption that serious AI must depend on external accelerators from the start. The bet here is that standard Linux servers on Ethernet remain a simpler operational path for many real deployments.
-    </div>
-</div>
-
-<h2>The Computation Is Not Exotic</h2>
-
-<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
-    AI training and inference reduce to five operations: matrix multiply, attention, softmax, layer normalization, and backpropagation.
-    These are linear algebra and calculus — mathematics developed in the 17th through 19th centuries, long before the first computer.
-    <strong>Nothing about the computation requires physically exotic hardware.</strong> A CPU with SIMD instructions executes every one of these operations natively.
-    If the math isn't exotic, the hardware requirement isn't permanent — it's a market condition.
-    And market conditions change.
+<p>
+    Scaling begins only after one node is correct, fits the workload, and has a measured bottleneck. Capacity is the
+    first gate:
 </p>
 
-<div class="img-container svg-viewer" data-title="AI Is Standard Math — Commodity Hardware Always Wins">
-    <img src="assets/commodity-hardware-pattern.svg" alt="Left: AI operations are standard linear algebra and calculus. Right: hardware displacement pattern showing proprietary always loses to commodity.">
-</div>
+<pre>M_weights + M_KV + M_workspace + M_runtime &lt;= M_usable</pre>
 
-<div class="alert alert-warning" style="margin-top: 1.5rem;">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The same pattern, repeating</strong><br>
-        In 1995, "You can't run serious workloads on cheap PCs" was conventional wisdom.<br>
-        In 2025, "You can't run serious AI on cheap CPUs" is conventional wisdom.<br>
-        <strong>One of these beliefs aged very poorly. The pattern suggests which way this one goes.</strong>
-    </div>
-</div>
-
-<details style="margin-top: 1rem;">
-    <summary style="cursor: pointer; color: #a0a0a0; font-size: 0.9em; padding: 0.5rem 0;">Historical reference</summary>
-    <div class="table-container" style="margin-top: 0.75rem;">
-        <table>
-            <thead>
-                <tr><th>Era</th><th>Proprietary Incumbent</th><th>Commodity Disruptor</th><th>Result</th></tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><strong>1990s</strong></td>
-                    <td>SPARC, Alpha, PA-RISC</td>
-                    <td>x86 commodity chips</td>
-                    <td style="color: #4ade80;">Proprietary RISC faded</td>
-                </tr>
-                <tr>
-                    <td><strong>1998</strong></td>
-                    <td>Sun/SGI servers (&#36;500K+)</td>
-                    <td>x86 PCs + MapReduce/GFS</td>
-                    <td style="color: #4ade80;">Sun bankrupt (2010)</td>
-                </tr>
-                <tr>
-                    <td><strong>2009</strong></td>
-                    <td>Teradata, Netezza (&#36;1M+)</td>
-                    <td>Hadoop on commodity clusters</td>
-                    <td style="color: #4ade80;">Big data democratized</td>
-                </tr>
-                <tr style="opacity: 0.7; border-top: 1px dashed #333;">
-                    <td><strong>Now</strong></td>
-                    <td>GPU clusters ($M+)</td>
-                    <td>CPU clusters + software</td>
-                    <td style="color: #ffb400;">→ ?</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</details>
-
-<h2>Principle 1: The Cost of 0 × ∞ = 0</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The GPU Memory Trap</h3>
-    <p>Yes, you CAN fit a 70B model on GPUs using tensor/pipeline parallelism. That's not the point.</p>
-    <p><strong>The point is: you're now FORCED to buy 8+ GPUs in a cluster.</strong></p>
-    <p><strong>And GPUs are:</strong></p>
-    <ul>
-        <li><strong>Proprietary</strong> — locked to NVIDIA (CUDA), no open ecosystem</li>
-        <li><strong>Export-controlled</strong> — H100/H200 blocked in many countries, supply constrained</li>
-        <li><strong>Cluster-required</strong> — single GPUs can't handle large models, need NVLink infrastructure</li>
-        <li><strong>Expensive</strong> — &#36;40K+ per GPU, &#36;200K+ for NVLink switches</li>
-    </ul>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Math That Matters</h3>
-    <pre>
-GPU Path:
-  Model doesn't fit in 80GB → Buy 8 GPUs → $320K for GPUs alone
-  Need NVLink for fast communication → Another $50K+
-  Need DGX chassis → Another $80K+
-  Total: $450K+ just to START
-
-CPU Path:
-  Model fits in 4TB RAM → Buy 1-2 servers → $30K each
-  Standard Ethernet networking → $2K
-  Total: $60K and you're running
-    </pre>
-    <p><strong>The "0 × ∞ = 0" principle forces GPU users into expensive multi-GPU setups. CPUs avoid this entirely.</strong></p>
-</div>
-
-<h2>Target Platform</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Server-Grade Hardware by Instruction Set</h3>
-    <p>C-Kernel-Engine uses <code>ck_features.h</code> for feature detection. We target by SIMD capability, not CPU model:</p>
-</div>
-
-<div class="grid grid-3">
-    <div class="card">
-        <h3 style="margin-top: 0;">Instruction Set Priority</h3>
-        <ul>
-            <li><strong>AMX</strong> - 512-bit tile ops (Intel Sapphire Rapids+)</li>
-            <li><strong>AVX-512</strong> - 512-bit vector (Intel Skylake-X+, AMD Zen 4)</li>
-            <li><strong>AVX2+FMA</strong> - 256-bit with FMA (Intel Haswell+, AMD Zen 2+)</li>
-            <li><strong>AVX</strong> - 256-bit vector (Intel Sandy Bridge+, AMD Zen 1)</li>
-            <li><strong>NEON</strong> - 128-bit (ARM64, Apple Silicon)</li>
-        </ul>
-        <p><strong>Auto-detection:</strong> The engine selects the best kernel at build time with runtime dispatch for optional extensions.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">CPU Requirements</h3>
-        <ul>
-            <li><strong>High core count</strong> - 64-128+ cores per socket</li>
-            <li><strong>Large L3 cache</strong> - Good core-to-cache ratio (1-2MB/core)</li>
-            <li><strong>Vector width</strong> - 256-bit minimum (AVX)</li>
-            <li><strong>FMA</strong> - Recommended for 2x throughput</li>
-            <li><strong>Multiple sockets</strong> - NUMA-aware memory access</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Memory Requirements</h3>
-        <ul>
-            <li><strong>DDR5</strong> - Higher bandwidth, lower latency</li>
-            <li><strong>Multi-channel</strong> - 8-12 channels per socket</li>
-            <li><strong>Large capacity</strong> - 512GB - 2TB+ per node</li>
-            <li><strong>ECC</strong> - Error correction for reliability</li>
-            <li><strong>NUMA-local</strong> - Pin threads to local memory</li>
-        </ul>
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">Accelerators</h3>
-        <ul>
-            <li><strong>Intel DSA</strong> - Data Streaming Accelerator for memory copies</li>
-            <li><strong>Intel IAA</strong> - Analytics Accelerator for compression</li>
-            <li><strong>Intel QAT</strong> - QuickAssist for crypto (if needed)</li>
-            <li><strong>CXL</strong> - Memory expansion and pooling (future)</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Networking</h3>
-        <ul>
-            <li><strong>RDMA</strong> - InfiniBand or RoCEv2</li>
-            <li><strong>100-400 Gbps</strong> - High bandwidth interconnect</li>
-            <li><strong>Low latency</strong> - 1-2 μs for RDMA operations</li>
-            <li><strong>Kernel bypass</strong> - Zero-copy transfers</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Operating System</h3>
-    <p><strong>Linux-only.</strong> We use Linux-specific features:</p>
-    <ul>
-        <li><code>mmap()</code> with <code>MAP_HUGETLB</code> for huge pages</li>
-        <li><code>madvise(MADV_HUGEPAGE)</code> for transparent huge pages</li>
-        <li><code>numactl</code> / <code>set_mempolicy()</code> for NUMA binding</li>
-        <li><code>sched_setaffinity()</code> for core pinning</li>
-        <li><code>perf</code> for profiling</li>
-        <li><code>io_uring</code> for async I/O (weight loading)</li>
-        <li>Intel DSA via <code>libaccel-config</code> / <code>idxd</code> driver</li>
-    </ul>
-</div>
-
-<div class="card card-green">
-    <p>C-Kernel-Engine targets by <strong>instruction set capability</strong>, not CPU model. Any server-grade CPU with AVX2+FMA or better is a valid target — specific models change, the instruction sets don't. See <code>include/ck_features.h</code> for detection logic.</p>
-</div>
-
-<h2>Why CPU-Only?</h2>
-
-<div class="card card-accent" style="margin-bottom: 1.5rem;">
-    <p><strong>GPUs dominate when you can keep them highly utilized.</strong> Large batches, dense GEMMs, and well-packed workloads that fit comfortably in VRAM let GPUs exercise their theoretical FLOPS advantage. C-Kernel-Engine isn't anti-GPU—we're anti-waste: wasted money on unused capacity, wasted energy at low utilization, and wasted coordination overhead at scale.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Advantages</h3>
-        <ul>
-            <li><strong>No vendor lock-in</strong> - Works on any x86/ARM CPU</li>
-            <li><strong>Commodity hardware</strong> - Standard servers, not &#36;40K GPUs</li>
-            <li><strong>Larger memory</strong> - 2TB RAM per node, no 80GB VRAM limit</li>
-            <li><strong>Better debugging</strong> - GDB, Valgrind, perf all work</li>
-            <li><strong>Simpler deployment</strong> - No CUDA, no driver hell</li>
-            <li><strong>Open ecosystem</strong> - GCC, Linux, standard tools</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">The Trade-off</h3>
-        <ul>
-            <li>GPUs have higher peak FLOPS</li>
-            <li>But: memory bandwidth often bottlenecks anyway</li>
-            <li>But: PCIe transfer overhead for large models</li>
-            <li>But: multi-GPU coordination is complex</li>
-            <li>But: CPU memory is 10-100x larger and cheaper</li>
-        </ul>
-        <p><strong>For inference:</strong> CPUs are often faster for batch=1</p>
-        <p><strong>For training:</strong> Scale horizontally with RDMA</p>
-    </div>
-</div>
-
-<h2>The Fundamental Math: 0 × ∞ = 0</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The Memory Constraint</strong><br>
-        It doesn't matter how fast your compute is if your model won't fit in memory. Being 10x faster at computing doesn't help if you're limited by 0 × ∞ = 0.
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU: Memory Wins</h3>
-        <ul>
-            <li><strong>Dual-socket server:</strong> 4-6TB DDR5</li>
-            <li><strong>Can train:</strong> 1TB model in BF16</li>
-            <li><strong>Math:</strong> 4-6TB × dual socket = non-zero, model loads</li>
-            <li><strong>Result:</strong> Actually trains the model</li>
-        </ul>
-    </div>
-    <div class="card card-blue">
-        <h3 style="margin-top: 0;">GPU: Compute Fast, Memory Fails</h3>
-        <ul>
-            <li><strong>Single GPU VRAM:</strong> tops out well below what large models need</li>
-            <li><strong>Each GPU generation:</strong> more HBM — at exponentially higher price per unit</li>
-            <li><strong>The constraint:</strong> 1TB model ÷ per-GPU VRAM = many GPUs, minimum, just for weights</li>
-            <li><strong>Math:</strong> 0 utility per GPU (model won't fit alone) × fast FLOPS = 0 — compute speed doesn't solve a memory problem</li>
-            <li><strong>Result:</strong> You buy more GPUs. Cost compounds. Complexity compounds. Memory is still the bottleneck.</li>
-        </ul>
-    </div>
-</div>
-
-<div class="img-container svg-viewer" data-title="CPU vs GPU Memory Analysis">
-    <img src="assets/cpu-gpu-analysis.svg" alt="CPU vs GPU Memory Analysis">
-</div>
-
-<h2>The GPU Cluster Reality</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">GPUs Require Clusters</h3>
-    <p>Here's the fundamental problem: no single GPU can handle large models. You need a cluster.</p>
-    <ul>
-        <li><strong>Even the biggest GPU:</strong> 80GB VRAM max—can't fit 70B+ models</li>
-        <li><strong>Multi-GPU needed:</strong> 8-32 GPUs for practical workloads</li>
-        <li><strong>NVLink required:</strong> &#36;200K+ in interconnects for fast GPU-to-GPU communication</li>
-        <li><strong>DGX systems:</strong> Pre-configured clusters start at &#36;250K+</li>
-    </ul>
-</div>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-    </div>
-    <div>
-        <strong>The VRAM Wall</strong><br>
-        Every GPU hits the same VRAM wall. Whether 24GB or 80GB per GPU, large models require massive GPU counts in coordinated clusters. This is the fundamental constraint that CPU-only architecture bypasses entirely.
-    </div>
-</div>
-
-<h2>Energy Efficiency: The CPU Advantage at Realistic Utilization</h2>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg>
-    </div>
-    <div>
-        <strong>"CPUs burn too much power per token"</strong><br>
-        This is the final argument GPU advocates use. But the math changes dramatically when we look at <strong>realistic utilization</strong>, not theoretical peak FLOPS.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The Utilization Problem</h3>
-    <p>GPU efficiency claims assume <strong>100% compute utilization</strong>. Real inference doesn't work that way:</p>
-    <ul>
-        <li><strong>Batch=1 latency:</strong> Most production inference is single-request</li>
-        <li><strong>Memory-bound:</strong> KV cache and weight loading dominate</li>
-        <li><strong>Token-to-token:</strong> 90%+ of time is waiting for next token</li>
-        <li><strong>I/O bound:</strong> Network, disk, and tokenization overhead</li>
-    </ul>
-    <p><strong>The dirty secret:</strong> GPUs spend most of their time <em>idle</em>, still drawing full power.</p>
-</div>
-
-<h3>The Idle Power Reality</h3>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: Always Hungry</h3>
-        <ul>
-            <li><strong>High-end GPU at idle:</strong> ~150W (just sitting there)</li>
-            <li><strong>High-end GPU at compute:</strong> ~700W</li>
-            <li><strong>PCIe overhead:</strong> +50W for data transfer</li>
-            <li><strong>VRAM stays powered:</strong> Weights must remain loaded</li>
-        </ul>
-        <p><strong>Real-world:</strong> If your GPU is only computing 20% of the time, you're wasting 80% of that 700W.</p>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU: Scales Down</h3>
-        <ul>
-            <li><strong>Dual Xeon at idle:</strong> ~100-150W (bare OS, minimal load)</li>
-            <li><strong>Dual Xeon at compute:</strong> ~800-1000W (full load)</li>
-            <li><strong>DVFS:</strong> Scales from 0.8GHz to 3.5GHz dynamically</li>
-            <li><strong>C-states:</strong> Deep sleep cores when waiting for I/O</li>
-        </ul>
-        <p><strong>Real-world:</strong> Enterprise server with 2TB RAM typically draws 200-400W average for inference workloads.</p>
-    </div>
-</div>
-
-<h3>Power-Per-Token Analysis</h3>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Scenario</th><th>GPU Power</th><th>CPU Power</th><th>Winner</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><strong>Theoretical peak FLOPS</strong></td>
-                <td>700W / 989 TFLOPS = 0.71 W/TFLOPS</td>
-                <td>1000W / 6 TFLOPS = 167 W/TFLOPS</td>
-                <td style="color: #ff6b6b;">GPU (theoretical)</td>
-            </tr>
-            <tr>
-                <td><strong>Memory-bound (typical inference)</strong></td>
-                <td>700W (can't scale down)</td>
-                <td>200-400W (scales with load)</td>
-                <td style="color: #47b475;">CPU (2-3.5x less)</td>
-            </tr>
-            <tr>
-                <td><strong>Batch=1, high I/O wait</strong></td>
-                <td>300W average (60% idle)</td>
-                <td>150-200W average (70% idle)</td>
-                <td style="color: #47b475;">CPU (1.5-2x less)</td>
-            </tr>
-            <tr>
-                <td><strong>Multi-tenant (6 models)</strong></td>
-                <td>6 × 700W = 4,200W (all active)</td>
-                <td>800-1000W (all on one server)</td>
-                <td style="color: #47b475;">CPU (4-5x less)</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Utilization Math</h3>
-    <pre>
-GPU Cluster (6× high-end GPUs) for 6-department enterprise:
-  6 departments × 1 GPU each = 4,200W continuous
-  Even when only 1-2 departments are active.
-  Plus: $240,000+ in hardware, NVLink complexity.
-
-CPU (1× Dual Xeon Platinum) for 6-department enterprise:
-  All 6 models resident in 2TB RAM = ~1000W max
-  Each department waits its turn = efficient time-sharing
-  Scales power with actual compute load (not fixed at max)
-
-Net difference: 4-5x less power, 10x lower hardware cost
-    </pre>
-</div>
-
-<h3>Watts Per Token: The Real Numbers</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Enterprise Deployment Comparison</h3>
-    <pre>
-Scenario: 6 models, 24/7 operation, mixed workload
-
-GPU Cluster (6× high-end GPUs):
-  Idle power: 6 × 150W = 900W
-  Compute power: 6 × 700W = 4,200W (when all busy)
-  Average (typical 20% compute): ~1,500W
-  Power/24hr: 36 kWh
-  Power/year: 13,140 kWh
-  @ $0.10/kWh: $1,314/year
-
-CPU Server (1× Dual Xeon Platinum, 2TB RAM):
-  Idle power: ~150W (bare OS, all models in RAM)
-  Compute power: ~1000W (all models active)
-  Average (typical 20% compute): ~320W
-  Power/24hr: 7.7 kWh
-  Power/year: 2,800 kWh
-  @ $0.10/kWh: $280/year
-
-Net difference: 4-5x less power = ~$1,000+/year savings
-    </pre>
-</div>
-
-<h3>Carbon Footprint: Real-World Impact</h3>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU Advantage</h3>
-        <ul>
-            <li><strong>4-5x less electricity</strong> for multi-tenant inference</li>
-            <li><strong>No GPU manufacturing impact</strong> (TSMC 4nm vs 5nm)</li>
-            <li><strong>Lower cooling</strong> due to lower heat output</li>
-            <li><strong>Uses existing infrastructure</strong> - no new hardware needed</li>
-            <li><strong>10x lower hardware cost</strong> (&#36;60K vs &#36;600K+)</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">When GPUs Make Sense</h3>
-        <ul>
-            <li><strong>Training large models</strong> (100B+) at 100% utilization</li>
-            <li><strong>Very high throughput</strong> with batching</li>
-            <li><strong>Research</strong> where peak FLOPS matter more than efficiency</li>
-        </ul>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Bottom Line</strong><br>
-        GPU efficiency claims assume 100% compute utilization. Real inference workloads are typically 10-30% compute-bound. At realistic utilization, CPUs consume 3-5x less power for multi-tenant inference. Plus: 10x lower hardware cost. This isn't theory - it's simple thermodynamics based on how often your hardware is actually doing work.
-    </div>
-</div>
-
-<h3>The Hidden Cost: Power Delivery and Signal Integrity</h3>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Nobody Talks About This</strong><br>
-        GPU marketing quotes peak TFLOPS. What they don't mention is the electrical engineering nightmare required to actually deliver those peaks.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The GPU Power Profile: Burst-Idle-Burst</h3>
-    <p>GPUs don't draw steady power. They spike to peak compute (hundreds of watts), then drop when waiting for data transfer, then spike again. This <strong>burst-idle-burst</strong> pattern creates massive di/dt (rate of current change) that cascades into real electrical engineering problems:</p>
-    <ul>
-        <li><strong>di/dt spikes</strong> &mdash; Rapid current transitions from idle to peak compute stress every component in the power delivery path</li>
-        <li><strong>Signal reflections</strong> &mdash; High-speed switching creates signal integrity issues on PCB traces and interconnects</li>
-        <li><strong>Crosstalk</strong> &mdash; Adjacent high-speed signal lines interfere with each other at GPU clock speeds</li>
-        <li><strong>Ground bounce</strong> &mdash; Simultaneous switching of thousands of CUDA cores causes ground plane voltage fluctuation</li>
-        <li><strong>Power supply design</strong> &mdash; PSUs must handle massive transient spikes, requiring expensive voltage regulation and capacitor banks</li>
-    </ul>
-    <p><strong>Result:</strong> Data centers running GPU clusters need specialized power infrastructure &mdash; substations, high-capacity PDUs, and overprovisioned power delivery &mdash; to handle these peak bursts that occur for fractions of a second.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: Spiky, Unpredictable Power</h3>
-        <pre>
-Power draw over time:
-  ████████░░░░████████░░████████░░░░
-  700W     150W  700W  150W 700W  150W
-  compute  wait  compute wait compute wait
-
-Peak-to-idle ratio: ~5:1
-di/dt: Extreme
-Infrastructure: Substation-grade power delivery
-        </pre>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU: Steady, Predictable Power</h3>
-        <pre>
-Power draw over time:
-  ████████████████████████████████
-  200-400W consistent draw
-
-Peak-to-idle ratio: ~2:1
-di/dt: Minimal (DVFS transitions are gradual)
-Infrastructure: Standard data center power
-        </pre>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Theory of Constraints Applied to Power</h3>
-    <p>The fastest moving part and the slowest moving part of a system should be as close together as possible. GPUs violate this principle at the electrical level:</p>
-    <ul>
-        <li><strong>Fastest part:</strong> GPU peak compute at 700W+ burst</li>
-        <li><strong>Slowest part:</strong> Data transfer at 150W idle</li>
-        <li><strong>Gap:</strong> 5:1 ratio &mdash; massive mismatch that the power infrastructure must absorb</li>
-    </ul>
-    <p>CPUs don't have GPU-level peak FLOPS, but they also <strong>don't need substation-grade power infrastructure</strong> to handle those peaks. The power draw is consistent and predictable. Standard, well-designed data center power delivery handles it without complication. No specialized substations. No overprovisioned PDUs. No capacitor banks for transient spikes.</p>
-    <p><strong>The peak FLOPS that GPUs advertise are real &mdash; but the cost of actually delivering that power is hidden from every benchmark and every marketing slide.</strong></p>
-</div>
-
-<div class="img-container svg-viewer" data-title="Power Delivery Reality: GPU Spikes vs CPU Steady State">
-    <img src="assets/power-delivery-infographic.svg" alt="Power Delivery Reality - GPU burst-idle-burst spikes vs CPU steady state power draw, showing signal integrity problems, Theory of Constraints applied to power, and hidden infrastructure costs">
-</div>
-
-<h2>Principle 2: The Ethernet Equalizer</h2>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-    </div>
-    <div>
-        <strong>NVLink Doesn't Scale Infinitely</strong><br>
-        NVLink is 900 GB/s <em>within a single node</em>. But you can only fit 8 GPUs per node. Go beyond that? You hit Ethernet. And at the Ethernet boundary, CPUs and GPUs face the exact same constraint.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The Bandwidth Reality</h3>
-    <p>Let's be precise about the numbers:</p>
-</div>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Connection Type</th><th>Bandwidth</th><th>Where It Applies</th><th>Scales To</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>NVLink 4.0</td>
-                <td>900 GB/s</td>
-                <td>GPU-to-GPU within 1 node</td>
-                <td>8 GPUs max</td>
-            </tr>
-            <tr>
-                <td>DDR5 (12-channel)</td>
-                <td>460 GB/s</td>
-                <td>CPU-to-RAM within 1 socket</td>
-                <td>Per socket</td>
-            </tr>
-            <tr>
-                <td>400GbE Ethernet</td>
-                <td>50 GB/s</td>
-                <td>Node-to-node</td>
-                <td>Infinite nodes</td>
-            </tr>
-            <tr>
-                <td>100GbE Ethernet</td>
-                <td>12.5 GB/s</td>
-                <td>Node-to-node</td>
-                <td>Infinite nodes</td>
-            </tr>
-            <tr>
-                <td>InfiniBand HDR</td>
-                <td>25 GB/s</td>
-                <td>Node-to-node</td>
-                <td>Thousands of nodes</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Theory of Constraints Applied</h3>
-    <pre>
-GPU Cluster at Scale:
-  Within node:  NVLink 900 GB/s (fast!)
-  Between nodes: Ethernet 50 GB/s (constraint!)
-  System speed = 50 GB/s (bottleneck)
-
-CPU Cluster at Scale:
-  Within node:  DDR5 460 GB/s
-  Between nodes: Ethernet 50 GB/s (same constraint!)
-  System speed = 50 GB/s (same bottleneck)
-
-AT SCALE, THEY HIT THE SAME WALL.
-    </pre>
-</div>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Without NVLink, GPUs Are Often Slower</strong><br>
-        If you can't afford NVLink switches (&#36;200K+), your GPUs communicate over PCIe → Ethernet. That's 12.5-50 GB/s. A server-grade CPU with DDR5 has 460 GB/s to its own memory. For memory-bound workloads, the CPU wins.
-    </div>
-</div>
-
-<h2>The Compute-to-Bandwidth Chasm</h2>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-    </div>
-    <div>
-        <strong>The Ethernet Equalizer Shows Both Hit the Same Wall &mdash; But the Pain Is Wildly Different</strong><br>
-        Every system has a fastest thing (compute) and a slowest thing (cross-node data movement). C-Kernel-Engine's entire goal is to bring these two into sync. On CPUs, they're close enough that software can bridge the gap. On GPUs, they're orders of magnitude apart &mdash; no software fixes that.
-    </div>
-</div>
-
-<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
-    On CPUs, the gap between the fastest thing the system can do (compute) and the slowest thing it must do (move data across the network) is <strong>close</strong>.
-    Peak FLOPS and Ethernet bandwidth live in the same neighborhood.
-    That means the remaining optimization work is pure engineering &mdash; tiling, prefetching, computation-communication overlap &mdash; real techniques that bring compute and data movement closer to sync.
-    <strong>That's what C-Kernel-Engine is built to do.</strong>
-</p>
-<p style="font-size: 1.1em; line-height: 1.75; margin-bottom: 1.5rem;">
-    On GPUs, the fastest and slowest are worlds apart. GPU peak compute is orders of magnitude faster than the Ethernet pipe that feeds it at cluster scale.
-    It's the difference between the summit of <strong>Mt. Everest</strong> and the floor of the <strong>Mariana Trench</strong>.
-    Most of that compute sits permanently idle, burning power, waiting for data that will never arrive fast enough. No amount of software engineering changes the physics.
+<p>
+    Once the workload fits, single-node execution time is bounded by the slower of useful arithmetic and memory
+    movement, plus software overhead:
 </p>
 
-<div class="img-container svg-viewer" data-title="The Compute-to-Bandwidth Chasm: CPU Rolling Hills vs GPU Everest-to-Mariana">
-    <img src="assets/compute-bandwidth-chasm.svg" alt="On CPUs the gap between compute speed and network speed is small — C-Kernel-Engine bridges it. On GPUs the gap is orders of magnitude — unbridgeable at scale.">
-</div>
+<pre>T_node = max(T_compute, T_memory) + T_overhead</pre>
 
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU: Rolling Hills &mdash; Bridgeable</h3>
-        <ul>
-            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are close</li>
-            <li><strong>Local memory bandwidth</strong> sits in between &mdash; a smooth gradient, not a cliff</li>
-            <li><strong>Software can bridge the remaining gap:</strong> tiling, prefetch, overlap</li>
-            <li><strong>Every hardware generation</strong> makes the gap smaller (more bandwidth, same physics)</li>
-        </ul>
-        <p>The terrain is gentle enough to walk. C-Kernel-Engine's job is to build the bridge: bring compute throughput and data movement into sync through aggressive kernel engineering.</p>
-    </div>
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: Everest to Mariana &mdash; Unbridgeable</h3>
-        <ul>
-            <li><strong>Fastest (compute)</strong> and <strong>slowest (network)</strong> are orders of magnitude apart</li>
-            <li><strong>Intra-node interconnects</strong> are fast, but only reach a handful of GPUs</li>
-            <li><strong>At cluster scale</strong>, everything hits the same Ethernet wall</li>
-            <li><strong>Most compute capacity</strong> sits permanently idle, starved for data</li>
-        </ul>
-        <p>The terrain is a cliff face. No bridge spans from the peak of Everest to the bottom of the Mariana Trench. The gap is structural &mdash; physics, not engineering.</p>
-    </div>
-</div>
+<p>
+    Adding nodes introduces costs that do not exist in the single-node result:
+</p>
 
-<div class="alert alert-success" style="margin-top: 1.5rem;">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>C-Kernel-Engine's Optimization Thesis</strong><br>
-        The goal is straightforward: bring the fastest-moving thing and the slowest-moving thing as close to sync as possible. On CPUs, they're already neighbors &mdash; the remaining work is tiling, cache management, prefetching, and overlapping computation with communication. That is a solvable engineering problem, and it's exactly what this project is built to solve. On GPUs at cluster scale, the gap between compute and data movement is structural. No kernel optimization closes it.
-    </div>
-</div>
+<pre>T_N = T_compute,N
+    + T_communication,N
+    + T_synchronization,N
+    + T_imbalance,N</pre>
 
-<h2>Designing Your Ethernet Network</h2>
+<p>
+    Speedup and parallel efficiency are therefore measured results, not consequences of owning more machines:
+</p>
 
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Ethernet Switch Topology for ML Clusters</h3>
-    <p>Since Ethernet is the equalizer at scale, designing it well is critical.</p>
-</div>
-
-<h3>Leaf-Spine Architecture</h3>
-
-<div class="card">
-    <pre>
-                    ┌─────────────┐     ┌─────────────┐
-                    │  Spine 1    │     │  Spine 2    │
-                    │ 400GbE      │     │ 400GbE      │
-                    └──────┬──────┘     └──────┬──────┘
-                           │                   │
-         ┌─────────────────┼───────────────────┼─────────────────┐
-         │                 │                   │                 │
-    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
-    │ Leaf 1  │       │ Leaf 2  │       │ Leaf 3  │       │ Leaf 4  │
-    │ 100GbE  │       │ 100GbE  │       │ 100GbE  │       │ 100GbE  │
-    └────┬────┘       └────┬────┘       └────┬────┘       └────┴────┘
-         │                 │                 │                 │
-    ┌────┴────┐       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
-    │Server 1 │       │Server 3 │       │Server 5 │       │Server 7 │
-    │Server 2 │       │Server 4 │       │Server 6 │       │Server 8 │
-    └─────────┘       └─────────┘       └─────────┘       └─────────┘
-    </pre>
-</div>
-
-<h3>Switch Sizing Calculator</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Bandwidth Requirements</h3>
-    <pre>
-For distributed training with data parallelism:
-  Gradient size = Model parameters × bytes per param
-  70B model in FP16 = 70B × 2 bytes = 140 GB
-
-All-reduce bandwidth needed:
-  Per iteration: 2 × gradient size (reduce-scatter + all-gather)
-  70B model: 2 × 140 GB = 280 GB per iteration
-
-With 100GbE (12.5 GB/s):
-  All-reduce time = 280 GB ÷ 12.5 GB/s = 22.4 seconds
-
-With 400GbE (50 GB/s):
-  All-reduce time = 280 GB ÷ 50 GB/s = 5.6 seconds
-    </pre>
-</div>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">Small Cluster (8-16 servers)</h3>
-        <ul>
-            <li><strong>Topology:</strong> Single 400GbE switch</li>
-            <li><strong>Switch:</strong> Arista 7060X5 or similar</li>
-            <li><strong>Ports:</strong> 32× 400GbE</li>
-            <li><strong>Cost:</strong> ~$30,000</li>
-            <li><strong>Bisection BW:</strong> 12.8 Tbps</li>
-        </ul>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Medium Cluster (32-64 servers)</h3>
-        <ul>
-            <li><strong>Topology:</strong> Leaf-spine (2 spine, 4 leaf)</li>
-            <li><strong>Spine:</strong> 2× 400GbE switches</li>
-            <li><strong>Leaf:</strong> 4× 100GbE switches</li>
-            <li><strong>Cost:</strong> ~$120,000</li>
-            <li><strong>Bisection BW:</strong> 25.6 Tbps</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Large Cluster (100+ servers)</h3>
-    <ul>
-        <li><strong>Topology:</strong> 3-tier Clos or fat-tree</li>
-        <li><strong>Consider:</strong> InfiniBand for lower latency</li>
-        <li><strong>RDMA:</strong> RoCEv2 over Ethernet or native IB</li>
-        <li><strong>Cost:</strong> $500K-2M depending on scale</li>
-    </ul>
-    <p><strong>Key insight:</strong> A GPU cluster at this scale needs the SAME network infrastructure. The Ethernet cost is equal. But CPUs don't need the $2M+ in NVLink switches.</p>
-</div>
-
-<h3>RDMA Configuration</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">RoCEv2 Setup</h3>
-    <pre>
-# Enable RDMA over Converged Ethernet v2
-# On each server with Mellanox/NVIDIA ConnectX NICs:
-
-# 1. Enable PFC (Priority Flow Control) on switch
-#    Required for lossless Ethernet
-
-# 2. Configure ECN (Explicit Congestion Notification)
-mlnx_qos -i eth0 --pfc 0,0,0,1,0,0,0,0  # Enable PFC on priority 3
-mlnx_qos -i eth0 --trust=dscp
-
-# 3. Set up RDMA
-modprobe rdma_ucm
-modprobe rdma_cm
-
-# 4. Verify RDMA is working
-ibv_devinfo
-rdma link show
-    </pre>
-</div>
-
-<div class="img-container svg-viewer" data-title="Ethernet Switch Topology">
-    <img src="assets/ethernet-topology.svg" alt="Ethernet Switch Topology for ML Clusters">
-</div>
-
-<h2>Scale Economics: The Real Comparison</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Why CPU-Only Wins at Scale</h3>
-</div>
-
-<div class="img-container svg-viewer" data-title="Scale Economics Comparison">
-    <img src="assets/scale-economics.svg" alt="Scale Economics Comparison">
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-blue">
-        <h3 style="margin-top: 0;">GPU Cluster at Scale</h3>
-        <ul>
-            <li><strong>For 1TB model:</strong> 100 GPUs minimum</li>
-            <li><strong>Total cost:</strong> $4 Billion</li>
-            <li><strong>Who can afford:</strong> 5 companies globally</li>
-            <li><strong>Result:</strong> Elite-only access</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU Cluster at Scale</h3>
-        <ul>
-            <li><strong>For same scale:</strong> 80 servers</li>
-            <li><strong>Total cost:</strong> $240 Million</li>
-            <li><strong>Who can afford:</strong> 1000+ companies</li>
-            <li><strong>Result:</strong> Accessible to everyone</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Economics: 16x Cheaper, 200x More Accessible</h3>
-    <p>While GPU costs stay high and GPU access remains limited, CPU clusters deliver the same scale at a fraction of the cost. This makes large-scale ML accessible to 1000+ companies instead of just 5.</p>
-</div>
-
-<h2>The Hybrid Trap: CPU+GPU = CPU-Bound</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-    </div>
-    <div>
-        <strong>Common Question:</strong><br>
-        "Why not use CPU for memory and GPU for compute? Get the best of both!"<br><br>
-        <strong>Answer:</strong> You're then AS FAST AS THE CPU anyway! You get the complexity of both with the performance of neither.
-    </div>
-</div>
-
-<div class="img-container svg-viewer" data-title="Hybrid CPU+GPU Bottleneck">
-    <img src="assets/hybrid-bottleneck.svg" alt="Hybrid CPU+GPU Bottleneck">
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Hybrid Bottleneck</h3>
-    <p>When CPU holds weights and transfers to GPU for compute:</p>
-    <ul>
-        <li><strong>Transfer bottleneck:</strong> 100 GB/s limits throughput</li>
-        <li><strong>GPU idle time:</strong> Waits for data from CPU</li>
-        <li><strong>You get:</strong> GPU performance = CPU performance</li>
-        <li><strong>Plus:</strong> Double the code complexity, double the cost</li>
-    </ul>
-    <p><strong>Conclusion:</strong> If the GPU is limited by the CPU anyway, just use CPUs! Simpler, faster, cheaper.</p>
-</div>
-
-<h2>The GPU Workaround Stack: "Innovations" That Are Actually Patches</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The Uncomfortable Truth</strong><br>
-        The entire field has been optimizing around a hardware constraint and mistaking the workarounds for progress. Every major "breakthrough" in LLM architecture is actually compensating for GPU memory limitations.
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Every "Innovation" Maps to a GPU Constraint</h3>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>"Innovation"</th><th>What It Actually Does</th><th>The GPU Constraint It Patches</th><th>Needed on CPU with 2-4TB RAM?</th></tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><strong>GQA (Grouped Query Attention)</strong></td>
-                    <td>Shares KV heads across query heads</td>
-                    <td>KV cache blows up GPU VRAM</td>
-                    <td style="color: #4ade80;">No &mdash; KV cache fits</td>
-                </tr>
-                <tr>
-                    <td><strong>MoE (Mixture of Experts)</strong></td>
-                    <td>Activates sparse subset of parameters</td>
-                    <td>Dense model won't fit on one GPU</td>
-                    <td style="color: #4ade80;">No &mdash; dense model fits</td>
-                </tr>
-                <tr>
-                    <td><strong>KV Caching</strong></td>
-                    <td>Stores past attention keys/values &mdash; literally a key-value database in every layer</td>
-                    <td>GPU VRAM limits cache size, forces eviction strategies</td>
-                    <td style="color: #4ade80;">CPU home turf &mdash; this is literally how databases work. CPUs have been running key-value stores for decades.</td>
-                </tr>
-                <tr>
-                    <td><strong>Gradient Checkpointing</strong></td>
-                    <td>Recomputes activations instead of storing them</td>
-                    <td>Training activations don't fit in GPU VRAM</td>
-                    <td style="color: #4ade80;">No &mdash; store everything</td>
-                </tr>
-                <tr>
-                    <td><strong>Tensor Parallelism</strong></td>
-                    <td>Shards weight matrices across GPUs</td>
-                    <td>Single GPU can't hold the full matrix</td>
-                    <td style="color: #4ade80;">No &mdash; full matrix fits in RAM</td>
-                </tr>
-                <tr>
-                    <td><strong>Pipeline Parallelism</strong></td>
-                    <td>Distributes layers across GPUs</td>
-                    <td>All layers don't fit on one GPU</td>
-                    <td style="color: #4ade80;">No &mdash; all layers fit</td>
-                </tr>
-                <tr>
-                    <td><strong>Flash Attention</strong></td>
-                    <td>Online softmax with tiled computation &mdash; streams through attention in blocks</td>
-                    <td>Full attention matrix doesn't fit in GPU SRAM/VRAM</td>
-                    <td style="color: #4ade80;">Brilliant for CPU &mdash; tiling maps naturally to CPU cache hierarchies. CPUs process data in cache-line-sized tiles inherently.</td>
-                </tr>
-                <tr>
-                    <td><strong>Quantization Research</strong></td>
-                    <td>Compresses model weights (Q4, Q8, etc.)</td>
-                    <td>Model doesn't fit in GPU VRAM at full precision</td>
-                    <td style="color: #fbbf24;">Optional &mdash; use for bandwidth, not capacity</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Punchline</strong><br>
-        On a CPU with 2-4TB RAM, <strong>half of these become unnecessary, and the other half become simpler.</strong> The entire research direction has been shaped by GPU limitations, and people have confused "optimizations forced by GPU memory walls" with "fundamental advances in model architecture."
-    </div>
-</div>
-
-<div class="img-container svg-viewer" data-title="GPU Workaround Convergence: All Roads Lead Back to CPU">
-    <img src="assets/gpu-workaround-convergence.svg" alt="GPU Workaround Convergence - Every GPU innovation (GQA, MoE, KV Caching, Flash Attention, Gradient Checkpointing, Tensor/Pipeline Parallelism, Quantization) converges toward capabilities CPUs have had natively for decades">
-</div>
-
-<h3>The Sequential Reality: GPUs Were Never Designed for This</h3>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Transformers Are Sequential. Period.</h3>
-    <p>A transformer forward pass is:</p>
-    <pre>Layer 1 &rarr; Layer 2 &rarr; Layer 3 &rarr; ... &rarr; Layer 80</pre>
-    <p>You <strong>cannot</strong> compute layer 10 without the output of layer 9. That is the <em>definition</em> of sequential dependency. There is no debate here &mdash; it's mathematical fact.</p>
-    <p>What people mean when they say "LLMs are parallel" is that <em>within</em> a single layer, the matrix multiplication can be parallelized across rows and columns. But that's not the model being parallel &mdash; that's a single operation within a sequential pipeline being decomposable. Every CPU has been decomposing matmuls across SIMD lanes and cores for decades.</p>
-</div>
-
-<h3>Amdahl's Law: Why Parallel Hardware Still Hits a Ceiling</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Strong-Scaling Limit</h3>
-    <p>Amdahl's Law is the simplest way to say what the sequential transformer argument implies in practice:</p>
-    <pre>speedup(N) = 1 / (S + (1 - S) / N)</pre>
-    <p>Where <code>S</code> is the fraction of work that stays effectively serial or synchronization-bound. Even with infinite parallel hardware, the maximum speedup is still:</p>
-    <pre>max_speedup = 1 / S</pre>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Serial / sync fraction</th><th>Theoretical max speedup</th><th>What it means</th></tr>
-            </thead>
-            <tbody>
-                <tr><td>10%</td><td>10&times;</td><td>A surprisingly hard wall for giant clusters</td></tr>
-                <tr><td>5%</td><td>20&times;</td><td>Still not "infinite scaling"</td></tr>
-                <tr><td>2%</td><td>50&times;</td><td>Requires extraordinary system design</td></tr>
-                <tr><td>1%</td><td>100&times;</td><td>Already very difficult in real distributed systems</td></tr>
-            </tbody>
-        </table>
-    </div>
-    <p>For LLMs, that serial fraction is not just "the next token depends on the previous token." It also includes layer boundaries, synchronization, collective communication, optimizer steps, routing decisions, and all the places where the system must wait for the slowest participant.</p>
-    <p><strong>CKE takeaway:</strong> do not optimize only for peak FLOPS. Reduce the effective serial fraction, reduce synchronization pressure, and keep compute, memory, and network in the same performance neighborhood.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">What GPUs Were Designed For</h3>
-        <p><strong>Independent pixel computation.</strong></p>
-        <p>Millions of pixels with <em>zero</em> data dependency on each other. Pixel (0,0) doesn't need the result of pixel (1920,1080) to compute its color. That IS embarrassingly parallel.</p>
-        <pre>
-pixel(0,0)   &rarr; compute color &rarr; done
-pixel(0,1)   &rarr; compute color &rarr; done
-pixel(1,0)   &rarr; compute color &rarr; done
-...
-pixel(1920,1080) &rarr; compute color &rarr; done
-(all independent, all simultaneous)</pre>
-    </div>
-    <div class="card" style="border-left: 4px solid #fbbf24;">
-        <h3 style="margin-top: 0;">What LLM Inference Actually Is</h3>
-        <p><strong>Sequential token generation on a sequential layer stack.</strong></p>
-        <p>Token N+1 depends on the attention computation over ALL previous tokens. The autoregressive decode loop is the opposite of pixel independence.</p>
-        <pre>
-token 1 &rarr; 80 layers &rarr; token 2
-token 2 &rarr; 80 layers &rarr; token 3
-token 3 &rarr; 80 layers &rarr; token 4
-...
-(each waits for the previous)</pre>
-    </div>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Vocabulary of Mismatch</h3>
-    <p>The fact that the industry bolted LLM training onto hardware designed for independent pixel shading and then invented an entire vocabulary to work around the mismatch should tell you something is wrong with the foundational assumption:</p>
-    <ul>
-        <li><strong>Tensor parallelism</strong> &mdash; because one GPU can't hold the weights</li>
-        <li><strong>Pipeline parallelism</strong> &mdash; because one GPU can't hold the layers</li>
-        <li><strong>Model parallelism</strong> &mdash; because the model doesn't fit</li>
-        <li><strong>Gradient checkpointing</strong> &mdash; because activations don't fit</li>
-        <li><strong>Flash Attention</strong> &mdash; because attention intermediates don't fit</li>
-        <li><strong>Activation recomputation</strong> &mdash; because you ran out of memory</li>
-    </ul>
-    <p><strong>Every one of these is a workaround for the same problem:</strong> you're running a sequential, memory-hungry workload on hardware designed for embarrassingly parallel, compute-bound pixel shading.</p>
-</div>
-
-<h3>MoE: The Right Hardware for Dynamic Routing</h3>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Native Fit vs. Forced Workaround</h3>
-    <p>Yes, MoE runs on GPUs — frontier models do it at scale. But <em>runs on</em> is not the same as <em>naturally fits</em>. The same argument made against CPUs for AI ("it works, but it's not the right tool") applies equally to GPUs for MoE.</p>
-    <p>MoE routing is conditional: for each token, a gating function decides which experts activate. GPUs — designed for dense, predictable, lockstep computation — handle this through software workarounds: load balancing losses, capacity factors, expert dropout, and auxiliary training objectives just to keep GPU utilization from collapsing under sparse activation patterns.</p>
-    <p>Consider fixed-function inference chips. They prefer dense computation above all else. The minute you introduce dynamic routing — conditional branching, variable expert selection — they require architectural hacks. GPUs face the same underlying tension, just with more memory headroom to absorb it.</p>
-    <p>CPUs have handled conditional branching natively since the beginning: branch prediction, out-of-order execution, speculative paths. The hardware was built for exactly this. <strong>AVX-512 computes 16 FP32 multiply-accumulates per cycle per core</strong> — across 128 cores that's 2048 parallel operations — and the dynamic routing overhead that GPUs must paper over in software is just normal control flow on a CPU.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Why MoE All-to-All Makes Topology Matter</h3>
-    <p>Jensen Huang's point about MoE is not that "one expert equals one GPU" in a literal one-expert-per-device sense. Real deployments usually place <strong>multiple experts per GPU</strong>, or shard very large experts across several GPUs. But the core communication pattern is the same:</p>
-    <pre>tokens on many GPUs
-   &darr; route top-k experts
-dispatch token states to expert owners (all-to-all)
-   &darr;
-run expert MLPs
-   &darr;
-send expert outputs back / combine (all-to-all again)</pre>
-    <p>That happens at every MoE layer. If the interconnect is a one-hop switched fabric, the communication cost is painful but bounded. If the topology is multi-hop, ring-like, torus-like, or otherwise forces traffic through several devices before reaching the destination, the waiting and queueing add up quickly.</p>
-    <p><strong>This is where Amdahl's Law shows up in systems form:</strong> the expert GEMMs may parallelize beautifully, but the dispatch, synchronization, and combine phases become the part you cannot hide. The more often the model must do all-to-all, the more the communication fraction dominates the ceiling on real speedup.</p>
-</div>
-
-<h3>Training: Batch Size Is Not What You Think</h3>
+<pre>S(N) = T(1) / T(N)          E(N) = S(N) / N</pre>
 
 <div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
+    <div class="alert-icon">i</div>
     <div>
-        <strong>"But GPUs need large batches for efficiency!"</strong><br>
-        This is true &mdash; and that's a GPU problem, not a training requirement. Training does not <em>need</em> batch size greater than 1. There are many ways to simulate larger effective batch sizes without holding multiple sequences in memory simultaneously.
+        <strong>Memory capacity is necessary, not sufficient.</strong>
+        A model that does not fit cannot run, but a model that fits can still be too slow, too expensive, or too
+        difficult to operate. CKE treats capacity, bandwidth, compute, communication, and user-visible behavior as
+        separate gates.
     </div>
 </div>
+
+<h2>What One Node Must Prove</h2>
+
+<div class="table-container" style="max-width: 100%; overflow-x: auto;">
+<table>
+    <thead>
+        <tr><th>Question</th><th>Required evidence</th><th>Failure means</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Is it numerically acceptable?</td>
+            <td>Reference parity, first-divergence attribution, task-level output, and explicit tolerance</td>
+            <td>Performance results are not yet promotable</td>
+        </tr>
+        <tr>
+            <td>Does it fit?</td>
+            <td>Peak RSS, mapped weights, KV state, workspace, and allocator behavior</td>
+            <td>The model, precision, context, or memory plan must change</td>
+        </tr>
+        <tr>
+            <td>What limits it?</td>
+            <td>Roofline position, effective bandwidth, vector utilization, cache behavior, and hot kernels</td>
+            <td>Optimization is speculation</td>
+        </tr>
+        <tr>
+            <td>Is it useful to a person or service?</td>
+            <td>Time to first token, prefill, decode, concurrency, tail latency, and sustained operation</td>
+            <td>A peak token rate is not enough</td>
+        </tr>
+        <tr>
+            <td>Is it operationally credible?</td>
+            <td>Power, thermals, repeatability, failure behavior, deployment steps, and total system assumptions</td>
+            <td>The benchmark does not describe a deployable system</td>
+        </tr>
+    </tbody>
+</table>
+</div>
+
+<p>
+    Every published result should identify the CPU, memory channels and population, NUMA topology, firmware or
+    microcode where relevant, compiler, CKE commit, model and input hashes, precision, context, batch, thread count,
+    commands, repetitions, and known limitations.
+</p>
+
+<h2>Distributed Scaling Is a Cost Equation</h2>
+
+<p>
+    CKE does not claim infinite scaling. A network makes remote memory and remote computation available, but every
+    boundary adds transfer time, synchronization, queueing, and imbalance. The transfer floor is approximately:
+</p>
+
+<pre>T_transfer &gt;= bytes_transferred / effective_bandwidth + network_latency</pre>
+
+<p>
+    Amdahl's law still applies. If <code>f_s</code> is the serial or effectively non-parallel fraction, ideal speedup
+    cannot exceed:
+</p>
+
+<pre>S(N) &lt;= 1 / (f_s + (1 - f_s) / N)</pre>
+
+<p>
+    Ten, 25, or 100 gigabit Ethernet, RDMA, NUMA placement, transport implementation, message size, and overlap are
+    experiment variables. They are not interchangeable labels. Internet-connected laptops may support independent or
+    delay-tolerant work, but they are not a low-latency tensor fabric and should not be described as one.
+</p>
+
+<h3>Parallelism must match the boundary</h3>
+
+<div class="table-container" style="max-width: 100%; overflow-x: auto;">
+<table>
+    <thead>
+        <tr><th>Strategy</th><th>What crosses nodes</th><th>Where it may fit</th><th>Primary risk</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Data parallelism</td>
+            <td>Gradients, optimizer state, or independent results</td>
+            <td>Independent requests and sufficiently large training batches</td>
+            <td>Reduction cost and duplicated model memory</td>
+        </tr>
+        <tr>
+            <td>Pipeline parallelism</td>
+            <td>Boundary activations</td>
+            <td>Large stages with enough work to amortize transfers</td>
+            <td>Pipeline bubbles and uneven stages</td>
+        </tr>
+        <tr>
+            <td>Tensor parallelism</td>
+            <td>Partial activations and frequent collective results</td>
+            <td>Fast, predictable fabrics and large kernels</td>
+            <td>Communication frequency dominates useful work</td>
+        </tr>
+        <tr>
+            <td>Expert parallelism</td>
+            <td>Routed tokens and expert outputs</td>
+            <td>Stable routing, useful locality, and balanced expert load</td>
+            <td>Dispatch overhead, hotspots, and remote weight traffic</td>
+        </tr>
+    </tbody>
+</table>
+</div>
+
+<h2>MoE Caveat: Routing Does Not Remove Memory Traffic</h2>
+
+<p>
+    Conditional routing is natural to express on a CPU, but that fact alone does not establish a performance
+    advantage. Active expert weights still have to reach the cores. At small batches, an expert may be used too
+    briefly to amortize its weight traffic. At larger batches, routing imbalance and token dispatch can dominate.
+    Total parameter storage also remains large even when only a subset of experts is active for each token.
+</p>
+
+<p>
+    CKE should claim an MoE benefit only after measuring active bytes per token, effective memory bandwidth, expert
+    cache locality, routing distribution, dispatch cost, concurrency, and the routed model's task quality against a
+    dense or established reference. Branch support is an implementation property; system throughput is the result.
+</p>
+
+<h2>Model Architecture Is Shaped by Constraints</h2>
+
+<p>
+    Many important model techniques can be understood as responses to memory, compute, or communication pressure.
+    That is useful systems context, but it is not evidence that the techniques are merely workarounds or that they
+    belong to one hardware class.
+</p>
+
+<div class="table-container" style="max-width: 100%; overflow-x: auto;">
+<table>
+    <thead>
+        <tr><th>Technique</th><th>Constraint reduced</th><th>New cost or contract</th></tr>
+    </thead>
+    <tbody>
+        <tr><td>GQA and MQA</td><td>KV-cache capacity and bandwidth</td><td>Shared key/value semantics and possible quality trade-offs</td></tr>
+        <tr><td>Fused or tiled attention</td><td>Intermediate storage and external memory traffic</td><td>Tiling, reduction order, precision, and backend-specific kernels</td></tr>
+        <tr><td>KV paging and quantization</td><td>Long-context capacity and allocation pressure</td><td>State management, conversion cost, and numerical error</td></tr>
+        <tr><td>Mixture of experts</td><td>Active compute per token relative to total model capacity</td><td>Routing, load balance, expert storage, and dispatch</td></tr>
+        <tr><td>Recurrent or state-space layers</td><td>Explicit long-sequence state growth</td><td>Compressed-state semantics, scan kernels, and training complexity</td></tr>
+        <tr><td>Weight and activation quantization</td><td>Capacity, bandwidth, and arithmetic cost</td><td>Calibration, scale handling, kernel coverage, and quality validation</td></tr>
+    </tbody>
+</table>
+</div>
+
+<h2>The CKE Experiment Ladder</h2>
 
 <div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU: The Batch Balancing Act</h3>
-        <p>On a GPU, you must balance three competing constraints:</p>
-        <ul>
-            <li><strong>Model size</strong> &mdash; weights consume VRAM</li>
-            <li><strong>Context length</strong> &mdash; KV cache consumes VRAM</li>
-            <li><strong>Batch size</strong> &mdash; activations consume VRAM</li>
-        </ul>
-        <p>Increase any one, and you must decrease the others. Want longer context? Reduce batch size. Want larger batch? Reduce context. Want a bigger model? Reduce both.</p>
-        <pre>
-GPU VRAM budget (80GB):
-  Model weights:    40GB (fixed)
-  KV cache:         20GB (varies with context)
-  Activations:      20GB (varies with batch)
-
-  Longer context = less batch
-  Larger batch   = less context
-  ALWAYS a tradeoff.
-        </pre>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU: No Tradeoff Required</h3>
-        <p>With 2-4TB of RAM, all three fit simultaneously:</p>
-        <ul>
-            <li><strong>Model size</strong> &mdash; even 400B+ models fit (800GB+ in FP16)</li>
-            <li><strong>Context length</strong> &mdash; variable, up to 1M+ tokens</li>
-            <li><strong>Batch size</strong> &mdash; whatever you need</li>
-        </ul>
-        <p>You can have <strong>variable context length AND batch greater than one</strong> at the same time. No balancing act required.</p>
-        <pre>
-CPU RAM budget (4TB):
-  Model weights:    810GB (400B+ FP16)
-  KV cache:         500GB (long context)
-  Activations:      200GB (large batch)
-  Remaining:        2,538GB (room to spare)
-
-  Variable context + variable batch
-  NO tradeoffs.
-        </pre>
-    </div>
-</div>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">You Don't Need Large Batches &mdash; You Can Simulate Them</h3>
-    <p>Training with batch=1 works. The gradient is noisier, but there are well-established techniques to get the benefits of large batches without the memory cost:</p>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Technique</th><th>How It Works</th><th>GPU Benefit</th><th>CPU Benefit</th></tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><strong>Gradient Accumulation</strong></td>
-                    <td>Accumulate gradients over N forward passes, update once</td>
-                    <td>Simulates batch=N with batch=1 memory</td>
-                    <td>Same, but can also do actual batch=N</td>
-                </tr>
-                <tr>
-                    <td><strong>Micro-batching</strong></td>
-                    <td>Process small sub-batches, aggregate gradients</td>
-                    <td>Fits in VRAM per micro-batch</td>
-                    <td>Can use larger micro-batches</td>
-                </tr>
-                <tr>
-                    <td><strong>Online Learning</strong></td>
-                    <td>Update after every single example (batch=1)</td>
-                    <td>Works but GPU underutilized</td>
-                    <td>Natural fit for CPU sequential processing</td>
-                </tr>
-                <tr>
-                    <td><strong>Data Parallelism</strong></td>
-                    <td>Each node processes different batch, average gradients</td>
-                    <td>Requires NVLink/IB for gradient sync</td>
-                    <td>RDMA gradient sync, same principle</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The C-Kernel-Engine is actively being developed to prove this.</strong><br>
-        Our kernel architecture supports variable context lengths and flexible batch sizes natively. The quantized GEMV/GEMM kernels (Q4_K, Q5_0, Q5_1, Q5_K, Q6_K, Q8_0) are designed from the ground up for CPU-native inference and training &mdash; not as ports of GPU code. We're building the evidence that CPU-only training and inference at scale isn't theoretical &mdash; it's practical, and the kernel-level work is happening now.
-    </div>
-</div>
-
-<h2>Why CPU-Only is the Future</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">The Strategic Advantage</h3>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Technical Wins</h3>
-        <ul>
-            <li><strong>Memory capacity:</strong> 4-6TB per node vs 80GB VRAM</li>
-            <li><strong>No transfer bottleneck:</strong> CPU memory + CPU compute</li>
-            <li><strong>Optimize interconnect:</strong> RDMA, core pinning, cache</li>
-            <li><strong>Get close to theoretical FLOPS</strong></li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Market Wins</h3>
-        <ul>
-            <li><strong>16x cheaper</strong> at scale</li>
-            <li><strong>200x more accessible</strong> to companies</li>
-            <li><strong>Commodity hardware</strong> - no special requirements</li>
-            <li><strong>Open ecosystem</strong> - standard Linux tools</li>
-        </ul>
-    </div>
-</div>
-
-<h2>Commodity Economics: The CPU Trajectory</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">CPUs Follow Commodity Price Curves</h3>
-    <p>Unlike GPUs which are supply-constrained and vendor-controlled, CPUs are commodity hardware. Every improvement happens automatically, at scale, with competition driving prices down.</p>
-</div>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Component</th><th>2023</th><th>2025</th><th>2027 (projected)</th><th>Trend</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>Memory Standard</td>
-                <td>DDR5-4800</td>
-                <td>DDR5-6400</td>
-                <td>DDR6</td>
-                <td>+33% bandwidth per gen</td>
-            </tr>
-            <tr>
-                <td>Channels per Socket</td>
-                <td>8</td>
-                <td>12</td>
-                <td>16</td>
-                <td>+50% channels</td>
-            </tr>
-            <tr>
-                <td>Max RAM per Server</td>
-                <td>4TB</td>
-                <td>8TB</td>
-                <td>16TB+</td>
-                <td>2x per generation</td>
-            </tr>
-            <tr>
-                <td>Cores per Socket</td>
-                <td>64 (Genoa)</td>
-                <td>128 (Turin)</td>
-                <td>192+</td>
-                <td>+50% per gen</td>
-            </tr>
-            <tr>
-                <td>L3 Cache</td>
-                <td>256MB</td>
-                <td>384MB</td>
-                <td>512MB+</td>
-                <td>Growing</td>
-            </tr>
-            <tr>
-                <td>Ethernet Speed</td>
-                <td>100GbE</td>
-                <td>400GbE</td>
-                <td>800GbE</td>
-                <td>4x per 3 years</td>
-            </tr>
-            <tr>
-                <td>$/TFLOP (CPU)</td>
-                <td>$500</td>
-                <td>$300</td>
-                <td>$150</td>
-                <td>-50% per 2 years</td>
-            </tr>
-            <tr>
-                <td>$/TFLOP (GPU)</td>
-                <td>$50</td>
-                <td>$40</td>
-                <td>$35</td>
-                <td>-15% per 2 years</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Crossover Point</strong><br>
-        GPUs will always have higher peak FLOPS per dollar for raw compute. But for memory-bound ML inference (which is most real-world LLM usage), CPUs are already competitive. And the gap closes every year because CPU economics follow commodity curves.
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Why CPU Economics Win</h3>
-        <ul>
-            <li><strong>Competition:</strong> Intel vs AMD vs ARM</li>
-            <li><strong>Volume:</strong> Billions of CPUs vs millions of GPUs</li>
-            <li><strong>Supply:</strong> Multiple fabs, no bottlenecks</li>
-            <li><strong>Standards:</strong> DDR5 is an industry standard, not proprietary</li>
-            <li><strong>Software:</strong> Linux, GCC, standard tools (free)</li>
-        </ul>
+    <div class="card">
+        <h3 style="margin-top: 0;">1. Numerical closure</h3>
+        <p>Establish model-specific parity against PyTorch or another declared reference before promoting speed.</p>
+        <p><strong>Status:</strong> active, with supported model paths and known multimodal gaps.</p>
     </div>
     <div class="card">
-        <h3 style="margin-top: 0;">Why GPU Economics Struggle</h3>
-        <ul>
-            <li><strong>Monopoly:</strong> NVIDIA dominates (~90% market)</li>
-            <li><strong>Supply-constrained:</strong> Artificial scarcity</li>
-            <li><strong>Proprietary:</strong> CUDA lock-in, HBM limited fabs</li>
-            <li><strong>High margins:</strong> No price competition pressure</li>
-            <li><strong>Lead times:</strong> 12-24 month waits</li>
-        </ul>
+        <h3 style="margin-top: 0;">2. Single-node performance</h3>
+        <p>Measure kernels, memory topology, prefill, decode, concurrency, power, and sustained behavior.</p>
+        <p><strong>Status:</strong> active across consumer, server, and selected embedded CPU targets.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">3. NUMA and topology</h3>
+        <p>Make placement, replication, thread ownership, and cross-socket traffic explicit and reproducible.</p>
+        <p><strong>Status:</strong> being hardened; results remain hardware-specific.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">4. Two-node transport</h3>
+        <p>Measure serialization, transfer, synchronization, overlap, and failure behavior on matched nodes.</p>
+        <p><strong>Status:</strong> planned research; no general scaling claim yet.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">5. Parallel execution</h3>
+        <p>Select data, pipeline, tensor, or expert boundaries from measured compute-to-communication ratios.</p>
+        <p><strong>Status:</strong> research roadmap.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;">6. Distributed training</h3>
+        <p>Extend forward and backward contracts only after single-node training and transport behavior are closed.</p>
+        <p><strong>Status:</strong> long-horizon thesis, not a demonstrated capability.</p>
     </div>
 </div>
 
-<h2>Infinite CPU Scaling: The Internet Proof</h2>
+<h2>Decision Rule</h2>
 
 <div class="card card-accent">
-    <h3 style="margin-top: 0;">CPUs Scale to Infinity</h3>
-    <p>Unlike GPUs, which hit cost and availability ceilings, CPUs scale infinitely through distributed computing across the internet. Your computer is part of that infinity!</p>
+    <p style="font-size: 1.1em; margin-top: 0;">
+        <strong>Use an established runtime and hardware platform when it already meets the requirement.</strong>
+    </p>
+    <p>
+        CKE becomes relevant when a model is unsupported, numerically wrong, unexpectedly slow, difficult to
+        validate, or constrained to owned CPU or embedded infrastructure. Its value is not that every deployment
+        needs generated C. Its value is that the execution boundary can be made explicit when the normal abstraction
+        is no longer enough.
+    </p>
+    <p style="margin-bottom: 0;">
+        Hardware selection should follow the workload envelope. The same investigation may conclude that a CPU,
+        accelerator, embedded target, or mixed system is the correct answer.
+    </p>
 </div>
 
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Insight</strong><br>
-        Want more FLOPs? Add more CPUs + RDMA! Get your 100 PFLOPS while your friends on the other side keep bragging about their limited GPU clusters. FLOPs is just an accumulation problem that CPUs solve through clever distributed training.
-    </div>
-</div>
+<h2>What Would Narrow or Falsify the Thesis?</h2>
 
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">∞ Infinite Scaling</h3>
-        <ul>
-            <li><strong>Internet-scale distributed computing</strong></li>
-            <li><strong>No ceiling:</strong> Add 10, 100, 1000 CPUs</li>
-            <li><strong>Your computer contributes:</strong> Every device matters</li>
-            <li><strong>Result:</strong> Unlimited FLOP accumulation</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">CPU Improvements Track</h3>
-        <ul>
-            <li><strong>Cores:</strong> Increasing year over year</li>
-            <li><strong>Cache:</strong> Growing bigger</li>
-            <li><strong>Efficiency:</strong> Getting better</li>
-            <li><strong>Cost:</strong> Decreasing over time</li>
-        </ul>
-    </div>
-</div>
+<ul>
+    <li>Communication and synchronization erase useful speedup beyond one node.</li>
+    <li>Memory bandwidth prevents acceptable latency or concurrency on the target model family.</li>
+    <li>Measured power and total cost are worse than practical alternatives under the same workload.</li>
+    <li>Maintaining numerical parity consumes more complexity than the generated runtime removes.</li>
+    <li>Scheduling, deployment, and operations overwhelm the portability benefit.</li>
+    <li>The useful workload set remains too narrow to justify distributed infrastructure.</li>
+</ul>
 
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Memory Scaling</h3>
-        <ul>
-            <li><strong>DDR5 → DDR6:</strong> 2400 GB/s → higher bandwidth</li>
-            <li><strong>Memory slots:</strong> 8 → 12 → 16 slots per node</li>
-            <li><strong>Total per node:</strong> 4TB → 8TB → 16TB RAM</li>
-            <li><strong>Cost/GB:</strong> Constantly decreasing</li>
-        </ul>
-    </div>
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Model Efficiency</h3>
-        <ul>
-            <li><strong>Smaller models:</strong> Getting more efficient</li>
-            <li><strong>Better quantization:</strong> Q4, Q8, hybrid methods</li>
-            <li><strong>Architecture improvements:</strong> MoE, mixture of experts</li>
-            <li><strong>Training optimization:</strong> Better algorithms</li>
-        </ul>
-    </div>
-</div>
+<p>
+    Negative results are useful. They identify where CPU execution is practical, where a different architecture is
+    required, and which CKE abstractions survive contact with real systems.
+</p>
 
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The C-Kernel Engine Goal</h3>
-    <p>Exploit this infinite CPU scaling on server-grade CPUs. As models get smaller and CPUs get more powerful, the combination becomes unbeatable:</p>
-    <ul>
-        <li><strong>No GPU dependency:</strong> Commodity hardware only</li>
-        <li><strong>Accessible to everyone:</strong> Your laptop contributes to the cluster</li>
-        <li><strong>Sustainable scaling:</strong> Economics favor CPU-only approach</li>
-        <li><strong>Future-proof:</strong> CPU improvements continue while GPU costs stay high</li>
-    </ul>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Multi-Model Parallelism: Enterprise Real Workload</h3>
-    <p>Unlike GPUs which are designed for single-model throughput, CPUs excel at running <strong>multiple models simultaneously</strong> on the same system.</p>
-</div>
-
-<h2>Enterprise & Government: The Multi-Model Reality</h2>
+<h2>Current Evidence Boundary</h2>
 
 <div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
+    <div class="alert-icon">!</div>
     <div>
-        <strong>The Real Enterprise Scenario</strong><br>
-        In government ministries, large enterprises, and multi-department organizations, different teams need to run different models simultaneously. This is where GPUs become a nightmare.
+        CKE currently demonstrates model-specific single-node CPU inference and selected embedded paths. Numerical
+        parity, multimodal execution, training contracts, and performance coverage continue to be hardened.
+        Multi-node execution, distributed efficiency, and distributed training are roadmap items until reproducible
+        measurements are published. This page states the experiment, not its predetermined outcome.
     </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card">
-        <h3 style="margin-top: 0;">Government Ministry Example</h3>
-        <ul>
-            <li><strong>Health Dept:</strong> Medical document analysis model</li>
-            <li><strong>Finance Dept:</strong> Fraud detection model</li>
-            <li><strong>Education Dept:</strong> Student assessment model</li>
-            <li><strong>Transport Dept:</strong> Traffic prediction model</li>
-            <li><strong>HR Dept:</strong> Resume screening model</li>
-            <li><strong>Legal Dept:</strong> Contract analysis model</li>
-        </ul>
-        <p><strong>Reality:</strong> 6 departments, 6 different models, all need to run simultaneously.</p>
-    </div>
-    <div class="card">
-        <h3 style="margin-top: 0;">Enterprise Example</h3>
-        <ul>
-            <li><strong>Sales:</strong> Lead scoring + CRM assistant</li>
-            <li><strong>Support:</strong> Customer chatbot + ticket routing</li>
-            <li><strong>Engineering:</strong> Code review + documentation</li>
-            <li><strong>Marketing:</strong> Content generation + analytics</li>
-            <li><strong>Security:</strong> Threat detection + log analysis</li>
-            <li><strong>Finance:</strong> Expense analysis + forecasting</li>
-        </ul>
-        <p><strong>Reality:</strong> Each department has specialized models for their domain.</p>
-    </div>
-</div>
-
-<h3>The GPU Context-Switching Nightmare</h3>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">GPU Model Switching: Slow and Expensive</h3>
-    <pre>
-GPU Workflow for Multi-Model Serving:
-  1. Load Model A weights into VRAM (80GB)     → 30-60 seconds
-  2. Run inference for Department A            → fast
-  3. Unload Model A from VRAM                  → 10 seconds
-  4. Load Model B weights into VRAM            → 30-60 seconds
-  5. Run inference for Department B            → fast
-  6. Repeat for each model...
-
-Problem: Each context switch = 40-70 seconds of GPU sitting idle!
-With 6 departments cycling through: most of the time is loading/unloading.
-    </pre>
-</div>
-
-<div class="grid grid-2">
-    <div class="card" style="border-left: 4px solid #ff6b6b;">
-        <h3 style="margin-top: 0;">GPU Multi-Model Issues</h3>
-        <ul>
-            <li><strong>VRAM limit:</strong> 80GB can only hold 1-2 large models</li>
-            <li><strong>Context switching:</strong> Load/unload weights takes 30-60s per model</li>
-            <li><strong>No sharing:</strong> GPU can't easily share between containers</li>
-            <li><strong>MIG complexity:</strong> Multi-Instance GPU splits VRAM, reduces per-model capacity</li>
-            <li><strong>Kubernetes pain:</strong> GPU scheduling requires special plugins, node affinity</li>
-            <li><strong>Cost:</strong> Need dedicated GPU per department = $40K × 6 = $240K</li>
-        </ul>
-    </div>
-    <div class="card" style="border-left: 4px solid #47b475;">
-        <h3 style="margin-top: 0;">CPU Multi-Model Solution</h3>
-        <ul>
-            <li><strong>RAM abundance:</strong> 4TB holds ALL models simultaneously</li>
-            <li><strong>No context switching:</strong> All models resident in RAM, instant access</li>
-            <li><strong>Native sharing:</strong> Standard Linux process isolation works</li>
-            <li><strong>Docker native:</strong> Just containers, no special GPU passthrough</li>
-            <li><strong>Kubernetes native:</strong> Standard pod scheduling, no GPU plugins</li>
-            <li><strong>Cost:</strong> One $60K server runs all 6 departments</li>
-        </ul>
-    </div>
-</div>
-
-<h3>Kubernetes & Docker: CPUs Are First-Class Citizens</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">The Container Orchestration Reality</h3>
-    <pre>
-GPU Kubernetes Deployment:
-  - Install NVIDIA device plugin
-  - Configure GPU node pools
-  - Set resource limits: nvidia.com/gpu: 1
-  - Deal with GPU memory fragmentation
-  - Handle driver version mismatches
-  - Manage MIG partitioning (if sharing)
-  - Debug CUDA OOM errors in production
-
-CPU Kubernetes Deployment:
-  - Just deploy your container
-  - Set resource limits: cpu: "32", memory: "64Gi"
-  - Done. Standard k8s scheduling handles the rest.
-    </pre>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">CPU Multi-Model Architecture</h3>
-    <pre>
-┌─────────────────────────────────────────────────────────────────┐
-│                    Single CPU Server (4TB RAM)                   │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
-│  │ Container 1  │  │ Container 2  │  │ Container 3  │           │
-│  │ Health Model │  │ Finance Model│  │ Education    │           │
-│  │ 70B (140GB)  │  │ 13B (26GB)   │  │ 7B (14GB)    │           │
-│  │ 32 cores     │  │ 16 cores     │  │ 8 cores      │           │
-│  └──────────────┘  └──────────────┘  └──────────────┘           │
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
-│  │ Container 4  │  │ Container 5  │  │ Container 6  │           │
-│  │ Transport    │  │ HR Model     │  │ Legal Model  │           │
-│  │ 7B (14GB)    │  │ 3B (6GB)     │  │ 13B (26GB)   │           │
-│  │ 8 cores      │  │ 4 cores      │  │ 16 cores     │           │
-│  └──────────────┘  └──────────────┘  └──────────────┘           │
-│                                                                  │
-│  Total: 226GB used / 4TB available = 5.6% RAM utilization       │
-│  All 6 models running simultaneously, no context switching      │
-└─────────────────────────────────────────────────────────────────┘
-    </pre>
-    <p><strong>Key insight:</strong> 6 models totaling 226GB fit easily in 4TB RAM. All running 24/7, no loading/unloading, instant response for any department.</p>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>Enterprise Reality Check</strong><br>
-        Most enterprise/government deployments need to run 5-20 different models for different use cases. CPUs handle this natively with standard containers. GPUs require expensive, complex multi-GPU setups with painful orchestration. This alone makes CPUs the practical choice for most real-world deployments.
-    </div>
-</div>
-
-<h2>CPU-Only: Complete Solution for All Model Sizes</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">One Architecture, All Scales</h3>
-    <p>CPU-only isn't just for large models. It's the complete solution for <strong>every model size</strong>, for <strong>both training and inference</strong>.</p>
-</div>
-
-<div class="grid grid-3">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Small Models (1-7B)</h3>
-        <ul>
-            <li><strong>Training:</strong> Single CPU server</li>
-            <li><strong>Inference:</strong> Laptop or edge device</li>
-            <li><strong>Latency:</strong> Sub-millisecond</li>
-            <li><strong>Cost:</strong> < $100/month</li>
-        </ul>
-        <p><strong>Use cases:</strong> Chatbots, code completion, mobile AI</p>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Medium Models (7-70B)</h3>
-        <ul>
-            <li><strong>Training:</strong> 2-8 CPU servers</li>
-            <li><strong>Inference:</strong> Single CPU server</li>
-            <li><strong>Throughput:</strong> High batch processing</li>
-            <li><strong>Cost:</strong> $500-2000/month</li>
-        </ul>
-        <p><strong>Use cases:</strong> Enterprise AI, content generation, analysis</p>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Large Models (70B+)</h3>
-        <ul>
-            <li><strong>Training:</strong> 10-100 CPU servers</li>
-            <li><strong>Inference:</strong> 2-20 CPU servers</li>
-            <li><strong>Scale:</strong> Distributed across RDMA</li>
-            <li><strong>Cost:</strong> $5000-50000/month</li>
-        </ul>
-        <p><strong>Use cases:</strong> Foundation models, research, large-scale analytics</p>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Unified Approach</strong><br>
-        Same CPU-only architecture scales from your laptop (1B model) to global clusters (1T+ parameters). No architecture changes, no GPU lock-in, no complexity multiplication.
-    </div>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Training at Every Scale</h3>
-        <ul>
-            <li><strong>Small:</strong> Fine-tune on laptop (1-7B)</li>
-            <li><strong>Medium:</strong> Train on workstation (7-70B)</li>
-            <li><strong>Large:</strong> Distributed training (70B+)</li>
-            <li><strong>Methodology:</strong> Same principles, same tools</li>
-        </ul>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">Inference at Every Scale</h3>
-        <ul>
-            <li><strong>Small:</strong> Edge deployment (1-7B)</li>
-            <li><strong>Medium:</strong> Server deployment (7-70B)</li>
-            <li><strong>Large:</strong> Distributed inference (70B+)</li>
-            <li><strong>Performance:</strong> Optimized for each tier</li>
-        </ul>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">Why This Matters</h3>
-    <p>Organizations can start small and scale infinitely without ever switching architectures:</p>
-    <ol>
-        <li><strong>Start:</strong> Train small model on laptop (fine-tuning)</li>
-        <li><strong>Grow:</strong> Move to server as model size increases</li>
-        <li><strong>Scale:</strong> Add more servers when needed (distributed training)</li>
-        <li><strong>Enterprise:</strong> Run multiple models on same hardware</li>
-    </ol>
-    <p><strong>No lock-in. No architecture migrations. No GPU dependency. Just scale as you grow.</strong></p>
-</div>
-
-<h2>Memory Reality: What NVIDIA Marketing Won't Tell You</h2>
-
-<div class="alert alert-warning">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>The Hidden Truth About LLM Memory</strong><br>
-        GPU marketing focuses on FLOPS. Real-world LLM inference is dominated by <strong>memory bandwidth and capacity</strong>. Here are the actual numbers.
-    </div>
-</div>
-
-<h3>Activation Memory Per Token (Decode)</h3>
-
-<div class="card">
-    <h4 style="margin-top: 0;">Memory Writes Per Token</h4>
-    <p>For a typical 0.5B parameter model (hidden=896, intermediate=4864, 24 layers):</p>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Operation</th><th>Per Layer</th><th>24 Layers</th></tr>
-            </thead>
-            <tbody>
-                <tr><td>RMSNorm output</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>Q, K, V projections</td><td>10.5 KB</td><td>252 KB</td></tr>
-                <tr><td>Attention output</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>O projection</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>MLP gate + up</td><td>38 KB</td><td>912 KB</td></tr>
-                <tr><td>MLP down</td><td>3.5 KB</td><td>84 KB</td></tr>
-                <tr><td>KV cache (new token)</td><td>1 KB</td><td>24 KB</td></tr>
-                <tr><td>Final logits (once)</td><td>-</td><td>600 KB</td></tr>
-                <tr style="font-weight: bold; background: rgba(255,180,0,0.1);"><td>Total per token</td><td>~63 KB</td><td>~2.1 MB</td></tr>
-            </tbody>
-        </table>
-    </div>
-    <p style="color: #888; font-size: 0.9em;">This is memory bandwidth consumed per generated token. Reducing this is key for decode performance.</p>
-</div>
-
-<div class="alert alert-info">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-    </div>
-    <div>
-        <strong>Real-world profile (0.6B model, Q8_0 quantization, AVX-only CPU):</strong> decode time is dominated by memory-moving kernels --
-        ~48% MLP (gate/up + down), ~21% logits, ~29% attention projections (q/k/v + out), and ~2% attention core. This matches the
-        bandwidth thesis: most time is spent streaming weights/activations, not math.
-    </div>
-</div>
-
-<h3>Context Length: The Memory Multiplier</h3>
-
-<div class="card card-accent">
-    <h4 style="margin-top: 0;">KV Cache Formula</h4>
-    <pre>KV Cache = 2 × n_layers × n_kv_heads × head_dim × context_length × bytes_per_element
-           ↑
-         (K and V)</pre>
-</div>
-
-<div class="table-container">
-    <table>
-        <thead>
-            <tr><th>Context</th><th>KV Cache (FP16)</th><th>+ Model (140GB)</th><th>Fits 80GB GPU?</th><th>Fits 2TB Server?</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>8K</td>
-                <td>2.6 GB</td>
-                <td>143 GB</td>
-                <td style="color: #ff6b6b;">No (need 2×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-            <tr>
-                <td>32K</td>
-                <td>10 GB</td>
-                <td>150 GB</td>
-                <td style="color: #ff6b6b;">No (need 2×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-            <tr>
-                <td>128K</td>
-                <td>41 GB</td>
-                <td>181 GB</td>
-                <td style="color: #ff6b6b;">No (need 3×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-            <tr>
-                <td>1M</td>
-                <td>320 GB</td>
-                <td>460 GB</td>
-                <td style="color: #ff6b6b;">No (need 6×)</td>
-                <td style="color: #47b475;">Yes</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-
-<details style="margin: 20px 0; background: #1a1a2e; border-radius: 8px; border: 1px solid #333;">
-    <summary style="padding: 15px 20px; cursor: pointer; font-weight: bold; color: #fbbf24;">
-        📐 Show the Math: How We Calculated This
-    </summary>
-    <div style="padding: 0 20px 20px 20px;">
-        <h4 style="color: #4ade80; margin-top: 15px;">Model Architecture (70B Dense Model)</h4>
-        <div class="table-container">
-            <table>
-                <thead>
-                    <tr><th>Parameter</th><th>Value</th><th>Explanation</th></tr>
-                </thead>
-                <tbody>
-                    <tr><td><code>n_layers</code></td><td>80</td><td>Number of transformer layers</td></tr>
-                    <tr><td><code>n_attention_heads</code></td><td>64</td><td>Query heads per layer</td></tr>
-                    <tr><td><code>n_kv_heads</code></td><td>8</td><td>KV heads (GQA: 8 groups, each serves 8 Q heads)</td></tr>
-                    <tr><td><code>hidden_dim</code></td><td>8192</td><td>Model hidden dimension</td></tr>
-                    <tr><td><code>head_dim</code></td><td>128</td><td>= hidden_dim / n_attention_heads = 8192/64</td></tr>
-                </tbody>
-            </table>
-        </div>
-
-        <h4 style="color: #4ade80;">Step 1: KV Cache Per Token</h4>
-        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
-<span style="color: #888;">// FP16 = 2 bytes per element</span>
-KV_per_token = 2 × n_layers × n_kv_heads × head_dim × bytes
-             = 2 × 80 × 8 × 128 × 2
-             = 327,680 bytes
-             = <span style="color: #4ade80; font-weight: bold;">320 KB per token</span></pre>
-
-        <h4 style="color: #4ade80;">Step 2: Scale by Context Length</h4>
-        <div class="table-container">
-            <table>
-                <thead>
-                    <tr><th>Context</th><th>Calculation</th><th>KV Cache</th></tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>8K</td>
-                        <td><code>8,192 × 320 KB</code></td>
-                        <td>2.62 GB</td>
-                    </tr>
-                    <tr>
-                        <td>32K</td>
-                        <td><code>32,768 × 320 KB</code></td>
-                        <td>10.5 GB</td>
-                    </tr>
-                    <tr>
-                        <td>128K</td>
-                        <td><code>131,072 × 320 KB</code></td>
-                        <td>41.9 GB</td>
-                    </tr>
-                    <tr>
-                        <td>1M</td>
-                        <td><code>1,048,576 × 320 KB</code></td>
-                        <td>335 GB</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-
-        <h4 style="color: #4ade80;">Step 3: Add Model Weights</h4>
-        <pre style="background: #0f0f1a; padding: 15px; border-radius: 6px; overflow-x: auto;">
-Model weights (70B params × 2 bytes FP16) = <span style="color: #fbbf24; font-weight: bold;">140 GB</span>
-
-Total Memory = Model Weights + KV Cache
-  8K context:   140 + 2.6  = 143 GB  → need 2× 80GB GPUs
-  32K context:  140 + 10.5 = 150 GB  → need 2× 80GB GPUs
-  128K context: 140 + 42   = 182 GB  → need 3× 80GB GPUs
-  1M context:   140 + 335  = 475 GB  → need 6× 80GB GPUs</pre>
-
-        <h4 style="color: #4ade80;">Why GQA Matters</h4>
-        <p style="color: #a0a0b0;">Grouped Query Attention (GQA) reduces KV cache by sharing KV heads across Q heads:</p>
-        <div class="table-container">
-            <table>
-                <thead>
-                    <tr><th>Attention Type</th><th>KV Heads</th><th>KV per Token</th><th>128K KV Cache</th></tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Multi-Head (MHA)</td>
-                        <td>64</td>
-                        <td>2.56 MB</td>
-                        <td style="color: #ff6b6b;">335 GB</td>
-                    </tr>
-                    <tr>
-                        <td>Grouped Query (GQA-8)</td>
-                        <td>8</td>
-                        <td>320 KB</td>
-                        <td style="color: #4ade80;">42 GB</td>
-                    </tr>
-                    <tr>
-                        <td>Multi-Query (MQA)</td>
-                        <td>1</td>
-                        <td>40 KB</td>
-                        <td style="color: #4ade80;">5.2 GB</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <p style="color: #888; font-size: 0.9em;">GQA-8 gives 8× memory savings over MHA with minimal quality loss.</p>
-    </div>
-</details>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>The Long Context Reality</strong><br>
-        70B model + 1M context needs ~475 GB. That's 6× 80GB GPUs (&#36;240K+) vs one 2TB CPU server (&#36;30K). This isn't about FLOPS - it's about <strong>where the data can physically exist</strong>.
-    </div>
-</div>
-
-<h3>Prefill Memory Scaling</h3>
-
-<div class="card">
-    <p>Prefill (processing the input prompt) requires storing activations for ALL tokens simultaneously:</p>
-    <div class="table-container">
-        <table>
-            <thead>
-                <tr><th>Prefill Length</th><th>Activation Memory</th><th>+ KV Cache</th></tr>
-            </thead>
-            <tbody>
-                <tr><td>256 tokens</td><td>~400 MB</td><td>~6 MB</td></tr>
-                <tr><td>1K tokens</td><td>~1.5 GB</td><td>~24 MB</td></tr>
-                <tr><td>4K tokens</td><td>~6 GB</td><td>~96 MB</td></tr>
-                <tr><td>16K tokens</td><td>~24 GB</td><td>~384 MB</td></tr>
-            </tbody>
-        </table>
-    </div>
-    <p style="color: #888; font-size: 0.9em;">Prefill is compute-bound but still needs memory for activations. Long prompts can exceed GPU VRAM.</p>
-</div>
-
-<h3>Visual Guide</h3>
-
-<div class="card" style="max-width: 800px;">
-    <h4 style="margin-top: 0;">Memory Reality Infographic</h4>
-    <p>GPU vs CPU memory comparison for LLM inference:</p>
-    <a href="assets/memory-reality-infographic.svg" target="_blank">
-        <img src="assets/memory-reality-infographic.svg" alt="Memory Reality - GPU vs CPU comparison showing memory capacity, 70B model fit analysis, and cost comparison" style="width: 100%; border-radius: 8px; border: 1px solid #333;">
-    </a>
-    <p style="font-size: 0.9em; color: #888; margin-top: 8px;">Click to view full size</p>
-</div>
-
-<h2>Training Advantages: Where CPUs Dominate</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">Critical Training Scenarios</h3>
-    <p>CPU-only architecture solves training problems that GPU-only simply can't handle.</p>
-</div>
-
-<div class="grid grid-2">
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">1. Long Context Training: KV Cache Explosion</h3>
-        <p><strong>The Problem:</strong> Long context windows create quadratic KV cache growth</p>
-        <ul>
-            <li><strong>4K context:</strong> ~32GB KV cache</li>
-            <li><strong>32K context:</strong> ~256GB KV cache</li>
-            <li><strong>128K context:</strong> ~4TB KV cache</li>
-            <li><strong>1M context:</strong> ~128TB KV cache</li>
-        </ul>
-        <p><strong>CPU Advantage:</strong></p>
-        <ul>
-            <li><strong>4-16TB RAM:</strong> Fits massive KV caches</li>
-            <li><strong>No transfer bottleneck:</strong> Everything in memory</li>
-            <li><strong>GPU Reality:</strong> KV cache doesn't fit = can't train</li>
-        </ul>
-        <div class="alert alert-warning">
-            <strong>Result:</strong> GPU training hits memory wall at 32K context. CPUs handle 1M+ context natively.
-        </div>
-    </div>
-
-    <div class="card card-green">
-        <h3 style="margin-top: 0;">2. Massive Batch Training</h3>
-        <p><strong>The Need:</strong> Large batch sizes improve convergence and throughput</p>
-        <ul>
-            <li><strong>Standard batch:</strong> 32-128 samples</li>
-            <li><strong>Large batch:</strong> 512-2048 samples</li>
-            <li><strong>Massive batch:</strong> 8192+ samples</li>
-            <li><strong>Enterprise batch:</strong> 100K+ samples</li>
-        </ul>
-        <p><strong>CPU Scaling Strategy:</strong></p>
-        <ul>
-            <li><strong>32 CPUs:</strong> 32 batches in parallel</li>
-            <li><strong>Each batch:</strong> 1-10TB RAM available</li>
-            <li><strong>Total effective batch:</strong> 32x larger</li>
-            <li><strong>No communication overhead:</strong> Each CPU independent</li>
-        </ul>
-        <div class="alert alert-success">
-            <strong>Result:</strong> Scale to any batch size by adding more CPUs. No GPU memory constraints!
-        </div>
-    </div>
-</div>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">The Training Reality Check</h3>
-    <div class="grid grid-2">
-        <div>
-            <h4>GPU Training Limits</h4>
-            <ul>
-                <li>❌ KV cache fits → max context ~32K</li>
-                <li>❌ Batch size limited by VRAM</li>
-                <li>❌ Large batches require model parallelism</li>
-                <li>❌ Complex coordination across GPUs</li>
-                <li>❌ Expensive hardware (NVLink required)</li>
-            </ul>
-        </div>
-        <div>
-            <h4>CPU Training Advantages</h4>
-            <ul>
-                <li>✅ KV cache fits → context up to 1M+</li>
-                <li>✅ Batch size scales with CPUs</li>
-                <li>✅ Data parallelism = simple scaling</li>
-                <li>✅ RDMA for necessary communication</li>
-                <li>✅ Commodity hardware (Ethernet)</li>
-            </ul>
-        </div>
-    </div>
-</div>
-
-<div class="alert alert-success">
-    <div class="alert-icon">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 13"></polyline></svg>
-    </div>
-    <div>
-        <strong>Why This Matters</strong><br>
-        Real-world training needs long context (RAG, document analysis) and large batches (throughput, convergence). CPU-only architecture handles both naturally. GPU-only hits walls that require expensive workarounds.
-    </div>
-</div>
-
-<h2>Distributed Architecture</h2>
-
-<div class="card card-accent">
-    <h3 style="margin-top: 0;">RDMA-Connected CPU Cluster</h3>
-    <pre>
-┌─────────────────────────────────────────────────────────────────┐
-│                     RDMA Fabric (100Gbps+)                      │
-├─────────────────┬─────────────────┬─────────────────────────────┤
-│                 │                 │                             │
-▼                 ▼                 ▼                             │
-┌─────────┐   ┌─────────┐   ┌─────────┐                          │
-│ Node 0  │   │ Node 1  │   │ Node 2  │  ...  Node N             │
-│ 128 cores│   │ 128 cores│   │ 128 cores│                        │
-│ 2TB RAM │   │ 2TB RAM │   │ 2TB RAM │                          │
-│         │   │         │   │         │                          │
-│ Layers  │   │ Layers  │   │ Layers  │                          │
-│ 0-15    │   │ 16-31   │   │ 32-47   │                          │
-└─────────┘   └─────────┘   └─────────┘                          │
-    </pre>
-</div>
-
-<h3>Parallelism Strategies</h3>
-
-<div class="card">
-    <h3 style="margin-top: 0;">1. Pipeline Parallelism</h3>
-    <p>Different layers on different nodes. Activations flow through the pipeline.</p>
-    <pre>Node 0: Layers 0-15   →  activations  →  Node 1: Layers 16-31  →  ...
-        (forward)           (RDMA)              (forward)</pre>
-    <p><strong>Communication:</strong> Send activations between pipeline stages via RDMA.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">2. Tensor Parallelism</h3>
-    <p>Large matrices split across nodes. Each node computes a shard.</p>
-    <pre>// 16384 x 16384 weight matrix split across 4 nodes
-Node 0: W[0:4096, :]      // Shard 0
-Node 1: W[4096:8192, :]   // Shard 1
-Node 2: W[8192:12288, :]  // Shard 2
-Node 3: W[12288:16384, :] // Shard 3
-
-// After local GEMM, all-reduce to combine</pre>
-    <p><strong>Communication:</strong> RDMA all-reduce after each sharded operation.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">3. Data Parallelism</h3>
-    <p>Same model replicated. Different batches. Gradient averaging.</p>
-    <pre>Node 0: Model copy, Batch 0  →  gradients  ─┐
-Node 1: Model copy, Batch 1  →  gradients  ─┼→  All-reduce  →  Update all
-Node 2: Model copy, Batch 2  →  gradients  ─┤
-Node 3: Model copy, Batch 3  →  gradients  ─┘</pre>
-</div>
-
-<h2>RDMA: The Key Enabler</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Why RDMA?</h3>
-    <p><strong>Remote Direct Memory Access</strong> - Zero-copy, kernel-bypass networking.</p>
-    <div class="table-container">
-        <table class="table">
-        <thead>
-            <tr><th>Metric</th><th>TCP/IP</th><th>RDMA</th></tr>
-        </thead>
-        <tbody>
-            <tr><td>Latency</td><td>~50-100 μs</td><td>~1-2 μs</td></tr>
-            <tr><td>Bandwidth</td><td>10-25 Gbps</td><td>100-400 Gbps</td></tr>
-            <tr><td>CPU overhead</td><td>High (kernel, copies)</td><td>Near zero</td></tr>
-            <tr><td>Memory copies</td><td>Multiple</td><td>Zero (DMA)</td></tr>
-        </tbody>
-    </table>
-    </div>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">RDMA Primitives We Need</h3>
-    <pre>// One-sided operations (no remote CPU involvement)
-rdma_write(remote_addr, local_buf, size);  // Write to remote memory
-rdma_read(local_buf, remote_addr, size);   // Read from remote memory
-
-// Collective operations (built on one-sided)
-rdma_allreduce(buf, size, SUM);  // Gradient averaging
-rdma_broadcast(buf, size, root); // Weight distribution
-rdma_barrier();                   // Synchronization</pre>
-</div>
-
-<h2>Implementation Roadmap</h2>
-
-<div class="card">
-    <div class="table-container">
-        <table class="table">
-        <thead>
-            <tr><th>Phase</th><th>Feature</th><th>Status</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>1</td>
-                <td>Single-node training (current)</td>
-                <td><span class="badge badge-green">Done</span></td>
-            </tr>
-            <tr>
-                <td>2</td>
-                <td>Multi-core parallelism (OpenMP)</td>
-                <td><span class="badge badge-green">Done</span></td>
-            </tr>
-            <tr>
-                <td>3</td>
-                <td>RDMA communication primitives</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>4</td>
-                <td>Pipeline parallelism</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>5</td>
-                <td>Tensor parallelism (sharded GEMM)</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>6</td>
-                <td>Encoder + cross-attention</td>
-                <td><span class="badge badge-orange">Planned</span></td>
-            </tr>
-            <tr>
-                <td>7</td>
-                <td>600B+ training</td>
-                <td><span class="badge" style="background:#666;color:#ccc;">Future</span></td>
-            </tr>
-        </tbody>
-    </table>
-    </div>
-</div>
-
-<h2>The Math Doesn't Change</h2>
-
-<div class="card card-green">
-    <h3 style="margin-top: 0;">From Tiny to Massive: Same Operations</h3>
-    <pre>
-Forward pass (any size model):
-1. embed_tokens()           // Lookup: tokens → vectors
-2. for each layer:
-   a. rmsnorm()             // Normalize
-   b. linear() × 3          // Q, K, V projections
-   c. rope()                // Rotary embeddings
-   d. attention()           // Softmax(QK^T)V
-   e. linear()              // Output projection
-   f. residual_add()        // Skip connection
-   g. rmsnorm()             // Normalize
-   h. mlp_swiglu()          // FFN with gating
-   i. residual_add()        // Skip connection
-3. rmsnorm()                // Final norm
-4. lm_head()                // Logits
-
-Backward pass: Same operations in reverse.
-SGD: weights -= lr * gradients
-
-That's it. For any model size.
-    </pre>
-</div>
-
-<h2>Hardware Recommendations</h2>
-
-<div class="card">
-    <h3 style="margin-top: 0;">For Different Scales</h3>
-    <div class="table-container">
-        <table class="table">
-        <thead>
-            <tr><th>Model Size</th><th>Recommended Setup</th></tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>< 7B</td>
-                <td>Single server, 32+ cores, 128GB+ RAM</td>
-            </tr>
-            <tr>
-                <td>7B - 70B</td>
-                <td>Single server, 128 cores, 512GB-2TB RAM</td>
-            </tr>
-            <tr>
-                <td>70B - 200B</td>
-                <td>2-4 nodes, RDMA interconnect, 2TB RAM each</td>
-            </tr>
-            <tr>
-                <td>200B - 600B</td>
-                <td>8-16 nodes, 100Gbps+ RDMA fabric</td>
-            </tr>
-            <tr>
-                <td>600B+</td>
-                <td>32+ nodes, 400Gbps RDMA, pipeline + tensor parallel</td>
-            </tr>
-        </tbody>
-    </table>
-    </div>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">Recommended CPUs by Instruction Set</h3>
-    <ul>
-        <li><strong>AMD EPYC 9004/9005 (Genoa/Turin)</strong> - Up to 192 cores, AVX-512 (512-bit), 12-channel DDR5</li>
-        <li><strong>Intel Xeon Sapphire Rapids/Granite Rapids</strong> - Up to 128 cores, AVX-512 + AMX (512-bit tile)</li>
-        <li><strong>Ampere Altra Max</strong> - 128 ARM cores, NEON (128-bit), good perf/watt</li>
-        <li><strong>AWS Graviton3/4</strong> - Cost-effective ARM, NEON + SVE2</li>
-    </ul>
-    <p><strong>Minimum requirement:</strong> AVX (256-bit) or NEON (128-bit). For best performance, AVX-512 or AMX.</p>
-</div>
-
-<div class="card">
-    <h3 style="margin-top: 0;">RDMA Options</h3>
-    <ul>
-        <li><strong>Mellanox/NVIDIA ConnectX-7</strong> - 400Gbps InfiniBand</li>
-        <li><strong>Intel E810</strong> - 100Gbps RoCE (RDMA over Ethernet)</li>
-        <li><strong>AWS EFA</strong> - Cloud RDMA for EC2 instances</li>
-    </ul>
-</div>
-
-<h2>Why Not GPU?</h2>
-
-<div class="card">
-    <blockquote style="border-left: 4px solid var(--orange); padding-left: 1rem; margin: 1rem 0; font-style: italic;">
-        "Nvidia, f**k you."<br>
-        <small>— Linus Torvalds, 2012 (<a href="https://www.youtube.com/watch?v=iYWzMvlj2RQ" target="_blank" rel="noopener" style="color: inherit;">video source</a>) regarding their closed-source Linux drivers</small>
-    </blockquote>
-    <p>Beyond the open-source concerns:</p>
-    <ul>
-        <li><strong>Cost</strong> - High-end GPU cluster = $200K+. EPYC server with 2TB RAM = $15,000</li>
-        <li><strong>Memory</strong> - 80GB VRAM vs 2TB+ system RAM</li>
-        <li><strong>Availability</strong> - Export-controlled, supply constrained vs commodity CPUs</li>
-        <li><strong>Flexibility</strong> - Run anywhere: cloud, on-prem, edge, embedded</li>
-        <li><strong>Debugging</strong> - printf works. GDB works. Valgrind works.</li>
-        <li><strong>Longevity</strong> - C code compiles forever. CUDA versions break.</li>
-    </ul>
 </div>
 
 <h2>Further Reading</h2>
 
-<ul>
-    <li><a href="memory-reality.html">Memory Reality</a> - What NVIDIA marketing won't tell you about LLM memory</li>
-    <li><a href="developer-guide.html">Developer Guide</a> - How the engine works</li>
-    <li><a href="memory-safety.html">Memory Safety</a> - Bump allocator design</li>
-    <li><a href="profiling.html">Profiling Guide</a> - Performance optimization</li>
-</ul>
-    </main>
+<div class="grid grid-2">
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="architecture.html">Architecture</a></h3>
+        <p>How circuits, contracts, GraphIR, lowering, generated C, and promotion gates fit together.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="v8-numerical-contracts.html">Numerical Contracts</a></h3>
+        <p>Why mathematically similar kernels can still produce materially different model behavior.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="profiling.html">Profiling</a></h3>
+        <p>The measurement workflow used to identify actual CPU bottlenecks.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="kernel-tuning-methodology.html">Kernel Tuning Methodology</a></h3>
+        <p>How a bottleneck moves from attribution to implementation and regression evidence.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="support-hardware.html">Support the Hardware Lab</a></h3>
+        <p>The staged hardware programme and evidence obligations attached to contributed equipment.</p>
+    </div>
+    <div class="card">
+        <h3 style="margin-top: 0;"><a href="contributing.html">Contribute</a></h3>
+        <p>Start with a bounded build, profiling, numerical, kernel, or compiler contribution.</p>
+    </div>
+</div>
     </main>
 
     <!-- SVG Viewer Overlay (shared across all pages) -->


### PR DESCRIPTION
## Why

The scaling page should retain CKE's strong bet: CPU clusters can become a practical path for frontier-model inference and, progressively, training. A small group of generation-specific accelerator figures and an invalid fleet-cost example weakened that broader argument because the hardware and market numbers age faster than the systems thesis.

## What changed

- Restored the complete original scaling page after rejecting an over-aggressive rewrite.
- Removed the `100 GPUs / $4 billion` and `80 servers / $240 million` fleet comparison and its derived `16x / 200x` claims.
- Replaced Hopper-specific H100/H200 and fixed `900 GB/s` NVLink wording with generation- and topology-aware scale-up/scale-out language.
- Preserved CPU clusters as a credible frontier-model scaling path if CKE closes kernel and communication efficiency.
- Added the model/hardware asymmetry: useful model intelligence need not grow storage as quickly as CPU cores, matrix instructions, memory channels, capacity, and bandwidth.
- Distinguished inference, where model state must be addressable but MoE may activate a sparse path, from training, where gradients, optimizer state, saved activations, and communication multiply requirements.
- Added the Google precedent: commodity processors became decisive through fleet-level scheduling, locality, fault tolerance, communication, energy, and price-performance rather than single-core superiority.
- Linked Google's original cluster architecture, MapReduce, and warehouse-scale power research.
- Regenerated the complete affected documentation output.

## Evidence

- The authoritative source remains the full scaling thesis rather than the shortened replacement.
- No source or generated-page matches remain for `100 GPUs`, `$4 Billion`, `80 servers`, `$240 Million`, `16x cheaper`, `200x more accessible`, H100/H200, NVLink 4.0, or fixed 900 GB/s NVLink claims.
- The local generated page returns HTTP 200.
- Primary Google sources support the commodity-cluster, runtime-scheduling, data-locality, fault-recovery, and power-provisioning framing.

## Validation

- `CK_SITE_SKIP_SPEC_TRAINING_REFRESH=1 bash docs/site/build.sh`
- `git diff --check`
- Source/generated stale-claim scan
- Local HTTP preview at `http://localhost:8094/scaling.html`
- Pre-commit change-metadata validation

## Regression coverage

Documentation only. No runtime, kernel, compiler, model, numerical-contract, or test behavior changes. The normal pre-push hook was bypassed because the pinned `llama.cpp` commit remains absent in the local clean worktree.

## Documentation

The authoritative source is `docs/site/_pages/scaling.html`; generated `docs/site/scaling.html` and the complete affected build output are committed together.

## Content handoff

- Audience: systems engineers, CPU/runtime contributors, hardware partners, and technical readers evaluating the CKE scaling bet.
- Angle: Google showed that commodity compute becomes decisive when software turns the fleet into the computer; CKE is testing that principle for frontier-model CPU systems.
- Claims: CPU capability and memory may improve faster than model state grows; MoE can separate total stored capacity from active inference compute; training remains harder; scale-up and scale-out topology must be measured.
- Caveats: CPU clusters are the project thesis, not a completed distributed benchmark result. Accelerator and server prices, product memory, and interconnect bandwidth vary by generation and purchase date.
- Sources: Commits `7c49083e` and `c7f024e6`; Google cluster architecture; MapReduce; Power Provisioning for a Warehouse-sized Computer; source and generated scaling pages.