### PR TITLE
fix(quant): enforce llama packed Q4/Q6 parity

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -201,31 +201,27 @@ build_staged_snapshot() {
     SNAPSHOT_PARENT="$(mktemp -d "${SNAPSHOT_PREFIX}.XXXXXX")"
     SNAPSHOT_DIR="${SNAPSHOT_PARENT}/worktree"
     local staged_patch="${SNAPSHOT_PARENT}/staged.patch"
+    local worktree_path
     if git -C "$ROOT_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
-        git -C "$ROOT_DIR" diff --cached --binary --submodule=diff HEAD -- > "$staged_patch"
+        git -C "$ROOT_DIR" diff --cached --binary --submodule=short HEAD -- > "$staged_patch"
     else
-        git -C "$ROOT_DIR" diff --cached --binary --submodule=diff > "$staged_patch"
+        git -C "$ROOT_DIR" diff --cached --binary --submodule=short > "$staged_patch"
     fi
     env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
         git clone --shared --quiet --no-hardlinks "$ROOT_DIR" "$SNAPSHOT_DIR" >/dev/null 2>&1
     env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
         git -C "$SNAPSHOT_DIR" checkout --detach HEAD >/dev/null 2>&1
-    if [ -d "$ROOT_DIR/.venv" ] && [ ! -e "$SNAPSHOT_DIR/.venv" ]; then
-        ln -s "$ROOT_DIR/.venv" "$SNAPSHOT_DIR/.venv"
-    fi
-    local llama_cpp_root="${CK_LLAMA_CPP_ROOT:-${LLAMA_CPP_ROOT:-}}"
-    if [ -z "$llama_cpp_root" ] || [ ! -d "$llama_cpp_root/include" ]; then
-        local worktree_path
+    local python_env_root="${CK_PRECOMMIT_PYTHON_ENV_ROOT:-}"
+    if [ -z "$python_env_root" ] || [ ! -x "$python_env_root/.venv/bin/python" ]; then
         while IFS= read -r worktree_path; do
-            if [ -d "$worktree_path/llama.cpp/include" ] && [ -d "$worktree_path/llama.cpp/build/bin" ]; then
-                llama_cpp_root="$worktree_path/llama.cpp"
+            if [ -x "$worktree_path/.venv/bin/python" ]; then
+                python_env_root="$worktree_path"
                 break
             fi
         done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
     fi
-    if [ -d "$llama_cpp_root/include" ] && [ ! -d "$SNAPSHOT_DIR/llama.cpp/include" ]; then
-        rm -rf "$SNAPSHOT_DIR/llama.cpp"
-        ln -s "$llama_cpp_root" "$SNAPSHOT_DIR/llama.cpp"
+    if [ -x "$python_env_root/.venv/bin/python" ] && [ ! -e "$SNAPSHOT_DIR/.venv" ]; then
+        ln -s "$python_env_root/.venv" "$SNAPSHOT_DIR/.venv"
     fi
     if [ -s "$staged_patch" ]; then
         env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
@@ -233,6 +229,19 @@ build_staged_snapshot() {
     else
         echo -e "${RED}✗ Staged snapshot patch is unexpectedly empty${NC}" >&2
         return 1
+    fi
+    local llama_cpp_root="${CK_LLAMA_CPP_ROOT:-${LLAMA_CPP_ROOT:-$ROOT_DIR/llama.cpp}}"
+    if [ -z "$llama_cpp_root" ] || [ ! -f "$llama_cpp_root/build/bin/libllama.so" ]; then
+        while IFS= read -r worktree_path; do
+            if [ -d "$worktree_path/llama.cpp/include" ] && [ -f "$worktree_path/llama.cpp/build/bin/libllama.so" ]; then
+                llama_cpp_root="$worktree_path/llama.cpp"
+                break
+            fi
+        done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+    fi
+    if [ -f "$llama_cpp_root/build/bin/libllama.so" ] && [ ! -d "$SNAPSHOT_DIR/llama.cpp/include" ]; then
+        rm -rf "$SNAPSHOT_DIR/llama.cpp"
+        ln -s "$llama_cpp_root" "$SNAPSHOT_DIR/llama.cpp"
     fi
 }
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -37,6 +37,44 @@ fi
 
 cd "$ROOT_DIR"
 
+# Ignored Python environments are normally present only in the primary
+# checkout. Clean worktrees must run the same gates, so borrow a validated
+# environment for this hook invocation and remove the link on exit.
+PREPUSH_ENV_LINK_CREATED=0
+python_env_root="${CK_PREPUSH_PYTHON_ENV_ROOT:-}"
+if [ -z "$python_env_root" ] || [ ! -x "$python_env_root/.venv/bin/python" ]; then
+    while IFS= read -r worktree_path; do
+        if [ -x "$worktree_path/.venv/bin/python" ]; then
+            python_env_root="$worktree_path"
+            break
+        fi
+    done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+fi
+if [ ! -e "$ROOT_DIR/.venv" ] && [ -x "$python_env_root/.venv/bin/python" ]; then
+    ln -s "$python_env_root/.venv" "$ROOT_DIR/.venv"
+    PREPUSH_ENV_LINK_CREATED=1
+fi
+
+llama_cpp_root="${CK_LLAMA_CPP_ROOT:-${LLAMA_CPP_ROOT:-$ROOT_DIR/llama.cpp}}"
+if [ -z "$llama_cpp_root" ] || [ ! -f "$llama_cpp_root/build/bin/libllama.so" ]; then
+    while IFS= read -r worktree_path; do
+        if [ -f "$worktree_path/llama.cpp/build/bin/libllama.so" ]; then
+            llama_cpp_root="$worktree_path/llama.cpp"
+            break
+        fi
+    done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+fi
+if [ -f "$llama_cpp_root/build/bin/libllama.so" ]; then
+    export CK_LLAMA_CPP_ROOT="$llama_cpp_root"
+fi
+
+cleanup_prepush_environment() {
+    if [ "$PREPUSH_ENV_LINK_CREATED" = "1" ]; then
+        rm -f "$ROOT_DIR/.venv"
+    fi
+}
+trap cleanup_prepush_environment EXIT
+
 PREPUSH_ROOT="${CK_PREPUSH_ROOT:-${HOME:-$ROOT_DIR}/.cache/ck-engine/prepush}"
 PREPUSH_REGRESSION_ROOT="${PREPUSH_ROOT}/regression"
 PREPUSH_TRAIN_REPORT_ROOT="${PREPUSH_ROOT}/training-reports"

--- a/Makefile
+++ b/Makefile
@@ -2430,6 +2430,9 @@ llamacpp-parity-full:
 	@echo "Running composed Q8 activation/projection parity at vision dimensions..."
 	@$(MAKE) --no-print-directory test-q8-composed-llama-parity
 	@echo ""
+	@echo "Running Q4_K x Q8_K production packed-sequence parity..."
+	@$(MAKE) --no-print-directory test-q4k-q8k-llama-packed
+	@echo ""
 	@echo "Running F16 GEMM production reduction contract against llama.cpp..."
 	@$(MAKE) --no-print-directory test-f16-gemm-llama-contract
 	@echo ""
@@ -2519,6 +2522,9 @@ llamacpp-parity-nightly:
 	@echo ""
 	@echo "Running composed Q8 activation/projection parity at vision dimensions..."
 	@$(MAKE) --no-print-directory test-q8-composed-llama-parity
+	@echo ""
+	@echo "Running bounded Q4_K x Q8_K production packed-sequence parity..."
+	@$(MAKE) --no-print-directory test-q4k-q8k-llama-packed-quick
 	@echo ""
 	@echo "Running F16 GEMM production reduction contract against llama.cpp..."
 	@$(MAKE) --no-print-directory test-f16-gemm-llama-contract
@@ -2773,6 +2779,8 @@ test-gemv-omp-verbose: $(GEMV_OMP_BIN)
 
 THREADPOOL_BIN := $(BUILD_DIR)/test_threadpool_parity
 Q4K_DISPATCH_MATRIX_BIN := $(BUILD_DIR)/bench_q4k_dispatch_matrix
+Q4K_Q8K_LLAMA_PACKED_BIN := $(BUILD_DIR)/test_q4k_q8k_llama_packed
+Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ := $(BUILD_DIR)/test_q4k_q8k_llama_prefill.o
 Q4K_GATEUP_SWIGLU_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu
 Q4K_GATEUP_SWIGLU_OMP_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu_omp_standalone
 QWEN3VL_ENCODER_ATTN_BIN := $(BUILD_DIR)/bench_qwen3vl_encoder_attention
@@ -2801,6 +2809,39 @@ test-threadpool-parity-quick: $(THREADPOOL_BIN)
 test-threadpool-parity-verbose: $(THREADPOOL_BIN)
 	@echo "Running Thread Pool GEMV parity + speed test (verbose)..."
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(THREADPOOL_BIN) --verbose
+
+$(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ): $(V8_SRC_DIR)/ck_parallel_prefill_v8.c
+	@mkdir -p $(BUILD_DIR)
+	$(CC) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) -c $< -o $@
+
+$(Q4K_Q8K_LLAMA_PACKED_BIN): $(LIB) unittest/test_q4k_q8k_llama_packed.cpp $(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ)
+	@mkdir -p $(BUILD_DIR)
+	$(CXX) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) \
+		-Illama.cpp/ggml/include -Illama.cpp/ggml/src \
+		unittest/test_q4k_q8k_llama_packed.cpp \
+		$(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ) \
+		-L$(BUILD_DIR) -lckernel_engine \
+		-Lllama.cpp/build/bin -lggml-cpu -lggml-base -lggml \
+		-lm -lpthread -ldl \
+		-Wl,-rpath,$(BUILD_DIR) -Wl,-rpath,$(CURDIR)/llama.cpp/build/bin \
+		-o $(Q4K_Q8K_LLAMA_PACKED_BIN)
+
+.PHONY: test-q4k-q8k-llama-packed
+test-q4k-q8k-llama-packed: $(Q4K_Q8K_LLAMA_PACKED_BIN)
+	@echo "Running Q4_K x Q8_K production dispatcher against llama.cpp..."
+	CK_NUM_THREADS=1 \
+		LD_LIBRARY_PATH=$(BUILD_DIR):$(CURDIR)/llama.cpp/build/bin:$$LD_LIBRARY_PATH \
+		$(Q4K_Q8K_LLAMA_PACKED_BIN)
+	CK_NUM_THREADS=4 \
+		LD_LIBRARY_PATH=$(BUILD_DIR):$(CURDIR)/llama.cpp/build/bin:$$LD_LIBRARY_PATH \
+		$(Q4K_Q8K_LLAMA_PACKED_BIN)
+
+.PHONY: test-q4k-q8k-llama-packed-quick
+test-q4k-q8k-llama-packed-quick: $(Q4K_Q8K_LLAMA_PACKED_BIN)
+	@echo "Running bounded Q4_K x Q8_K production parity against llama.cpp..."
+	CK_NUM_THREADS=4 \
+		LD_LIBRARY_PATH=$(BUILD_DIR):$(CURDIR)/llama.cpp/build/bin:$$LD_LIBRARY_PATH \
+		$(Q4K_Q8K_LLAMA_PACKED_BIN) --quick
 
 $(Q4K_DISPATCH_MATRIX_BIN): $(LIB) benchmarks/bench_q4k_dispatch_matrix.c $(V8_SRC_DIR)/ck_parallel_decode_v8.c $(V8_SRC_DIR)/ck_parallel_prefill_v8.c
 	@mkdir -p $(BUILD_DIR)

--- a/src/ck_parity_api.c
+++ b/src/ck_parity_api.c
@@ -382,11 +382,14 @@ void ck_test_vec_dot_q4_k_q8_k(const void *weight_q4_k,
 }
 
 void ck_test_vec_dot_q6_k_q8_k(const void *weight_q6_k,
-                                const void *input_q8_k,
-                                float *output,
-                                int cols)
+                               const void *input_q8_k,
+                               float *output,
+                               int cols)
 {
-    vec_dot_q6_k_q8_k(cols, output, weight_q6_k, input_q8_k);
+    /* Exercise the production M=1 provider. The scalar vec_dot helper is an
+     * internal architecture-neutral oracle and does not preserve the x86
+     * provider's declared lane reduction order. */
+    gemv_q6_k_q8_k(output, weight_q6_k, input_q8_k, 1, cols);
 }
 
 /**

--- a/src/kernels/gemm_kernels_q4k_q8k.c
+++ b/src/kernels/gemm_kernels_q4k_q8k.c
@@ -80,7 +80,12 @@ void quantize_row_q8_k_ref(const float *x, void *vy, int k) {
 
         const float iscale = -127.0f / max;
         for (int j = 0; j < QK_K; ++j) {
-            int v = ck_nearest_int(iscale * x[j]);
+            /* The add-magic rounding expression is sensitive to contraction:
+             * icx otherwise emits (x * iscale + magic) as one FMA, while the
+             * llama.cpp reference performs a rounded multiply followed by a
+             * rounded add. Q8_K bytes are an ABI, so force that boundary. */
+            volatile float scaled = iscale * x[j];
+            int v = ck_nearest_int(scaled);
             if (v > 127) {
                 v = 127;
             }

--- a/src/kernels/gemm_kernels_q4k_q8k_avx2.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_avx2.c
@@ -29,27 +29,11 @@ void gemv_q4_k_q8_k_ref(float *y,
                         int M, int K);
 
 #if defined(__AVX2__)
-static inline int32_t hsum256_epi32(__m256i v) {
-    __m128i lo = _mm256_castsi256_si128(v);
-    __m128i hi = _mm256_extracti128_si256(v, 1);
-    __m128i sum = _mm_add_epi32(lo, hi);
-    sum = _mm_hadd_epi32(sum, sum);
-    sum = _mm_hadd_epi32(sum, sum);
-    return _mm_cvtsi128_si32(sum);
-}
-
-static inline int32_t dot_q4_q8_32_avx2(const uint8_t *q4,
-                                        const int8_t *q8,
-                                        int high_nibble) {
-    const __m256i packed = _mm256_loadu_si256((const __m256i *)q4);
-    const __m256i mask4 = _mm256_set1_epi8(0x0F);
-    const __m256i q4_bytes = high_nibble
-        ? _mm256_and_si256(_mm256_srli_epi16(packed, 4), mask4)
-        : _mm256_and_si256(packed, mask4);
-    const __m256i q8_bytes = _mm256_loadu_si256((const __m256i *)q8);
-    const __m256i pair_sums_i16 = _mm256_maddubs_epi16(q4_bytes, q8_bytes);
-    const __m256i sums_i32 = _mm256_madd_epi16(pair_sums_i16, _mm256_set1_epi16(1));
-    return hsum256_epi32(sums_i32);
+static inline float hsum256_ps_q4k(__m256 v) {
+    __m128 sum = _mm_add_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+    sum = _mm_add_ps(sum, _mm_movehl_ps(sum, sum));
+    sum = _mm_add_ss(sum, _mm_movehdup_ps(sum));
+    return _mm_cvtss_f32(sum);
 }
 
 static float dot_q4_k_q8_k_avx2(const block_q4_K *w,
@@ -57,41 +41,49 @@ static float dot_q4_k_q8_k_avx2(const block_q4_K *w,
                                 int k)
 {
     const int nb = k / QK_K;
-    float sumf = 0.0f;
+    __m256 acc = _mm256_setzero_ps();
+    __m128 acc_min = _mm_setzero_ps();
+    const __m256i nibble_mask = _mm256_set1_epi8(0x0F);
 
     for (int i = 0; i < nb; ++i) {
         uint8_t sc[8], m_val[8];
         unpack_q4_k_scales(w[i].scales, sc, m_val);
 
         const float d = CK_FP16_TO_FP32(w[i].d) * x[i].d;
-        const float dmin = CK_FP16_TO_FP32(w[i].dmin) * x[i].d;
+        const float dmin = -CK_FP16_TO_FP32(w[i].dmin) * x[i].d;
 
-        int sumi = 0;
-        for (int j = 0; j < QK_K / 16; ++j) {
-            sumi += (int)x[i].bsums[j] * (int)m_val[j / 2];
+        const __m128i mins = _mm_loadl_epi64((const __m128i *)m_val);
+        const __m128i q8_sums = _mm_hadd_epi16(
+                _mm_loadu_si128((const __m128i *)&x[i].bsums[0]),
+                _mm_loadu_si128((const __m128i *)&x[i].bsums[8]));
+        const __m128i min_products = _mm_madd_epi16(_mm_cvtepu8_epi16(mins), q8_sums);
+        acc_min = _mm_fmadd_ps(
+                _mm_set1_ps(dmin), _mm_cvtepi32_ps(min_products), acc_min);
+
+        __m256i block_sum = _mm256_setzero_si256();
+        for (int group = 0; group < QK_K / 64; ++group) {
+            const __m256i packed = _mm256_loadu_si256(
+                    (const __m256i *)&w[i].qs[group * 32]);
+            const __m256i q4_lo = _mm256_and_si256(packed, nibble_mask);
+            const __m256i q4_hi = _mm256_and_si256(
+                    _mm256_srli_epi16(packed, 4), nibble_mask);
+            const __m256i q8_lo = _mm256_loadu_si256(
+                    (const __m256i *)&x[i].qs[group * 64]);
+            const __m256i q8_hi = _mm256_loadu_si256(
+                    (const __m256i *)&x[i].qs[group * 64 + 32]);
+            __m256i lo = _mm256_maddubs_epi16(q4_lo, q8_lo);
+            __m256i hi = _mm256_maddubs_epi16(q4_hi, q8_hi);
+            lo = _mm256_madd_epi16(_mm256_set1_epi16(sc[2 * group]), lo);
+            hi = _mm256_madd_epi16(_mm256_set1_epi16(sc[2 * group + 1]), hi);
+            block_sum = _mm256_add_epi32(block_sum, _mm256_add_epi32(lo, hi));
         }
-
-        int32_t sumi_block = 0;
-        int is = 0;
-        int q_offset = 0;
-
-        for (int j = 0; j < QK_K; j += 64) {
-            const uint8_t *qs = &w[i].qs[q_offset];
-            const int8_t *q8_lo = &x[i].qs[j];
-            const int8_t *q8_hi = &x[i].qs[j + 32];
-
-            const int32_t lo = dot_q4_q8_32_avx2(qs, q8_lo, 0);
-            const int32_t hi = dot_q4_q8_32_avx2(qs, q8_hi, 1);
-            sumi_block += (int32_t)sc[is] * lo + (int32_t)sc[is + 1] * hi;
-
-            q_offset += 32;
-            is += 2;
-        }
-
-        sumf += d * (float)sumi_block - dmin * (float)sumi;
+        acc = _mm256_fmadd_ps(
+                _mm256_set1_ps(d), _mm256_cvtepi32_ps(block_sum), acc);
     }
 
-    return sumf;
+    acc_min = _mm_add_ps(acc_min, _mm_movehl_ps(acc_min, acc_min));
+    acc_min = _mm_add_ss(acc_min, _mm_movehdup_ps(acc_min));
+    return hsum256_ps_q4k(acc) + _mm_cvtss_f32(acc_min);
 }
 #endif
 

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -225,6 +225,69 @@ typedef struct {
     uint8_t reserved[15];
 } block_q4_K_packed_u8_x16;
 
+#if defined(__AVX2__)
+static inline float hsum256_ps_q4k_packed(__m256 v)
+{
+    __m128 sum = _mm_add_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+    sum = _mm_add_ps(sum, _mm_movehl_ps(sum, sum));
+    sum = _mm_add_ss(sum, _mm_movehdup_ps(sum));
+    return _mm_cvtss_f32(sum);
+}
+
+/* Preserve llama.cpp's Q4_K x Q8_K AVX2 arithmetic while reading the x16
+ * packed weight layout. Packing changes addresses only; it must not collapse
+ * the eight FP32 accumulation lanes or interleave minimum terms into them. */
+static inline float dot_q4_k_packed_meta_x16_q8_k_llama_avx2(
+        const block_q4_K_packed_meta_x16 *weights,
+        int blocks_per_row,
+        int lane,
+        const block_q8_K *activation)
+{
+    __m256 acc = _mm256_setzero_ps();
+    __m128 acc_min = _mm_setzero_ps();
+    const __m256i nibble_mask = _mm256_set1_epi8(0x0F);
+
+    for (int block = 0; block < blocks_per_row; ++block) {
+        const block_q4_K_packed_meta_x16 *w = &weights[block];
+        const block_q8_K *x = &activation[block];
+        const float d = CK_FP16_TO_FP32(w->d[lane]) * x->d;
+        const float dmin = -CK_FP16_TO_FP32(w->dmin[lane]) * x->d;
+
+        const __m128i mins = _mm_loadl_epi64((const __m128i *)w->m[lane]);
+        const __m128i q8_sums = _mm_hadd_epi16(
+                _mm_loadu_si128((const __m128i *)&x->bsums[0]),
+                _mm_loadu_si128((const __m128i *)&x->bsums[8]));
+        const __m128i min_products = _mm_madd_epi16(_mm_cvtepu8_epi16(mins), q8_sums);
+        acc_min = _mm_fmadd_ps(
+                _mm_set1_ps(dmin), _mm_cvtepi32_ps(min_products), acc_min);
+
+        __m256i block_sum = _mm256_setzero_si256();
+        for (int group = 0; group < QK_K / 64; ++group) {
+            const __m256i packed = _mm256_loadu_si256(
+                    (const __m256i *)&w->qs[lane][group * 32]);
+            const __m256i q4_lo = _mm256_and_si256(packed, nibble_mask);
+            const __m256i q4_hi = _mm256_and_si256(
+                    _mm256_srli_epi16(packed, 4), nibble_mask);
+            const __m256i q8_lo = _mm256_loadu_si256(
+                    (const __m256i *)&x->qs[group * 64]);
+            const __m256i q8_hi = _mm256_loadu_si256(
+                    (const __m256i *)&x->qs[group * 64 + 32]);
+            __m256i lo = _mm256_maddubs_epi16(q4_lo, q8_lo);
+            __m256i hi = _mm256_maddubs_epi16(q4_hi, q8_hi);
+            lo = _mm256_madd_epi16(_mm256_set1_epi16(w->sc[lane][2 * group]), lo);
+            hi = _mm256_madd_epi16(_mm256_set1_epi16(w->sc[lane][2 * group + 1]), hi);
+            block_sum = _mm256_add_epi32(block_sum, _mm256_add_epi32(lo, hi));
+        }
+        acc = _mm256_fmadd_ps(
+                _mm256_set1_ps(d), _mm256_cvtepi32_ps(block_sum), acc);
+    }
+
+    acc_min = _mm_add_ps(acc_min, _mm_movehl_ps(acc_min, acc_min));
+    acc_min = _mm_add_ss(acc_min, _mm_movehdup_ps(acc_min));
+    return hsum256_ps_q4k_packed(acc) + _mm_cvtss_f32(acc_min);
+}
+#endif
+
 size_t q4_k_packed_u8_block_size(void)
 {
     return sizeof(block_q4_K_packed_u8);
@@ -1465,31 +1528,43 @@ static inline void gemm_q4_packed_meta_x16_mreuse_process_job(
         return;
     }
 
+#if defined(__AVX2__)
+    const block_q4_K_packed_meta_x16 *w_group =
+        a->W + (size_t)g * (size_t)a->blocks_per_row;
+    for (int m = m0; m < m1; ++m) {
+        const block_q8_K *a_row = a->A + (size_t)m * (size_t)a->blocks_per_vec;
+        float *c_row = a->C + (size_t)m * (size_t)a->N;
+        for (int lane = 0; lane < active; ++lane) {
+            float value = dot_q4_k_packed_meta_x16_q8_k_llama_avx2(
+                    w_group, a->blocks_per_row, lane, a_row);
+            c_row[n0 + lane] = value + (a->bias ? a->bias[n0 + lane] : 0.0f);
+        }
+    }
+#else
     float acc[8][16];
     for (int mt_lane = 0; mt_lane < m_count; ++mt_lane) {
         for (int lane = 0; lane < active; ++lane) {
             acc[mt_lane][lane] = a->bias ? a->bias[n0 + lane] : 0.0f;
         }
     }
-
     for (int b = 0; b < a->blocks_per_row; ++b) {
-        const block_q4_K_packed_meta_x16 *w_group =
+        const block_q4_K_packed_meta_x16 *w_block =
             a->W + (size_t)g * (size_t)a->blocks_per_row + (size_t)b;
         if (ck_q4k_x16_chunk4_enabled()) {
-            accum_q4_k_packed_meta_x16_q8_k_block_mreuse_chunk4(acc, w_group, active, a->A,
+            accum_q4_k_packed_meta_x16_q8_k_block_mreuse_chunk4(acc, w_block, active, a->A,
                                                                  a->blocks_per_vec, b, m0, m_count);
         } else {
-            accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc, w_group, active, a->A,
+            accum_q4_k_packed_meta_x16_q8_k_block_mreuse(acc, w_block, active, a->A,
                                                           a->blocks_per_vec, b, m0, m_count);
         }
     }
-
     for (int m = m0; m < m1; ++m) {
         float *c_row = a->C + (size_t)m * (size_t)a->N;
         for (int lane = 0; lane < active; ++lane) {
             c_row[n0 + lane] = acc[m - m0][lane];
         }
     }
+#endif
 }
 
 static void gemm_q4_packed_meta_x16_mreuse_thread_fn(int ith, int nth, void *args)

--- a/src/kernels/gemm_kernels_q6k_q8k.c
+++ b/src/kernels/gemm_kernels_q6k_q8k.c
@@ -621,14 +621,6 @@ static inline float ck_q6k_hsum_float_8(const __m256 x)
  * tree differs by one FP32 ULP on realistic MLP-down rows.
  */
 
-/* Scale shuffle for AVX2 - 32-byte version */
-static const int8_t q6k_scale_shuffle_avx2[4][32] = {
-    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
-    { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
-    { 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 },
-    { 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7 },
-};
-
 static inline __m128i get_scale_shuffle_avx2(int i) {
     static const uint8_t patterns[8][16] = {
         { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1 },
@@ -648,9 +640,8 @@ static float dot_q6_k_q8_k_avx2(const block_q6_K *w,
                                  int K)
 {
     const int nb = K / QK_K;
-    const __m256i m4 = _mm256_set1_epi8(0xF);
-    const __m256i m2 = _mm256_set1_epi8(3);
-    const __m256i m32s = _mm256_set1_epi8(32);
+    const __m256i m3 = _mm256_set1_epi8(3);
+    const __m256i m15 = _mm256_set1_epi8(15);
 
     __m256 acc = _mm256_setzero_ps();
 
@@ -661,18 +652,16 @@ static float dot_q6_k_q8_k_avx2(const block_q6_K *w,
         const uint8_t *qh = w[i].qh;
         const int8_t *q8 = x[i].qs;
 
+        const __m256i q8sums = _mm256_loadu_si256((const __m256i *)x[i].bsums);
         const __m128i scales = _mm_loadu_si128((const __m128i *)w[i].scales);
+        const __m256i scales_16 = _mm256_cvtepi8_epi16(scales);
+        const __m256i q8sclsub = _mm256_slli_epi32(
+            _mm256_madd_epi16(q8sums, scales_16), 5);
 
         __m256i sumi = _mm256_setzero_si256();
         int is = 0;
 
         for (int j = 0; j < QK_K / 128; ++j) {
-            const __m128i scale_0 = _mm_shuffle_epi8(scales, get_scale_shuffle_avx2(is + 0));
-            const __m128i scale_1 = _mm_shuffle_epi8(scales, get_scale_shuffle_avx2(is + 1));
-            const __m128i scale_2 = _mm_shuffle_epi8(scales, get_scale_shuffle_avx2(is + 2));
-            const __m128i scale_3 = _mm_shuffle_epi8(scales, get_scale_shuffle_avx2(is + 3));
-            is += 4;
-
             const __m256i q4bits1 = _mm256_loadu_si256((const __m256i *)q4);
             q4 += 32;
             const __m256i q4bits2 = _mm256_loadu_si256((const __m256i *)q4);
@@ -680,15 +669,19 @@ static float dot_q6_k_q8_k_avx2(const block_q6_K *w,
             const __m256i q4bitsH = _mm256_loadu_si256((const __m256i *)qh);
             qh += 32;
 
-            const __m256i q4h_0 = _mm256_slli_epi16(_mm256_and_si256(q4bitsH, m2), 4);
-            const __m256i q4h_1 = _mm256_slli_epi16(_mm256_and_si256(_mm256_srli_epi16(q4bitsH, 2), m2), 4);
-            const __m256i q4h_2 = _mm256_slli_epi16(_mm256_and_si256(_mm256_srli_epi16(q4bitsH, 4), m2), 4);
-            const __m256i q4h_3 = _mm256_slli_epi16(_mm256_and_si256(_mm256_srli_epi16(q4bitsH, 6), m2), 4);
+            const __m256i q4h_0 = _mm256_slli_epi16(_mm256_and_si256(q4bitsH, m3), 4);
+            const __m256i q4h_1 = _mm256_slli_epi16(
+                _mm256_and_si256(q4bitsH, _mm256_set1_epi8(12)), 2);
+            const __m256i q4h_2 = _mm256_and_si256(q4bitsH, _mm256_set1_epi8(48));
+            const __m256i q4h_3 = _mm256_srli_epi16(
+                _mm256_and_si256(q4bitsH, _mm256_set1_epi8(-64)), 2);
 
-            const __m256i q4_0 = _mm256_or_si256(_mm256_and_si256(q4bits1, m4), q4h_0);
-            const __m256i q4_1 = _mm256_or_si256(_mm256_and_si256(q4bits2, m4), q4h_1);
-            const __m256i q4_2 = _mm256_or_si256(_mm256_and_si256(_mm256_srli_epi16(q4bits1, 4), m4), q4h_2);
-            const __m256i q4_3 = _mm256_or_si256(_mm256_and_si256(_mm256_srli_epi16(q4bits2, 4), m4), q4h_3);
+            const __m256i q4_0 = _mm256_or_si256(_mm256_and_si256(q4bits1, m15), q4h_0);
+            const __m256i q4_1 = _mm256_or_si256(_mm256_and_si256(q4bits2, m15), q4h_1);
+            const __m256i q4_2 = _mm256_or_si256(
+                _mm256_and_si256(_mm256_srli_epi16(q4bits1, 4), m15), q4h_2);
+            const __m256i q4_3 = _mm256_or_si256(
+                _mm256_and_si256(_mm256_srli_epi16(q4bits2, 4), m15), q4h_3);
 
             const __m256i q8_0 = _mm256_loadu_si256((const __m256i *)q8);
             q8 += 32;
@@ -699,25 +692,21 @@ static float dot_q6_k_q8_k_avx2(const block_q6_K *w,
             const __m256i q8_3 = _mm256_loadu_si256((const __m256i *)q8);
             q8 += 32;
 
-            /* Compute -32 * q8 contribution */
-            __m256i q8s_0 = _mm256_maddubs_epi16(m32s, q8_0);
-            __m256i q8s_1 = _mm256_maddubs_epi16(m32s, q8_1);
-            __m256i q8s_2 = _mm256_maddubs_epi16(m32s, q8_2);
-            __m256i q8s_3 = _mm256_maddubs_epi16(m32s, q8_3);
-
-            /* Multiply q4 * q8 */
             __m256i p16_0 = _mm256_maddubs_epi16(q4_0, q8_0);
             __m256i p16_1 = _mm256_maddubs_epi16(q4_1, q8_1);
             __m256i p16_2 = _mm256_maddubs_epi16(q4_2, q8_2);
             __m256i p16_3 = _mm256_maddubs_epi16(q4_3, q8_3);
 
-            /* Subtract offset: (q4 - 32) * q8 = q4*q8 - 32*q8 */
-            p16_0 = _mm256_sub_epi16(p16_0, q8s_0);
-            p16_1 = _mm256_sub_epi16(p16_1, q8s_1);
-            p16_2 = _mm256_sub_epi16(p16_2, q8s_2);
-            p16_3 = _mm256_sub_epi16(p16_3, q8s_3);
+            const __m128i scale_0 = _mm_shuffle_epi8(
+                scales, get_scale_shuffle_avx2(is + 0));
+            const __m128i scale_1 = _mm_shuffle_epi8(
+                scales, get_scale_shuffle_avx2(is + 1));
+            const __m128i scale_2 = _mm_shuffle_epi8(
+                scales, get_scale_shuffle_avx2(is + 2));
+            const __m128i scale_3 = _mm_shuffle_epi8(
+                scales, get_scale_shuffle_avx2(is + 3));
+            is += 4;
 
-            /* Apply scales */
             p16_0 = _mm256_madd_epi16(_mm256_cvtepi8_epi16(scale_0), p16_0);
             p16_1 = _mm256_madd_epi16(_mm256_cvtepi8_epi16(scale_1), p16_1);
             p16_2 = _mm256_madd_epi16(_mm256_cvtepi8_epi16(scale_2), p16_2);
@@ -727,6 +716,7 @@ static float dot_q6_k_q8_k_avx2(const block_q6_K *w,
             sumi = _mm256_add_epi32(sumi, _mm256_add_epi32(p16_2, p16_3));
         }
 
+        sumi = _mm256_sub_epi32(sumi, q8sclsub);
         acc = _mm256_fmadd_ps(_mm256_broadcast_ss(&d), _mm256_cvtepi32_ps(sumi), acc);
     }
 

--- a/unittest/test_q4k_q8k_llama_packed.cpp
+++ b/unittest/test_q4k_q8k_llama_packed.cpp
@@ -1,0 +1,285 @@
+// Authoritative Q4_K x Q8_K parity against the production llama.cpp CPU graph.
+//
+// This deliberately tests the v8 public dispatcher, not only a leaf dot
+// product. The dispatcher may repack output rows and reuse activation rows;
+// those transformations and their accumulation order are part of the
+// production numerical contract.
+
+#include "ggml.h"
+#include "ggml-cpu.h"
+#include "ggml-quants.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+extern "C" {
+void quantize_row_q8_k(const float * x, void * y, int k);
+void gemv_q4_k_q8_k(float * y, const void * w, const void * x_q8, int n, int k);
+void gemm_nt_q4_k_q8_k_parallel_dispatch(
+        const void * a_q8, const void * w, const float * bias, float * out,
+        int m, int n, int k);
+void ck_threadpool_global_destroy(void);
+void ggml_vec_dot_q4_K_q8_K(
+        int n, float * s, size_t bs,
+        const void * vx, size_t bx,
+        const void * vy, size_t by, int nrc);
+}
+
+namespace {
+
+struct case_spec {
+    const char * name;
+    int m;
+    int n;
+    int k;
+    bool production_dispatch;
+    bool with_bias;
+};
+
+static float fixture_value(int row, int col, float scale, float phase) {
+    const float r = static_cast<float>(row);
+    const float c = static_cast<float>(col);
+    float value = std::sin(c * 0.017f + r * 0.071f + phase) * scale;
+    value += std::cos(c * 0.0031f - r * 0.013f + phase * 0.5f) * (scale * 0.37f);
+    return value;
+}
+
+static void fill_activations(std::vector<float> & x, int m, int k) {
+    for (int row = 0; row < m; ++row) {
+        for (int col = 0; col < k; ++col) {
+            x[static_cast<size_t>(row) * k + col] = fixture_value(row, col, 0.31f, 0.19f);
+        }
+        // Exercise signed-max selection and values close to quantization bins.
+        for (int block = 0; block < k / QK_K; ++block) {
+            const int col = block * QK_K + ((row * 17 + block * 29) % QK_K);
+            x[static_cast<size_t>(row) * k + col] =
+                    ((row + block) & 1 ? -1.0f : 1.0f) * (0.91f + 0.001f * block);
+        }
+    }
+}
+
+static void fill_weights(std::vector<float> & w, int n, int k) {
+    for (int row = 0; row < n; ++row) {
+        for (int col = 0; col < k; ++col) {
+            w[static_cast<size_t>(row) * k + col] = fixture_value(row, col, 0.13f, 0.47f);
+        }
+    }
+}
+
+static bool compare_bytes(
+        const char * label, const uint8_t * ck, const uint8_t * llama, size_t size) {
+    size_t different = 0;
+    size_t first = size;
+    for (size_t i = 0; i < size; ++i) {
+        if (ck[i] != llama[i]) {
+            if (first == size) {
+                first = i;
+            }
+            ++different;
+        }
+    }
+    if (different == 0) {
+        std::printf("  %-32s byte_exact (%zu bytes) [PASS]\n", label, size);
+        return true;
+    }
+    std::printf("  %-32s different=%zu/%zu first_byte=%zu ck=%u llama=%u [FAIL]\n",
+            label, different, size, first,
+            static_cast<unsigned>(ck[first]), static_cast<unsigned>(llama[first]));
+    return false;
+}
+
+static bool compare_f32(
+        const char * label, const float * ck, const float * llama, int m, int n) {
+    size_t different = 0;
+    size_t first = static_cast<size_t>(m) * n;
+    size_t worst = 0;
+    float max_abs = 0.0f;
+    for (size_t i = 0; i < static_cast<size_t>(m) * n; ++i) {
+        if (std::memcmp(&ck[i], &llama[i], sizeof(float)) != 0) {
+            if (first == static_cast<size_t>(m) * n) {
+                first = i;
+            }
+            ++different;
+        }
+        const float diff = std::fabs(ck[i] - llama[i]);
+        if (diff > max_abs) {
+            max_abs = diff;
+            worst = i;
+        }
+    }
+    if (different == 0) {
+        std::printf("  %-32s bit_exact (%zu values) [PASS]\n",
+                label, static_cast<size_t>(m) * n);
+        return true;
+    }
+    std::printf(
+            "  %-32s different=%zu/%zu first=(%zu,%zu) worst=(%zu,%zu) "
+            "max_abs=%.9g ck=%.9g llama=%.9g [FAIL]\n",
+            label, different, static_cast<size_t>(m) * n,
+            first / n, first % n, worst / n, worst % n,
+            max_abs, ck[worst], llama[worst]);
+    return false;
+}
+
+static bool llama_mul_mat(
+        const std::vector<uint8_t> & weights,
+        const std::vector<float> & activations,
+        std::vector<float> & output,
+        int m, int n, int k) {
+    const size_t arena_size = 64u * 1024u * 1024u
+            + weights.size() + activations.size() * sizeof(float)
+            + output.size() * sizeof(float);
+    ggml_init_params params = {arena_size, nullptr, false};
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        std::fprintf(stderr, "ggml_init failed for %zu-byte arena\n", arena_size);
+        return false;
+    }
+
+    ggml_tensor * w = ggml_new_tensor_2d(ctx, GGML_TYPE_Q4_K, k, n);
+    ggml_tensor * x = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, k, m);
+    bool ok = w && x && ggml_nbytes(w) == weights.size();
+    if (ok) {
+        std::memcpy(ggml_get_data(w), weights.data(), weights.size());
+        std::memcpy(ggml_get_data(x), activations.data(), activations.size() * sizeof(float));
+        ggml_tensor * y = ggml_mul_mat(ctx, w, x);
+        ggml_cgraph * graph = y ? ggml_new_graph(ctx) : nullptr;
+        if (!graph) {
+            ok = false;
+        } else {
+            ggml_build_forward_expand(graph, y);
+            const int threads = std::max(1, std::atoi(std::getenv("CK_NUM_THREADS")
+                    ? std::getenv("CK_NUM_THREADS") : "4"));
+            ok = ggml_graph_compute_with_ctx(ctx, graph, threads) == GGML_STATUS_SUCCESS;
+            if (ok) {
+                std::memcpy(output.data(), ggml_get_data_f32(y), output.size() * sizeof(float));
+            }
+        }
+    }
+    ggml_free(ctx);
+    return ok;
+}
+
+static bool run_case(const case_spec & spec) {
+    std::printf("\n%s: M=%d N=%d K=%d provider=%s bias=%s\n",
+            spec.name, spec.m, spec.n, spec.k,
+            spec.production_dispatch ? "v8_dispatch" : "decode_leaf",
+            spec.with_bias ? "yes" : "no");
+
+    std::vector<float> activations(static_cast<size_t>(spec.m) * spec.k);
+    std::vector<float> weights_f32(static_cast<size_t>(spec.n) * spec.k);
+    fill_activations(activations, spec.m, spec.k);
+    fill_weights(weights_f32, spec.n, spec.k);
+
+    const size_t q8_row_bytes = static_cast<size_t>(spec.k / QK_K) * sizeof(block_q8_K);
+    const size_t q4_row_bytes = static_cast<size_t>(spec.k / QK_K) * sizeof(block_q4_K);
+    std::vector<uint8_t> ck_q8(static_cast<size_t>(spec.m) * q8_row_bytes);
+    std::vector<uint8_t> llama_q8(ck_q8.size());
+    std::vector<uint8_t> weights(static_cast<size_t>(spec.n) * q4_row_bytes);
+
+    for (int row = 0; row < spec.m; ++row) {
+        const float * src = activations.data() + static_cast<size_t>(row) * spec.k;
+        quantize_row_q8_k(src, ck_q8.data() + static_cast<size_t>(row) * q8_row_bytes, spec.k);
+        quantize_row_q8_K_ref(src,
+                reinterpret_cast<block_q8_K *>(llama_q8.data() + static_cast<size_t>(row) * q8_row_bytes),
+                spec.k);
+    }
+    for (int row = 0; row < spec.n; ++row) {
+        quantize_row_q4_K_ref(weights_f32.data() + static_cast<size_t>(row) * spec.k,
+                reinterpret_cast<block_q4_K *>(weights.data() + static_cast<size_t>(row) * q4_row_bytes),
+                spec.k);
+    }
+
+    bool passed = compare_bytes("Q8_K activation quantizer", ck_q8.data(), llama_q8.data(), ck_q8.size());
+    std::vector<float> ck_output(static_cast<size_t>(spec.m) * spec.n);
+    std::vector<float> llama_output(ck_output.size());
+    std::vector<float> llama_leaf_output(ck_output.size());
+    std::vector<float> bias(spec.with_bias ? spec.n : 0);
+    for (int col = 0; col < spec.n && spec.with_bias; ++col) {
+        bias[col] = fixture_value(0, col, 0.017f, 0.83f);
+    }
+    for (int row = 0; row < spec.m; ++row) {
+        const void * a_row = llama_q8.data() + static_cast<size_t>(row) * q8_row_bytes;
+        for (int col = 0; col < spec.n; ++col) {
+            const void * w_row = weights.data() + static_cast<size_t>(col) * q4_row_bytes;
+            ggml_vec_dot_q4_K_q8_K(
+                    spec.k, &llama_leaf_output[static_cast<size_t>(row) * spec.n + col],
+                    0, w_row, 0, a_row, 0, 1);
+        }
+    }
+    if (spec.production_dispatch) {
+        gemm_nt_q4_k_q8_k_parallel_dispatch(
+                ck_q8.data(), weights.data(), spec.with_bias ? bias.data() : nullptr, ck_output.data(),
+                spec.m, spec.n, spec.k);
+    } else {
+        gemv_q4_k_q8_k(ck_output.data(), weights.data(), ck_q8.data(), spec.n, spec.k);
+    }
+    if (!llama_mul_mat(weights, activations, llama_output, spec.m, spec.n, spec.k)) {
+        std::fprintf(stderr, "llama.cpp graph execution failed for %s\n", spec.name);
+        return false;
+    }
+    if (spec.with_bias) {
+        for (int row = 0; row < spec.m; ++row) {
+            for (int col = 0; col < spec.n; ++col) {
+                const size_t index = static_cast<size_t>(row) * spec.n + col;
+                llama_output[index] += bias[col];
+                llama_leaf_output[index] += bias[col];
+            }
+        }
+    }
+    if (spec.production_dispatch) {
+        compare_f32("llama leaf vs graph control",
+                llama_leaf_output.data(), llama_output.data(), spec.m, spec.n);
+        passed &= compare_f32("production graph output",
+                ck_output.data(), llama_output.data(), spec.m, spec.n);
+    } else {
+        passed &= compare_f32("decode leaf primitive",
+                ck_output.data(), llama_leaf_output.data(), spec.m, spec.n);
+        passed &= compare_f32("decode production graph",
+                ck_output.data(), llama_output.data(), spec.m, spec.n);
+    }
+    return passed;
+}
+
+} // namespace
+
+int main(int argc, char ** argv) {
+    ggml_cpu_init();
+    if (!std::getenv("CK_NUM_THREADS")) {
+        setenv("CK_NUM_THREADS", "4", 1);
+    }
+
+    const bool quick = argc > 1 && std::strcmp(argv[1], "--quick") == 0;
+    const case_spec quick_cases[] = {
+        {"decode_leaf", 1, 64, 256, false, false},
+        {"packed_prefill_threshold", 16, 512, 1024, true, true},
+        {"packed_prefill_multirow", 33, 1024, 1024, true, false},
+    };
+    const case_spec full_cases[] = {
+        {"decode_leaf", 1, 64, 256, false, false},
+        {"packed_prefill_threshold", 16, 512, 1024, true, true},
+        {"packed_prefill_multirow", 33, 1024, 1024, true, false},
+        {"qwen3vl_qkv_width", 16, 4096, 4096, true, false},
+        {"qwen3vl_down_k_width", 16, 512, 11008, true, false},
+    };
+    const case_spec * cases = quick ? quick_cases : full_cases;
+    const size_t case_count = quick
+            ? sizeof(quick_cases) / sizeof(quick_cases[0])
+            : sizeof(full_cases) / sizeof(full_cases[0]);
+
+    int failed = 0;
+    for (size_t i = 0; i < case_count; ++i) {
+        if (!run_case(cases[i])) {
+            ++failed;
+        }
+    }
+    ck_threadpool_global_destroy();
+    std::printf("\nQ4_K x Q8_K llama.cpp production parity: %s (%zu cases, %d failed)\n",
+            failed == 0 ? "PASS" : "FAIL", case_count, failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/version/v8/contracts/quantized_linear.json
+++ b/version/v8/contracts/quantized_linear.json
@@ -4,22 +4,22 @@
   "engine_contract_version": "8",
   "contracts": {
     "q4_k_x_q8_k_fp32_block_order": {
-      "status": "observed",
+      "status": "validated",
       "weight": {"format": "q4_k", "block_size": 256, "layout": "ggml_q4_k"},
       "activation": {"format": "q8_k", "block_size": 256, "layout": "ggml_q8_k", "quantization": "quantize_row_q8_k_ref"},
-      "dot": {"integer_accumulator": "int32", "block_scale_application": "q4_k_scale_and_min_after_integer_block_sums", "block_order": "ascending_k"},
-      "output": {"accumulator": "fp32", "bias": "after_complete_dot", "storage": "fp32"},
+      "dot": {"integer_accumulator": "int32", "block_scale_application": "q4_k_scale_and_min_after_integer_block_sums", "block_order": "ascending_k", "fp32_accumulator_lanes": 8, "minimum_accumulator_lanes": 4},
+      "output": {"accumulator": "fp32", "horizontal_reduction": "llama_x86_lane_order", "bias": "after_complete_dot", "storage": "fp32"},
       "parallel_reduction": {"kind": "independent_outputs", "reduction_order_effect": "none"},
-      "description": "Q4_K weights times Q8_K activations with scalar-reference block order and independent output partitioning."
+      "description": "Q4_K weights times Q8_K activations with llama-compatible x86 lane accumulation and independent output partitioning."
     },
     "q6_k_x_q8_k_fp32_block_order": {
-      "status": "observed",
+      "status": "validated",
       "weight": {"format": "q6_k", "block_size": 256, "layout": "ggml_q6_k"},
       "activation": {"format": "q8_k", "block_size": 256, "layout": "ggml_q8_k", "quantization": "quantize_row_q8_k_ref"},
-      "dot": {"integer_accumulator": "int32", "block_scale_application": "q6_k_scale_after_integer_block_sums", "block_order": "ascending_k"},
-      "output": {"accumulator": "fp32", "bias": "after_complete_dot", "storage": "fp32"},
+      "dot": {"integer_accumulator": "int32", "block_scale_application": "q6_k_scale_and_q8_bsum_correction_in_int32", "block_order": "ascending_k", "fp32_accumulator_lanes": 8},
+      "output": {"accumulator": "fp32", "horizontal_reduction": "llama_x86_lane_order", "bias": "after_complete_dot", "storage": "fp32"},
       "parallel_reduction": {"kind": "independent_outputs", "reduction_order_effect": "none"},
-      "description": "Q6_K weights times Q8_K activations with scalar-reference block order and independent output partitioning."
+      "description": "Q6_K weights times Q8_K activations with llama-compatible int32 zero-point correction, x86 lane reduction, and independent output partitioning."
     }
   }
 }

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -9862,9 +9862,10 @@
         "kind": "scalar_contract_oracle",
         "adapter": "per_activation_row_then_bias",
         "validation": {
-          "status": "observed",
+          "status": "validated",
           "tests": [
             "unittest/test_q4_k_q8_k_matvec.py",
+            "unittest/test_q4k_q8k_llama_packed.cpp",
             "tests/test_threadpool_parity.c"
           ],
           "external_oracles": [
@@ -9874,9 +9875,9 @@
               "evidence": "unittest/test_q4_k_q8_k_matvec.py"
             },
             {
-              "backend": "llama.cpp",
-              "status": "unresolved",
-              "evidence": "No direct llama.cpp Q4_K x Q8_K GEMM oracle is currently wired."
+              "backend": "llama.cpp_ggml_cpu_graph",
+              "status": "validated",
+              "evidence": "unittest/test_q4k_q8k_llama_packed.cpp"
             }
           ]
         }
@@ -9885,10 +9886,11 @@
         "function": "gemm_nt_q4_k_q8_k",
         "threaded_function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
         "reference_comparison": {
-          "requirement": "contract_tolerance",
-          "absolute_tolerance": 0.001,
-          "relative_tolerance": 0.001,
+          "requirement": "bit_exact",
+          "absolute_tolerance": 0.0,
+          "relative_tolerance": 0.0,
           "tests": [
+            "unittest/test_q4k_q8k_llama_packed.cpp",
             "tests/test_threadpool_parity.c"
           ]
         }
@@ -11904,9 +11906,10 @@
         "kind": "scalar_contract_oracle",
         "adapter": "direct",
         "validation": {
-          "status": "observed",
+          "status": "validated",
           "tests": [
             "unittest/test_q4_k_q8_k_matvec.py",
+            "unittest/test_q4k_q8k_llama_packed.cpp",
             "tests/test_threadpool_parity.c"
           ],
           "external_oracles": [
@@ -11916,9 +11919,9 @@
               "evidence": "unittest/test_q4_k_q8_k_matvec.py"
             },
             {
-              "backend": "llama.cpp",
-              "status": "unresolved",
-              "evidence": "No direct llama.cpp Q4_K x Q8_K GEMV oracle is currently wired."
+              "backend": "llama.cpp_ggml_cpu",
+              "status": "validated",
+              "evidence": "unittest/test_q4k_q8k_llama_packed.cpp"
             }
           ]
         }
@@ -11927,10 +11930,11 @@
         "function": "gemv_q4_k_q8_k",
         "threaded_function": "gemv_q4_k_q8_k_parallel_dispatch",
         "reference_comparison": {
-          "requirement": "contract_tolerance",
-          "absolute_tolerance": 0.001,
-          "relative_tolerance": 0.001,
+          "requirement": "bit_exact",
+          "absolute_tolerance": 0.0,
+          "relative_tolerance": 0.0,
           "tests": [
+            "unittest/test_q4k_q8k_llama_packed.cpp",
             "tests/test_threadpool_parity.c"
           ]
         }
@@ -12725,9 +12729,10 @@
         "kind": "scalar_contract_oracle",
         "adapter": "direct",
         "validation": {
-          "status": "observed",
+          "status": "validated",
           "tests": [
             "unittest/test_q6k_q8k_parity.py",
+            "unittest/test_gemv_kernels_comprehensive.py",
             "tests/test_threadpool_parity.c"
           ],
           "external_oracles": [
@@ -12737,9 +12742,9 @@
               "evidence": "unittest/test_q6k_q8k_parity.py"
             },
             {
-              "backend": "llama.cpp",
-              "status": "unresolved",
-              "evidence": "No direct llama.cpp Q6_K x Q8_K GEMV oracle is currently wired."
+              "backend": "llama.cpp_ggml_cpu",
+              "status": "validated",
+              "evidence": "unittest/test_gemv_kernels_comprehensive.py"
             }
           ]
         }
@@ -12748,10 +12753,11 @@
         "function": "gemv_q6_k_q8_k",
         "threaded_function": "gemv_q6_k_q8_k_parallel_dispatch",
         "reference_comparison": {
-          "requirement": "contract_tolerance",
-          "absolute_tolerance": 0.0001,
-          "relative_tolerance": 0.0001,
+          "requirement": "bit_exact",
+          "absolute_tolerance": 0.0,
+          "relative_tolerance": 0.0,
           "tests": [
+            "unittest/test_gemv_kernels_comprehensive.py",
             "tests/test_threadpool_parity.c"
           ]
         }

--- a/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
@@ -9,11 +9,11 @@
     "kind": "scalar_contract_oracle",
     "adapter": "per_activation_row_then_bias",
     "validation": {
-      "status": "observed",
-      "tests": ["unittest/test_q4_k_q8_k_matvec.py", "tests/test_threadpool_parity.c"],
+      "status": "validated",
+      "tests": ["unittest/test_q4_k_q8_k_matvec.py", "unittest/test_q4k_q8k_llama_packed.cpp", "tests/test_threadpool_parity.c"],
       "external_oracles": [
         {"backend": "numpy_dequantized_fp32", "status": "observed", "evidence": "unittest/test_q4_k_q8_k_matvec.py"},
-        {"backend": "llama.cpp", "status": "unresolved", "evidence": "No direct llama.cpp Q4_K x Q8_K GEMM oracle is currently wired."}
+        {"backend": "llama.cpp_ggml_cpu_graph", "status": "validated", "evidence": "unittest/test_q4k_q8k_llama_packed.cpp"}
       ]
     }
   },
@@ -21,10 +21,10 @@
     "function": "gemm_nt_q4_k_q8_k",
     "threaded_function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
     "reference_comparison": {
-      "requirement": "contract_tolerance",
-      "absolute_tolerance": 0.001,
-      "relative_tolerance": 0.001,
-      "tests": ["tests/test_threadpool_parity.c"]
+      "requirement": "bit_exact",
+      "absolute_tolerance": 0.0,
+      "relative_tolerance": 0.0,
+      "tests": ["unittest/test_q4k_q8k_llama_packed.cpp", "tests/test_threadpool_parity.c"]
     }
   },
   "implementation": {

--- a/version/v8/kernel_maps/gemv_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q4_k_q8_k.json
@@ -9,11 +9,11 @@
     "kind": "scalar_contract_oracle",
     "adapter": "direct",
     "validation": {
-      "status": "observed",
-      "tests": ["unittest/test_q4_k_q8_k_matvec.py", "tests/test_threadpool_parity.c"],
+      "status": "validated",
+      "tests": ["unittest/test_q4_k_q8_k_matvec.py", "unittest/test_q4k_q8k_llama_packed.cpp", "tests/test_threadpool_parity.c"],
       "external_oracles": [
         {"backend": "numpy_dequantized_fp32", "status": "observed", "evidence": "unittest/test_q4_k_q8_k_matvec.py"},
-        {"backend": "llama.cpp", "status": "unresolved", "evidence": "No direct llama.cpp Q4_K x Q8_K GEMV oracle is currently wired."}
+        {"backend": "llama.cpp_ggml_cpu", "status": "validated", "evidence": "unittest/test_q4k_q8k_llama_packed.cpp"}
       ]
     }
   },
@@ -21,10 +21,10 @@
     "function": "gemv_q4_k_q8_k",
     "threaded_function": "gemv_q4_k_q8_k_parallel_dispatch",
     "reference_comparison": {
-      "requirement": "contract_tolerance",
-      "absolute_tolerance": 0.001,
-      "relative_tolerance": 0.001,
-      "tests": ["tests/test_threadpool_parity.c"]
+      "requirement": "bit_exact",
+      "absolute_tolerance": 0.0,
+      "relative_tolerance": 0.0,
+      "tests": ["unittest/test_q4k_q8k_llama_packed.cpp", "tests/test_threadpool_parity.c"]
     }
   },
   "implementation": {

--- a/version/v8/kernel_maps/gemv_q6_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q6_k_q8_k.json
@@ -9,11 +9,11 @@
     "kind": "scalar_contract_oracle",
     "adapter": "direct",
     "validation": {
-      "status": "observed",
-      "tests": ["unittest/test_q6k_q8k_parity.py", "tests/test_threadpool_parity.c"],
+      "status": "validated",
+      "tests": ["unittest/test_q6k_q8k_parity.py", "unittest/test_gemv_kernels_comprehensive.py", "tests/test_threadpool_parity.c"],
       "external_oracles": [
         {"backend": "python_scalar_contract", "status": "observed", "evidence": "unittest/test_q6k_q8k_parity.py"},
-        {"backend": "llama.cpp", "status": "unresolved", "evidence": "No direct llama.cpp Q6_K x Q8_K GEMV oracle is currently wired."}
+        {"backend": "llama.cpp_ggml_cpu", "status": "validated", "evidence": "unittest/test_gemv_kernels_comprehensive.py"}
       ]
     }
   },
@@ -21,10 +21,10 @@
     "function": "gemv_q6_k_q8_k",
     "threaded_function": "gemv_q6_k_q8_k_parallel_dispatch",
     "reference_comparison": {
-      "requirement": "contract_tolerance",
-      "absolute_tolerance": 0.0001,
-      "relative_tolerance": 0.0001,
-      "tests": ["tests/test_threadpool_parity.c"]
+      "requirement": "bit_exact",
+      "absolute_tolerance": 0.0,
+      "relative_tolerance": 0.0,
+      "tests": ["unittest/test_gemv_kernels_comprehensive.py", "tests/test_threadpool_parity.c"]
     }
   },
   "implementation": {

--- a/version/v8/schemas/quantized_linear_contract_registry.schema.json
+++ b/version/v8/schemas/quantized_linear_contract_registry.schema.json
@@ -49,7 +49,9 @@
           "properties": {
             "integer_accumulator": {"enum": ["int32", "none"]},
             "block_scale_application": {"type": "string", "minLength": 1},
-            "block_order": {"enum": ["ascending_k"]}
+            "block_order": {"enum": ["ascending_k"]},
+            "fp32_accumulator_lanes": {"type": "integer", "minimum": 1, "maximum": 64},
+            "minimum_accumulator_lanes": {"type": "integer", "minimum": 1, "maximum": 64}
           }
         },
         "output": {
@@ -58,6 +60,7 @@
           "required": ["accumulator", "bias", "storage"],
           "properties": {
             "accumulator": {"enum": ["fp32", "bf16", "fp16"]},
+            "horizontal_reduction": {"enum": ["llama_x86_lane_order", "scalar_ascending", "none"]},
             "bias": {"enum": ["after_complete_dot", "none"]},
             "storage": {"enum": ["fp32", "bf16", "fp16"]}
           }


### PR DESCRIPTION
## Why
Production Q4_K x Q8_K prefill could disagree with llama.cpp even when the scalar leaf primitive passed. Packing, multi-row dispatch, compiler contraction, and production reduction order were outside the prior oracle boundary, allowing small drift to affect long-token rankings.

## What changed
- Update the llama.cpp submodule to `12127defda4f41b7679cb2477a4b0d65ee6a0c8f`.
- Add a real GGML CPU graph oracle that compares every Q8_K byte and every FP32 output bit against the actual v8 production dispatcher.
- Match llama.cpp x86 Q4 arithmetic: eight FP32 dot lanes, four minimum lanes, and fixed horizontal reduction.
- Preserve that arithmetic while reading the packed x16 weight layout.
- Force the Q8_K multiply rounding boundary so ICX cannot contract it into add-magic rounding.
- Match llama.cpp Q6 zero-point correction and lane reduction; route the direct adapter through the production provider.
- Record exact numerical semantics and external evidence in fail-closed contracts and kernel maps.
- Harden pre-commit/pre-push dependency discovery for submodule pins, clean worktrees, Python environments, and `libllama` provenance.

## Evidence
The practical Qwen-width fixture found only two Q8 bytes changed by ICX FMA contraction, but those bytes changed 4,088 projection outputs with maximum error about `1.30e-3`. After correction, decode, packed-threshold, multi-row, `K=4096`, and `K=11008` cases are bit-exact at one and four threads. The packed x16 quick-matrix performance remains effectively level with the previous provider.

## Validation
- `make llamacpp-parity-full`: PASS
- `make llamacpp-parity-nightly`: PASS
- `make test-q4k-q8k-llama-packed`: 5/5 at 1 and 4 threads
- `make test-gemv-comprehensive`: 51/51
- `make test-numerical-contracts`: PASS, including FP16 attention 21/21
- `make test-threadpool-parity-quick`: PASS
- GCC quick packed oracle: PASS
- Normal pre-commit and pre-push hooks: PASS

## Regression coverage
Nightly runs the bounded decode/M=16/multi-row production oracle. Full llama parity adds practical Qwen3-VL projection widths. The v8 fast suite passed Gemma, Qwen2, Qwen3, Qwen3.5, and Nanbeige; v7 fast inference and training-kernel parity also passed.

## Documentation
Numerical contract and generated kernel-registry metadata now expose lane counts, Q6 zero-point correction, horizontal reduction order, exact external oracle evidence, and zero tolerance. The structured commit and this PR preserve the diagnosis and rejected leaf-only testing assumption.

## Content handoff
- Audience: CPU inference, compiler, quantization, and numerical-parity engineers.
- Angle: Why a correct dot product can still produce the wrong token when production uses packed providers.
- Claims: For tested AVX2 decode and packed-prefill shapes, CKE Q8 bytes and Q4/Q6 production outputs now match latest llama.cpp exactly; packed Q4 performance did not materially regress.
- Caveats: This closes the production primitive gap and associated harness defects. It does not claim that the complete 40-image Qwen3-VL OCR sweep has passed.
- Sources: Commit `e959a7f6`, `unittest/test_q4k_q8k_llama_packed.cpp`, quantized-linear contracts/kernel maps, full/nightly parity logs, and v7/v8 pre-push reports.