### PR TITLE
fix(v8): make parity runtime provenance fail closed

### DIFF
--- a/docs/qwen3vl-parity-investigation-2026-07-14.txt
+++ b/docs/qwen3vl-parity-investigation-2026-07-14.txt
@@ -1,0 +1,191 @@
+Qwen3-VL Q4_K_M parity investigation ledger
+Date: 2026-07-14
+PR branch: fix/v8-parity-runtime-provenance
+PR base: origin/main 216440a5
+
+Purpose
+
+This file records the experiments used to distinguish real CKE numerical bugs from parity-harness, runtime-provenance, and diagnostic-mode bugs. A result is not accepted unless the exact image, prompt, model, runtime libraries, compiler, execution mode, and pre-EOS token step are recorded.
+
+Canonical workload
+
+Model: Qwen3VL-8B-Instruct-Q4_K_M GGUF decoder with Q8_0 mmproj
+Prompt: Extract visible form fields as compact JSON.
+Image policy: image_max_tokens=1024
+Context: 4096
+Temperature: 0
+Primary promotion order: 5 images, 10 images, then 40 images
+Acceptance: exact greedy top-1 equality through the bridge-declared stop token
+
+Confirmed model/runtime fixes
+
+1. Vision position interpolation evaluation order differed from the reference path.
+Resolution: match the required interpolation coordinate and FP32 evaluation order in the vision kernel and guard it with production-shape tests.
+
+2. Qwen3-VL M-RoPE width and section semantics were interpreted incorrectly in earlier paths.
+Resolution: treat rotary width as the full head dimension and sections as the axis pattern. Validate width and section combinations instead of silently skipping rotation.
+
+3. Fused Q4 gate/up SwiGLU prefill changed parity.
+Resolution: keep the path off by default until its exact numerical contract is independently validated.
+
+4. Mixed multimodal prefill was incorrectly treated as one combined batch.
+Reference execution is text_before, visual_prefix, text_after with persistent cache append and separate physical-cache and semantic M-RoPE positions.
+Resolution: represent segmented prefill in the circuit/call IR. This fixed the former sample-2 step-108 persistent-decode failure and produced 128/128 matching tokens for that sample.
+
+5. Cache position and semantic M-RoPE position are different state variables.
+Resolution: preserve and trace both values. Do not derive semantic text position from physical cache length.
+
+6. Decode attention above the reference split threshold requires an explicit FP16 online-softmax partial and FP32 merge contract.
+Resolution: expose the reduction contract explicitly and test KV lengths 511, 512, 1047, 1058, and 1609 against the local llama.cpp GGML oracle.
+
+7. Qwen3-VL Q/K decode projections require the resolved Q4_K by Q8_K numerical provider selected by the circuit and kernel map.
+Resolution: select the provider explicitly for Q/K decode rather than routing every Q4_K operation globally.
+
+Confirmed harness and diagnostic bugs
+
+8. The multi-token runner continued comparing after both runtimes emitted EOS.
+Effect: a false step-310 failure was reported after 307 valid matching tokens.
+Resolution: stop at bridge-declared stop-token metadata. Never report post-EOS divergence.
+
+9. llama.cpp reuses Qcur and Kcur tensor names for projection, normalization, and post-RoPE occurrences.
+Effect: occurrence zero, intermediate occurrence, and final occurrence were mapped to the wrong CKE semantic boundaries.
+Resolution: occurrence zero is projection, the intermediate occurrence is Q/K normalization when present, and the final occurrence is post-RoPE. Ambiguous mappings hard-fail.
+
+10. Requesting internal llama.cpp attention score/probability dumps can disable flash attention.
+Effect: production-flash logits could be compared against an unfused diagnostic graph and incorrectly attributed to a production kernel.
+Resolution: every report records decode and flash modes. Diagnostic mode changes must be labeled and incompatible arithmetic boundaries must not certify production parity.
+
+11. Direct leaf-kernel parity was treated as sufficient evidence for production dispatch.
+Effect: the direct Q4_K by Q8_K GEMV could be exact while a packed multi-row production GEMM used a different reduction order.
+Resolution: test quantization bytes, packed activation bytes, actual production invocation, and every FP32 output separately.
+
+12. The production packed Q8_K x4 activation layout was not independently checked.
+Resolution: reconstruct the packed ABI from byte-exact row blocks and compare every packed byte before testing GEMM arithmetic.
+
+13. The parity report hashed an adjacent engine library that the generated decoder did not execute.
+Evidence: generated decoder RUNPATH pointed to /tmp/cke-qwen3vl-sweep/build while the report hashed /tmp/qwen3vl-image05-selective-qk/libckernel_engine.so.
+Observed hashes:
+reported adjacent engine: 1373f662b7fd415b1147923d4dca8afeeaef3ef5dc88e8264f4b90b19b6c040c
+actually resolved build engine: f9263e730a8c95932843a9ca1ff88b327bec0b0940dded3d5283b3c0b900fdc5
+Effect: direct primitive replay was bit-exact while the model dump differed, creating a false contradiction.
+Resolution: generated runtimes use RUNPATH=$ORIGIN, copy the exact engine beside the model, include the engine hash in the build fingerprint, and verify the resolved symbol library with dladdr before inference.
+
+14. Loading an explicit engine with RTLD_GLOBAL did not guarantee that generated-model symbols resolved to it when the model had an absolute RUNPATH dependency.
+Resolution: verify a dependency symbol through the generated model handle and hard-fail when dladdr reports a different engine path.
+
+15. Decoder tokenizer loading depended on another path having already loaded libckernel_tokenizer.so globally.
+Effect: runtime success depended on process history.
+Resolution: load the adjacent tokenizer deterministically before loading the generated decoder and include its hash in runtime evidence.
+
+16. Generated-runtime build caching did not include all executed dependency provenance.
+Effect: replacing an engine could leave a decoder linked to stale runtime assumptions.
+Resolution: include compiler, source hash, engine hash, and $ORIGIN runpath policy in the build fingerprint.
+
+17. A generated tokenizer debug printf contained an unescaped newline.
+Effect: generated C emitted a missing-terminating-quote compiler warning.
+Resolution: emit an escaped newline in build_ir_v8.py and test both BPE and SentencePiece generated initialization source. Existing stale generated C files must be regenerated before the warning disappears.
+
+18. The original granular command expected a known divergence step.
+Effect: a changed runtime moved the first divergence and made a fixed --dump-step stale.
+Resolution: --dump-first-divergence observes the production run first and captures the actual first pre-EOS failure.
+
+19. Diagnostic exceptions could prevent a useful base parity report from being written.
+Resolution: persist the coarse report, attach structured diagnostic_errors, continue independent bounded diagnostics, and return a failing exit status when any requested diagnostic fails.
+
+20. /tmp quota was exhausted by duplicate 4.7 GB weight conversions.
+Effect: conversion failed with disk quota exceeded and could be mistaken for a model failure.
+Resolution: reuse exact runtime artifacts, symlink immutable weights where appropriate, remove only failed duplicate conversions, and record disk/resource failures separately from numerical failures.
+
+21. A runtime described as GCC contained both GCC and Intel oneAPI object provenance.
+Evidence: ELF .comment contained GCC 15.2.0 and Intel oneAPI 2026.0.0.
+Resolution: label it mixed-object, not pure GCC. Record compiler comments and hashes for model, engine, and tokenizer. A clean GCC build must be measured separately.
+
+22. The automatic first-divergence dump dropped the explicitly selected CK engine.
+Effect: the coarse production comparison used the requested engine, while the nested granular replay attempted to use the repository build engine. This could attribute one runtime's logits to tensors produced by another runtime.
+Detection: the new hash and dladdr checks stopped the run before tensor comparison instead of silently accepting mixed provenance.
+Resolution: preserve engine_so in runtime state, propagate it through nested replay and dump helpers, sync the exact engine beside every generated model, and hard-fail any requested/adjacent/loaded identity disagreement.
+
+Rejected or refined hypotheses
+
+23. Hypothesis: image-5 divergence was only llama.cpp tensor repacking.
+Control: llama.cpp --no-repack diverged earlier at step 60.
+Conclusion: repacking is numerically relevant but is not the only end-to-end cause.
+
+24. Hypothesis: the layer-0 attention reduction kernel was wrong.
+Natural-path observation: kqv_out max difference 2.8885901e-4 at image-5 step 116.
+Same-input replay: exact llama Q plus all 1143 FP16 K/V cache rows through CKE differed from llama kqv_out by only 1.4901161e-8 maximum and 3.1198238e-10 RMSE across all 4096 outputs.
+Conclusion: the attention provider is correct for identical inputs. The natural-path difference is amplification of an earlier input difference or use of a different loaded runtime.
+
+25. Hypothesis: the Q8_K activation quantizer differed for the real layer-0 input.
+Experiment: use the exact real llama attn_norm vector.
+Result: CKE and llama Q8_K bytes matched exactly.
+Conclusion: the quantizer is not the first divergence for this boundary.
+
+26. Hypothesis: the Q4_K by Q8_K Q-projection primitive differed for the real weights and input.
+Experiment: run all 4096 real Q weight rows in groups of eight with identical Q8_K bytes.
+Result: CKE, llama production primitive, and llama graph Q projection matched bit-for-bit.
+Conclusion: the earlier model-dump discrepancy came from executing a different engine than the report identified, not from this primitive.
+
+27. Hypothesis: one compact eight-output FP accumulator would reproduce llama packed GEMM.
+Result: it reproduced independent GEMV order and retained the packed GEMM mismatch.
+Conclusion: the remaining packed-GEMM difference is in packed integer traversal/evaluation order. The experiment was removed.
+
+28. Hypothesis: a generic llama wrapper could directly expose the required packed primitive without ABI work.
+Result: the temporary wrapper returned invalid zero output.
+Conclusion: wrapper was removed; no result was accepted.
+
+Current exact evidence
+
+Synthetic and shape-specific FP16 split-KV attention oracle: 22/22 pass.
+Layer-0 attn_norm at image-5 step 116: 4096/4096 values bit-exact.
+Real layer-0 Q8_K quantization: byte-exact.
+Real layer-0 Q projection primitive: 4096/4096 values bit-exact.
+Real same-input attention: max difference 1.4901161e-8 across 4096 outputs.
+Packed Q4_K by packed-Q8_K production GEMM remains non-exact in the standalone gate. Example M=4,K=256: 12/32 outputs differ, maximum 2.3841858e-7. This is unresolved and must not be hidden by tolerance changes.
+
+Origin-verified image-5 rerun on 2026-07-14:
+Requested engine SHA256: 1373f662b7fd415b1147923d4dca8afeeaef3ef5dc88e8264f4b90b19b6c040c.
+Adjacent loaded engine SHA256: 1373f662b7fd415b1147923d4dca8afeeaef3ef5dc88e8264f4b90b19b6c040c.
+Generated model RUNPATH: $ORIGIN.
+First pre-EOS divergence: step 116, CKE token 12116 Have, llama.cpp token 6986 Did.
+Logit cosine: 0.9988274213. Top-16 overlap: 16/16.
+First granular failing boundary: layer-0 kqv_out, maximum absolute difference 2.8885901e-4.
+Conclusion: the runtime-provenance bug was real and is now guarded, but it did not remove this numerical divergence.
+
+Important artifact paths
+
+First-divergence report:
+/tmp/qwen3vl-image05-step119-granular/report-first.json
+
+Expanded upstream-boundary report:
+/tmp/qwen3vl-image05-step119-granular/report-upstream.json
+
+Origin-verified report after runtime-link hardening:
+/tmp/qwen3vl-image05-step119-granular/report-origin-verified.json
+
+Granular dump:
+/tmp/qwen3vl-image05-step119-granular/dump-upstream
+
+Original no-repack control:
+/tmp/qwen3vl-image05-original-norepack-128/report.json
+
+Current decoder artifacts:
+/tmp/qwen3vl-image05-step119-granular/decoder
+
+Unresolved gates
+
+1. Implement exact packed Q4_K by packed-Q8_K GEMM traversal rather than substituting independent GEMV order.
+2. Promote bounded real Q8/projection/attention fixtures through X-ray without committing private OCR data.
+3. Run focused, nightly, and rolling llama.cpp compatibility tests without relaxing tolerances.
+4. Pass 5 images, then 10, then all 40 through EOS before claiming Qwen3-VL end-to-end parity.
+
+Rules for future conclusions
+
+Do not compare checksums when every element can be compared.
+Do not call a compiler build pure when ELF provenance shows mixed objects.
+Do not trust a requested library path; verify the loaded symbol path.
+Do not compare post-EOS tokens.
+Do not compare production flash arithmetic with an unlabeled unfused dump graph.
+Do not promote a leaf-kernel result as production parity without testing the actual dispatch ABI and batch shape.
+Do not loosen numerical tolerances to make a gate green.
+Do not claim 5, 10, or 40 image parity until those sweeps have actually completed through EOS.

--- a/tests/test_v8_multitoken_eos_contract.py
+++ b/tests/test_v8_multitoken_eos_contract.py
@@ -5,6 +5,7 @@ import importlib.util
 import json
 import tempfile
 import unittest
+from array import array
 from argparse import Namespace
 from pathlib import Path
 from unittest import mock
@@ -25,6 +26,40 @@ def load_module():
 
 
 class MultitokenEOSContractTests(unittest.TestCase):
+    def test_dump_first_divergence_resolves_observed_step(self) -> None:
+        report = {"first_divergence": {"step": 60}}
+        self.assertEqual(self.runner._resolve_dump_step(report, None, True), 60)
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            self.runner._resolve_dump_step(report, 119, True)
+        with self.assertRaisesRegex(RuntimeError, "did not diverge"):
+            self.runner._resolve_dump_step({}, None, True)
+
+    def test_diagnostic_failure_preserves_coarse_report_and_continues(self) -> None:
+        report = {"status": "fail", "first_divergence": {"step": 4}}
+        args = Namespace(
+            dump_step=None,
+            dump_first_divergence=True,
+            full_replay_step=4,
+            hidden_state_step=None,
+        )
+        with mock.patch.object(
+            self.runner,
+            "_capture_step_dump",
+            side_effect=RuntimeError("wrong engine"),
+        ), mock.patch.object(
+            self.runner,
+            "_capture_full_replay_step",
+            return_value={"step": 4, "status": "ok"},
+        ):
+            passed = self.runner._run_requested_diagnostics(report, args)
+
+        self.assertFalse(passed)
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(report["full_replay_step"]["status"], "ok")
+        self.assertEqual(report["diagnostic_errors"][0]["diagnostic"], "step_dump")
+        self.assertEqual(report["diagnostic_errors"][0]["error_type"], "RuntimeError")
+        self.assertIn("wrong engine", report["diagnostic_errors"][0]["message"])
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.runner = load_module()
@@ -49,6 +84,32 @@ class MultitokenEOSContractTests(unittest.TestCase):
         self.assertFalse(self.runner._is_matched_stop_token(151645, 4, stops))
         self.assertFalse(self.runner._is_matched_stop_token(4, 4, stops))
 
+    def test_segmented_append_auto_selects_batched_oracle(self) -> None:
+        bridge = {
+            "bridge_contract": {
+                "prefill_schedule": {
+                    "segments": ["text_before", "visual", "text_after"],
+                    "cache_transition": "append_preserve",
+                }
+            }
+        }
+        result = self.runner._resolve_oracle_prefill_mode("auto", bridge)
+        self.assertEqual(result["resolved"], "batched")
+        self.assertTrue(result["compatible"])
+        self.assertEqual(result["scope"], "production")
+
+    def test_segmented_append_rejects_sequential_oracle(self) -> None:
+        bridge = {
+            "bridge_contract": {
+                "prefill_schedule": {
+                    "segments": ["text_before", "visual", "text_after"],
+                    "cache_transition": "append_preserve",
+                }
+            }
+        }
+        with self.assertRaisesRegex(RuntimeError, "HARD PARITY CONTRACT FAULT"):
+            self.runner._resolve_oracle_prefill_mode("sequential", bridge)
+
     def test_exact_runtime_reuse_loads_only_declared_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             decoder_dir = Path(tmp)
@@ -67,6 +128,10 @@ class MultitokenEOSContractTests(unittest.TestCase):
             )
             for name in ("weights.bump", "weights_manifest.map", "libdecoder_v8.so"):
                 (decoder_dir / name).touch()
+            (decoder_dir / "libdecoder_v8.so.build.json").write_text(
+                json.dumps({"compiler": {"command": "cc", "version": "gcc test"}}),
+                encoding="utf-8",
+            )
 
             runtime = self.runner._load_exact_decoder_runtime(
                 Path("decoder.gguf"),
@@ -82,8 +147,25 @@ class MultitokenEOSContractTests(unittest.TestCase):
             evidence = self.runner._runtime_evidence(runtime, exact_reuse=True)
             self.assertTrue(evidence["exact_reuse"])
             self.assertEqual(
+                evidence["shared_library"]["build"]["compiler"]["version"],
+                "gcc test",
+            )
+            self.assertEqual(
                 evidence["shared_library"]["sha256"],
                 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+
+            explicit_engine = decoder_dir / "libckernel_engine_gcc.so"
+            explicit_engine.write_bytes(b"gcc-engine")
+            evidence = self.runner._runtime_evidence(
+                runtime,
+                exact_reuse=True,
+                engine_so=explicit_engine,
+            )
+            self.assertEqual(evidence["engine_library"]["path"], str(explicit_engine.resolve()))
+            self.assertEqual(
+                evidence["engine_library"]["sha256"],
+                "a6fa04e316b06ba1c57d027077def545c4f53954cc7005713e3edffc74255ca5",
             )
 
     def test_exact_runtime_reuse_fails_instead_of_regenerating(self) -> None:
@@ -264,6 +346,48 @@ class MultitokenEOSContractTests(unittest.TestCase):
                     self.runner._capture_step_dump(report, args)
 
             capture.assert_not_called()
+
+    def test_prepare_inputs_preserves_explicit_engine_for_nested_dumps(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            engine = root / "selected-engine.so"
+            engine.write_bytes(b"selected")
+            runtime = {
+                "so_path": root / "decoder" / "libdecoder_v8.so",
+                "embed_dim": 4,
+                "input_embed_dim": 4,
+                "context_length": 32,
+            }
+            runtime["so_path"].parent.mkdir(parents=True)
+            runtime["so_path"].touch()
+            bridge_report = {
+                "decoder_runtime": {"gguf": str(root / "model.gguf")},
+                "decoder_context_len": 32,
+            }
+            args = Namespace(
+                bridge_report=root / "bridge.json",
+                workdir=root / "work",
+                reuse_bridge_decoder_runtime=False,
+                reuse_bridge_decoder_runtime_exact=False,
+                ctx_len=32,
+                prefix_f32=None,
+                prefix_row_dim=None,
+                prefix_grid_x=None,
+                prefix_grid_y=None,
+                prefix_text_pos=None,
+                ck_engine_so=engine,
+            )
+            with mock.patch.object(self.runner.first_token, "_load_bridge_report", return_value=bridge_report), \
+                 mock.patch.object(self.runner.first_token.bridge_runner_v8, "_prepare_decoder_runtime", return_value=runtime), \
+                 mock.patch.object(self.runner, "GGUFTokenizer") as tokenizer_cls, \
+                 mock.patch.object(self.runner.first_token, "_resolve_prompt_token_segments", return_value=(None, [], [], {})), \
+                 mock.patch.object(self.runner.first_token, "_load_prefix_embeddings", return_value=(array("f"), 0, 4, "none")), \
+                 mock.patch.object(self.runner.first_token.bridge_runner_v8, "_sync_runtime_engine") as sync:
+                tokenizer_cls.from_gguf.return_value = object()
+                inputs = self.runner._prepare_inputs(args)
+
+            self.assertEqual(inputs["runtime"]["engine_so"], str(engine.resolve()))
+            sync.assert_called_once_with(engine.resolve(), runtime["so_path"])
 
     def test_runner_records_eos_step_without_decoding_past_it(self) -> None:
         class Tokenizer:

--- a/tests/test_v8_native_bridge_host.py
+++ b/tests/test_v8_native_bridge_host.py
@@ -257,6 +257,34 @@ def _build_tiny_decoder_runtime(workdir: Path) -> tuple[Path, Path, Path]:
 
 
 class V8NativeBridgeHostTests(unittest.TestCase):
+    def test_decoder_execution_loads_runtime_selected_engine(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            selected = root / "selected-engine.so"
+            selected.touch()
+            runtime = {
+                "so_path": root / "libdecoder_v8.so",
+                "prefill_so_path": root / "libdecoder_v8_prefill.so",
+                "engine_so": str(selected),
+            }
+            sentinel = RuntimeError("loader reached")
+            with mock.patch.object(bridge_runner_v8, "_load_decoder_lib", side_effect=sentinel) as loader:
+                with self.assertRaisesRegex(RuntimeError, "loader reached"):
+                    bridge_runner_v8._run_decoder(runtime, array("f"), 0, [])
+            loader.assert_called_once_with(runtime["prefill_so_path"], engine_so=selected)
+
+    def test_decoder_loader_hard_fails_when_tokenizer_runtime_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            model_so = root / "libdecoder_v8.so"
+            engine_so = root / "libckernel_engine.so"
+            model_so.touch()
+            engine_so.touch()
+            with mock.patch.object(bridge_runner_v8.ctypes, "CDLL", return_value=object()):
+                with mock.patch.object(bridge_runner_v8, "BUILD_DIR", root / "missing-build"):
+                    with self.assertRaisesRegex(FileNotFoundError, "requires libckernel_tokenizer"):
+                        bridge_runner_v8._load_decoder_lib(model_so, engine_so=engine_so)
+
     def test_vision_prefix_position_policy_keeps_qwen_mrope_but_gemma_linear(self) -> None:
         self.assertEqual(
             bridge_runner_v8._vision_prefix_position_policy({"model": "qwen3_vl_vision"}),
@@ -1217,6 +1245,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 fake_decoder_gguf.resolve(),
                 workdir.resolve() / "decoder",
                 context_override=61,
+                profile=False,
             )
 
             report = json.loads((workdir / "bridge_report.json").read_text(encoding="utf-8"))
@@ -1293,13 +1322,13 @@ class V8NativeBridgeHostTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             ensure_engine.assert_called_once_with(openmp=True)
             _, decoder_kwargs = run_decoder.call_args
-            self.assertEqual(decoder_kwargs["prefix_grid"], (3, 1))
+            self.assertIsNone(decoder_kwargs["prefix_grid"])
             self.assertEqual(decoder_kwargs["prefix_text_pos"], 3)
             report = json.loads((workdir / "bridge_report.json").read_text(encoding="utf-8"))
             self.assertEqual(report["prefix_source"], "encoder")
             self.assertEqual(report["prefix_tokens"], 3)
-            self.assertEqual(report["prefix_grid_x"], 3)
-            self.assertEqual(report["prefix_grid_y"], 1)
+            self.assertIsNone(report["prefix_grid_x"])
+            self.assertIsNone(report["prefix_grid_y"])
             self.assertEqual(report["decoder_context_len"], 32)
 
     def test_run_decoder_uses_decode_runtime_for_mixed_prefix_continuation(self) -> None:
@@ -1683,6 +1712,10 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 image_mode="checker",
                 vision_top_k=7,
                 vision_activation_pref=["out_proj=q8", "mlp_down=q8"],
+                image_min_tokens=None,
+                image_max_tokens=None,
+                bridge_runtime=None,
+                bridge_generation_mode=None,
                 max_tokens=32,
                 no_chat_template=False,
                 chat_template="auto",
@@ -1753,6 +1786,10 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 image_mode="checker",
                 vision_top_k=8,
                 vision_activation_pref=[],
+                image_min_tokens=None,
+                image_max_tokens=None,
+                bridge_runtime=None,
+                bridge_generation_mode=None,
                 max_tokens=16,
                 no_chat_template=False,
                 chat_template="auto",
@@ -2217,7 +2254,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
             def fake_run_converter(path: Path, out_dir: Path, context_override: int | None = None):
                 return manifest, manifest_path, bump_path, config_path
 
-            def fake_compile_generated_model(c_src: Path, so_dst: Path) -> Path:
+            def fake_compile_generated_model(c_src: Path, so_dst: Path, *, profile: bool = False) -> Path:
                 so_dst.write_bytes(b"so")
                 return so_dst
 
@@ -2229,7 +2266,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
 
         build_ir_main.assert_not_called()
         codegen_main.assert_not_called()
-        compile_model.assert_called_once_with(c_path, so_path)
+        compile_model.assert_called_once_with(c_path, so_path, profile=False)
         self.assertEqual(runtime["embed_dim"], 1536)
         self.assertEqual(runtime["so_path"], so_path)
 
@@ -2283,7 +2320,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 c_path.write_text("/* generated */", encoding="utf-8")
                 return 0
 
-            def fake_compile_generated_model(c_src: Path, so_dst: Path) -> Path:
+            def fake_compile_generated_model(c_src: Path, so_dst: Path, *, profile: bool = False) -> Path:
                 so_dst.write_bytes(b"so")
                 return so_dst
 
@@ -2384,7 +2421,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
             def fake_run_converter(path: Path, out_dir: Path, context_override: int | None = None):
                 return manifest, manifest_path, bump_path, config_path
 
-            def fake_compile_generated_model(c_src: Path, so_dst: Path) -> Path:
+            def fake_compile_generated_model(c_src: Path, so_dst: Path, *, profile: bool = False) -> Path:
                 so_dst.write_bytes(b"so")
                 return so_dst
 
@@ -2401,8 +2438,8 @@ class V8NativeBridgeHostTests(unittest.TestCase):
         build_ir_main.assert_not_called()
         codegen_main.assert_not_called()
         self.assertEqual(compile_model.call_count, 2)
-        compile_model.assert_any_call(c_path, so_path)
-        compile_model.assert_any_call(prefill_c_path, prefill_so_path)
+        compile_model.assert_any_call(c_path, so_path, profile=False)
+        compile_model.assert_any_call(prefill_c_path, prefill_so_path, profile=False)
         self.assertEqual(runtime["embed_dim"], 4096)
         self.assertEqual(runtime["input_embed_dim"], 16384)
         self.assertEqual(runtime["vocab_size"], 151936)
@@ -2474,7 +2511,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 output_path.write_text("/* generated */", encoding="utf-8")
                 return 0
 
-            def fake_compile_generated_model(c_path: Path, so_path: Path) -> Path:
+            def fake_compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = False) -> Path:
                 so_path.parent.mkdir(parents=True, exist_ok=True)
                 so_path.write_bytes(b"so")
                 return so_path
@@ -2499,7 +2536,11 @@ class V8NativeBridgeHostTests(unittest.TestCase):
             Path(decode_codegen[0][decode_codegen[0].index("--prefill") + 1]),
             output_dir / "call_prefill.json",
         )
-        self.assertNotIn("--prefill-layout", decode_codegen[0])
+        self.assertIn("--prefill-layout", decode_codegen[0])
+        self.assertEqual(
+            Path(decode_codegen[0][decode_codegen[0].index("--prefill-layout") + 1]),
+            output_dir / "layout_prefill.json",
+        )
         self.assertEqual(runtime["embed_dim"], 4096)
         self.assertEqual(runtime["input_embed_dim"], 16384)
         self.assertEqual(runtime["vocab_size"], 151936)
@@ -2512,27 +2553,27 @@ class V8NativeBridgeHostTests(unittest.TestCase):
             stamp_path = so_path.with_suffix(so_path.suffix + ".build.json")
             c_path.write_text("/* first */", encoding="utf-8")
             so_path.write_bytes(b"so")
-            initial_hash = hashlib.sha256(c_path.read_bytes()).hexdigest()
-            stamp_path.write_text(
-                json.dumps(
-                    {
-                        "version": 1,
-                        "source_path": str(c_path.resolve()),
-                        "source_sha256": initial_hash,
-                        "source_size": c_path.stat().st_size,
-                    }
-                ),
-                encoding="utf-8",
-            )
+            def fake_run(cmd: list[str]) -> None:
+                so_path.write_bytes(b"rebuilt")
+
+            with mock.patch.object(bridge_runner_v8, "_run", side_effect=fake_run) as run_cmd:
+                bridge_runner_v8._compile_generated_model(c_path, so_path)
+                run_cmd.assert_called_once()
+                self.assertIn("-Wl,-rpath,$ORIGIN", run_cmd.call_args.args[0])
 
             with mock.patch.object(bridge_runner_v8, "_run") as run_cmd:
                 bridge_runner_v8._compile_generated_model(c_path, so_path)
-            run_cmd.assert_not_called()
+                run_cmd.assert_not_called()
+
+            initial = json.loads(stamp_path.read_text(encoding="utf-8"))
+            self.assertEqual(initial["version"], 2)
+            self.assertEqual(initial["runtime_dependency"]["runpath"], "$ORIGIN")
+            self.assertEqual(
+                initial["runtime_dependency"]["sha256"],
+                hashlib.sha256((BUILD_DIR / "libckernel_engine.so").read_bytes()).hexdigest(),
+            )
 
             c_path.write_text("/* second */", encoding="utf-8")
-
-            def fake_run(cmd: list[str]) -> None:
-                so_path.write_bytes(b"rebuilt")
 
             with mock.patch.object(bridge_runner_v8, "_run", side_effect=fake_run) as run_cmd:
                 bridge_runner_v8._compile_generated_model(c_path, so_path)

--- a/tests/test_v8_tokenizer_capability_codegen.py
+++ b/tests/test_v8_tokenizer_capability_codegen.py
@@ -28,6 +28,7 @@ class TestV8TokenizerCapabilityCodegen(unittest.TestCase):
         self.assertNotIn("CK_ENABLE_FULL_BPE_TOKENIZER", c_code)
         self.assertIn("CK_EXPORT int ck_model_can_encode_text(void)", c_code)
         self.assertIn("return (g_model && g_model->tokenizer) ? 1 : 0;", c_code)
+        self.assertIn('printf("[Tokenizer] Registered special: %s -> %d\\n",', str(generated["init"]))
 
     def test_sentencepiece_exports_text_encode_capability(self) -> None:
         generated = build_ir_v8._generate_tokenizer_c_code(
@@ -42,6 +43,7 @@ class TestV8TokenizerCapabilityCodegen(unittest.TestCase):
         self.assertIn("CK_EXPORT int ck_model_has_tokenizer(void)", c_code)
         self.assertIn("CK_EXPORT int ck_model_can_encode_text(void)", c_code)
         self.assertIn("return (g_model && g_model->tokenizer) ? 1 : 0;", c_code)
+        self.assertIn('printf("[Tokenizer] Registered special: %s -> %d\\n",', str(generated["init"]))
 
 
 if __name__ == "__main__":

--- a/version/v8/scripts/build_ir_v8.py
+++ b/version/v8/scripts/build_ir_v8.py
@@ -1551,7 +1551,7 @@ def _generate_tokenizer_c_code(tokenizer_type: str, vocab_size: int, num_merges:
                 if (check && strcmp(check, special_tokens[i]) == 0) {{
                     ck_true_bpe_add_special_token(g_model->tokenizer, special_tokens[i], id);
                     #ifdef CK_DEBUG_TOKENIZER
-                    printf("[Tokenizer] Registered special: %s -> %d\n", special_tokens[i], id);
+                    printf("[Tokenizer] Registered special: %s -> %d\\n", special_tokens[i], id);
                     #endif
                 }}
             }}

--- a/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
+++ b/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
@@ -351,16 +351,52 @@ def _load_exact_decoder_runtime(
     }
 
 
-def _runtime_evidence(runtime: dict[str, Any], *, exact_reuse: bool) -> dict[str, Any]:
+def _runtime_evidence(
+    runtime: dict[str, Any],
+    *,
+    exact_reuse: bool,
+    engine_so: Path | None = None,
+) -> dict[str, Any]:
     def describe(path_value: Any) -> dict[str, Any]:
         path = Path(path_value).resolve()
         digest = hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else None
-        return {"path": str(path), "sha256": digest}
+        result: dict[str, Any] = {"path": str(path), "sha256": digest}
+        build_path = path.with_suffix(path.suffix + ".build.json")
+        if build_path.is_file():
+            try:
+                result["build"] = json.loads(build_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                result["build_metadata_error"] = str(exc)
+        if path.is_file():
+            probe = subprocess.run(
+                ["readelf", "--string-dump=.comment", str(path)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if probe.returncode == 0:
+                comments = [
+                    line.split("]", 1)[-1].strip()
+                    for line in probe.stdout.splitlines()
+                    if "]" in line and line.split("]", 1)[-1].strip()
+                ]
+                result["elf_compiler_comments"] = comments
+            else:
+                result["elf_comment_error"] = probe.stderr.strip() or f"readelf rc={probe.returncode}"
+        return result
 
+    requested_engine = Path(engine_so or REPO_ROOT / "build" / "libckernel_engine.so").resolve()
+    runtime_engine = Path(runtime["so_path"]).resolve().parent / "libckernel_engine.so"
+    if not runtime_engine.is_file():
+        runtime_engine = requested_engine
     return {
         "exact_reuse": bool(exact_reuse),
         "shared_library": describe(runtime["so_path"]),
-        "engine_library": describe(REPO_ROOT / "build" / "libckernel_engine.so"),
+        "engine_library": describe(runtime_engine),
+        "engine_library_requested": describe(requested_engine),
+        "tokenizer_library": describe(
+            Path(runtime["so_path"]).resolve().parent / "libckernel_tokenizer.so"
+        ),
         "manifest_map": describe(runtime["manifest_map"]),
         "weights_bump_path": str(Path(runtime["weights_bump"]).resolve()),
         "context_length": int(runtime.get("context_length", 0) or 0),
@@ -453,6 +489,17 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
             parity_dump=bool(parity_dump),
             context_override=resolved_ctx_len,
         )
+
+    requested_engine = getattr(args, "ck_engine_so", None)
+    if requested_engine is not None:
+        requested_engine = Path(requested_engine).resolve()
+        first_token.bridge_runner_v8._sync_runtime_engine(
+            requested_engine, Path(runtime["so_path"])
+        )
+        # The runtime dictionary is passed through replay and granular dump
+        # helpers. Preserve the requested engine here so those nested paths
+        # cannot silently fall back to the repository build library.
+        runtime["engine_so"] = str(requested_engine)
 
     bridge_grid_x = None if bridge_report.get("prefix_grid_x") is None else int(bridge_report.get("prefix_grid_x"))
     bridge_grid_y = None if bridge_report.get("prefix_grid_y") is None else int(bridge_report.get("prefix_grid_y"))
@@ -601,6 +648,19 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
     }
 
 
+def _resolve_dump_step(
+    report: dict[str, Any], requested_step: int | None, dump_first_divergence: bool
+) -> int | None:
+    if requested_step is not None and dump_first_divergence:
+        raise ValueError("--dump-step and --dump-first-divergence are mutually exclusive")
+    if not dump_first_divergence:
+        return requested_step
+    first = report.get("first_divergence")
+    if not isinstance(first, dict) or "step" not in first:
+        raise RuntimeError("--dump-first-divergence requested, but the parity run did not diverge")
+    return int(first["step"])
+
+
 
 
 def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
@@ -641,7 +701,9 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
     capture_error: Exception | None = None
     try:
         _restore_process_env({key: None for key in env_keys})
-        lib, logits_buf, _vocab_size = _init_ck_state(inputs, bool(args.ck_strict_parity))
+        lib, logits_buf, _vocab_size = _init_ck_state(
+            inputs, bool(args.ck_strict_parity), getattr(args, "ck_engine_so", None)
+        )
         try:
             last_i = len(generated_prefix) - 1
             for i, token in enumerate(generated_prefix):
@@ -669,7 +731,9 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
         _set_process_env("CK_DEBUG_EXPORT_HIDDEN_NAMES", ",".join(replay_names))
         if layer >= 0:
             _set_process_env("CK_DEBUG_EXPORT_HIDDEN_LAYER", str(layer))
-        lib2, _logits2, _vocab2 = _init_ck_state(replay_inputs, bool(args.ck_strict_parity))
+        lib2, _logits2, _vocab2 = _init_ck_state(
+            replay_inputs, bool(args.ck_strict_parity), getattr(args, "ck_engine_so", None)
+        )
         if hasattr(lib2, "ck_model_free"):
             try:
                 lib2.ck_model_free()
@@ -775,7 +839,9 @@ def _capture_full_replay_step(report: dict[str, Any], args: argparse.Namespace) 
     llama_seq = _run_llama_greedy_sequence(inputs, llama_args)
     llama_logits = llama_seq["logits"][step_index]
 
-    lib, logits_buf, vocab_size = _init_ck_state(replay_inputs, bool(args.ck_strict_parity))
+    lib, logits_buf, vocab_size = _init_ck_state(
+        replay_inputs, bool(args.ck_strict_parity), getattr(args, "ck_engine_so", None)
+    )
     try:
         replay_logits = _ck_logits_from_buffer(logits_buf, vocab_size)
     finally:
@@ -816,7 +882,7 @@ def _capture_full_replay_step(report: dict[str, Any], args: argparse.Namespace) 
     }
 
 
-def _set_ck_strict_parity(lib: Any, strict_parity: bool) -> None:
+def _set_ck_strict_parity(lib: Any, strict_parity: bool, engine_so: Path | None = None) -> None:
     value = 1 if strict_parity else 0
     if hasattr(lib, "ck_set_strict_parity"):
         lib.ck_set_strict_parity.argtypes = [ctypes.c_int]
@@ -824,27 +890,31 @@ def _set_ck_strict_parity(lib: Any, strict_parity: bool) -> None:
         lib.ck_set_strict_parity(value)
         return
 
-    engine_so = REPO_ROOT / "build" / "libckernel_engine.so"
-    if not engine_so.exists():
+    engine_path = engine_so or REPO_ROOT / "build" / "libckernel_engine.so"
+    if not engine_path.exists():
         return
-    engine = ctypes.CDLL(str(engine_so))
+    engine = ctypes.CDLL(str(engine_path))
     if hasattr(engine, "ck_set_strict_parity"):
         engine.ck_set_strict_parity.argtypes = [ctypes.c_int]
         engine.ck_set_strict_parity.restype = None
         engine.ck_set_strict_parity(value)
 
 
-def _init_ck_state(inputs: dict[str, Any], strict_parity: bool) -> tuple[Any, Any, int]:
+def _init_ck_state(
+    inputs: dict[str, Any],
+    strict_parity: bool,
+    engine_so: Path | None = None,
+) -> tuple[Any, Any, int]:
     runtime = inputs["runtime"]
     model_so = Path(runtime["so_path"])
-    lib = first_token.bridge_runner_v8._load_decoder_lib(model_so)
+    lib = first_token.bridge_runner_v8._load_decoder_lib(model_so, engine_so=engine_so)
     rc = lib.ck_model_init_with_manifest(
         str(runtime["weights_bump"]).encode(),
         str(runtime["manifest_map"]).encode(),
     )
     if rc != 0:
         raise RuntimeError(f"decoder init failed with rc={rc}")
-    _set_ck_strict_parity(lib, strict_parity)
+    _set_ck_strict_parity(lib, strict_parity, engine_so)
 
     vocab_size = int(lib.ck_model_get_vocab_size())
     if vocab_size <= 0:
@@ -909,9 +979,18 @@ def _init_ck_state(inputs: dict[str, Any], strict_parity: bool) -> tuple[Any, An
 
 def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]:
     inputs = _prepare_inputs(args)
+    mode_contract = getattr(args, "prefill_mode_contract", None)
+    if not isinstance(mode_contract, dict):
+        mode_contract = _resolve_oracle_prefill_mode(
+            str(args.llama_decode_mode),
+            inputs["bridge_report"],
+            allow_diagnostic_mismatch=True,
+        )
     tokenizer: GGUFTokenizer = inputs["tokenizer"]
     llama_seq = _run_llama_greedy_sequence(inputs, args)
-    lib, logits_buf, vocab_size = _init_ck_state(inputs, bool(args.ck_strict_parity))
+    lib, logits_buf, vocab_size = _init_ck_state(
+        inputs, bool(args.ck_strict_parity), getattr(args, "ck_engine_so", None)
+    )
     generated: list[int] = []
     llama_generated = [int(t) for t in list((llama_seq.get("meta") or {}).get("greedy_generated", []))]
     stop_token_ids = _resolve_stop_token_ids(inputs["bridge_report"])
@@ -979,9 +1058,14 @@ def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]
             except Exception:
                 pass
 
+    production_pass = first_divergence is None and bool(mode_contract["compatible"])
     return {
-        "status": "pass" if first_divergence is None else "fail",
-        "pass": first_divergence is None,
+        "status": (
+            "pass" if production_pass else
+            "diagnostic_only" if first_divergence is None else
+            "fail"
+        ),
+        "pass": production_pass,
         "bridge_report_path": str(args.bridge_report.resolve()),
         "gguf_path": str(inputs["gguf_path"]),
         "workdir": str(inputs["workdir"]),
@@ -999,14 +1083,19 @@ def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]
             "ck_strict_parity": bool(args.ck_strict_parity),
             "llama_decode_mode": str(args.llama_decode_mode),
             "llama_tensor_repack": not bool(args.llama_no_repack),
-            "diagnostic_tensor_dump": bool(getattr(args, "dump_step", None) is not None),
+            "diagnostic_tensor_dump": bool(
+                getattr(args, "dump_step", None) is not None
+                or getattr(args, "dump_first_divergence", False)
+            ),
             "ck_environment": _ck_environment_evidence(),
+            "prefill_mode_contract": mode_contract,
         },
         "llama_greedy_generated": llama_generated,
         "append_on_divergence": str(args.append_on_divergence),
         "ck_runtime": _runtime_evidence(
             inputs["runtime"],
             exact_reuse=bool(getattr(args, "reuse_bridge_decoder_runtime_exact", False)),
+            engine_so=getattr(args, "ck_engine_so", None),
         ),
         "stop_token_ids": sorted(stop_token_ids),
         "stop_reason": stop_reason,
@@ -1038,6 +1127,83 @@ def _is_matched_stop_token(ck_token: int, llama_token: int, stop_token_ids: set[
     return ck_token == llama_token and ck_token in stop_token_ids
 
 
+def _resolve_oracle_prefill_mode(
+    requested: str,
+    bridge_report: dict[str, Any],
+    *,
+    allow_diagnostic_mismatch: bool = False,
+) -> dict[str, Any]:
+    """Fail closed when the oracle and CK execute different prefill schedules."""
+    bridge = bridge_report.get("bridge_contract")
+    bridge = bridge if isinstance(bridge, dict) else {}
+    schedule = bridge.get("prefill_schedule")
+    schedule = schedule if isinstance(schedule, dict) else {}
+    segmented_append = (
+        schedule.get("segments") == ["text_before", "visual", "text_after"]
+        and schedule.get("cache_transition") == "append_preserve"
+    )
+    required = "batched" if segmented_append else None
+    resolved = "batched" if requested == "auto" and required == "batched" else requested
+    compatible = required is None or resolved == required
+    if not compatible and not allow_diagnostic_mismatch:
+        raise RuntimeError(
+            "HARD PARITY CONTRACT FAULT: CK segmented-append prefill requires a batched "
+            f"llama.cpp oracle, but {resolved!r} was requested. Use --llama-decode-mode batched "
+            "for production parity. Sequential replay is diagnostic-only and requires "
+            "--allow-diagnostic-prefill-mode-mismatch."
+        )
+    return {
+        "requested": requested,
+        "resolved": resolved,
+        "required": required,
+        "compatible": compatible,
+        "scope": "production" if compatible else "diagnostic_only",
+    }
+
+
+def _run_requested_diagnostics(report: dict[str, Any], args: argparse.Namespace) -> bool:
+    """Run bounded diagnostics without discarding the completed coarse report."""
+    errors: list[dict[str, str]] = []
+
+    def capture(name: str, callback: Any) -> None:
+        try:
+            report[name] = callback()
+        except Exception as exc:
+            errors.append(
+                {
+                    "diagnostic": name,
+                    "error_type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            )
+
+    try:
+        args.dump_step = _resolve_dump_step(
+            report,
+            args.dump_step,
+            bool(args.dump_first_divergence),
+        )
+    except Exception as exc:
+        errors.append(
+            {
+                "diagnostic": "step_dump",
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            }
+        )
+    else:
+        if args.dump_step is not None:
+            capture("step_dump", lambda: _capture_step_dump(report, args))
+    if args.full_replay_step is not None:
+        capture("full_replay_step", lambda: _capture_full_replay_step(report, args))
+    if args.hidden_state_step is not None:
+        capture("hidden_state_step", lambda: _capture_hidden_state_step(report, args))
+
+    if errors:
+        report["diagnostic_errors"] = errors
+    return not errors
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Multimodal multi-token greedy parity (CK vs llama.cpp)")
     ap.add_argument("--bridge-report", required=True, type=Path)
@@ -1055,6 +1221,12 @@ def main() -> int:
     )
     ap.add_argument("--ck-runtime-so", type=Path, default=None, help="Explicit CK decoder shared library for exact-runtime parity")
     ap.add_argument("--ck-runtime-manifest-map", type=Path, default=None, help="Explicit CK decoder manifest map for exact-runtime parity")
+    ap.add_argument(
+        "--ck-engine-so",
+        type=Path,
+        default=None,
+        help="Explicit CK engine shared library; the executed file is hashed into parity evidence",
+    )
     ap.add_argument("--ctx-len", type=int, default=None)
     ap.add_argument("--max-new-tokens", type=int, default=16)
     ap.add_argument("--top-k", type=int, default=16)
@@ -1065,7 +1237,12 @@ def main() -> int:
         default=None,
         help="CK runtime threads; defaults to --threads when omitted",
     )
-    ap.add_argument("--llama-decode-mode", choices=["batched", "sequential"], default="sequential")
+    ap.add_argument("--llama-decode-mode", choices=["auto", "batched", "sequential"], default="auto")
+    ap.add_argument(
+        "--allow-diagnostic-prefill-mode-mismatch",
+        action="store_true",
+        help="Allow sequential llama replay against batched CK prefill; the report is diagnostic-only.",
+    )
     ap.add_argument("--llama-no-repack", action="store_true", help="Disable llama.cpp CPU tensor repacking in the replay helper")
     ap.add_argument("--llama-repack-fallback", action=argparse.BooleanOptionalAction, default=True, help="Retry a failed llama replay step with --no-repack")
     ap.add_argument("--append-on-divergence", choices=["stop", "llama", "ck"], default="stop")
@@ -1080,6 +1257,11 @@ def main() -> int:
     )
     ap.add_argument("--json-out", type=Path, default=None)
     ap.add_argument("--dump-step", type=int, default=None, help="Capture CK-vs-llama tensor dumps at this generated step")
+    ap.add_argument(
+        "--dump-first-divergence",
+        action="store_true",
+        help="Capture CK-vs-llama tensors at the first observed pre-EOS divergence",
+    )
     ap.add_argument("--full-replay-step", type=int, default=None, help="Compare a generated step by full mixed-prefix replay instead of incremental CK decode, without tensor dumps")
     ap.add_argument("--dump-dir", type=Path, default=None, help="Directory for --dump-step tensor dumps")
     ap.add_argument(
@@ -1098,18 +1280,26 @@ def main() -> int:
     ap.add_argument("--hidden-state-atol", type=float, default=1.0e-5)
     ap.add_argument("--summary", action="store_true")
     args = ap.parse_args()
+    if args.ck_engine_so is not None:
+        args.ck_engine_so = args.ck_engine_so.resolve()
+        if not args.ck_engine_so.is_file():
+            raise FileNotFoundError(f"explicit CK engine shared library does not exist: {args.ck_engine_so}")
+
+    bridge_report = json.loads(args.bridge_report.resolve().read_text(encoding="utf-8"))
+    mode_contract = _resolve_oracle_prefill_mode(
+        str(args.llama_decode_mode),
+        bridge_report,
+        allow_diagnostic_mismatch=bool(args.allow_diagnostic_prefill_mode_mismatch),
+    )
+    args.llama_decode_mode = mode_contract["resolved"]
+    args.prefill_mode_contract = mode_contract
 
     ck_threads = _ck_threads(args)
     if ck_threads > 0:
         os.environ["CK_NUM_THREADS"] = str(ck_threads)
         os.environ["OMP_NUM_THREADS"] = str(ck_threads)
     report = run_multimodal_multitoken_parity(args)
-    if args.dump_step is not None:
-        report["step_dump"] = _capture_step_dump(report, args)
-    if args.full_replay_step is not None:
-        report["full_replay_step"] = _capture_full_replay_step(report, args)
-    if args.hidden_state_step is not None:
-        report["hidden_state_step"] = _capture_hidden_state_step(report, args)
+    diagnostics_passed = _run_requested_diagnostics(report, args)
     if args.json_out is not None:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(json.dumps(report, indent=2), encoding="utf-8")
@@ -1161,7 +1351,7 @@ def main() -> int:
             )
     else:
         print(json.dumps(report, indent=2))
-    return 0 if report.get("pass") else 3
+    return 0 if report.get("pass") and diagnostics_passed else 3
 
 
 if __name__ == "__main__":

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -12,6 +12,7 @@ import json
 import math
 import os
 import random
+import shutil
 import subprocess
 import sys
 import time
@@ -1684,6 +1685,10 @@ def _gemma4_geometry_overrides(config: dict[str, Any], image_path: Path) -> dict
     image_height = vision_grid_h * patch_size
     vision_num_patches = vision_grid_w * vision_grid_h
     vision_merged_tokens = pooled_w * pooled_h
+    patch_area = patch_size * patch_size
+    merge_factor = merge_size * merge_size
+    min_pixels = min_tokens * merge_factor * patch_area
+    max_pixels = max_tokens * merge_factor * patch_area
     return {
         "image_width": int(image_width),
         "image_height": int(image_height),
@@ -1692,7 +1697,7 @@ def _gemma4_geometry_overrides(config: dict[str, Any], image_path: Path) -> dict
         "vision_num_patches": int(vision_num_patches),
         "vision_merged_tokens": int(vision_merged_tokens),
         "spatial_merge_size": int(merge_size),
-        "spatial_merge_factor": int(merge_size * merge_size),
+        "spatial_merge_factor": int(merge_factor),
         "context_length": int(vision_num_patches),
         "max_seq_len": int(vision_num_patches),
         "merged_grid_x": int(pooled_w),
@@ -1701,25 +1706,60 @@ def _gemma4_geometry_overrides(config: dict[str, Any], image_path: Path) -> dict
         "image_source_height": int(source_height),
         "image_min_pixels": int(min_pixels),
         "image_max_pixels": int(max_pixels),
-        "image_min_tokens": int(min_pixels // patch_area),
-        "image_max_tokens": int(max_pixels // patch_area),
+        "image_min_tokens": int(min_tokens),
+        "image_max_tokens": int(max_tokens),
     }
+
+
+def _sync_runtime_engine(engine_path: Path, model_so: Path) -> Path:
+    source = engine_path.resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"CK engine library is missing: {source}")
+    destination = model_so.resolve().parent / "libckernel_engine.so"
+    if destination == source:
+        return destination
+    source_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+    if destination.is_file() and hashlib.sha256(destination.read_bytes()).hexdigest() == source_hash:
+        return destination
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    shutil.copy2(source, temporary)
+    os.replace(temporary, destination)
+    return destination
 
 
 def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = False) -> Path:
     stamp_path = so_path.with_suffix(so_path.suffix + ".build.json")
+    engine_path = (BUILD_DIR / "libckernel_engine.so").resolve()
+    if not engine_path.is_file():
+        raise FileNotFoundError(f"CK engine library is missing: {engine_path}")
+    engine_hash = hashlib.sha256(engine_path.read_bytes()).hexdigest()
     source_hash = hashlib.sha256(c_path.read_bytes()).hexdigest()
     source_size = int(c_path.stat().st_size)
+    compiler_probe = subprocess.run(
+        ["cc", "--version"], text=True, capture_output=True, check=False
+    )
+    compiler_version = (
+        compiler_probe.stdout.splitlines()[0]
+        if compiler_probe.returncode == 0 and compiler_probe.stdout
+        else f"cc probe failed rc={compiler_probe.returncode}"
+    )
     build_fingerprint = {
-        "version": 1,
+        "version": 2,
         "source_path": str(c_path.resolve()),
         "source_sha256": source_hash,
         "source_size": source_size,
         "profile": bool(profile),
+        "compiler": {"command": "cc", "version": compiler_version},
+        "runtime_dependency": {
+            "name": "libckernel_engine.so",
+            "sha256": engine_hash,
+            "runpath": "$ORIGIN",
+        },
     }
     if so_path.exists():
         cached = _json_read(stamp_path)
         if cached == build_fingerprint:
+            _sync_runtime_engine(engine_path, so_path)
             return so_path
     cmd = [
         "cc",
@@ -1736,13 +1776,14 @@ def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = Fal
         "version/v8/src/ck_parallel_prefill_v8.c",
         "-Lbuild",
         "-lckernel_engine",
-        f"-Wl,-rpath,{BUILD_DIR}",
+        "-Wl,-rpath,$ORIGIN",
         "-o",
         str(so_path),
         "-lm",
         "-lpthread",
     ]
     _run(cmd)
+    _sync_runtime_engine(engine_path, so_path)
     _json_write(stamp_path, build_fingerprint)
     return so_path
 
@@ -2226,9 +2267,58 @@ def _load_encoder_lib(model_so: Path) -> ctypes.CDLL:
     return lib
 
 
-def _load_decoder_lib(model_so: Path) -> ctypes.CDLL:
-    ctypes.CDLL(str(BUILD_DIR / "libckernel_engine.so"), mode=ctypes.RTLD_GLOBAL)
+class _DlInfo(ctypes.Structure):
+    _fields_ = [
+        ("dli_fname", ctypes.c_char_p),
+        ("dli_fbase", ctypes.c_void_p),
+        ("dli_sname", ctypes.c_char_p),
+        ("dli_saddr", ctypes.c_void_p),
+    ]
+
+
+def _resolved_symbol_library(lib: ctypes.CDLL, symbol: str) -> Path:
+    function = getattr(lib, symbol)
+    dladdr = ctypes.CDLL(None).dladdr
+    dladdr.argtypes = [ctypes.c_void_p, ctypes.POINTER(_DlInfo)]
+    dladdr.restype = ctypes.c_int
+    info = _DlInfo()
+    if dladdr(ctypes.cast(function, ctypes.c_void_p), ctypes.byref(info)) == 0 or not info.dli_fname:
+        raise RuntimeError(f"dladdr could not resolve generated-runtime symbol {symbol}")
+    return Path(os.fsdecode(info.dli_fname)).resolve()
+
+
+def _load_decoder_lib(model_so: Path, *, engine_so: Path | None = None) -> ctypes.CDLL:
+    requested_engine = (engine_so if engine_so is not None else BUILD_DIR / "libckernel_engine.so").resolve()
+    adjacent_engine = model_so.resolve().parent / "libckernel_engine.so"
+    engine_path = requested_engine
+    if adjacent_engine.is_file():
+        requested_hash = hashlib.sha256(requested_engine.read_bytes()).hexdigest()
+        adjacent_hash = hashlib.sha256(adjacent_engine.read_bytes()).hexdigest()
+        if adjacent_hash != requested_hash:
+            raise RuntimeError(
+                "generated decoder has a different adjacent CK engine than requested: "
+                f"requested={requested_engine} adjacent={adjacent_engine}"
+            )
+        engine_path = adjacent_engine.resolve()
+    ctypes.CDLL(str(engine_path), mode=ctypes.RTLD_GLOBAL)
+    tokenizer_candidates = [
+        model_so.resolve().parent / "libckernel_tokenizer.so",
+        BUILD_DIR / "libckernel_tokenizer.so",
+    ]
+    tokenizer_path = next((path for path in tokenizer_candidates if path.is_file()), None)
+    if tokenizer_path is None:
+        raise FileNotFoundError(
+            "generated decoder requires libckernel_tokenizer.so; checked "
+            + ", ".join(str(path) for path in tokenizer_candidates)
+        )
+    ctypes.CDLL(str(tokenizer_path), mode=ctypes.RTLD_GLOBAL)
     lib = ctypes.CDLL(str(model_so))
+    resolved_engine = _resolved_symbol_library(lib, "ck_set_num_threads")
+    if resolved_engine != engine_path:
+        raise RuntimeError(
+            "generated decoder resolved a different CK engine than the parity report requested: "
+            f"requested={engine_path} loaded={resolved_engine}; rebuild with $ORIGIN runtime linking"
+        )
     lib.ck_model_init_with_manifest.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     lib.ck_model_init_with_manifest.restype = ctypes.c_int
     lib.ck_model_decode.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_float)]
@@ -2537,7 +2627,11 @@ def _run_decoder(
         model_so = Path(runtime["so_path"])
     else:
         model_so = Path(runtime.get("prefill_so_path") or runtime["so_path"])
-    lib = _load_decoder_lib(model_so)
+    runtime_engine = runtime.get("engine_so")
+    if runtime_engine:
+        lib = _load_decoder_lib(model_so, engine_so=Path(runtime_engine))
+    else:
+        lib = _load_decoder_lib(model_so)
     _log_progress("decoder: init start")
     rc = lib.ck_model_init_with_manifest(
         str(runtime["weights_bump"]).encode(),


### PR DESCRIPTION
## Why

Parity investigations were not fail-closed about the executable and oracle mode. A report could hash one engine while generated code loaded another through ambient library search; nested replay and granular diagnostics could drop the selected engine; diagnostic failure could discard the useful coarse result; and sequential llama execution could be mistaken for production segmented-prefill evidence.

## What changed

- Copy the selected CKE engine atomically beside each generated multimodal model and link the model with `RUNPATH=$ORIGIN`.
- Resolve loaded symbols with `dladdr` and reject requested-versus-executing engine mismatches.
- Propagate engine identity through normal decode, full replay, hidden-state capture, and granular first-divergence paths.
- Preserve coarse reports when diagnostics fail, record structured diagnostic errors, and continue independent bounded diagnostics.
- Require the batched llama oracle for production segmented mixed prefill; sequential execution is diagnostic-only and explicitly labeled.
- Record engine/tokenizer paths and hashes, ELF compiler comments, and generated-model build metadata.
- Fix deterministic tokenizer loading, generated tokenizer newline escaping, and stale Gemma4 bridge geometry variables exposed by host coverage.

## Evidence

The hardened harness confirms that Qwen3-VL OCR image 5 still has a genuine pre-EOS mismatch at step 116: CKE emits `Have` while llama.cpp emits `Did`. The first layer-0 granular divergence is `kqv_out` with maximum difference approximately `2.89e-4`. Same-input attention, Q8_K activation bytes, and direct Q projection are exact, so unresolved packed Q4_K x Q8_K production traversal experiments are intentionally excluded from this PR.

## Validation

- Focused parity/provenance tests: 23/23 PASS.
- Native bridge, EOS, and tokenizer suites: 78/78 PASS.
- Staged pre-commit `v7-regression-fast`: PASS.
- Staged pre-commit `v8-regression-fast`: PASS.
- Pre-push v8 end-to-end text smoke and inference contracts: PASS.
- Pre-push v7 and v8 fast regressions: PASS.
- Pre-push v7 training contract and training-kernel parity: PASS.
- `git diff --check`: PASS.
- The optional standalone kernel parity row was reported SKIP because this clean worktree did not build `libck_parity.so`; no skipped row is described as passing.

## Regression coverage

Unit coverage now guards runtime engine identity, relocatable RUNPATH, nested engine propagation, stale artifact invalidation, coarse-report persistence, independent diagnostic continuation, EOS handling, tokenizer capabilities, and fail-closed production-oracle semantics. Existing staged and pre-push family regressions exercise Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige.

## Documentation

`docs/qwen3vl-parity-investigation-2026-07-14.txt` records validated findings, harness failures, rejected hypotheses, artifact provenance rules, and the unresolved packed-production boundary in plain text for future parity work.

## Content handoff

- Audience: CPU inference engineers, runtime authors, and teams validating quantized multimodal models.
- Angle: Numerical parity work is invalid unless the executing binary, oracle execution schedule, EOS boundary, and diagnostic provenance are proven first.
- Claims: Runtime identity is now fail-closed; 78 focused host tests pass; staged and pre-push v7/v8 regressions pass with the exact pinned llama oracle.
- Caveats: Qwen3-VL image 5 still diverges pre-EOS at step 116; this PR does not claim complete 40-image parity or fix packed Q4_K x Q8_K traversal.
- Sources: Commit `0ddab65b`, the investigation text, changed unit tests, and generated structured parity reports.