### PR TITLE
fix(qwen3vl): match shape-dependent llama prefill math

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2528,7 +2528,11 @@ llamacpp-parity-nightly:
 	@$(MAKE) --no-print-directory test-q8-composed-llama-parity
 	@echo ""
 	@echo "Running bounded Q4_K x Q8_K production packed-sequence parity..."
+	@$(MAKE) --no-print-directory test-q4k-q8k-isa-compile
 	@$(MAKE) --no-print-directory test-q4k-q8k-llama-packed-quick
+	@echo ""
+	@echo "Building Qwen3-VL mtmd adapter against pinned llama.cpp..."
+	@CK_LLAMA_CPP_ROOT="$(CURDIR)/llama.cpp" $(PYTHON) tests/test_v8_mtmd_clip_shim_build.py
 	@echo ""
 	@echo "Running F16 GEMM production reduction contract against llama.cpp..."
 	@$(MAKE) --no-print-directory test-f16-gemm-llama-contract
@@ -2786,6 +2790,8 @@ Q4K_DISPATCH_MATRIX_BIN := $(BUILD_DIR)/bench_q4k_dispatch_matrix
 Q4K_Q8K_LLAMA_PACKED_BIN := $(BUILD_DIR)/test_q4k_q8k_llama_packed
 Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ := $(BUILD_DIR)/test_q4k_q8k_llama_prefill.o
 Q4K_Q8K_LLAMA_PACKED_DECODE_OBJ := $(BUILD_DIR)/test_q4k_q8k_llama_decode.o
+Q4K_Q8K_ISA_AVX2_OBJ := $(BUILD_DIR)/test_q4k_q8k_isa_avx2.o
+Q4K_Q8K_ISA_AVX512_OBJ := $(BUILD_DIR)/test_q4k_q8k_isa_avx512.o
 Q4K_GATEUP_SWIGLU_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu
 Q4K_GATEUP_SWIGLU_OMP_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu_omp_standalone
 QWEN3VL_ENCODER_ATTN_BIN := $(BUILD_DIR)/bench_qwen3vl_encoder_attention
@@ -2822,6 +2828,20 @@ $(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ): $(V8_SRC_DIR)/ck_parallel_prefill_v8.c
 $(Q4K_Q8K_LLAMA_PACKED_DECODE_OBJ): $(V8_SRC_DIR)/ck_parallel_decode_v8.c
 	@mkdir -p $(BUILD_DIR)
 	$(CC) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) -c $< -o $@
+
+.PHONY: test-q4k-q8k-isa-compile
+test-q4k-q8k-isa-compile:
+ifeq ($(IS_X86_ARCH),)
+	@echo "Q4_K x Q8_K ISA compile matrix: SKIP ($(UNAME_M))"
+else
+	@mkdir -p $(BUILD_DIR)
+	$(CC) -O3 -fPIC -Iinclude -mavx2 -mfma -mavxvnni -mf16c -mssse3 \
+		-c src/kernels/gemm_kernels_q4k_q8k_vnni.c -o $(Q4K_Q8K_ISA_AVX2_OBJ)
+	$(CC) -O3 -fPIC -Iinclude -mavx512f -mavx512bw -mavx512dq -mavx512vl \
+		-mfma -mavx512vnni -mavx512bf16 -mf16c -mssse3 \
+		-c src/kernels/gemm_kernels_q4k_q8k_vnni.c -o $(Q4K_Q8K_ISA_AVX512_OBJ)
+	@echo "Q4_K x Q8_K ISA compile matrix: PASS (AVX2, AVX-512/VNNI)"
+endif
 
 $(Q4K_Q8K_LLAMA_PACKED_BIN): $(LIB) unittest/test_q4k_q8k_llama_packed.cpp $(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ) $(Q4K_Q8K_LLAMA_PACKED_DECODE_OBJ)
 	@mkdir -p $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -2781,6 +2781,7 @@ THREADPOOL_BIN := $(BUILD_DIR)/test_threadpool_parity
 Q4K_DISPATCH_MATRIX_BIN := $(BUILD_DIR)/bench_q4k_dispatch_matrix
 Q4K_Q8K_LLAMA_PACKED_BIN := $(BUILD_DIR)/test_q4k_q8k_llama_packed
 Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ := $(BUILD_DIR)/test_q4k_q8k_llama_prefill.o
+Q4K_Q8K_LLAMA_PACKED_DECODE_OBJ := $(BUILD_DIR)/test_q4k_q8k_llama_decode.o
 Q4K_GATEUP_SWIGLU_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu
 Q4K_GATEUP_SWIGLU_OMP_BIN := $(BUILD_DIR)/bench_q4k_gateup_swiglu_omp_standalone
 QWEN3VL_ENCODER_ATTN_BIN := $(BUILD_DIR)/bench_qwen3vl_encoder_attention
@@ -2814,12 +2815,17 @@ $(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ): $(V8_SRC_DIR)/ck_parallel_prefill_v8.c
 	@mkdir -p $(BUILD_DIR)
 	$(CC) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) -c $< -o $@
 
-$(Q4K_Q8K_LLAMA_PACKED_BIN): $(LIB) unittest/test_q4k_q8k_llama_packed.cpp $(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ)
+$(Q4K_Q8K_LLAMA_PACKED_DECODE_OBJ): $(V8_SRC_DIR)/ck_parallel_decode_v8.c
+	@mkdir -p $(BUILD_DIR)
+	$(CC) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) -c $< -o $@
+
+$(Q4K_Q8K_LLAMA_PACKED_BIN): $(LIB) unittest/test_q4k_q8k_llama_packed.cpp $(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ) $(Q4K_Q8K_LLAMA_PACKED_DECODE_OBJ)
 	@mkdir -p $(BUILD_DIR)
 	$(CXX) -O3 -march=native -Iinclude -I$(V8_SRC_DIR) \
 		-Illama.cpp/ggml/include -Illama.cpp/ggml/src \
 		unittest/test_q4k_q8k_llama_packed.cpp \
 		$(Q4K_Q8K_LLAMA_PACKED_PREFILL_OBJ) \
+		$(Q4K_Q8K_LLAMA_PACKED_DECODE_OBJ) \
 		-L$(BUILD_DIR) -lckernel_engine \
 		-Lllama.cpp/build/bin -lggml-cpu -lggml-base -lggml \
 		-lm -lpthread -ldl \

--- a/Makefile
+++ b/Makefile
@@ -781,9 +781,9 @@ $(BUILD_STAMP): FORCE_BUILD_FLAGS | $(BUILD_DIR)
 	@printf 'CC=%s\nCFLAGS=%s\nLDFLAGS=%s\n' "$(CC)" "$(CFLAGS)" "$(LDFLAGS)" > $@.tmp
 	@if [ ! -f $@ ] || ! cmp -s $@.tmp $@; then mv $@.tmp $@; else rm $@.tmp; fi
 
-$(LIB): $(BUILD_STAMP) $(SRCS)
+$(LIB): $(BUILD_STAMP) $(SRCS) Makefile
 	@mkdir -p $(BUILD_DIR)
-	$(CC) $(CFLAGS) -shared -o $@ $(SRCS) $(LDFLAGS) -lm -lpthread
+	$(CC) $(CFLAGS) -shared -Wl,-soname,libckernel_engine.so -o $@ $(SRCS) $(LDFLAGS) -lm -lpthread
 
 $(IR_DEMO): $(BUILD_DIR) src/ckernel_ir.c src/ckernel_ir_demo.c src/ckernel_codegen.c src/ckernel_kernel_specs.c src/ckernel_registry.c include/ckernel_ir.h include/ckernel_codegen.h include/ckernel_registry.h include/ckernel_kernel_specs.h
 	$(CC) -O2 -Wall -Iinclude -o $@ src/ckernel_ir.c src/ckernel_codegen.c src/ckernel_kernel_specs.c src/ckernel_registry.c src/ckernel_ir_demo.c
@@ -1290,9 +1290,13 @@ test-head-major-q5-outproj: $(LIB)
 test-head-major-q5-outproj-quick: $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) unittest/test_head_major_q5_outproj.py --quick
 
-test-v8-qwen3vl: $(LIB_VISION)
+test-v8-qwen3vl: $(LIB_VISION) $(LIB)
 	LD_LIBRARY_PATH=$(BUILD_DIR):$$LD_LIBRARY_PATH $(PYTHON) $(PYTHONFLAGS) tests/test_v8_qwen3vl_template.py
 	$(PYTHON) $(PYTHONFLAGS) -m unittest tests.test_v8_codegen_bridge.V8CodegenBridgeTests.test_qwen3vl_decode_uses_resolved_mrope_and_attention_contracts -v
+	$(PYTHON) $(PYTHONFLAGS) -m unittest \
+		tests.test_v8_native_bridge_host.V8NativeBridgeHostTests.test_engine_has_canonical_soname \
+		tests.test_v8_native_bridge_host.V8NativeBridgeHostTests.test_decoder_loader_uses_requested_engine_when_adjacent_copy_matches \
+		tests.test_v8_native_bridge_host.V8NativeBridgeHostTests.test_decoder_loader_rejects_mismatched_adjacent_engine -v
 	$(PYTHON) $(PYTHONFLAGS) tests/test_v8_vision_encoder_accuracy_gate.py
 	$(PYTHON) $(PYTHONFLAGS) tests/test_nightly_runner_artifact_status.py
 

--- a/docs/site/_pages/divergence-harness.html
+++ b/docs/site/_pages/divergence-harness.html
@@ -29,6 +29,29 @@
     one transpose, or one template seam instead of the whole transformer.
   </p>
 
+  <h2>Why Effective Contracts Matter</h2>
+  <p>
+    A function name is not a complete numerical identity. During Qwen3-VL parity work,
+    CK and llama.cpp invoked attention over the same FP16 cache through apparently
+    equivalent public operations, but llama.cpp selected different arithmetic at a
+    query-batch threshold. Short segments used FP16 online single-range attention;
+    batches of 64 or more queries used 64 x 64 FP32 tiles. The real mixed prefill used
+    segment sizes 5, 1008, and 14, so neither a single-range-only nor tiled-only provider
+    could match all three segments.
+  </p>
+  <p>
+    Execution-state X-ray therefore records the exact kernel ID, declared numerical
+    contract ID, and shape-selected effective contract ID for every bounded kernel
+    batch. It reports <code>KERNEL_CONTRACT_MISMATCH</code> before loading tensor dumps.
+    This prevents a downstream Q8 boundary from being blamed for an upstream dispatch
+    difference and prevents leaf-kernel parity from certifying an untested production route.
+  </p>
+  <p>
+    The complete experiment and rejected-hypothesis record is published as
+    <a href="assets/qwen3vl-q4-parity-investigation.txt">plain text</a> so future agents
+    can reuse the evidence rather than repeat the investigation.
+  </p>
+
   <h2>Current Backend Contract</h2>
   <table>
     <tr>

--- a/docs/site/assets/qwen3vl-q4-parity-investigation.txt
+++ b/docs/site/assets/qwen3vl-q4-parity-investigation.txt
@@ -1,0 +1,73 @@
+Qwen3-VL Q4_K_M parity investigation record
+Reference: llama.cpp a5822222909b785f23ddc74ce3c8f85bd0e38562
+CK branch: test/q4k-q8k-llama-packed
+Date: 2026-07-15
+
+Scope
+
+Canonical prompt: Extract visible form fields as compact JSON.
+Visual prefix: 1008 x 16384 float32 rows from the Q8_0 vision encoder.
+Decoder: Qwen3-VL-8B-Instruct Q4_K_M GGUF.
+Goal: production CK and llama.cpp logits and greedy tokens, with no relaxed tolerance.
+
+Confirmed defects and fixes
+
+1. The parity runner compared tokens after both runtimes had emitted a bridge-declared stop token.
+   Fix: stop comparison at the shared EOS/stop token and report post-EOS differences as invalid.
+
+2. Diagnostic Q/K occurrence mapping confused projection, normalization, and post-RoPE tensors.
+   Fix: map occurrence zero to projection, occurrence one to Q/K normalization when present, and the final occurrence to post-RoPE.
+
+3. Runtime reuse could execute stale generated C or a different engine shared object.
+   Fix: exact-runtime mode requires explicit decoder, manifest, and engine paths and records hashes/compiler provenance.
+
+4. Combined mixed prefill did not reproduce llama.cpp segmented execution.
+   Fix: represent text-before, visual, and text-after as cache-preserving circuit calls with separate physical cache and semantic M-RoPE positions.
+
+5. Direct scalar Q4_K x Q8_K tests did not certify the packed multi-row production provider.
+   Fix: add current llama.cpp GGML graph oracles at decode, packed M=16, and practical Qwen3-VL dimensions. Record exact packed reduction semantics in the quantized-linear contracts and kernel maps.
+
+6. ICX contraction changed Q8_K rounding bytes at a production quantization boundary.
+   Fix: preserve the required arithmetic boundary and validate both GCC and ICX paths against llama.cpp rather than treating compiler agreement as an oracle.
+
+7. CK SwiGLU used a mathematically similar exponential/evaluation order rather than GGML's exact x86 contract.
+   Fix: add swiglu_forward_ggml, select it through the Qwen3-VL circuit and kernel map, and test the exact intermediate boundary.
+
+8. Qwen3-VL visual prefill used one attention reduction contract for every segment.
+   llama.cpp dispatches by query batch shape: Q below 64 uses FP16 online single-range arithmetic; Q at or above 64 uses 64 x 64 FP32 tiled flash attention.
+   Qwen3-VL uses Q=5, Q=1008, and Q=14 for text-before, visual, and text-after. A single-range-only implementation corrupted visual history; a tiled-only experiment corrupted both short text segments.
+   Fix: add the explicit f16_flash_auto_qtile64 composite contract. The circuit requests it, the kernel map binds it, and the kernel selects only between two independently validated arithmetic contracts at Q=64.
+
+Disproved or incomplete hypotheses
+
+1. The initial layer-0 Q/K/V Q8 quantization and projection were not the remaining failure. Natural layer-0 Q/K/V matched exactly.
+
+2. A generic Q8 amplification diagnosis was too broad. Small differences did cross later quantization boundaries, but their upstream cause was visual prefill attention dispatch.
+
+3. Persistent KV-cache corruption was not the final explanation for the canonical failure. Full replay reproduced some failures, while execution-state X-ray separately found and fixed a real segmented-prefill/cache-policy mismatch.
+
+4. Replacing all prefill attention with the 64 x 64 tiled provider improved long visual arithmetic but still failed because Q=5 and Q=14 require llama.cpp's short-query contract.
+
+5. Leaf primitive parity alone was insufficient. Production provider, batch shape, selected reduction, compiler, and runtime artifact hashes must all be part of the oracle evidence.
+
+Hardening added
+
+1. llama.cpp-backed Q4_K/Q6_K x Q8_K production graph tests in full/nightly parity.
+2. FP16 attention oracle cases at Q=5, Q=14, Q=63, Q=64, and Q=1008 with H=32, Hkv=8, D=128.
+3. Fail-closed composite attention-contract schema with missing and unvalidated route rejection.
+4. Exact circuit to kernel-map resolution for segmented prefill, decode attention, SwiGLU, and packed quantized linear providers.
+5. X-ray execution traces require kernel ID, declared numerical contract ID, and shape-selected effective contract ID.
+6. X-ray reports KERNEL_CONTRACT_MISMATCH before loading tensor dumps.
+7. EOS-aware multi-token parity and explicit runtime provenance.
+
+Measured status
+
+Direct FP16 attention oracle: 27/27 pass on current llama.cpp.
+Production visual segment Q=1008, KV=1013, H=32, Hkv=8, D=128: byte-exact.
+Canonical image: 384/384 token steps pass with RMSE 0 and identical top-16 logits. EOS was not reached within that bound.
+Five-image gate: 5/5 images pass 64/64 token steps, including prefix_text_pos 41 and 45 variants.
+The 10-image, 40-image, and per-image EOS gates remain to be run before claiming universal OCR parity.
+
+Research lesson
+
+Numerical parity is a property of an executed circuit, not a function name. Input storage, arithmetic order, rounding boundaries, batch shape, thread partition, compiler contraction, effective runtime dispatch, cache history, and stop-token semantics can each change the token path. X-ray must compare this execution state before interpreting downstream tensor error.

--- a/docs/site/divergence-harness.html
+++ b/docs/site/divergence-harness.html
@@ -1006,6 +1006,29 @@
     one transpose, or one template seam instead of the whole transformer.
   </p>
 
+  <h2>Why Effective Contracts Matter</h2>
+  <p>
+    A function name is not a complete numerical identity. During Qwen3-VL parity work,
+    CK and llama.cpp invoked attention over the same FP16 cache through apparently
+    equivalent public operations, but llama.cpp selected different arithmetic at a
+    query-batch threshold. Short segments used FP16 online single-range attention;
+    batches of 64 or more queries used 64 x 64 FP32 tiles. The real mixed prefill used
+    segment sizes 5, 1008, and 14, so neither a single-range-only nor tiled-only provider
+    could match all three segments.
+  </p>
+  <p>
+    Execution-state X-ray therefore records the exact kernel ID, declared numerical
+    contract ID, and shape-selected effective contract ID for every bounded kernel
+    batch. It reports <code>KERNEL_CONTRACT_MISMATCH</code> before loading tensor dumps.
+    This prevents a downstream Q8 boundary from being blamed for an upstream dispatch
+    difference and prevents leaf-kernel parity from certifying an untested production route.
+  </p>
+  <p>
+    The complete experiment and rejected-hypothesis record is published as
+    <a href="assets/qwen3vl-q4-parity-investigation.txt">plain text</a> so future agents
+    can reuse the evidence rather than repeat the investigation.
+  </p>
+
   <h2>Current Backend Contract</h2>
   <table>
     <tr>
@@ -1545,7 +1568,7 @@ ck_dump_tensor_head_major_token_major(q_buffer, layer_id, "Qcur", heads, tokens,
             </div>
             <div style="text-align: right;">
                 <p style="color: #606060; font-size: 0.75rem; margin: 0;">Static docs · C-first execution</p>
-                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-14</p>
+                <p style="color: #606060; font-size: 0.75rem; margin: 0.5rem 0 0 0;">2026-07-15</p>
             </div>
         </div>
     </footer>

--- a/include/ckernel_engine.h
+++ b/include/ckernel_engine.h
@@ -1595,6 +1595,8 @@ void attention_forward_decode_head_major_gqa_flash_f16cache(const float *q_token
 typedef enum {
     CK_ATTN_REDUCTION_FP32_ONLINE = 0,
     CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE = 1,
+    CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE = 2,
+    CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64 = 3,
 } ck_attention_reduction_t;
 
 typedef enum {
@@ -1613,22 +1615,6 @@ ck_attention_status_t attention_forward_decode_head_major_gqa_flash_f16cache_con
     int num_heads,
     int num_kv_heads,
     int kv_tokens,
-    int cache_capacity,
-    int head_dim,
-    int aligned_head_dim,
-    ck_attention_reduction_t reduction);
-
-// Causal prefill over a cache-preserving segment. Current-segment K/V rows
-// must already be appended at [past_tokens, past_tokens + q_tokens).
-ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(
-    const float *q,
-    const uint16_t *k_cache,
-    const uint16_t *v_cache,
-    float *output,
-    int num_heads,
-    int num_kv_heads,
-    int q_tokens,
-    int past_tokens,
     int cache_capacity,
     int head_dim,
     int aligned_head_dim,
@@ -2417,6 +2403,11 @@ void sigmoid_backward_bf16(const uint16_t *input,
 	                          float *output,
 	                          int tokens,
 	                          int dim);
+
+	void swiglu_forward_ggml(const float *input,
+	                         float *output,
+	                         int tokens,
+	                         int dim);
 
 	void swiglu_backward_exact(const float *input,
 	                           const float *d_output,

--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -5182,6 +5182,13 @@ ck_attention_status_t attention_forward_decode_head_major_gqa_flash_f16cache_con
         return CK_ATTENTION_STATUS_OK;
     }
 
+    case CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE:
+        attention_forward_decode_head_major_gqa_flash_f16cache_split(
+            q_token, k_cache, v_cache, out_token,
+            num_heads, num_kv_heads, kv_tokens, cache_capacity,
+            head_dim, aligned_head_dim, 1);
+        return CK_ATTENTION_STATUS_OK;
+
     default:
         return CK_ATTENTION_STATUS_UNSUPPORTED_CONTRACT;
     }
@@ -5206,6 +5213,150 @@ ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16
         past_tokens < 0 || past_tokens + q_tokens > cache_capacity ||
         head_dim <= 0 || aligned_head_dim < head_dim) {
         return CK_ATTENTION_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (reduction == CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64 &&
+        q_tokens < CK_GGML_FA_TILE_Q) {
+        reduction = CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE;
+    }
+
+    if (reduction == CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64) {
+        const int kv_tokens = past_tokens + q_tokens;
+        const float scale = ck_attention_strict_scale_f32(head_dim);
+        const size_t kv_head_stride = (size_t) cache_capacity * (size_t) aligned_head_dim;
+
+        float *q_tile = (float *) alloca(
+            (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
+        float *k_tile = (float *) alloca(
+            (size_t) head_dim * (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
+        float *v_tile = (float *) alloca(
+            (size_t) CK_GGML_FA_TILE_KV * (size_t) head_dim * sizeof(float));
+        float *kq = (float *) alloca(
+            (size_t) CK_GGML_FA_TILE_Q * (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
+        float *vkq = (float *) alloca(
+            (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
+
+        for (int h = 0; h < num_heads; ++h) {
+            const int kv_head =
+                (int) ((long long) h * (long long) num_kv_heads / (long long) num_heads);
+            const uint16_t *k_head = k_cache + (size_t) kv_head * kv_head_stride;
+            const uint16_t *v_head = v_cache + (size_t) kv_head * kv_head_stride;
+
+            for (int iq = 0; iq < q_tokens; iq += CK_GGML_FA_TILE_Q) {
+                const int tile_rows =
+                    (q_tokens - iq) < CK_GGML_FA_TILE_Q ? (q_tokens - iq) : CK_GGML_FA_TILE_Q;
+                float sum_row[CK_GGML_FA_TILE_Q];
+                float max_row[CK_GGML_FA_TILE_Q];
+
+                for (int tq = 0; tq < CK_GGML_FA_TILE_Q; ++tq) {
+                    sum_row[tq] = 0.0f;
+                    max_row[tq] = -INFINITY;
+                }
+                memset(q_tile, 0,
+                       (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
+                memset(vkq, 0,
+                       (size_t) CK_GGML_FA_TILE_Q * (size_t) head_dim * sizeof(float));
+
+                for (int tq = 0; tq < tile_rows; ++tq) {
+                    const float *q_vec = q + qkv_index(
+                        h, iq + tq, 0, q_tokens, aligned_head_dim);
+                    memcpy(q_tile + (size_t) tq * (size_t) head_dim,
+                           q_vec,
+                           (size_t) head_dim * sizeof(float));
+                }
+
+                for (int ik = 0; ik < kv_tokens; ik += CK_GGML_FA_TILE_KV) {
+                    const int kv_tile =
+                        (kv_tokens - ik) < CK_GGML_FA_TILE_KV
+                            ? (kv_tokens - ik)
+                            : CK_GGML_FA_TILE_KV;
+                    memset(k_tile, 0,
+                           (size_t) head_dim * (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
+                    memset(v_tile, 0,
+                           (size_t) CK_GGML_FA_TILE_KV * (size_t) head_dim * sizeof(float));
+                    memset(kq, 0,
+                           (size_t) CK_GGML_FA_TILE_Q * (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
+
+                    for (int tk = 0; tk < kv_tile; ++tk) {
+                        const uint16_t *k_vec = k_head +
+                            (size_t) (ik + tk) * (size_t) aligned_head_dim;
+                        const uint16_t *v_vec = v_head +
+                            (size_t) (ik + tk) * (size_t) aligned_head_dim;
+                        for (int d = 0; d < head_dim; ++d) {
+                            k_tile[(size_t) d * (size_t) CK_GGML_FA_TILE_KV + (size_t) tk] =
+                                CK_FP16_TO_FP32(k_vec[d]);
+                            v_tile[(size_t) tk * (size_t) head_dim + (size_t) d] =
+                                CK_FP16_TO_FP32(v_vec[d]);
+                        }
+                    }
+
+                    ck_attention_matmul_f32_accum(
+                        kq, q_tile, k_tile,
+                        CK_GGML_FA_TILE_Q, head_dim, CK_GGML_FA_TILE_KV);
+                    ck_vec_scale_f32_inplace(
+                        kq, CK_GGML_FA_TILE_Q * CK_GGML_FA_TILE_KV, scale);
+
+                    for (int tq = 0; tq < CK_GGML_FA_TILE_Q; ++tq) {
+                        float *kq_row = kq +
+                            (size_t) tq * (size_t) CK_GGML_FA_TILE_KV;
+                        const int last_valid_key = past_tokens + iq + tq;
+                        for (int tk = 0; tk < CK_GGML_FA_TILE_KV; ++tk) {
+                            const int key = ik + tk;
+                            if (tk >= kv_tile || tq >= tile_rows || key > last_valid_key) {
+                                kq_row[tk] = -INFINITY;
+                            }
+                        }
+
+                        const float tile_max =
+                            ck_vec_max_f32_contig(kq_row, CK_GGML_FA_TILE_KV);
+                        if (tile_max == -INFINITY) {
+                            memset(kq_row, 0,
+                                   (size_t) CK_GGML_FA_TILE_KV * sizeof(float));
+                            continue;
+                        }
+
+                        const float old_max = max_row[tq];
+                        const float new_max = old_max > tile_max ? old_max : tile_max;
+                        if (new_max > old_max) {
+                            const float ms = ck_attention_reference_expf(old_max - new_max);
+                            ck_vec_scale_f32_inplace(
+                                vkq + (size_t) tq * (size_t) head_dim, head_dim, ms);
+                            sum_row[tq] *= ms;
+                        }
+                        max_row[tq] = new_max;
+                        sum_row[tq] = (float) (
+                            (double) sum_row[tq] +
+                            ck_ggml_vec_soft_max_row(
+                                CK_GGML_FA_TILE_KV, kq_row, kq_row, new_max));
+                    }
+
+                    ck_attention_matmul_f32_accum(
+                        vkq, kq, v_tile,
+                        CK_GGML_FA_TILE_Q, CK_GGML_FA_TILE_KV, head_dim);
+                }
+
+                for (int tq = 0; tq < tile_rows; ++tq) {
+                    float *out_vec = output + qkv_index(
+                        h, iq + tq, 0, q_tokens, aligned_head_dim);
+                    const float inv_sum =
+                        sum_row[tq] == 0.0f ? 0.0f : 1.0f / sum_row[tq];
+                    for (int d = 0; d < head_dim; ++d) {
+                        out_vec[d] =
+                            vkq[(size_t) tq * (size_t) head_dim + (size_t) d] * inv_sum;
+                    }
+                    for (int d = head_dim; d < aligned_head_dim; ++d) {
+                        out_vec[d] = 0.0f;
+                    }
+                }
+            }
+        }
+        return CK_ATTENTION_STATUS_OK;
+    }
+
+    if (reduction != CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE &&
+        reduction != CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE &&
+        reduction != CK_ATTN_REDUCTION_FP32_ONLINE) {
+        return CK_ATTENTION_STATUS_UNSUPPORTED_CONTRACT;
     }
 
     const size_t token_elems = (size_t) num_heads * (size_t) aligned_head_dim;

--- a/src/kernels/gemm_kernels_bf16.c
+++ b/src/kernels/gemm_kernels_bf16.c
@@ -430,13 +430,15 @@ void gemm_bf16_fp32out(const uint16_t *A,
     }
 
 #if HAVE_NATIVE_BF16
+#if HAVE_AMX_BF16
     const char *amx_env = getenv("CK_BF16_AMX");
-    if (amx_env && amx_env[0] == '1' && HAVE_AMX_BF16 &&
+    if (amx_env && amx_env[0] == '1' &&
         (M % 16) == 0 && (N % 16) == 0 && (K % 32) == 0 &&
         M >= 16 && N >= 16 && K >= 32 && ck_amx_request_xtile_data()) {
         gemm_bf16_fp32out_amx(A, B, bias, C, M, N, K);
         return;
     }
+#endif
 
     #pragma omp parallel for schedule(dynamic)
     for (int i = 0; i < M; ++i) {

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -618,13 +618,19 @@ static inline void accum_q4_k_packed_meta_x8_q8_k_superblock(
         const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
                                 (int32_t)x->bsums[(j + 32) / 16 + 1];
 
-#if defined(__AVX2__)
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#elif defined(__AVX2__)
         const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
         const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
 #endif
         for (int lane = 0; lane < active; ++lane) {
             const uint8_t *qs = &w->qs[lane][q_offset];
-#if defined(__AVX2__)
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+            const int32_t sum_lo = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_lo, 0);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_hi, 1);
+#elif defined(__AVX2__)
             const __m256i packed = _mm256_loadu_si256((const __m256i *)qs);
             const __m256i q4_lo = q4_k_unpack_32_avx2_bytes(packed, 0);
             const __m256i q4_hi = q4_k_unpack_32_avx2_bytes(packed, 1);
@@ -683,13 +689,19 @@ static inline void accum_q4_k_packed_meta_x8_q8_k_gemv_block(
                                 (int32_t)x->bsums[j / 16 + 1];
         const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
                                 (int32_t)x->bsums[(j + 32) / 16 + 1];
-#if defined(__AVX2__)
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#elif defined(__AVX2__)
         const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
         const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
 #endif
         for (int lane = 0; lane < active; ++lane) {
             const uint8_t *qs = &w->qs[lane][q_offset];
-#if defined(__AVX2__)
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+            const int32_t sum_lo = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_lo, 0);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_vnni_q8v(qs, q8_hi, 1);
+#elif defined(__AVX2__)
             const __m256i packed = _mm256_loadu_si256((const __m256i *)qs);
             const __m256i q4_lo = q4_k_unpack_32_avx2_bytes(packed, 0);
             const __m256i q4_hi = q4_k_unpack_32_avx2_bytes(packed, 1);

--- a/src/kernels/gemm_kernels_q4k_q8k_vnni.c
+++ b/src/kernels/gemm_kernels_q4k_q8k_vnni.c
@@ -588,6 +588,154 @@ static inline void accum_q4_k_packed_meta_x8_q8_k_block(float acc[8],
     }
 }
 
+/* Match the loaded-model Q4_Kx8 contract: each pair of 32-element subblocks
+ * is reduced in integer arithmetic, followed by one FP32 value FMA and one
+ * minimum FMA. The two FP32 accumulators remain separate until the end. */
+static inline void accum_q4_k_packed_meta_x8_q8_k_superblock(
+        float acc[8], float acc_min[8],
+        const block_q4_K_packed_meta_x8 *w, int active,
+        const block_q8_K *x)
+{
+    const float xd = x->d;
+#if defined(__AVX2__)
+    float d[8] = {0};
+    float dmin[8] = {0};
+    for (int lane = 0; lane < active; ++lane) {
+        d[lane] = CK_FP16_TO_FP32(w->d[lane]);
+        dmin[lane] = CK_FP16_TO_FP32(w->dmin[lane]);
+    }
+    const __m256 scale = _mm256_mul_ps(_mm256_loadu_ps(d), _mm256_set1_ps(xd));
+    const __m256 min_scale = _mm256_mul_ps(_mm256_loadu_ps(dmin), _mm256_set1_ps(xd));
+#endif
+
+    for (int j = 0, is = 0, q_offset = 0; j < QK_K; j += 64, is += 2, q_offset += 32) {
+        int32_t iacc[8] = {0};
+        int32_t iacc_min[8] = {0};
+        const int8_t *q8_lo_ptr = &x->qs[j];
+        const int8_t *q8_hi_ptr = &x->qs[j + 32];
+        const int32_t bsum_lo = (int32_t)x->bsums[j / 16] +
+                                (int32_t)x->bsums[j / 16 + 1];
+        const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
+                                (int32_t)x->bsums[(j + 32) / 16 + 1];
+
+#if defined(__AVX2__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#endif
+        for (int lane = 0; lane < active; ++lane) {
+            const uint8_t *qs = &w->qs[lane][q_offset];
+#if defined(__AVX2__)
+            const __m256i packed = _mm256_loadu_si256((const __m256i *)qs);
+            const __m256i q4_lo = q4_k_unpack_32_avx2_bytes(packed, 0);
+            const __m256i q4_hi = q4_k_unpack_32_avx2_bytes(packed, 1);
+            const int32_t sum_lo = dot_q4_k_q8_k_32_avx2_q4v_q8v(q4_lo, q8_lo);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_avx2_q4v_q8v(q4_hi, q8_hi);
+#else
+            int32_t sum_lo = 0;
+            int32_t sum_hi = 0;
+            for (int l = 0; l < 32; ++l) {
+                sum_lo += (int32_t)(qs[l] & 0x0F) * (int32_t)q8_lo_ptr[l];
+                sum_hi += (int32_t)(qs[l] >> 4) * (int32_t)q8_hi_ptr[l];
+            }
+#endif
+            iacc[lane] = (int32_t)w->sc[lane][is] * sum_lo +
+                         (int32_t)w->sc[lane][is + 1] * sum_hi;
+            iacc_min[lane] = (int32_t)w->m[lane][is] * bsum_lo +
+                             (int32_t)w->m[lane][is + 1] * bsum_hi;
+        }
+
+#if defined(__AVX2__)
+    const __m256 acc_vec = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_loadu_si256((const __m256i *)iacc)),
+            scale,
+            _mm256_loadu_ps(acc));
+    const __m256 acc_min_vec = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_loadu_si256((const __m256i *)iacc_min)),
+            min_scale,
+            _mm256_loadu_ps(acc_min));
+    _mm256_storeu_ps(acc, acc_vec);
+    _mm256_storeu_ps(acc_min, acc_min_vec);
+#else
+    for (int lane = 0; lane < active; ++lane) {
+        const float d = CK_FP16_TO_FP32(w->d[lane]) * xd;
+        const float dmin = CK_FP16_TO_FP32(w->dmin[lane]) * xd;
+        acc[lane] = fmaf((float)iacc[lane], d, acc[lane]);
+        acc_min[lane] = fmaf((float)iacc_min[lane], dmin, acc_min[lane]);
+    }
+#endif
+    }
+}
+
+/* The repacked GEMV provider has a distinct reduction boundary from GEMM:
+ * all four 64-element pairs in one Q4_K block are combined in int32 before
+ * one value FMA and one minimum FMA update the FP32 accumulators. */
+static inline void accum_q4_k_packed_meta_x8_q8_k_gemv_block(
+        float acc[8], float acc_min[8],
+        const block_q4_K_packed_meta_x8 *w, int active,
+        const block_q8_K *x)
+{
+    int32_t iacc[8] = {0};
+    int32_t iacc_min[8] = {0};
+    for (int j = 0, is = 0, q_offset = 0; j < QK_K; j += 64, is += 2, q_offset += 32) {
+        const int8_t *q8_lo_ptr = &x->qs[j];
+        const int8_t *q8_hi_ptr = &x->qs[j + 32];
+        const int32_t bsum_lo = (int32_t)x->bsums[j / 16] +
+                                (int32_t)x->bsums[j / 16 + 1];
+        const int32_t bsum_hi = (int32_t)x->bsums[(j + 32) / 16] +
+                                (int32_t)x->bsums[(j + 32) / 16 + 1];
+#if defined(__AVX2__)
+        const __m256i q8_lo = _mm256_loadu_si256((const __m256i *)q8_lo_ptr);
+        const __m256i q8_hi = _mm256_loadu_si256((const __m256i *)q8_hi_ptr);
+#endif
+        for (int lane = 0; lane < active; ++lane) {
+            const uint8_t *qs = &w->qs[lane][q_offset];
+#if defined(__AVX2__)
+            const __m256i packed = _mm256_loadu_si256((const __m256i *)qs);
+            const __m256i q4_lo = q4_k_unpack_32_avx2_bytes(packed, 0);
+            const __m256i q4_hi = q4_k_unpack_32_avx2_bytes(packed, 1);
+            const int32_t sum_lo = dot_q4_k_q8_k_32_avx2_q4v_q8v(q4_lo, q8_lo);
+            const int32_t sum_hi = dot_q4_k_q8_k_32_avx2_q4v_q8v(q4_hi, q8_hi);
+#else
+            int32_t sum_lo = 0;
+            int32_t sum_hi = 0;
+            for (int l = 0; l < 32; ++l) {
+                sum_lo += (int32_t)(qs[l] & 0x0F) * (int32_t)q8_lo_ptr[l];
+                sum_hi += (int32_t)(qs[l] >> 4) * (int32_t)q8_hi_ptr[l];
+            }
+#endif
+            iacc[lane] += (int32_t)w->sc[lane][is] * sum_lo +
+                           (int32_t)w->sc[lane][is + 1] * sum_hi;
+            iacc_min[lane] += (int32_t)w->m[lane][is] * bsum_lo +
+                               (int32_t)w->m[lane][is + 1] * bsum_hi;
+        }
+    }
+
+#if defined(__AVX2__)
+    float d[8] = {0};
+    float dmin[8] = {0};
+    for (int lane = 0; lane < active; ++lane) {
+        d[lane] = CK_FP16_TO_FP32(w->d[lane]);
+        dmin[lane] = CK_FP16_TO_FP32(w->dmin[lane]);
+    }
+    const __m256 xd = _mm256_set1_ps(x->d);
+    const __m256 acc_vec = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_loadu_si256((const __m256i *)iacc)),
+            _mm256_mul_ps(_mm256_loadu_ps(d), xd), _mm256_loadu_ps(acc));
+    const __m256 min_vec = _mm256_fmadd_ps(
+            _mm256_cvtepi32_ps(_mm256_loadu_si256((const __m256i *)iacc_min)),
+            _mm256_mul_ps(_mm256_loadu_ps(dmin), xd), _mm256_loadu_ps(acc_min));
+    _mm256_storeu_ps(acc, acc_vec);
+    _mm256_storeu_ps(acc_min, min_vec);
+#else
+    for (int lane = 0; lane < active; ++lane) {
+        const float d = CK_FP16_TO_FP32(w->d[lane]) * x->d;
+        const float dmin = CK_FP16_TO_FP32(w->dmin[lane]) * x->d;
+        acc[lane] = fmaf((float)iacc[lane], d, acc[lane]);
+        acc_min[lane] = fmaf((float)iacc_min[lane], dmin, acc_min[lane]);
+    }
+#endif
+}
+
 
 
 
@@ -1016,6 +1164,90 @@ void gemm_nt_q4_k_packed_meta_x8_q8_k(const void *A_q8,
             }
             for (int lane = 0; lane < active; ++lane) {
                 c_row[n0 + lane] = acc[lane];
+            }
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_meta_x8_q8_k_superblock_order(
+        const void *A_q8, const void *B_packed_x8, const float *bias, float *C,
+        int M, int N, int K)
+{
+    if (!A_q8 || !B_packed_x8 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    const block_q8_K *A = (const block_q8_K *)A_q8;
+    const block_q4_K_packed_meta_x8 *W = (const block_q4_K_packed_meta_x8 *)B_packed_x8;
+    const int blocks_per_row = K / QK_K;
+    const int groups = (N + 7) / 8;
+
+    for (int m = 0; m < M; ++m) {
+        const block_q8_K *a_row = A + (size_t)m * (size_t)blocks_per_row;
+        float *c_row = C + (size_t)m * (size_t)N;
+        for (int g = 0; g < groups; ++g) {
+            const int n0 = g * 8;
+            const int active = (n0 + 8 <= N) ? 8 : (N - n0);
+            float acc[8] = {0};
+            float acc_min[8] = {0};
+            for (int b = 0; b < blocks_per_row; ++b) {
+                const block_q4_K_packed_meta_x8 *w_group =
+                        W + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+                accum_q4_k_packed_meta_x8_q8_k_superblock(
+                        acc, acc_min, w_group, active, &a_row[b]);
+            }
+            float values[8];
+#if defined(__AVX2__)
+            _mm256_storeu_ps(values, _mm256_sub_ps(_mm256_loadu_ps(acc), _mm256_loadu_ps(acc_min)));
+#else
+            for (int lane = 0; lane < active; ++lane) {
+                values[lane] = acc[lane] - acc_min[lane];
+            }
+#endif
+            for (int lane = 0; lane < active; ++lane) {
+                float value = values[lane];
+                if (bias) {
+                    value += bias[n0 + lane];
+                }
+                c_row[n0 + lane] = value;
+            }
+        }
+    }
+}
+
+void gemm_nt_q4_k_packed_meta_x8_q8_k_gemv_order(
+        const void *A_q8, const void *B_packed_x8, const float *bias, float *C,
+        int M, int N, int K)
+{
+    if (!A_q8 || !B_packed_x8 || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) {
+        return;
+    }
+    const block_q8_K *A = (const block_q8_K *)A_q8;
+    const block_q4_K_packed_meta_x8 *W = (const block_q4_K_packed_meta_x8 *)B_packed_x8;
+    const int blocks_per_row = K / QK_K;
+    const int groups = (N + 7) / 8;
+    for (int m = 0; m < M; ++m) {
+        const block_q8_K *a_row = A + (size_t)m * (size_t)blocks_per_row;
+        float *c_row = C + (size_t)m * (size_t)N;
+        for (int g = 0; g < groups; ++g) {
+            const int n0 = g * 8;
+            const int active = (n0 + 8 <= N) ? 8 : (N - n0);
+            float acc[8] = {0};
+            float acc_min[8] = {0};
+            for (int b = 0; b < blocks_per_row; ++b) {
+                const block_q4_K_packed_meta_x8 *w_group =
+                        W + (size_t)g * (size_t)blocks_per_row + (size_t)b;
+                accum_q4_k_packed_meta_x8_q8_k_gemv_block(
+                        acc, acc_min, w_group, active, &a_row[b]);
+            }
+            float values[8];
+#if defined(__AVX2__)
+            _mm256_storeu_ps(values, _mm256_sub_ps(
+                    _mm256_loadu_ps(acc), _mm256_loadu_ps(acc_min)));
+#else
+            for (int lane = 0; lane < active; ++lane) values[lane] = acc[lane] - acc_min[lane];
+#endif
+            for (int lane = 0; lane < active; ++lane) {
+                c_row[n0 + lane] = values[lane] + (bias ? bias[n0 + lane] : 0.0f);
             }
         }
     }

--- a/src/kernels/swiglu_kernels.c
+++ b/src/kernels/swiglu_kernels.c
@@ -125,6 +125,54 @@ static inline __m256 sigmoid256_fast(__m256 x) {
     __m256 one = _mm256_set1_ps(1.0f);
     return _mm256_div_ps(one, _mm256_add_ps(one, exp_neg));
 }
+
+/* GGML's parity path uses this specific vector exponential approximation. */
+static inline __m256 ck_ggml_expf_avx2(__m256 x) {
+    const __m256 r = _mm256_set1_ps(0x1.8p23f);
+    const __m256 z = _mm256_fmadd_ps(x, _mm256_set1_ps(0x1.715476p+0f), r);
+    const __m256 n = _mm256_sub_ps(z, r);
+    const __m256 b = _mm256_fnmadd_ps(
+        n,
+        _mm256_set1_ps(0x1.7f7d1cp-20f),
+        _mm256_fnmadd_ps(n, _mm256_set1_ps(0x1.62e4p-1f), x));
+    const __m256i e = _mm256_slli_epi32(_mm256_castps_si256(z), 23);
+    const __m256 k = _mm256_castsi256_ps(
+        _mm256_add_epi32(e, _mm256_castps_si256(_mm256_set1_ps(1))));
+    const __m256i c = _mm256_castps_si256(
+        _mm256_cmp_ps(_mm256_andnot_ps(_mm256_set1_ps(-0.0f), n),
+                      _mm256_set1_ps(126), _CMP_GT_OQ));
+    const __m256 u = _mm256_mul_ps(b, b);
+    const __m256 j = _mm256_fmadd_ps(
+        _mm256_fmadd_ps(
+            _mm256_fmadd_ps(_mm256_set1_ps(0x1.0e4020p-7f), b,
+                            _mm256_set1_ps(0x1.573e2ep-5f)),
+            u,
+            _mm256_fmadd_ps(_mm256_set1_ps(0x1.555e66p-3f), b,
+                            _mm256_set1_ps(0x1.fffdb6p-2f))),
+        u,
+        _mm256_mul_ps(_mm256_set1_ps(0x1.ffffecp-1f), b));
+    if (!_mm256_movemask_ps(_mm256_castsi256_ps(c))) {
+        return _mm256_fmadd_ps(j, k, k);
+    }
+    const __m256i g = _mm256_and_si256(
+        _mm256_castps_si256(_mm256_cmp_ps(n, _mm256_setzero_ps(), _CMP_LE_OQ)),
+        _mm256_set1_epi32((int)0x82000000u));
+    const __m256 s1 = _mm256_castsi256_ps(
+        _mm256_add_epi32(g, _mm256_set1_epi32(0x7f000000u)));
+    const __m256 s2 = _mm256_castsi256_ps(_mm256_sub_epi32(e, g));
+    const __m256i d = _mm256_castps_si256(
+        _mm256_cmp_ps(_mm256_andnot_ps(_mm256_set1_ps(-0.0f), n),
+                      _mm256_set1_ps(192), _CMP_GT_OQ));
+    return _mm256_or_ps(
+        _mm256_and_ps(_mm256_castsi256_ps(d), _mm256_mul_ps(s1, s1)),
+        _mm256_andnot_ps(
+            _mm256_castsi256_ps(d),
+            _mm256_or_ps(
+                _mm256_and_ps(_mm256_castsi256_ps(c),
+                              _mm256_mul_ps(_mm256_fmadd_ps(s2, j, s2), s1)),
+                _mm256_andnot_ps(_mm256_castsi256_ps(c),
+                                 _mm256_fmadd_ps(k, j, k)))));
+}
 #endif
 
 /**
@@ -436,6 +484,34 @@ void swiglu_forward_exact(const float *input,
             float s = sigmoid_scalar_parity(a); // sigmoid(a)
             float silu = a * s;                 // silu(a)
             out_row[d] = silu * b;
+        }
+    }
+}
+
+void swiglu_forward_ggml(const float *input,
+                         float *output,
+                         int tokens,
+                         int dim)
+{
+    for (int t = 0; t < tokens; ++t) {
+        const float *row = input + (size_t)t * (2 * dim);
+        float *out_row = output + (size_t)t * dim;
+        int d = 0;
+
+#if defined(__AVX2__) && defined(__FMA__)
+        for (; d + 8 <= dim; d += 8) {
+            const __m256 gate = _mm256_loadu_ps(row + d);
+            const __m256 up = _mm256_loadu_ps(row + dim + d);
+            const __m256 neg_gate = _mm256_sub_ps(_mm256_setzero_ps(), gate);
+            const __m256 denom = _mm256_add_ps(
+                _mm256_set1_ps(1.0f), ck_ggml_expf_avx2(neg_gate));
+            const __m256 silu = _mm256_div_ps(gate, denom);
+            _mm256_storeu_ps(out_row + d, _mm256_mul_ps(silu, up));
+        }
+#endif
+        for (; d < dim; ++d) {
+            const float gate = row[d];
+            out_row[d] = (gate / (1.0f + expf(-gate))) * row[dim + d];
         }
     }
 }

--- a/tests/test_v8_attention_contracts.py
+++ b/tests/test_v8_attention_contracts.py
@@ -46,6 +46,26 @@ class AttentionContractV8Tests(unittest.TestCase):
     def test_registry_defines_complete_semantics(self) -> None:
         resolver.validate_contract_registry(copy.deepcopy(self.contracts))
 
+    def test_shape_dispatch_rejects_missing_reduction_contract(self) -> None:
+        contracts = copy.deepcopy(self.contracts)
+        contracts["contracts"]["f16_flash_auto_qtile64"]["partition"][
+            "below_threshold"
+        ] = "missing_short_query_contract"
+        with self.assertRaisesRegex(
+            resolver.ContractError,
+            "(?s)HARD CONTRACT FAULT.*references missing below_threshold",
+        ):
+            resolver.validate_contract_registry(contracts)
+
+    def test_shape_dispatch_rejects_unvalidated_reduction_contract(self) -> None:
+        contracts = copy.deepcopy(self.contracts)
+        contracts["contracts"]["f16_online_single_range"]["status"] = "observed"
+        with self.assertRaisesRegex(
+            resolver.ContractError,
+            "(?s)HARD CONTRACT FAULT.*references unvalidated below_threshold",
+        ):
+            resolver.validate_contract_registry(contracts)
+
     def test_f16_split_contract_declares_padded_scheduling_extent(self) -> None:
         contract = self.contracts["contracts"]["f16_online_fp32_merge"]
         self.assertEqual(contract["partition"]["kind"], "kv_chunks_by_workers")
@@ -115,13 +135,29 @@ class AttentionContractV8Tests(unittest.TestCase):
         result = self.resolve("prefill")
         self.assertEqual(
             result["kernel"]["id"],
-            "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+            "attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64",
         )
         self.assertEqual(
             result["requirements"]["execution.prefill_batching"],
             "segmented_append",
         )
         self.assertEqual(result["requirements"]["tensor.kv.dtype"], "fp16")
+        self.assertEqual(
+            result["reduction"]["id"],
+            "f16_flash_auto_qtile64",
+        )
+        self.assertEqual(
+            result["kernel"]["selector"],
+            "CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64",
+        )
+
+    def test_qwen3vl_decode_keeps_worker_split_reduction(self) -> None:
+        result = self.resolve("decode")
+        self.assertEqual(result["reduction"]["id"], "f16_online_fp32_merge")
+        self.assertEqual(
+            result["kernel"]["selector"],
+            "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
+        )
 
     def test_production_rejects_unvalidated_circuit_request(self) -> None:
         with self.assertRaisesRegex(resolver.ContractError, "Production contract resolution rejected"):
@@ -278,7 +314,7 @@ class AttentionContractV8Tests(unittest.TestCase):
             ("nemotron_h", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash"),
             ("llama", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_flash_strided_f16kv"),
             ("llama", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash_f16kv"),
-            ("qwen3vl", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract"),
+            ("qwen3vl", "decoder.attention", "prefill", "attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64"),
             ("qwen3vl", "decoder.attention", "decode", "attention_forward_decode_head_major_gqa_flash_f16cache_contract"),
             ("qwen3_vl_vision", "vision_encoder.attention", "prefill", "attention_forward_full_head_major_gqa_tiled_f16kv_fp32_strided"),
         )
@@ -332,7 +368,20 @@ class AttentionContractV8Tests(unittest.TestCase):
                 self.assertIn("ck_threadpool_dispatch_n", threading["dispatch"])
                 self.assertEqual(threading["reduction_order_effect"], "none")
                 self.assertIn(capabilities[kernel_id]["numerical_contract"], self.linear_contracts["contracts"])
-                self.assertTrue(capabilities[kernel_id]["reference"]["function"].endswith("_ref"))
+                reference = capabilities[kernel_id]["reference"]
+                if reference["kind"] == "scalar_contract_oracle":
+                    self.assertTrue(reference["function"].endswith("_ref"))
+                else:
+                    self.assertEqual(reference["kind"], "llama_repacked_graph_oracle")
+                    self.assertEqual(
+                        capabilities[kernel_id]["production"]["reference_comparison"]["requirement"],
+                        "bit_exact",
+                    )
+                    self.assertTrue(any(
+                        item["backend"] == "llama.cpp_ggml_cpu_graph"
+                        and item["status"] == "validated"
+                        for item in reference["validation"]["external_oracles"]
+                    ))
                 self.assertTrue(capabilities[kernel_id]["production"]["threaded_function"].endswith("_parallel_dispatch"))
 
     def test_quantized_linear_registry_defines_complete_semantics(self) -> None:

--- a/tests/test_v8_codegen_bridge.py
+++ b/tests/test_v8_codegen_bridge.py
@@ -316,7 +316,7 @@ class V8CodegenBridgeTests(unittest.TestCase):
         )
         self.assertEqual(
             by_op["q_proj"][0]["resolved_execution"]["reference"]["function"],
-            "gemv_q4_k_q8_k_ref",
+            "gemv_q4_k_q8_k_repacked_parallel_dispatch",
         )
         self.assertEqual(
             by_op["q_proj"][0]["resolved_execution"]["implementation"]["weight_storage"],
@@ -408,11 +408,11 @@ class V8CodegenBridgeTests(unittest.TestCase):
             self.assertEqual(mlp_down_call["resolved_execution"]["kernel_id"], "gemv_q6_k_q8_k")
             self.assertEqual(
                 q_proj_call["resolved_execution"]["production"]["function"],
-                "gemv_q4_k_q8_k",
+                "gemv_q4_k_q8_k_repacked_parallel_dispatch",
             )
             self.assertEqual(
                 q_proj_call["resolved_execution"]["production"]["threaded_function"],
-                "gemv_q4_k_q8_k_parallel_dispatch",
+                "gemv_q4_k_q8_k_repacked_parallel_dispatch",
             )
             self.assertEqual(
                 q_proj_call["resolved_execution"]["implementation"]["diagnostic_providers"],

--- a/tests/test_v8_decoder_first_token_parity.py
+++ b/tests/test_v8_decoder_first_token_parity.py
@@ -419,6 +419,33 @@ class V8DecoderFirstTokenParityTests(unittest.TestCase):
         np.testing.assert_allclose(q_rows[0].data, np.array([1.0], dtype=np.float32))
         np.testing.assert_allclose(q_rows[1].data, np.array([2.0], dtype=np.float32))
 
+    def test_expand_llama_prefill_decode_dumps_selects_execution_tail_not_largest_position(self) -> None:
+        dump = decoder_parity_v8.parity_test_v7.ParityDump
+        row_elems = 4
+        llama_dumps = [
+            dump(0, "q_proj", np.arange(5 * row_elems, dtype=np.float32), 4, "fp32"),
+            dump(0, "q_proj", np.arange(1008 * row_elems, dtype=np.float32), 1012, "fp32"),
+            dump(
+                0,
+                "q_proj",
+                np.arange(59 * row_elems, dtype=np.float32) + 10000.0,
+                99,
+                "fp32",
+            ),
+        ]
+
+        expanded = decoder_parity_v8._expand_llama_prefill_decode_dumps(
+            llama_dumps,
+            prompt_token_count=59,
+        )
+
+        self.assertEqual([item.token_id for item in expanded], list(range(59)))
+        self.assertTrue(all(item.data.size == row_elems for item in expanded))
+        np.testing.assert_allclose(
+            expanded[-1].data,
+            np.arange(232, 236, dtype=np.float32) + 10000.0,
+        )
+
     def test_resolve_decode_prompt_start_tokens_uses_stage_and_rope_windows(self) -> None:
         ck_start, llama_start = decoder_parity_v8._resolve_decode_prompt_start_tokens(
             tokens_before_count=4,

--- a/tests/test_v8_kernel_call_abi.py
+++ b/tests/test_v8_kernel_call_abi.py
@@ -15,11 +15,14 @@ SCHEMA = ROOT / "version" / "v8" / "schemas" / "kernel_call_abi.schema.json"
 REGISTRY = MAPS / "KERNEL_REGISTRY.json"
 EXCLUDED = {"KERNEL_REGISTRY.json", "kernel_bindings.json", "kernel_bindings.overlay.json"}
 BUILD_IR = ROOT / "version" / "v8" / "scripts" / "build_ir_v8.py"
-EXPECTED_GOVERNED_MAP_COUNT = 37
+EXPECTED_GOVERNED_MAP_COUNT = 40
 QWEN3VL_PARITY_PROVIDERS = {
     "attention_forward_decode_head_major_gqa_flash_f16cache_contract",
+    "attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64",
+    "attention_forward_causal_head_major_gqa_prefill_append_f16cache_single_range",
     "qk_norm_forward_fp64_sum",
     "rmsnorm_forward_fp64_sum",
+    "swiglu_forward_ggml",
 }
 
 

--- a/tests/test_v8_mtmd_clip_shim_build.py
+++ b/tests/test_v8_mtmd_clip_shim_build.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Compile and load the Qwen3-VL mtmd adapter against the pinned llama.cpp."""
+
+from __future__ import annotations
+
+import ctypes
+import importlib.util
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "version" / "v8" / "scripts" / "numeric_parity_qwen3vl_mmproj_v8.py"
+
+
+def main() -> int:
+    spec = importlib.util.spec_from_file_location("qwen3vl_mtmd_shim_build", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import numeric parity harness: {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    llama_root = module.LLAMA_CPP_ROOT
+    required = [
+        llama_root / "tools" / "mtmd" / "clip.h",
+        llama_root / "tools" / "mtmd" / "clip-impl.h",
+        llama_root / "build" / "bin" / "libmtmd.so",
+    ]
+    missing = [str(path) for path in required if not path.is_file()]
+    if missing:
+        raise FileNotFoundError("mtmd shim build requires: " + ", ".join(missing))
+
+    with tempfile.TemporaryDirectory(prefix="v8_mtmd_shim_build_") as tmpdir:
+        shim = module._compile_mtmd_shim(Path(tmpdir))
+        library = ctypes.CDLL(str(shim))
+        for symbol in (
+            "ck_mtmd_clip_embd_nbytes_by_img",
+            "ck_mtmd_clip_encode_float_image",
+        ):
+            if not hasattr(library, symbol):
+                raise RuntimeError(f"compiled mtmd shim is missing {symbol}")
+
+    print("Qwen3-VL mtmd clip shim build: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_v8_multitoken_eos_contract.py
+++ b/tests/test_v8_multitoken_eos_contract.py
@@ -178,6 +178,29 @@ class MultitokenEOSContractTests(unittest.TestCase):
                     manifest_map_override=None,
                 )
 
+    def test_explicit_runtime_tuple_is_exact_reuse(self) -> None:
+        args = Namespace(
+            ck_runtime_so=Path("/tmp/runtime/libdecoder_v8.so"),
+            ck_runtime_manifest_map=Path("/tmp/runtime/weights_manifest.map"),
+            reuse_bridge_decoder_runtime=False,
+            reuse_bridge_decoder_runtime_exact=False,
+        )
+        decoder_dir, exact = self.runner._resolve_decoder_runtime_request(
+            args, {}, Path("/tmp/output")
+        )
+        self.assertEqual(decoder_dir, Path("/tmp/runtime").resolve())
+        self.assertTrue(exact)
+
+    def test_partial_explicit_runtime_tuple_hard_fails(self) -> None:
+        args = Namespace(
+            ck_runtime_so=Path("/tmp/runtime/libdecoder_v8.so"),
+            ck_runtime_manifest_map=None,
+            reuse_bridge_decoder_runtime=False,
+            reuse_bridge_decoder_runtime_exact=False,
+        )
+        with self.assertRaisesRegex(ValueError, "requires both"):
+            self.runner._resolve_decoder_runtime_request(args, {}, Path("/tmp/output"))
+
     def test_segmented_hidden_capture_selects_final_physical_position(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_v8_native_bridge_host.py
+++ b/tests/test_v8_native_bridge_host.py
@@ -2566,7 +2566,7 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 run_cmd.assert_not_called()
 
             initial = json.loads(stamp_path.read_text(encoding="utf-8"))
-            self.assertEqual(initial["version"], 2)
+            self.assertEqual(initial["version"], 3)
             self.assertEqual(initial["runtime_dependency"]["runpath"], "$ORIGIN")
             self.assertEqual(
                 initial["runtime_dependency"]["sha256"],
@@ -2580,6 +2580,20 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 run_cmd.assert_called_once()
                 updated = json.loads(stamp_path.read_text(encoding="utf-8"))
                 self.assertEqual(updated["source_sha256"], hashlib.sha256(c_path.read_bytes()).hexdigest())
+
+            changed_support = {
+                "sha256": "support-source-changed",
+                "file_count": int(initial["compiled_support_source_set"]["file_count"]),
+            }
+            with mock.patch.object(
+                bridge_runner_v8,
+                "_compiled_runtime_support_fingerprint",
+                return_value=changed_support,
+            ), mock.patch.object(bridge_runner_v8, "_run", side_effect=fake_run) as run_cmd:
+                bridge_runner_v8._compile_generated_model(c_path, so_path)
+                run_cmd.assert_called_once()
+                dependency_updated = json.loads(stamp_path.read_text(encoding="utf-8"))
+                self.assertEqual(dependency_updated["compiled_support_source_set"], changed_support)
 
     def test_ck_run_v8_reuses_legacy_v7_hf_gguf_cache(self) -> None:
         with tempfile.TemporaryDirectory(prefix="v8_legacy_cache_") as tmpdir:

--- a/tests/test_v8_native_bridge_host.py
+++ b/tests/test_v8_native_bridge_host.py
@@ -257,6 +257,15 @@ def _build_tiny_decoder_runtime(workdir: Path) -> tuple[Path, Path, Path]:
 
 
 class V8NativeBridgeHostTests(unittest.TestCase):
+    def test_engine_has_canonical_soname(self) -> None:
+        dynamic = subprocess.run(
+            ["readelf", "-d", str(LIBCK)],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
+        self.assertRegex(dynamic, r"\(SONAME\).*\[libckernel_engine\.so\]")
+
     def test_decoder_execution_loads_runtime_selected_engine(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -284,6 +293,54 @@ class V8NativeBridgeHostTests(unittest.TestCase):
                 with mock.patch.object(bridge_runner_v8, "BUILD_DIR", root / "missing-build"):
                     with self.assertRaisesRegex(FileNotFoundError, "requires libckernel_tokenizer"):
                         bridge_runner_v8._load_decoder_lib(model_so, engine_so=engine_so)
+
+    def test_decoder_loader_uses_requested_engine_when_adjacent_copy_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            requested = root / "canonical" / "libckernel_engine.so"
+            adjacent = root / "runtime" / "libckernel_engine.so"
+            model_so = root / "runtime" / "libdecoder_v8.so"
+            tokenizer_so = root / "runtime" / "libckernel_tokenizer.so"
+            requested.parent.mkdir()
+            adjacent.parent.mkdir()
+            requested.write_bytes(b"same engine")
+            adjacent.write_bytes(b"same engine")
+            model_so.touch()
+            tokenizer_so.touch()
+
+            fake_lib = mock.Mock()
+            loads: list[Path] = []
+
+            def fake_cdll(path: str | None, mode: int = 0) -> object:
+                if path is not None:
+                    loads.append(Path(path).resolve())
+                return fake_lib
+
+            with mock.patch.object(bridge_runner_v8.ctypes, "CDLL", side_effect=fake_cdll):
+                with mock.patch.object(
+                    bridge_runner_v8,
+                    "_resolved_symbol_library",
+                    return_value=requested.resolve(),
+                ):
+                    bridge_runner_v8._load_decoder_lib(model_so, engine_so=requested)
+
+            self.assertEqual(loads[0], requested.resolve())
+            self.assertNotIn(adjacent.resolve(), loads)
+
+    def test_decoder_loader_rejects_mismatched_adjacent_engine(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            requested = root / "canonical" / "libckernel_engine.so"
+            adjacent = root / "runtime" / "libckernel_engine.so"
+            model_so = root / "runtime" / "libdecoder_v8.so"
+            requested.parent.mkdir()
+            adjacent.parent.mkdir()
+            requested.write_bytes(b"canonical engine")
+            adjacent.write_bytes(b"stale engine")
+            model_so.touch()
+
+            with self.assertRaisesRegex(RuntimeError, "different adjacent CK engine"):
+                bridge_runner_v8._load_decoder_lib(model_so, engine_so=requested)
 
     def test_vision_prefix_position_policy_keeps_qwen_mrope_but_gemma_linear(self) -> None:
         self.assertEqual(

--- a/tests/test_v8_xray_execution_state.py
+++ b/tests/test_v8_xray_execution_state.py
@@ -63,6 +63,8 @@ class XRayExecutionStateTests(unittest.TestCase):
             "position_start": start, "cache_action": action,
             "kernel_batches": [{
                 "checkpoint_id": "decoder.layer.0.q_proj", "kernel_id": "gemm_q4k_q8k",
+                "numerical_contract_id": "q4k_q8k_independent_rows",
+                "effective_contract_id": "q4k_q8k_independent_rows",
                 "m": count, "n": 4096, "k": 4096,
             }],
         }
@@ -102,6 +104,26 @@ class XRayExecutionStateTests(unittest.TestCase):
         result = xray.compare_traces(left, right)
         self.assertEqual(result["first_divergence"]["classification"], "CACHE_STATE_METADATA_MISMATCH")
         self.assertEqual(result["first_divergence"]["field"], "append_index")
+
+    def test_effective_shape_dispatch_contract_mismatch_precedes_tensors(self):
+        left = self.trace("ck", self.segmented_calls())
+        right = self.trace("llamacpp", self.segmented_calls())
+        visual_left = left["execution"]["calls"][1]["kernel_batches"][0]
+        visual_right = right["execution"]["calls"][1]["kernel_batches"][0]
+        for batch in (visual_left, visual_right):
+            batch["kernel_id"] = "attention_prefill_f16cache_flash_auto"
+            batch["numerical_contract_id"] = "f16_flash_auto_qtile64"
+        visual_left["effective_contract_id"] = "f16_online_single_range"
+        visual_right["effective_contract_id"] = "f16_kv_tiled64_fp32_softmax_fp64_sum_update"
+
+        result = xray.compare_traces(left, right)
+        failure = result["first_divergence"]
+        self.assertEqual(failure["classification"], "KERNEL_CONTRACT_MISMATCH")
+        self.assertEqual(failure["stage"], "kernel_contracts")
+        self.assertEqual(
+            failure["subject"][1]["effective_contract_id"],
+            "f16_online_single_range",
+        )
 
     def test_first_changed_cache_row_is_reported(self):
         expected = np.arange(32, dtype=np.float16).reshape(4, 8)

--- a/unittest/test_attention_f16_split_kv.py
+++ b/unittest/test_attention_f16_split_kv.py
@@ -88,8 +88,8 @@ static size_t tensor_offset(const ggml_tensor * t, int i0, int i1, int i2, int i
 }
 
 int main(int argc, char ** argv) {
-    if (argc != 10 && argc != 11) {
-        fprintf(stderr, "usage: %s q.f32 k.f16 v.f16 out.f32 H Hkv KV D threads [valid_KV]\n", argv[0]);
+    if (argc != 10 && argc != 11 && argc != 13) {
+        fprintf(stderr, "usage: %s q.f32 k.f16 v.f16 out.f32 H Hkv KV D threads [valid_KV [Q past]]\n", argv[0]);
         return 2;
     }
     const int H = atoi(argv[5]);
@@ -97,11 +97,14 @@ int main(int argc, char ** argv) {
     const int KV = atoi(argv[7]);
     const int D = atoi(argv[8]);
     const int threads = atoi(argv[9]);
-    const int valid_KV = argc == 11 ? atoi(argv[10]) : KV;
+    const int valid_KV = argc >= 11 ? atoi(argv[10]) : KV;
+    const int Q = argc == 13 ? atoi(argv[11]) : 1;
+    const int past = argc == 13 ? atoi(argv[12]) : 0;
     if (H <= 0 || Hkv <= 0 || KV <= 0 || valid_KV <= 0 || valid_KV > KV ||
+        Q <= 0 || past < 0 || past + Q > valid_KV ||
         D <= 0 || threads <= 0 || H % Hkv != 0) return 2;
 
-    const size_t q_count = (size_t) H * (size_t) D;
+    const size_t q_count = (size_t) H * (size_t) Q * (size_t) D;
     const size_t kv_count = (size_t) Hkv * (size_t) KV * (size_t) D;
     const size_t memory = 64u * 1024u * 1024u +
                           q_count * sizeof(float) +
@@ -111,7 +114,7 @@ int main(int argc, char ** argv) {
     if (!ctx) return 3;
     ggml_cpu_init();
 
-    ggml_tensor * q = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, D, 1, H, 1);
+    ggml_tensor * q = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, D, Q, H, 1);
     ggml_tensor * k = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, D, KV, Hkv, 1);
     ggml_tensor * v = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, D, KV, Hkv, 1);
     if (!read_exact(argv[1], q->data, q_count * sizeof(float)) ||
@@ -122,11 +125,15 @@ int main(int argc, char ** argv) {
     }
 
     ggml_tensor * mask = nullptr;
-    if (valid_KV != KV) {
-        mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, KV, 1);
+    if (Q > 1 || valid_KV != KV) {
+        mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, KV, Q);
         ggml_fp16_t * mask_data = (ggml_fp16_t *) mask->data;
-        for (int i = 0; i < KV; ++i) {
-            mask_data[i] = ggml_fp32_to_fp16(i < valid_KV ? 0.0f : -INFINITY);
+        for (int tq = 0; tq < Q; ++tq) {
+            const int row_limit = Q > 1 ? past + tq + 1 : valid_KV;
+            for (int i = 0; i < KV; ++i) {
+                mask_data[(size_t) tq * (size_t) KV + (size_t) i] =
+                    ggml_fp32_to_fp16(i < row_limit && i < valid_KV ? 0.0f : -INFINITY);
+            }
         }
     }
     ggml_tensor * out = ggml_flash_attn_ext(
@@ -146,9 +153,11 @@ int main(int argc, char ** argv) {
     float * host = (float *) malloc(q_count * sizeof(float));
     if (!host) return 7;
     for (int h = 0; h < H; ++h) {
-        for (int d = 0; d < D; ++d) {
-            memcpy(host + (size_t) h * (size_t) D + (size_t) d,
-                   (const char *) out->data + tensor_offset(out, d, h, 0, 0), sizeof(float));
+        for (int tq = 0; tq < Q; ++tq) {
+            for (int d = 0; d < D; ++d) {
+                memcpy(host + ((size_t) h * (size_t) Q + (size_t) tq) * (size_t) D + (size_t) d,
+                       (const char *) out->data + tensor_offset(out, d, h, tq, 0), sizeof(float));
+            }
         }
     }
     const bool ok = write_exact(argv[4], host, q_count * sizeof(float));
@@ -223,6 +232,34 @@ def _llama_split_output(q, k_bits, v_bits, head_dim, threads, padded_kv_tokens=N
                 f"llama.cpp split-KV helper failed ({completed.returncode}):\n{completed.stderr}"
             )
         return np.fromfile(out_path, dtype=np.float32).reshape(heads, head_dim)
+
+
+def _llama_prefill_output(q, k_bits, v_bits, head_dim, past_tokens, threads):
+    helper, bin_dir = _ensure_llama_helper()
+    heads, q_tokens, _ = q.shape
+    kv_heads, kv_tokens, _ = k_bits.shape
+    q_compact = np.ascontiguousarray(q[:, :, :head_dim], dtype=np.float32)
+    k_compact = np.ascontiguousarray(k_bits[:, :, :head_dim], dtype=np.uint16)
+    v_compact = np.ascontiguousarray(v_bits[:, :, :head_dim], dtype=np.uint16)
+    with tempfile.TemporaryDirectory(prefix="ck_f16_prefill_") as tmp:
+        tmp = Path(tmp)
+        q_path, k_path, v_path, out_path = [tmp / name for name in ("q.f32", "k.f16", "v.f16", "out.f32")]
+        q_compact.tofile(q_path)
+        k_compact.tofile(k_path)
+        v_compact.tofile(v_path)
+        command = [
+            str(helper), str(q_path), str(k_path), str(v_path), str(out_path),
+            str(heads), str(kv_heads), str(kv_tokens), str(head_dim), str(threads),
+            str(kv_tokens), str(q_tokens), str(past_tokens),
+        ]
+        env = os.environ.copy()
+        env["LD_LIBRARY_PATH"] = f"{bin_dir}:{env.get('LD_LIBRARY_PATH', '')}"
+        completed = subprocess.run(command, capture_output=True, text=True, env=env)
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"llama.cpp tiled prefill helper failed ({completed.returncode}):\n{completed.stderr}"
+            )
+        return np.fromfile(out_path, dtype=np.float32).reshape(heads, q_tokens, head_dim)
 
 
 def _llama_kv_partition_extent(kv_tokens):
@@ -476,7 +513,7 @@ def _prefill_append_matches_decode_loop_case():
     actual = np.zeros_like(q)
     status = lib.attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(
         _f32_ptr(q), _u16_ptr(k), _u16_ptr(v), _f32_ptr(actual),
-        heads, kv_heads, q_tokens, past_tokens, capacity, head_dim, aligned, 1,
+        heads, kv_heads, q_tokens, past_tokens, capacity, head_dim, aligned, 2,
     )
     expected = np.zeros_like(q)
     for token in range(q_tokens):
@@ -485,7 +522,7 @@ def _prefill_append_matches_decode_loop_case():
         token_status = lib.attention_forward_decode_head_major_gqa_flash_f16cache_contract(
             _f32_ptr(q_token), _u16_ptr(k), _u16_ptr(v), _f32_ptr(out_token),
             heads, kv_heads, past_tokens + token + 1, capacity,
-            head_dim, aligned, 1,
+            head_dim, aligned, 2,
         )
         if token_status != 0:
             status = token_status
@@ -495,6 +532,35 @@ def _prefill_append_matches_decode_loop_case():
     return Result(
         "prefill_append_matches_decode_loop",
         diff if status == 0 else float("inf"),
+        0.0,
+        status == 0 and np.array_equal(actual, expected),
+    )
+
+
+def _prefill_auto_matches_llama_case(
+    name, seed, heads, kv_heads, q_tokens, past_tokens, head_dim, threads=4
+):
+    capacity, aligned = past_tokens + q_tokens, head_dim
+    rng = np.random.default_rng(seed)
+    q = np.ascontiguousarray(
+        rng.normal(0.0, 0.55, (heads, q_tokens, aligned)).astype(np.float32)
+    )
+    k = _half_bits(
+        rng.normal(0.0, 0.55, (kv_heads, capacity, aligned)).astype(np.float32)
+    )
+    v = _half_bits(
+        rng.normal(0.0, 0.75, (kv_heads, capacity, aligned)).astype(np.float32)
+    )
+    actual = np.zeros_like(q)
+    status = lib.attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(
+        _f32_ptr(q), _u16_ptr(k), _u16_ptr(v), _f32_ptr(actual),
+        heads, kv_heads, q_tokens, past_tokens, capacity, head_dim, aligned, 3,
+    )
+    expected = _llama_prefill_output(q, k, v, head_dim, past_tokens, threads=4)
+    diff = float(np.max(np.abs(actual - expected))) if status == 0 else math.inf
+    return Result(
+        name,
+        diff,
         0.0,
         status == 0 and np.array_equal(actual, expected),
     )
@@ -531,6 +597,20 @@ def _case(name, seed, heads, kv_heads, kv_tokens, head_dim, aligned, chunks, tol
 def main():
     results = []
     results.append(_prefill_append_matches_decode_loop_case())
+    # Current llama.cpp changes flash-attention arithmetic at Q=64. Exercise
+    # both sides of that production dispatch boundary and the actual Qwen3-VL
+    # visual segment shape; leaf decode coverage cannot certify this route.
+    for case in (
+        ("flash_auto_short_text_before(Q=5)", 2026071505, 4, 2, 5, 0, 32),
+        ("flash_auto_short_text_after(Q=14)", 2026071514, 4, 2, 14, 1013, 32),
+        ("flash_auto_below_threshold(Q=63)", 2026071563, 4, 2, 63, 5, 32),
+        ("flash_auto_at_threshold(Q=64)", 2026071564, 4, 2, 64, 5, 32),
+        (
+            "flash_auto_qwen3vl_visual(Q=1008,KV=1013,H=32,Hkv=8,D=128)",
+            2026071508, 32, 8, 1008, 5, 128,
+        ),
+    ):
+        results.append(_prefill_auto_matches_llama_case(*case))
     results.append(_unfused_f16_causal_case())
     below, below_data = _case(
         "f16_split_below_threshold(KV=511,C=1)", 511, 8, 2, 511, 64, 64, 1, 2.0e-5,
@@ -575,6 +655,21 @@ def main():
         status, actual = _run_contract(q, k, v, q.shape[1], 1)
         diff = float(np.max(np.abs(actual - expected))) if status == 0 else math.inf
         results.append(Result(name, diff, 0.0, status == 0 and diff == 0.0))
+
+    q, k, v, _ = qwen_step20_data
+    expected_single = _run_explicit(q, k, v, q.shape[1], 1)
+    single_status, actual_single = _run_contract(q, k, v, q.shape[1], 2)
+    single_diff = (
+        float(np.max(np.abs(actual_single - expected_single)))
+        if single_status == 0
+        else math.inf
+    )
+    results.append(Result(
+        "explicit_single_range_prefill_route_qwen3vl(KV=1047)",
+        single_diff,
+        0.0,
+        single_status == 0 and single_diff == 0.0,
+    ))
 
     q, k, v, _ = below_data
     legacy = _run_legacy(q, k, v, q.shape[1])

--- a/unittest/test_gemv_kernels_comprehensive.py
+++ b/unittest/test_gemv_kernels_comprehensive.py
@@ -383,6 +383,8 @@ def get_test_cases(quick: bool = False, large: bool = False) -> dict:
             "Q6_K_Q8_K": [
                 TestCase("tiny", M=1, K=256, tol=1e-5, rtol=1e-4, description="Direct Q6_KxQ8_K"),
                 TestCase("small", M=1, K=512, tol=1e-5, rtol=1e-4, description="Small direct"),
+                TestCase("qwen3vl_lm_head", M=1, K=4096, tol=0.0, rtol=0.0,
+                         description="Qwen3-VL LM-head direct vec_dot"),
             ],
             "Q5_0": [
                 TestCase("tiny", M=1, K=32, tol=1e-2, description="Minimal Q5_0"),

--- a/unittest/test_q4k_q8k_llama_packed.cpp
+++ b/unittest/test_q4k_q8k_llama_packed.cpp
@@ -6,7 +6,9 @@
 // production numerical contract.
 
 #include "ggml.h"
+#include "ggml-backend.h"
 #include "ggml-cpu.h"
+#include "ggml-cpu/repack.h"
 #include "ggml-quants.h"
 
 #include <algorithm>
@@ -23,7 +25,24 @@ void gemv_q4_k_q8_k(float * y, const void * w, const void * x_q8, int n, int k);
 void gemm_nt_q4_k_q8_k_parallel_dispatch(
         const void * a_q8, const void * w, const float * bias, float * out,
         int m, int n, int k);
+void gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch(
+        const void * a_q8, const void * w, const float * bias, float * out,
+        int m, int n, int k);
+void gemv_q4_k_q8_k_repacked_parallel_dispatch(
+        float * y, const void * w, const void * x_q8, int n, int k);
+void gemv_q4_k_q8_k_parallel_dispatch(
+        float * y, const void * w, const void * x_q8, int n, int k);
+size_t q4_k_packed_meta_x8_block_size(void);
+void pack_q4_k_to_packed_meta_x8(const void * src, void * dst, int n, int k);
+void gemm_nt_q4_k_packed_meta_x8_q8_k_superblock_order(
+        const void * a_q8, const void * w_packed_x8, const float * bias, float * out,
+        int m, int n, int k);
 void ck_threadpool_global_destroy(void);
+void ck_q4k_packed_weight_cache_clear(void);
+void swiglu_forward_ggml(
+        const float * input, float * output, int tokens, int dim);
+void ggml_vec_swiglu_f32(
+        int n, float * output, const float * gate, const float * up);
 void ggml_vec_dot_q4_K_q8_K(
         int n, float * s, size_t bs,
         const void * vx, size_t bx,
@@ -32,12 +51,18 @@ void ggml_vec_dot_q4_K_q8_K(
 
 namespace {
 
+static const char * env_or(const char * name, const char * fallback) {
+    const char * value = std::getenv(name);
+    return value ? value : fallback;
+}
+
 struct case_spec {
     const char * name;
     int m;
     int n;
     int k;
     bool production_dispatch;
+    bool decode_dispatch;
     bool with_bias;
 };
 
@@ -165,10 +190,229 @@ static bool llama_mul_mat(
     return ok;
 }
 
+static bool llama_mul_mat_repacked(
+        const std::vector<uint8_t> & weights,
+        const std::vector<float> & activations,
+        std::vector<float> & output,
+        int m, int n, int k) {
+    ggml_init_params weight_params = {ggml_tensor_overhead() * 2, nullptr, true};
+    ggml_context * weight_ctx = ggml_init(weight_params);
+    if (!weight_ctx) {
+        return false;
+    }
+    ggml_tensor * w = ggml_new_tensor_2d(weight_ctx, GGML_TYPE_Q4_K, k, n);
+    ggml_backend_buffer_type_t buft = ggml_backend_cpu_repack_buffer_type();
+    const size_t buffer_size = ggml_backend_buft_get_alloc_size(buft, w);
+    ggml_backend_buffer_t buffer = ggml_backend_buft_alloc_buffer(buft, buffer_size);
+    bool ok = w && buffer &&
+            ggml_backend_tensor_alloc(buffer, w, ggml_backend_buffer_get_base(buffer)) == GGML_STATUS_SUCCESS;
+    if (ok) {
+        ggml_backend_tensor_set(w, weights.data(), 0, weights.size());
+    }
+
+    const size_t arena_size = 64u * 1024u * 1024u
+            + activations.size() * sizeof(float) + output.size() * sizeof(float);
+    ggml_init_params graph_params = {arena_size, nullptr, false};
+    ggml_context * graph_ctx = ok ? ggml_init(graph_params) : nullptr;
+    if (graph_ctx) {
+        ggml_tensor * x = ggml_new_tensor_2d(graph_ctx, GGML_TYPE_F32, k, m);
+        std::memcpy(ggml_get_data(x), activations.data(), activations.size() * sizeof(float));
+        ggml_tensor * y = ggml_mul_mat(graph_ctx, w, x);
+        ggml_cgraph * graph = y ? ggml_new_graph(graph_ctx) : nullptr;
+        if (!graph) {
+            ok = false;
+        } else {
+            ggml_build_forward_expand(graph, y);
+            const int threads = std::max(1, std::atoi(std::getenv("CK_NUM_THREADS")
+                    ? std::getenv("CK_NUM_THREADS") : "4"));
+            ok = ggml_graph_compute_with_ctx(graph_ctx, graph, threads) == GGML_STATUS_SUCCESS;
+            if (ok) {
+                std::memcpy(output.data(), ggml_get_data_f32(y), output.size() * sizeof(float));
+            }
+        }
+    } else {
+        ok = false;
+    }
+
+    if (graph_ctx) {
+        ggml_free(graph_ctx);
+    }
+    if (buffer) {
+        ggml_backend_buffer_free(buffer);
+    }
+    ggml_free(weight_ctx);
+    return ok;
+}
+
+static bool read_f32_file(const char * path, std::vector<float> & values, size_t count) {
+    FILE * file = std::fopen(path, "rb");
+    if (!file) {
+        std::perror(path);
+        return false;
+    }
+    values.resize(count);
+    const size_t read = std::fread(values.data(), sizeof(float), count, file);
+    std::fclose(file);
+    if (read != count) {
+        std::fprintf(stderr, "%s: read %zu/%zu float values\n", path, read, count);
+        return false;
+    }
+    return true;
+}
+
+static bool read_file_slice(
+        const char * path, size_t offset, std::vector<uint8_t> & bytes, size_t size) {
+    FILE * file = std::fopen(path, "rb");
+    if (!file) {
+        std::perror(path);
+        return false;
+    }
+    if (std::fseek(file, static_cast<long>(offset), SEEK_SET) != 0) {
+        std::perror(path);
+        std::fclose(file);
+        return false;
+    }
+    bytes.resize(size);
+    const size_t read = std::fread(bytes.data(), 1, size, file);
+    std::fclose(file);
+    if (read != size) {
+        std::fprintf(stderr, "%s: read %zu/%zu bytes at offset %zu\n", path, read, size, offset);
+        return false;
+    }
+    return true;
+}
+
+static bool run_real_artifact_case(void) {
+    const char * activation_path = std::getenv("CK_Q4K_Q8K_REAL_ACTIVATIONS_F32");
+    const char * weights_path = std::getenv("CK_Q4K_Q8K_REAL_WEIGHTS");
+    const char * offset_text = std::getenv("CK_Q4K_Q8K_REAL_WEIGHT_OFFSET");
+    if (!activation_path && !weights_path && !offset_text) {
+        return true;
+    }
+    if (!activation_path || !weights_path || !offset_text) {
+        std::fprintf(stderr,
+                "real-artifact mode requires CK_Q4K_Q8K_REAL_ACTIVATIONS_F32, "
+                "CK_Q4K_Q8K_REAL_WEIGHTS, and CK_Q4K_Q8K_REAL_WEIGHT_OFFSET\n");
+        return false;
+    }
+
+    const int m = std::atoi(env_or("CK_Q4K_Q8K_REAL_M", "0"));
+    const int n = std::atoi(env_or("CK_Q4K_Q8K_REAL_N", "0"));
+    const int k = std::atoi(env_or("CK_Q4K_Q8K_REAL_K", "0"));
+    if (m <= 0 || n <= 0 || k <= 0 || (k % QK_K) != 0) {
+        std::fprintf(stderr, "invalid real-artifact shape M=%d N=%d K=%d\n", m, n, k);
+        return false;
+    }
+
+    const size_t q8_row_bytes = static_cast<size_t>(k / QK_K) * sizeof(block_q8_K);
+    const size_t q4_row_bytes = static_cast<size_t>(k / QK_K) * sizeof(block_q4_K);
+    const size_t weight_offset = static_cast<size_t>(std::strtoull(offset_text, nullptr, 0));
+    std::vector<float> activations;
+    std::vector<uint8_t> weights;
+    if (!read_f32_file(activation_path, activations, static_cast<size_t>(m) * k) ||
+        !read_file_slice(weights_path, weight_offset, weights, static_cast<size_t>(n) * q4_row_bytes)) {
+        return false;
+    }
+
+    std::printf("\nreal_qwen_projection: M=%d N=%d K=%d offset=%zu\n", m, n, k, weight_offset);
+    std::vector<uint8_t> ck_q8(static_cast<size_t>(m) * q8_row_bytes);
+    std::vector<uint8_t> llama_q8(ck_q8.size());
+    for (int row = 0; row < m; ++row) {
+        const float * src = activations.data() + static_cast<size_t>(row) * k;
+        quantize_row_q8_k(src, ck_q8.data() + static_cast<size_t>(row) * q8_row_bytes, k);
+        quantize_row_q8_K_ref(src,
+                reinterpret_cast<block_q8_K *>(llama_q8.data() + static_cast<size_t>(row) * q8_row_bytes), k);
+    }
+    bool passed = compare_bytes(
+            "real Q8_K activation", ck_q8.data(), llama_q8.data(), ck_q8.size());
+
+    std::vector<float> ck_output(static_cast<size_t>(m) * n);
+    std::vector<float> llama_output(ck_output.size());
+    std::vector<float> llama_leaf(ck_output.size());
+    std::vector<float> llama_repacked(ck_output.size());
+    std::vector<float> ck_superblock(ck_output.size());
+    std::vector<float> ck_repacked_prefill(ck_output.size());
+    std::vector<float> ck_repacked_decode(ck_output.size());
+    std::vector<float> production_expected;
+    const char * production_expected_path = std::getenv("CK_Q4K_Q8K_REAL_EXPECTED_F32");
+    if (production_expected_path &&
+        !read_f32_file(production_expected_path, production_expected, ck_output.size())) {
+        return false;
+    }
+    gemm_nt_q4_k_q8_k_parallel_dispatch(
+            ck_q8.data(), weights.data(), nullptr, ck_output.data(), m, n, k);
+    for (int row = 0; row < m; ++row) {
+        const void * x_row = llama_q8.data() + static_cast<size_t>(row) * q8_row_bytes;
+        for (int col = 0; col < n; ++col) {
+            const void * w_row = weights.data() + static_cast<size_t>(col) * q4_row_bytes;
+            ggml_vec_dot_q4_K_q8_K(
+                    k, &llama_leaf[static_cast<size_t>(row) * n + col],
+                    0, w_row, 0, x_row, 0, 1);
+        }
+    }
+    if (!llama_mul_mat(weights, activations, llama_output, m, n, k)) {
+        return false;
+    }
+    if (!llama_mul_mat_repacked(weights, activations, llama_repacked, m, n, k)) {
+        return false;
+    }
+    const size_t packed_blocks = static_cast<size_t>((n + 7) / 8) * static_cast<size_t>(k / QK_K);
+    std::vector<uint8_t> packed_x8(packed_blocks * q4_k_packed_meta_x8_block_size());
+    pack_q4_k_to_packed_meta_x8(weights.data(), packed_x8.data(), n, k);
+    gemm_nt_q4_k_packed_meta_x8_q8_k_superblock_order(
+            ck_q8.data(), packed_x8.data(), nullptr, ck_superblock.data(), m, n, k);
+    gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch(
+            ck_q8.data(), weights.data(), nullptr, ck_repacked_prefill.data(), m, n, k);
+    if (m == 1) {
+        gemv_q4_k_q8_k_repacked_parallel_dispatch(
+                ck_repacked_decode.data(), weights.data(), ck_q8.data(), n, k);
+    }
+    passed &= compare_f32(
+            "real llama leaf vs graph", llama_leaf.data(), llama_output.data(), m, n);
+    passed &= compare_f32(
+            "real production graph", ck_output.data(), llama_output.data(), m, n);
+    compare_f32(
+            "canonical vs repack control", ck_output.data(), llama_repacked.data(), m, n);
+    if (m == 1) {
+        passed &= compare_f32(
+                "real repacked decode dispatch",
+                ck_repacked_decode.data(), llama_repacked.data(), m, n);
+    }
+    compare_f32(
+            "real superblock-order provider", ck_superblock.data(), llama_repacked.data(), m, n);
+    passed &= compare_f32(
+            "real repacked prefill provider", ck_repacked_prefill.data(), llama_repacked.data(), m, n);
+    compare_f32(
+            "superblock vs leaf control", ck_superblock.data(), llama_leaf.data(), m, n);
+    if (!production_expected.empty()) {
+        std::printf("\nactual model-graph projection oracle:\n");
+        compare_f32(
+                "canonical dispatch vs production", ck_output.data(), production_expected.data(), m, n);
+        compare_f32(
+                "llama leaf vs production", llama_leaf.data(), production_expected.data(), m, n);
+        compare_f32(
+                "llama graph vs production", llama_output.data(), production_expected.data(), m, n);
+        compare_f32(
+                "llama repack graph vs production", llama_repacked.data(), production_expected.data(), m, n);
+        if (m == 1) {
+            compare_f32(
+                    "CK repacked decode vs production",
+                    ck_repacked_decode.data(), production_expected.data(), m, n);
+        }
+        compare_f32(
+                "CK superblock vs production", ck_superblock.data(), production_expected.data(), m, n);
+        passed &= compare_f32(
+                "CK repacked prefill vs production",
+                ck_repacked_prefill.data(), production_expected.data(), m, n);
+    }
+    return passed;
+}
+
 static bool run_case(const case_spec & spec) {
     std::printf("\n%s: M=%d N=%d K=%d provider=%s bias=%s\n",
             spec.name, spec.m, spec.n, spec.k,
-            spec.production_dispatch ? "v8_dispatch" : "decode_leaf",
+            spec.production_dispatch ? "prefill_dispatch" :
+                    (spec.decode_dispatch ? "decode_dispatch" : "decode_leaf"),
             spec.with_bias ? "yes" : "no");
 
     std::vector<float> activations(static_cast<size_t>(spec.m) * spec.k);
@@ -199,6 +443,8 @@ static bool run_case(const case_spec & spec) {
     std::vector<float> ck_output(static_cast<size_t>(spec.m) * spec.n);
     std::vector<float> llama_output(ck_output.size());
     std::vector<float> llama_leaf_output(ck_output.size());
+    std::vector<float> llama_repacked_output(ck_output.size());
+    std::vector<float> ck_repacked_output(ck_output.size());
     std::vector<float> bias(spec.with_bias ? spec.n : 0);
     for (int col = 0; col < spec.n && spec.with_bias; ++col) {
         bias[col] = fixture_value(0, col, 0.017f, 0.83f);
@@ -216,6 +462,13 @@ static bool run_case(const case_spec & spec) {
         gemm_nt_q4_k_q8_k_parallel_dispatch(
                 ck_q8.data(), weights.data(), spec.with_bias ? bias.data() : nullptr, ck_output.data(),
                 spec.m, spec.n, spec.k);
+    } else if (spec.decode_dispatch) {
+        if (spec.m != 1 || spec.with_bias) {
+            std::fprintf(stderr, "decode dispatcher case requires M=1 and no bias\n");
+            return false;
+        }
+        gemv_q4_k_q8_k_parallel_dispatch(
+                ck_output.data(), weights.data(), ck_q8.data(), spec.n, spec.k);
     } else {
         gemv_q4_k_q8_k(ck_output.data(), weights.data(), ck_q8.data(), spec.n, spec.k);
     }
@@ -223,20 +476,42 @@ static bool run_case(const case_spec & spec) {
         std::fprintf(stderr, "llama.cpp graph execution failed for %s\n", spec.name);
         return false;
     }
+    if (spec.production_dispatch || spec.decode_dispatch) {
+        if (!llama_mul_mat_repacked(
+                weights, activations, llama_repacked_output, spec.m, spec.n, spec.k)) {
+            std::fprintf(stderr, "llama.cpp repacked graph failed for %s\n", spec.name);
+            return false;
+        }
+        if (spec.decode_dispatch) {
+            gemv_q4_k_q8_k_repacked_parallel_dispatch(
+                    ck_repacked_output.data(), weights.data(), ck_q8.data(), spec.n, spec.k);
+        } else {
+            gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch(
+                    ck_q8.data(), weights.data(), spec.with_bias ? bias.data() : nullptr,
+                    ck_repacked_output.data(), spec.m, spec.n, spec.k);
+        }
+    }
     if (spec.with_bias) {
         for (int row = 0; row < spec.m; ++row) {
             for (int col = 0; col < spec.n; ++col) {
                 const size_t index = static_cast<size_t>(row) * spec.n + col;
                 llama_output[index] += bias[col];
                 llama_leaf_output[index] += bias[col];
+                if (spec.production_dispatch || spec.decode_dispatch) {
+                    llama_repacked_output[index] += bias[col];
+                }
             }
         }
     }
-    if (spec.production_dispatch) {
+    if (spec.production_dispatch || spec.decode_dispatch) {
         compare_f32("llama leaf vs graph control",
                 llama_leaf_output.data(), llama_output.data(), spec.m, spec.n);
         passed &= compare_f32("production graph output",
                 ck_output.data(), llama_output.data(), spec.m, spec.n);
+        passed &= compare_f32("loaded-model repack output",
+                ck_repacked_output.data(), llama_repacked_output.data(), spec.m, spec.n);
+        compare_f32("canonical vs repack control",
+                ck_output.data(), llama_repacked_output.data(), spec.m, spec.n);
     } else {
         passed &= compare_f32("decode leaf primitive",
                 ck_output.data(), llama_leaf_output.data(), spec.m, spec.n);
@@ -244,6 +519,40 @@ static bool run_case(const case_spec & spec) {
                 ck_output.data(), llama_output.data(), spec.m, spec.n);
     }
     return passed;
+}
+
+static bool run_swiglu_case(int tokens, int dim) {
+    std::vector<float> input(static_cast<size_t>(tokens) * 2 * dim);
+    std::vector<float> ck(static_cast<size_t>(tokens) * dim);
+    std::vector<float> llama(ck.size());
+
+    for (int row = 0; row < tokens; ++row) {
+        float * gate = input.data() + static_cast<size_t>(row) * 2 * dim;
+        float * up = gate + dim;
+        for (int col = 0; col < dim; ++col) {
+            gate[col] = fixture_value(row, col, 0.73f, 0.31f);
+            up[col] = fixture_value(row, col, 0.41f, 0.79f);
+        }
+        if (dim > 4) {
+            gate[(row * 17 + 3) % dim] = -8.125f;
+            gate[(row * 29 + 4) % dim] = 7.875f;
+        }
+    }
+
+    swiglu_forward_ggml(input.data(), ck.data(), tokens, dim);
+    for (int row = 0; row < tokens; ++row) {
+        const float * gate = input.data() + static_cast<size_t>(row) * 2 * dim;
+        const float * up = gate + dim;
+        ggml_vec_swiglu_f32(
+                dim, llama.data() + static_cast<size_t>(row) * dim, gate, up);
+    }
+
+    char label[96];
+    std::snprintf(label, sizeof(label), "GGML SwiGLU T=%d D=%d", tokens, dim);
+    return compare_bytes(label,
+            reinterpret_cast<const uint8_t *>(ck.data()),
+            reinterpret_cast<const uint8_t *>(llama.data()),
+            ck.size() * sizeof(float));
 }
 
 } // namespace
@@ -256,16 +565,24 @@ int main(int argc, char ** argv) {
 
     const bool quick = argc > 1 && std::strcmp(argv[1], "--quick") == 0;
     const case_spec quick_cases[] = {
-        {"decode_leaf", 1, 64, 256, false, false},
-        {"packed_prefill_threshold", 16, 512, 1024, true, true},
-        {"packed_prefill_multirow", 33, 1024, 1024, true, false},
+        {"decode_leaf", 1, 64, 256, false, false, false},
+        {"decode_dispatch", 1, 4096, 4096, false, true, false},
+        {"qwen3vl_text_before", 5, 1024, 4096, true, false, false},
+        {"packed_prefill_threshold", 16, 512, 1024, true, false, true},
+        {"packed_prefill_multirow", 33, 1024, 1024, true, false, false},
+        {"qwen3vl_text_after", 58, 1024, 4096, true, false, false},
+        {"qwen3vl_replay_step45", 59, 1024, 4096, true, false, false},
     };
     const case_spec full_cases[] = {
-        {"decode_leaf", 1, 64, 256, false, false},
-        {"packed_prefill_threshold", 16, 512, 1024, true, true},
-        {"packed_prefill_multirow", 33, 1024, 1024, true, false},
-        {"qwen3vl_qkv_width", 16, 4096, 4096, true, false},
-        {"qwen3vl_down_k_width", 16, 512, 11008, true, false},
+        {"decode_leaf", 1, 64, 256, false, false, false},
+        {"decode_dispatch", 1, 4096, 4096, false, true, false},
+        {"qwen3vl_text_before", 5, 1024, 4096, true, false, false},
+        {"packed_prefill_threshold", 16, 512, 1024, true, false, true},
+        {"packed_prefill_multirow", 33, 1024, 1024, true, false, false},
+        {"qwen3vl_text_after", 58, 1024, 4096, true, false, false},
+        {"qwen3vl_replay_step45", 59, 1024, 4096, true, false, false},
+        {"qwen3vl_qkv_width", 16, 4096, 4096, true, false, false},
+        {"qwen3vl_down_k_width", 16, 512, 11008, true, false, false},
     };
     const case_spec * cases = quick ? quick_cases : full_cases;
     const size_t case_count = quick
@@ -277,9 +594,21 @@ int main(int argc, char ** argv) {
         if (!run_case(cases[i])) {
             ++failed;
         }
+        ck_q4k_packed_weight_cache_clear();
+    }
+    if (!run_real_artifact_case()) {
+        ++failed;
+    }
+    const int swiglu_dims[] = {7, 8, 15, 16, 12288};
+    for (int dim : swiglu_dims) {
+        if (!run_swiglu_case(dim == 12288 ? 2 : 3, dim)) {
+            ++failed;
+        }
     }
     ck_threadpool_global_destroy();
-    std::printf("\nQ4_K x Q8_K llama.cpp production parity: %s (%zu cases, %d failed)\n",
-            failed == 0 ? "PASS" : "FAIL", case_count, failed);
+    std::printf("\nQ4_K x Q8_K and SwiGLU llama.cpp production parity: %s "
+                "(%zu Q4 cases, %zu SwiGLU cases, %d failed)\n",
+            failed == 0 ? "PASS" : "FAIL", case_count,
+            sizeof(swiglu_dims) / sizeof(swiglu_dims[0]), failed);
     return failed == 0 ? 0 : 1;
 }

--- a/version/v8/circuits/qwen3vl.json
+++ b/version/v8/circuits/qwen3vl.json
@@ -121,10 +121,10 @@
             "tensor.q.dtype": "fp32",
             "tensor.kv.dtype": "fp16",
             "tensor.layout": "head_major",
-            "numerics.attention_reduction": "f16_online_fp32_merge"
+            "numerics.attention_reduction": "f16_flash_auto_qtile64"
           },
-          "validation": "observed",
-          "evidence": "Segmented mixed-prefix replay requires cache-preserving append attention; leaf and stitched parity are the production gates."
+          "validation": "validated",
+          "evidence": "llama.cpp production flash attention uses 64x64 FP32 tiles for multi-query segmented prefill; direct oracle and production-shape Qwen3-VL replay are required gates."
         },
         "decode": {
           "requires": {
@@ -205,6 +205,28 @@
         "producer": "rope_qk",
         "logical_layout": "head_major",
         "axis_names": ["head", "token", "channel"]
+      }
+    },
+    "decoder.swiglu": {
+      "op": "swiglu",
+      "template_ops": ["silu_mul"],
+      "phases": {
+        "prefill": {
+          "contract_id": "swiglu_fp32_ggml_vector_exp_fp32_output",
+          "validation": "validated",
+          "evidence": "Production Qwen3-VL gate/up tensors match llama.cpp byte-for-byte before SwiGLU; the resolved provider matches all 12,288 captured outputs exactly."
+        },
+        "decode": {
+          "contract_id": "swiglu_fp32_ggml_vector_exp_fp32_output",
+          "validation": "validated",
+          "evidence": "Layer-0 first-divergence attribution at decoder step 20 isolates GGML vector-exp and direct-division evaluation order."
+        }
+      },
+      "checkpoint": {
+        "id": "decoder.layer.{layer}.swiglu.output",
+        "producer": "silu_mul",
+        "logical_layout": "token_major",
+        "axis_names": ["token", "channel"]
       }
     }
   },

--- a/version/v8/contracts/attention_reductions.json
+++ b/version/v8/contracts/attention_reductions.json
@@ -73,8 +73,31 @@
         "reference": "llama.cpp GGML tiled flash attention with F16 K/V and GGML_PREC_F32"
       }
     },
+    "f16_flash_auto_qtile64": {
+      "status": "validated",
+      "q_compute": "shape_dependent_fp16_or_fp32",
+      "k_compute": "fp16",
+      "score_accumulator": "fp32",
+      "softmax_statistics": "fp32",
+      "value_compute": "fp16",
+      "value_accumulator": "shape_dependent_fp16_or_fp32",
+      "partial_storage": "shape_dependent_none_or_fp32",
+      "partial_merge": "shape_dependent_single_range_or_fp32_chunk_order",
+      "partition": {
+        "kind": "query_tile_threshold",
+        "threshold": 64,
+        "below_threshold": "f16_online_single_range",
+        "at_or_above_threshold": "f16_kv_tiled64_fp32_softmax_fp64_sum_update"
+      },
+      "description": "llama.cpp CPU flash-attention dispatch for segmented prefill: short query batches use the FP16 online single-range path; batches of 64 or more queries use 64x64 FP32 tiles.",
+      "validation": {
+        "test": "unittest/test_attention_f16_split_kv.py",
+        "cases": ["Q=5", "Q=14", "Q=64", "Q=1008 KV=1013 H=32 Hkv=8 D=128"],
+        "reference": "current llama.cpp ggml_flash_attn_ext with GGML_PREC_F32"
+      }
+    },
     "f16_online_single_range": {
-      "status": "observed",
+      "status": "validated",
       "q_compute": "fp16_rounded",
       "k_compute": "fp16_rounded",
       "score_accumulator": "fp32",
@@ -88,9 +111,9 @@
       },
       "description": "Single-range llama-compatible attention with FP16-rounded Q/K/V and FP16-rounded value updates.",
       "validation": {
-        "test": "make llamacpp-parity-full",
-        "cases": ["Nanbeige prefill", "Nanbeige decode"],
-        "reference": "llama.cpp GGML attention; promotion remains blocked on a dedicated leaf oracle"
+        "test": "unittest/test_attention_f16_split_kv.py and make llamacpp-parity-full",
+        "cases": ["Qwen3-VL Q=5", "Qwen3-VL Q=14", "Q=63 threshold boundary", "Nanbeige prefill", "Nanbeige decode"],
+        "reference": "current llama.cpp ggml_flash_attn_ext short-query path"
       }
     },
     "f16_online_fp32_merge": {

--- a/version/v8/contracts/numerical_execution.json
+++ b/version/v8/contracts/numerical_execution.json
@@ -695,6 +695,43 @@
       "description": "Elementwise residual addition of BF16-valued float buffers with BF16 RNE output storage.",
       "operator_family": "residual_add"
     },
+    "swiglu_fp32_ggml_vector_exp_fp32_output": {
+      "operator_family": "swiglu",
+      "status": "validated",
+      "storage": {
+        "input": "fp32",
+        "weight": "fp32",
+        "output": "fp32"
+      },
+      "compute": {
+        "input": "fp32",
+        "weight": "fp32",
+        "accumulator": "fp32",
+        "contraction": "disabled",
+        "evaluation_order": "ggml_isa_vector_exp_then_direct_gate_division_then_up_multiply"
+      },
+      "rounding": {
+        "mode": "rne",
+        "points": [
+          "input_load",
+          "output_store"
+        ]
+      },
+      "reduction": {
+        "kind": "none",
+        "order": "none",
+        "partial_accumulator": "none",
+        "merge_order": "none"
+      },
+      "threading": {
+        "work_partition": "serial",
+        "split_strategy": "serial",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false
+      },
+      "position_transform": null,
+      "description": "llama.cpp CPU SwiGLU semantics: evaluate GGML's ISA-specific vector exponential, divide gate by 1+exp(-gate), then multiply by up in FP32."
+    },
     "gelu_pytorch_tanh_bf16_storage": {
       "operator_family": "gelu",
       "status": "validated",

--- a/version/v8/contracts/quantized_linear.json
+++ b/version/v8/contracts/quantized_linear.json
@@ -12,6 +12,24 @@
       "parallel_reduction": {"kind": "independent_outputs", "reduction_order_effect": "none"},
       "description": "Q4_K weights times Q8_K activations with llama-compatible x86 lane accumulation and independent output partitioning."
     },
+    "q4_k_x_q8_k_repacked_matmul_fp32": {
+      "status": "validated",
+      "weight": {"format": "q4_k", "block_size": 256, "layout": "ggml_q4_k_repacked_x8"},
+      "activation": {"format": "q8_k", "block_size": 256, "layout": "ggml_q8_k", "quantization": "quantize_row_q8_k_ref"},
+      "dot": {"integer_accumulator": "int32", "block_scale_application": "pair_adjacent_32_element_integer_sums_then_separate_fp32_value_and_min_fma", "block_order": "ascending_k", "fp32_accumulator_lanes": 8, "minimum_accumulator_lanes": 8},
+      "output": {"accumulator": "fp32", "horizontal_reduction": "none", "bias": "after_complete_dot", "storage": "fp32"},
+      "parallel_reduction": {"kind": "independent_outputs", "reduction_order_effect": "none"},
+      "description": "Loaded-model Q4_K_8x8 matrix provider: adjacent 32-element integer-pair aggregation, separate FP32 value and minimum accumulators, and final subtraction for complete four-row groups; residual activation rows use the repacked matvec reduction."
+    },
+    "q4_k_x_q8_k_repacked_matvec_fp32": {
+      "status": "validated",
+      "weight": {"format": "q4_k", "block_size": 256, "layout": "ggml_q4_k_repacked_x8"},
+      "activation": {"format": "q8_k", "block_size": 256, "layout": "ggml_q8_k", "quantization": "quantize_row_q8_k_ref"},
+      "dot": {"integer_accumulator": "int32", "block_scale_application": "complete_256_element_superblock_integer_sum_then_separate_fp32_value_and_min_fma", "block_order": "ascending_k", "fp32_accumulator_lanes": 8, "minimum_accumulator_lanes": 8},
+      "output": {"accumulator": "fp32", "horizontal_reduction": "none", "bias": "after_complete_dot", "storage": "fp32"},
+      "parallel_reduction": {"kind": "independent_outputs", "reduction_order_effect": "none"},
+      "description": "Loaded-model Q4_K_8x8 single-row provider: all four 64-element pairs in each superblock are combined in int32 before one value FMA and one minimum FMA update the FP32 accumulators."
+    },
     "q6_k_x_q8_k_fp32_block_order": {
       "status": "validated",
       "weight": {"format": "q6_k", "block_size": 256, "layout": "ggml_q6_k"},

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -5,12 +5,12 @@
     "generated_by": "ck_run_v8.py",
     "source_dir": "version/v8/kernel_maps",
     "counts": {
-      "total": 205,
+      "total": 208,
       "by_op": {
         "add_backward": 1,
         "add_stream": 2,
         "assistant_layer_scale": 1,
-        "attention": 20,
+        "attention": 22,
         "attention_projection": 1,
         "attention_sliding": 6,
         "attn_gate_sigmoid_mul": 1,
@@ -88,7 +88,7 @@
         "split_qkv_packed_head_major": 1,
         "ssm_conv1d": 1,
         "ssm_conv1d_backward": 1,
-        "swiglu": 3,
+        "swiglu": 4,
         "tokenizer": 1,
         "v_norm": 1,
         "vision_patchify": 1
@@ -2322,6 +2322,346 @@
       },
       "name": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
       "_source_file": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract.json"
+    },
+    {
+      "id": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64",
+      "op": "attention",
+      "variant": "causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64",
+      "mode": "prefill",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "prefill"
+        ],
+        "execution.prefill_batching": [
+          "segmented_append"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp16"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "f16_flash_auto_qtile64"
+        ]
+      },
+      "supported_reductions": {
+        "f16_flash_auto_qtile64": {
+          "status": "validated",
+          "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+          "explicit_selector": true,
+          "selector": "CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64",
+          "notes": "Matches llama.cpp CPU flash dispatch: Q<64 uses FP16 online single-range arithmetic; Q>=64 uses 64x64 tiled FP32 arithmetic."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": [
+            "serial"
+          ],
+          "dispatch": [
+            "inline"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "q_tokens",
+            "head_dim"
+          ]
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp16",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ]
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp16",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "q_tokens",
+            "head_dim"
+          ]
+        }
+      ],
+      "dims": [
+        "num_heads",
+        "num_kv_heads",
+        "q_tokens",
+        "past_tokens",
+        "cache_capacity",
+        "head_dim",
+        "aligned_head_dim"
+      ],
+      "params": [
+        {
+          "name": "reduction",
+          "dtype": "ck_attention_reduction_t"
+        }
+      ],
+      "impl": {
+        "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+        "c_declaration": "ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(const float *q, const uint16_t *k_cache, const uint16_t *v_cache, float *output, int num_heads, int num_kv_heads, int q_tokens, int past_tokens, int cache_capacity, int head_dim, int aligned_head_dim, ck_attention_reduction_t reduction);",
+        "sources": [
+          "src/kernels/attention_kernels.c"
+        ]
+      },
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "name": "q",
+            "source": "scratch:q_scratch",
+            "cast": "const float*"
+          },
+          {
+            "name": "k_cache",
+            "source": "runtime:kv_cache_k_layer_f16",
+            "cast": "const uint16_t*"
+          },
+          {
+            "name": "v_cache",
+            "source": "runtime:kv_cache_v_layer_f16",
+            "cast": "const uint16_t*"
+          },
+          {
+            "name": "output",
+            "source": "output:out",
+            "cast": "float*"
+          },
+          {
+            "name": "num_heads",
+            "source": "dim:num_heads"
+          },
+          {
+            "name": "num_kv_heads",
+            "source": "dim:num_kv_heads"
+          },
+          {
+            "name": "q_tokens",
+            "source": "dim:seq_len"
+          },
+          {
+            "name": "past_tokens",
+            "source": "runtime:prefill_start_pos"
+          },
+          {
+            "name": "cache_capacity",
+            "source": "dim:max_seq_len"
+          },
+          {
+            "name": "head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "aligned_head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "reduction",
+            "source": "const:CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64"
+          }
+        ]
+      },
+      "name": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64",
+      "_source_file": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64.json"
+    },
+    {
+      "id": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_single_range",
+      "op": "attention",
+      "variant": "causal_head_major_gqa_prefill_append_f16cache_single_range",
+      "mode": "prefill",
+      "contract_schema_version": 1,
+      "provides": {
+        "execution.phase": [
+          "prefill"
+        ],
+        "execution.prefill_batching": [
+          "segmented_append"
+        ],
+        "tensor.q.dtype": [
+          "fp32"
+        ],
+        "tensor.kv.dtype": [
+          "fp16"
+        ],
+        "tensor.layout": [
+          "head_major"
+        ],
+        "numerics.attention_reduction": [
+          "f16_online_single_range"
+        ]
+      },
+      "supported_reductions": {
+        "f16_online_single_range": {
+          "status": "validated",
+          "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+          "explicit_selector": true,
+          "selector": "CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE",
+          "notes": "Single-range FP16 online-softmax arithmetic matching llama.cpp batched prefill, independent of runtime worker count."
+        }
+      },
+      "implementation": {
+        "isa_dispatch": "runtime",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": [
+            "serial"
+          ],
+          "dispatch": [
+            "inline"
+          ],
+          "reduction_order_effect": "contract_defined"
+        }
+      },
+      "inputs": [
+        {
+          "name": "q",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "q_tokens",
+            "head_dim"
+          ]
+        },
+        {
+          "name": "k_cache",
+          "dtype": "fp16",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ]
+        },
+        {
+          "name": "v_cache",
+          "dtype": "fp16",
+          "shape": [
+            "num_kv_heads",
+            "cache_capacity",
+            "head_dim"
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "dtype": "fp32",
+          "shape": [
+            "num_heads",
+            "q_tokens",
+            "head_dim"
+          ]
+        }
+      ],
+      "dims": [
+        "num_heads",
+        "num_kv_heads",
+        "q_tokens",
+        "past_tokens",
+        "cache_capacity",
+        "head_dim",
+        "aligned_head_dim"
+      ],
+      "params": [
+        {
+          "name": "reduction",
+          "dtype": "ck_attention_reduction_t"
+        }
+      ],
+      "impl": {
+        "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+        "c_declaration": "ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(const float *q, const uint16_t *k_cache, const uint16_t *v_cache, float *output, int num_heads, int num_kv_heads, int q_tokens, int past_tokens, int cache_capacity, int head_dim, int aligned_head_dim, ck_attention_reduction_t reduction);",
+        "sources": [
+          "src/kernels/attention_kernels.c"
+        ]
+      },
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "name": "q",
+            "source": "scratch:q_scratch",
+            "cast": "const float*"
+          },
+          {
+            "name": "k_cache",
+            "source": "runtime:kv_cache_k_layer_f16",
+            "cast": "const uint16_t*"
+          },
+          {
+            "name": "v_cache",
+            "source": "runtime:kv_cache_v_layer_f16",
+            "cast": "const uint16_t*"
+          },
+          {
+            "name": "output",
+            "source": "output:out",
+            "cast": "float*"
+          },
+          {
+            "name": "num_heads",
+            "source": "dim:num_heads"
+          },
+          {
+            "name": "num_kv_heads",
+            "source": "dim:num_kv_heads"
+          },
+          {
+            "name": "q_tokens",
+            "source": "dim:seq_len"
+          },
+          {
+            "name": "past_tokens",
+            "source": "runtime:prefill_start_pos"
+          },
+          {
+            "name": "cache_capacity",
+            "source": "dim:max_seq_len"
+          },
+          {
+            "name": "head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "aligned_head_dim",
+            "source": "dim:head_dim"
+          },
+          {
+            "name": "reduction",
+            "source": "const:CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE"
+          }
+        ]
+      },
+      "name": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_single_range",
+      "_source_file": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_single_range.json"
     },
     {
       "id": "attention_forward_causal_head_major_shared_kv_gemma4",
@@ -9856,11 +10196,11 @@
       "op": "gemm",
       "variant": "q4_k_w_q8_k_a",
       "contract_schema_version": 1,
-      "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+      "numerical_contract": "q4_k_x_q8_k_repacked_matmul_fp32",
       "reference": {
-        "function": "gemv_q4_k_q8_k_ref",
-        "kind": "scalar_contract_oracle",
-        "adapter": "per_activation_row_then_bias",
+        "function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
+        "kind": "llama_repacked_graph_oracle",
+        "adapter": "direct",
         "validation": {
           "status": "validated",
           "tests": [
@@ -9883,8 +10223,8 @@
         }
       },
       "production": {
-        "function": "gemm_nt_q4_k_q8_k",
-        "threaded_function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
+        "function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
+        "threaded_function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
         "reference_comparison": {
           "requirement": "bit_exact",
           "absolute_tolerance": 0.0,
@@ -10073,7 +10413,7 @@
         "notes": "Q4_K requires K dimension multiple of 256 for dequantization. Most aggressive quantization for W2 (down) projection."
       },
       "impl": {
-        "function": "gemm_nt_q4_k_q8_k",
+        "function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
         "sources": [
           "src/kernels/gemm_kernels_q4k.c"
         ],
@@ -11900,10 +12240,10 @@
       "op": "gemv",
       "variant": "q4_k_w_q8_k_a_fp32_out",
       "contract_schema_version": 1,
-      "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+      "numerical_contract": "q4_k_x_q8_k_repacked_matvec_fp32",
       "reference": {
-        "function": "gemv_q4_k_q8_k_ref",
-        "kind": "scalar_contract_oracle",
+        "function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
+        "kind": "llama_repacked_graph_oracle",
         "adapter": "direct",
         "validation": {
           "status": "validated",
@@ -11919,7 +12259,7 @@
               "evidence": "unittest/test_q4_k_q8_k_matvec.py"
             },
             {
-              "backend": "llama.cpp_ggml_cpu",
+              "backend": "llama.cpp_ggml_cpu_graph",
               "status": "validated",
               "evidence": "unittest/test_q4k_q8k_llama_packed.cpp"
             }
@@ -11927,8 +12267,8 @@
         }
       },
       "production": {
-        "function": "gemv_q4_k_q8_k",
-        "threaded_function": "gemv_q4_k_q8_k_parallel_dispatch",
+        "function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
+        "threaded_function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
         "reference_comparison": {
           "requirement": "bit_exact",
           "absolute_tolerance": 0.0,
@@ -12032,7 +12372,7 @@
         "notes": "Q4_K requires K dimension multiple of 256 for dequantization. Most aggressive quantization."
       },
       "impl": {
-        "function": "gemv_q4_k_q8_k",
+        "function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
         "c_declaration": "void gemv_q4_k_q8_k(float *y, const void *W, const void *x_q8, int M, int K);",
         "sources": [
           "src/kernels/gemm_kernels_q4k.c"
@@ -25623,6 +25963,165 @@
       "notes": "Exact SwiGLU forward for training/parity: silu(gate) * up with scalar expf-based sigmoid.",
       "name": "swiglu_forward_exact",
       "_source_file": "swiglu_forward_exact.json"
+    },
+    {
+      "id": "swiglu_forward_ggml",
+      "op": "swiglu",
+      "variant": "ggml_fp32",
+      "quant": {
+        "weight": "none",
+        "activation": "fp32",
+        "output": "fp32"
+      },
+      "inputs": [
+        {
+          "name": "gate_up",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "2 * I"
+          ],
+          "desc": "Contiguous gate then up projection values."
+        }
+      ],
+      "weights": [],
+      "activations": [],
+      "outputs": [
+        {
+          "name": "out",
+          "dtype": "fp32",
+          "shape": [
+            "T",
+            "I"
+          ],
+          "desc": "GGML-compatible SiLU(gate) times up output."
+        }
+      ],
+      "scratch": [],
+      "dims": [
+        "T",
+        "I"
+      ],
+      "parallelization": {
+        "supported": [
+          "serial"
+        ],
+        "preferred": {
+          "prefill": "serial",
+          "decode": "serial"
+        },
+        "strategies": [
+          {
+            "name": "serial",
+            "partition_dim": "T",
+            "param_style": "complete_call",
+            "notes": "Elementwise ISA-vector traversal; no cross-element reduction."
+          }
+        ]
+      },
+      "constraints": {
+        "alignment": {
+          "I": 1
+        },
+        "notes": "Vector-width tails use GGML scalar direct-division semantics."
+      },
+      "impl": {
+        "function": "swiglu_forward_ggml",
+        "c_declaration": "void swiglu_forward_ggml(const float *input, float *output, int tokens, int dim);",
+        "sources": [
+          "src/kernels/swiglu_kernels.c"
+        ],
+        "variants": [
+          {
+            "name": "avx2",
+            "requires": [
+              "avx2",
+              "fma"
+            ],
+            "compile_flags": [
+              "-mavx2",
+              "-mfma"
+            ]
+          },
+          {
+            "name": "ref",
+            "requires": [],
+            "compile_flags": []
+          }
+        ]
+      },
+      "modes": {
+        "inference": true,
+        "training": false,
+        "backward": false
+      },
+      "numerical_capabilities": [
+        {
+          "contract_id": "swiglu_fp32_ggml_vector_exp_fp32_output",
+          "status": "validated",
+          "phases": [
+            "prefill",
+            "decode"
+          ],
+          "function": "swiglu_forward_ggml",
+          "explicit_selector": true,
+          "implementation": {
+            "isa_dispatch": "compile_time",
+            "threading": {
+              "runtime": "serial",
+              "work_partition": [
+                "serial"
+              ],
+              "dispatch": [
+                "inline"
+              ],
+              "reduction_order_effect": "none"
+            }
+          },
+          "arithmetic": {
+            "partial_accumulator": "none",
+            "merge_order": "none",
+            "deterministic": true,
+            "thread_count_changes_arithmetic_order": false,
+            "split_strategy": "serial"
+          }
+        }
+      ],
+      "call_abi": {
+        "version": 1,
+        "params": [
+          {
+            "name": "input",
+            "source": "activation:gate",
+            "cast": "float*"
+          },
+          {
+            "name": "output",
+            "source": "output:out",
+            "cast": "float*"
+          },
+          {
+            "name": "tokens",
+            "source": "dim:seq_len"
+          },
+          {
+            "name": "dim",
+            "source": "dim:intermediate_size"
+          }
+        ]
+      },
+      "tests": {
+        "unit": [
+          "unittest/test_swiglu.py::GGML production-shape oracle"
+        ],
+        "bench": [],
+        "parity": [
+          "llama.cpp ggml_vec_swiglu_f32"
+        ]
+      },
+      "notes": "Exact llama.cpp CPU SwiGLU provider selected by numerical contract, never by model-name codegen logic.",
+      "name": "swiglu_forward_ggml",
+      "_source_file": "swiglu_forward_ggml.json"
     },
     {
       "id": "tokenizer_bpe_trie",

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64.json
@@ -1,0 +1,67 @@
+{
+  "id": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64",
+  "op": "attention",
+  "variant": "causal_head_major_gqa_prefill_append_f16cache_flash_auto_qtile64",
+  "mode": "prefill",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["prefill"],
+    "execution.prefill_batching": ["segmented_append"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp16"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["f16_flash_auto_qtile64"]
+  },
+  "supported_reductions": {
+    "f16_flash_auto_qtile64": {
+      "status": "validated",
+      "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+      "explicit_selector": true,
+      "selector": "CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64",
+      "notes": "Matches llama.cpp CPU flash dispatch: Q<64 uses FP16 online single-range arithmetic; Q>=64 uses 64x64 tiled FP32 arithmetic."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "serial",
+      "work_partition": ["serial"],
+      "dispatch": ["inline"],
+      "reduction_order_effect": "contract_defined"
+    }
+  },
+  "inputs": [
+    {"name": "q", "dtype": "fp32", "shape": ["num_heads", "q_tokens", "head_dim"]},
+    {"name": "k_cache", "dtype": "fp16", "shape": ["num_kv_heads", "cache_capacity", "head_dim"]},
+    {"name": "v_cache", "dtype": "fp16", "shape": ["num_kv_heads", "cache_capacity", "head_dim"]}
+  ],
+  "outputs": [
+    {"name": "output", "dtype": "fp32", "shape": ["num_heads", "q_tokens", "head_dim"]}
+  ],
+  "dims": ["num_heads", "num_kv_heads", "q_tokens", "past_tokens", "cache_capacity", "head_dim", "aligned_head_dim"],
+  "params": [
+    {"name": "reduction", "dtype": "ck_attention_reduction_t"}
+  ],
+  "impl": {
+    "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+    "c_declaration": "ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(const float *q, const uint16_t *k_cache, const uint16_t *v_cache, float *output, int num_heads, int num_kv_heads, int q_tokens, int past_tokens, int cache_capacity, int head_dim, int aligned_head_dim, ck_attention_reduction_t reduction);",
+    "sources": ["src/kernels/attention_kernels.c"]
+  },
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {"name": "q", "source": "scratch:q_scratch", "cast": "const float*"},
+      {"name": "k_cache", "source": "runtime:kv_cache_k_layer_f16", "cast": "const uint16_t*"},
+      {"name": "v_cache", "source": "runtime:kv_cache_v_layer_f16", "cast": "const uint16_t*"},
+      {"name": "output", "source": "output:out", "cast": "float*"},
+      {"name": "num_heads", "source": "dim:num_heads"},
+      {"name": "num_kv_heads", "source": "dim:num_kv_heads"},
+      {"name": "q_tokens", "source": "dim:seq_len"},
+      {"name": "past_tokens", "source": "runtime:prefill_start_pos"},
+      {"name": "cache_capacity", "source": "dim:max_seq_len"},
+      {"name": "head_dim", "source": "dim:head_dim"},
+      {"name": "aligned_head_dim", "source": "dim:head_dim"},
+      {"name": "reduction", "source": "const:CK_ATTN_REDUCTION_F16_FLASH_AUTO_QTILE64"}
+    ]
+  }
+}

--- a/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_single_range.json
+++ b/version/v8/kernel_maps/attention_forward_causal_head_major_gqa_prefill_append_f16cache_single_range.json
@@ -1,0 +1,67 @@
+{
+  "id": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_single_range",
+  "op": "attention",
+  "variant": "causal_head_major_gqa_prefill_append_f16cache_single_range",
+  "mode": "prefill",
+  "contract_schema_version": 1,
+  "provides": {
+    "execution.phase": ["prefill"],
+    "execution.prefill_batching": ["segmented_append"],
+    "tensor.q.dtype": ["fp32"],
+    "tensor.kv.dtype": ["fp16"],
+    "tensor.layout": ["head_major"],
+    "numerics.attention_reduction": ["f16_online_single_range"]
+  },
+  "supported_reductions": {
+    "f16_online_single_range": {
+      "status": "validated",
+      "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+      "explicit_selector": true,
+      "selector": "CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE",
+      "notes": "Single-range FP16 online-softmax arithmetic matching llama.cpp batched prefill, independent of runtime worker count."
+    }
+  },
+  "implementation": {
+    "isa_dispatch": "runtime",
+    "threading": {
+      "runtime": "serial",
+      "work_partition": ["serial"],
+      "dispatch": ["inline"],
+      "reduction_order_effect": "contract_defined"
+    }
+  },
+  "inputs": [
+    {"name": "q", "dtype": "fp32", "shape": ["num_heads", "q_tokens", "head_dim"]},
+    {"name": "k_cache", "dtype": "fp16", "shape": ["num_kv_heads", "cache_capacity", "head_dim"]},
+    {"name": "v_cache", "dtype": "fp16", "shape": ["num_kv_heads", "cache_capacity", "head_dim"]}
+  ],
+  "outputs": [
+    {"name": "output", "dtype": "fp32", "shape": ["num_heads", "q_tokens", "head_dim"]}
+  ],
+  "dims": ["num_heads", "num_kv_heads", "q_tokens", "past_tokens", "cache_capacity", "head_dim", "aligned_head_dim"],
+  "params": [
+    {"name": "reduction", "dtype": "ck_attention_reduction_t"}
+  ],
+  "impl": {
+    "function": "attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract",
+    "c_declaration": "ck_attention_status_t attention_forward_causal_head_major_gqa_prefill_append_f16cache_contract(const float *q, const uint16_t *k_cache, const uint16_t *v_cache, float *output, int num_heads, int num_kv_heads, int q_tokens, int past_tokens, int cache_capacity, int head_dim, int aligned_head_dim, ck_attention_reduction_t reduction);",
+    "sources": ["src/kernels/attention_kernels.c"]
+  },
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {"name": "q", "source": "scratch:q_scratch", "cast": "const float*"},
+      {"name": "k_cache", "source": "runtime:kv_cache_k_layer_f16", "cast": "const uint16_t*"},
+      {"name": "v_cache", "source": "runtime:kv_cache_v_layer_f16", "cast": "const uint16_t*"},
+      {"name": "output", "source": "output:out", "cast": "float*"},
+      {"name": "num_heads", "source": "dim:num_heads"},
+      {"name": "num_kv_heads", "source": "dim:num_kv_heads"},
+      {"name": "q_tokens", "source": "dim:seq_len"},
+      {"name": "past_tokens", "source": "runtime:prefill_start_pos"},
+      {"name": "cache_capacity", "source": "dim:max_seq_len"},
+      {"name": "head_dim", "source": "dim:head_dim"},
+      {"name": "aligned_head_dim", "source": "dim:head_dim"},
+      {"name": "reduction", "source": "const:CK_ATTN_REDUCTION_F16_ONLINE_SINGLE_RANGE"}
+    ]
+  }
+}

--- a/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemm_nt_q4_k_q8_k.json
@@ -3,11 +3,11 @@
   "op": "gemm",
   "variant": "q4_k_w_q8_k_a",
   "contract_schema_version": 1,
-  "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+  "numerical_contract": "q4_k_x_q8_k_repacked_matmul_fp32",
   "reference": {
-    "function": "gemv_q4_k_q8_k_ref",
-    "kind": "scalar_contract_oracle",
-    "adapter": "per_activation_row_then_bias",
+    "function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
+    "kind": "llama_repacked_graph_oracle",
+    "adapter": "direct",
     "validation": {
       "status": "validated",
       "tests": ["unittest/test_q4_k_q8_k_matvec.py", "unittest/test_q4k_q8k_llama_packed.cpp", "tests/test_threadpool_parity.c"],
@@ -18,8 +18,8 @@
     }
   },
   "production": {
-    "function": "gemm_nt_q4_k_q8_k",
-    "threaded_function": "gemm_nt_q4_k_q8_k_parallel_dispatch",
+    "function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
+    "threaded_function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
     "reference_comparison": {
       "requirement": "bit_exact",
       "absolute_tolerance": 0.0,
@@ -125,7 +125,7 @@
     "notes": "Q4_K requires K dimension multiple of 256 for dequantization. Most aggressive quantization for W2 (down) projection."
   },
   "impl": {
-    "function": "gemm_nt_q4_k_q8_k",
+    "function": "gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch",
     "sources": ["src/kernels/gemm_kernels_q4k.c"],
     "variants": [
       {"name": "avx2", "requires": ["avx2", "fma"], "compile_flags": ["-mavx2", "-mfma"]}

--- a/version/v8/kernel_maps/gemv_q4_k_q8_k.json
+++ b/version/v8/kernel_maps/gemv_q4_k_q8_k.json
@@ -3,23 +3,23 @@
   "op": "gemv",
   "variant": "q4_k_w_q8_k_a_fp32_out",
   "contract_schema_version": 1,
-  "numerical_contract": "q4_k_x_q8_k_fp32_block_order",
+  "numerical_contract": "q4_k_x_q8_k_repacked_matvec_fp32",
   "reference": {
-    "function": "gemv_q4_k_q8_k_ref",
-    "kind": "scalar_contract_oracle",
+    "function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
+    "kind": "llama_repacked_graph_oracle",
     "adapter": "direct",
     "validation": {
       "status": "validated",
       "tests": ["unittest/test_q4_k_q8_k_matvec.py", "unittest/test_q4k_q8k_llama_packed.cpp", "tests/test_threadpool_parity.c"],
       "external_oracles": [
         {"backend": "numpy_dequantized_fp32", "status": "observed", "evidence": "unittest/test_q4_k_q8_k_matvec.py"},
-        {"backend": "llama.cpp_ggml_cpu", "status": "validated", "evidence": "unittest/test_q4k_q8k_llama_packed.cpp"}
+        {"backend": "llama.cpp_ggml_cpu_graph", "status": "validated", "evidence": "unittest/test_q4k_q8k_llama_packed.cpp"}
       ]
     }
   },
   "production": {
-    "function": "gemv_q4_k_q8_k",
-    "threaded_function": "gemv_q4_k_q8_k_parallel_dispatch",
+    "function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
+    "threaded_function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
     "reference_comparison": {
       "requirement": "bit_exact",
       "absolute_tolerance": 0.0,
@@ -31,7 +31,9 @@
     "isa_dispatch": "runtime",
     "weight_storage": {"format": "q4_k", "block_elements": 256, "block_bytes": 144},
     "activation_storage": {"format": "q8_k", "block_elements": 256},
-    "diagnostic_providers": {"fp32_activation": "gemv_q4_k"},
+    "diagnostic_providers": {
+      "fp32_activation": "gemv_q4_k"
+    },
     "threading": {
       "runtime": "ck_threadpool",
       "work_partition": ["serial", "independent_rows"],
@@ -73,7 +75,7 @@
     "notes": "Q4_K requires K dimension multiple of 256 for dequantization. Most aggressive quantization."
   },
   "impl": {
-    "function": "gemv_q4_k_q8_k",
+    "function": "gemv_q4_k_q8_k_repacked_parallel_dispatch",
     "c_declaration": "void gemv_q4_k_q8_k(float *y, const void *W, const void *x_q8, int M, int K);",
     "sources": ["src/kernels/gemm_kernels_q4k.c"],
     "variants": [

--- a/version/v8/kernel_maps/swiglu_forward_ggml.json
+++ b/version/v8/kernel_maps/swiglu_forward_ggml.json
@@ -1,0 +1,96 @@
+{
+  "id": "swiglu_forward_ggml",
+  "op": "swiglu",
+  "variant": "ggml_fp32",
+  "quant": {
+    "weight": "none",
+    "activation": "fp32",
+    "output": "fp32"
+  },
+  "inputs": [
+    {
+      "name": "gate_up",
+      "dtype": "fp32",
+      "shape": ["T", "2 * I"],
+      "desc": "Contiguous gate then up projection values."
+    }
+  ],
+  "weights": [],
+  "activations": [],
+  "outputs": [
+    {
+      "name": "out",
+      "dtype": "fp32",
+      "shape": ["T", "I"],
+      "desc": "GGML-compatible SiLU(gate) times up output."
+    }
+  ],
+  "scratch": [],
+  "dims": ["T", "I"],
+  "parallelization": {
+    "supported": ["serial"],
+    "preferred": {"prefill": "serial", "decode": "serial"},
+    "strategies": [
+      {
+        "name": "serial",
+        "partition_dim": "T",
+        "param_style": "complete_call",
+        "notes": "Elementwise ISA-vector traversal; no cross-element reduction."
+      }
+    ]
+  },
+  "constraints": {
+    "alignment": {"I": 1},
+    "notes": "Vector-width tails use GGML scalar direct-division semantics."
+  },
+  "impl": {
+    "function": "swiglu_forward_ggml",
+    "c_declaration": "void swiglu_forward_ggml(const float *input, float *output, int tokens, int dim);",
+    "sources": ["src/kernels/swiglu_kernels.c"],
+    "variants": [
+      {"name": "avx2", "requires": ["avx2", "fma"], "compile_flags": ["-mavx2", "-mfma"]},
+      {"name": "ref", "requires": [], "compile_flags": []}
+    ]
+  },
+  "modes": {"inference": true, "training": false, "backward": false},
+  "numerical_capabilities": [
+    {
+      "contract_id": "swiglu_fp32_ggml_vector_exp_fp32_output",
+      "status": "validated",
+      "phases": ["prefill", "decode"],
+      "function": "swiglu_forward_ggml",
+      "explicit_selector": true,
+      "implementation": {
+        "isa_dispatch": "compile_time",
+        "threading": {
+          "runtime": "serial",
+          "work_partition": ["serial"],
+          "dispatch": ["inline"],
+          "reduction_order_effect": "none"
+        }
+      },
+      "arithmetic": {
+        "partial_accumulator": "none",
+        "merge_order": "none",
+        "deterministic": true,
+        "thread_count_changes_arithmetic_order": false,
+        "split_strategy": "serial"
+      }
+    }
+  ],
+  "call_abi": {
+    "version": 1,
+    "params": [
+      {"name": "input", "source": "activation:gate", "cast": "float*"},
+      {"name": "output", "source": "output:out", "cast": "float*"},
+      {"name": "tokens", "source": "dim:seq_len"},
+      {"name": "dim", "source": "dim:intermediate_size"}
+    ]
+  },
+  "tests": {
+    "unit": ["unittest/test_swiglu.py::GGML production-shape oracle"],
+    "bench": [],
+    "parity": ["llama.cpp ggml_vec_swiglu_f32"]
+  },
+  "notes": "Exact llama.cpp CPU SwiGLU provider selected by numerical contract, never by model-name codegen logic."
+}

--- a/version/v8/schemas/attention_reduction_registry.schema.json
+++ b/version/v8/schemas/attention_reduction_registry.schema.json
@@ -46,20 +46,20 @@
       ],
       "properties": {
         "status": {"enum": ["unresolved", "observed", "validated"]},
-        "q_compute": {"enum": ["fp32", "fp16", "fp16_rounded", "bf16", "bf16_rounded"]},
+        "q_compute": {"enum": ["fp32", "fp16", "fp16_rounded", "bf16", "bf16_rounded", "shape_dependent_fp16_or_fp32"]},
         "k_compute": {"enum": ["fp32", "fp16", "fp16_rounded", "bf16", "bf16_rounded"]},
         "score_accumulator": {"enum": ["fp32", "fp16", "bf16"]},
         "softmax_statistics": {"enum": ["fp32", "fp16", "bf16"]},
         "value_compute": {"enum": ["fp32", "fp16", "fp16_rounded", "bf16", "bf16_rounded"]},
-        "value_accumulator": {"enum": ["fp32", "fp16", "fp16_rounded_each_update", "bf16", "bf16_rounded_each_update"]},
-        "partial_storage": {"enum": ["none", "fp32", "fp16", "bf16"]},
-        "partial_merge": {"enum": ["none", "fp32_chunk_order", "fp16_chunk_order", "bf16_chunk_order"]},
+        "value_accumulator": {"enum": ["fp32", "fp16", "fp16_rounded_each_update", "bf16", "bf16_rounded_each_update", "shape_dependent_fp16_or_fp32"]},
+        "partial_storage": {"enum": ["none", "fp32", "fp16", "bf16", "shape_dependent_none_or_fp32"]},
+        "partial_merge": {"enum": ["none", "fp32_chunk_order", "fp16_chunk_order", "bf16_chunk_order", "shape_dependent_single_range_or_fp32_chunk_order"]},
         "partition": {
           "type": "object",
           "additionalProperties": false,
           "required": ["kind"],
           "properties": {
-            "kind": {"enum": ["single_range", "kv_chunks_by_workers", "query_key_tiles"]},
+            "kind": {"enum": ["single_range", "kv_chunks_by_workers", "query_key_tiles", "query_tile_threshold"]},
             "threshold": {"type": "integer", "minimum": 1},
             "extent_alignment": {"type": "integer", "minimum": 1},
             "below_threshold_chunks": {"type": "integer", "minimum": 1},
@@ -67,13 +67,21 @@
             "query_tile_size": {"type": "integer", "minimum": 1},
             "key_tile_size": {"type": "integer", "minimum": 1},
             "softmax_sum_update": {"enum": ["fp32_add", "fp64_add_then_fp32_store"]},
-            "worker_partition": {"enum": ["contiguous_head_query_rows"]}
+            "worker_partition": {"enum": ["contiguous_head_query_rows"]},
+            "below_threshold": {"type": "string", "minLength": 1},
+            "at_or_above_threshold": {"type": "string", "minLength": 1}
           },
           "allOf": [
             {
               "if": {"properties": {"kind": {"const": "query_key_tiles"}}},
               "then": {
                 "required": ["query_tile_size", "key_tile_size", "softmax_sum_update", "worker_partition"]
+              }
+            },
+            {
+              "if": {"properties": {"kind": {"const": "query_tile_threshold"}}},
+              "then": {
+                "required": ["threshold", "below_threshold", "at_or_above_threshold"]
               }
             }
           ]

--- a/version/v8/schemas/numerical_execution_contract_registry.schema.json
+++ b/version/v8/schemas/numerical_execution_contract_registry.schema.json
@@ -53,7 +53,8 @@
             "rmsnorm",
             "attention",
             "residual_add",
-            "gelu"
+            "gelu",
+            "swiglu"
           ]
         },
         "status": {

--- a/version/v8/schemas/quantized_linear_kernel_capability.schema.json
+++ b/version/v8/schemas/quantized_linear_kernel_capability.schema.json
@@ -15,7 +15,7 @@
       "required": ["function", "kind", "adapter", "validation"],
       "properties": {
         "function": {"type": "string", "minLength": 1},
-        "kind": {"const": "scalar_contract_oracle"},
+        "kind": {"enum": ["scalar_contract_oracle", "llama_repacked_graph_oracle"]},
         "adapter": {"enum": ["direct", "per_activation_row", "per_activation_row_then_bias"]},
         "validation": {
           "type": "object",

--- a/version/v8/schemas/xray_execution_trace.schema.json
+++ b/version/v8/schemas/xray_execution_trace.schema.json
@@ -42,10 +42,12 @@
                 "items": {
                   "type": "object",
                   "additionalProperties": false,
-                  "required": ["checkpoint_id", "kernel_id", "m", "n", "k"],
+                  "required": ["checkpoint_id", "kernel_id", "numerical_contract_id", "effective_contract_id", "m", "n", "k"],
                   "properties": {
                     "checkpoint_id": {"type": "string", "minLength": 1},
                     "kernel_id": {"type": "string", "minLength": 1},
+                    "numerical_contract_id": {"type": "string", "minLength": 1},
+                    "effective_contract_id": {"type": "string", "minLength": 1},
                     "m": {"type": "integer", "minimum": 1},
                     "n": {"type": "integer", "minimum": 1},
                     "k": {"type": "integer", "minimum": 1}

--- a/version/v8/scripts/codegen_core_v8.py
+++ b/version/v8/scripts/codegen_core_v8.py
@@ -3019,6 +3019,34 @@ CK_EXPORT int ck_model_kv_cache_enable(int capacity) {{
     return 0;
 }}
 
+/* Bounded X-ray ABI: export one layer and only currently valid FP16 KV rows.
+ * The file is diagnostic evidence, not a runtime checkpoint format. */
+CK_EXPORT int ck_model_debug_export_kv_f16(const char *path, int layer) {{
+    if (!g_model || !path || !path[0] || !g_model->kv_cache_f16) return -1;
+    if (layer < 0 || layer >= NUM_LAYERS || g_model->pos < 0 || g_model->pos > MAX_SEQ_LEN) return -2;
+    FILE *f = fopen(path, "wb");
+    if (!f) return -3;
+    const uint32_t header[8] = {{
+        UINT32_C(0x564b5843), UINT32_C(1), (uint32_t)layer, (uint32_t)g_model->pos,
+        (uint32_t)NUM_KV_HEADS, (uint32_t)MAX_SEQ_LEN, (uint32_t)HEAD_DIM, UINT32_C(0)
+    }};
+    if (fwrite(header, sizeof(header), 1, f) != 1) {{ fclose(f); return -4; }}
+    const size_t head_stride = (size_t)MAX_SEQ_LEN * (size_t)HEAD_DIM;
+    const size_t valid_bytes = (size_t)g_model->pos * (size_t)HEAD_DIM * sizeof(uint16_t);
+    const uint16_t *layer_k = g_model->kv_cache_f16 +
+        (size_t)(layer * 2) * (size_t)NUM_KV_HEADS * head_stride;
+    const uint16_t *layer_v = g_model->kv_cache_f16 +
+        (size_t)(layer * 2 + 1) * (size_t)NUM_KV_HEADS * head_stride;
+    for (int h = 0; h < NUM_KV_HEADS; ++h) {{
+        if (fwrite(layer_k + (size_t)h * head_stride, valid_bytes, 1, f) != 1) {{ fclose(f); return -5; }}
+    }}
+    for (int h = 0; h < NUM_KV_HEADS; ++h) {{
+        if (fwrite(layer_v + (size_t)h * head_stride, valid_bytes, 1, f) != 1) {{ fclose(f); return -6; }}
+    }}
+    fclose(f);
+    return 0;
+}}
+
 static int ck_trace_pos_enabled(void) {{
     const char *env = getenv("CK_TRACE_POS");
     return env && atoi(env) != 0;

--- a/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
+++ b/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
@@ -420,6 +420,32 @@ def _ck_threads(args: argparse.Namespace) -> int:
     return int(args.threads if explicit is None else explicit)
 
 
+def _resolve_decoder_runtime_request(
+    args: argparse.Namespace,
+    bridge_report: dict[str, Any],
+    workdir: Path,
+) -> tuple[Path, bool]:
+    explicit_so = getattr(args, "ck_runtime_so", None)
+    explicit_manifest = getattr(args, "ck_runtime_manifest_map", None)
+    if bool(explicit_so) != bool(explicit_manifest):
+        raise ValueError(
+            "exact runtime reuse requires both --ck-runtime-so and "
+            "--ck-runtime-manifest-map"
+        )
+    if explicit_so and explicit_manifest:
+        return Path(explicit_so).resolve().parent, True
+
+    exact_runtime = bool(getattr(args, "reuse_bridge_decoder_runtime_exact", False))
+    if bool(getattr(args, "reuse_bridge_decoder_runtime", False)) or exact_runtime:
+        decoder_workdir = str(
+            ((bridge_report.get("decoder_runtime") or {}).get("workdir") or "")
+        ).strip()
+        if not decoder_workdir:
+            raise ValueError("bridge report does not include decoder_runtime.workdir")
+        return Path(decoder_workdir).resolve(), exact_runtime
+    return workdir / "decoder", False
+
+
 def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> dict[str, Any]:
     bridge_report = first_token._load_bridge_report(args.bridge_report.resolve())
     gguf_value = str(((bridge_report.get("decoder_runtime") or {}).get("gguf") or "")).strip()
@@ -428,14 +454,9 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
     gguf_path = Path(gguf_value).resolve()
     workdir = args.workdir.resolve()
     workdir.mkdir(parents=True, exist_ok=True)
-    exact_runtime = bool(getattr(args, "reuse_bridge_decoder_runtime_exact", False))
-    if bool(getattr(args, "reuse_bridge_decoder_runtime", False)) or exact_runtime:
-        decoder_workdir = str(((bridge_report.get("decoder_runtime") or {}).get("workdir") or "")).strip()
-        if not decoder_workdir:
-            raise ValueError("bridge report does not include decoder_runtime.workdir")
-        decoder_dir = Path(decoder_workdir).resolve()
-    else:
-        decoder_dir = workdir / "decoder"
+    decoder_dir, exact_runtime = _resolve_decoder_runtime_request(
+        args, bridge_report, workdir
+    )
 
     requested_ctx_len = int(args.ctx_len or bridge_report.get("decoder_context_len") or 256)
     if exact_runtime and not parity_dump:
@@ -545,6 +566,7 @@ def _prepare_inputs(args: argparse.Namespace, *, parity_dump: bool = False) -> d
         "gguf_path": gguf_path,
         "workdir": workdir,
         "runtime": runtime,
+        "exact_runtime": bool(exact_runtime and not parity_dump),
         "tokenizer": tokenizer,
         "tokens_before": [int(t) for t in tokens_before],
         "tokens_after": [int(t) for t in tokens_after],
@@ -629,6 +651,7 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
             prefix_grid=inputs["prefix_grid"],
             prefix_text_pos=int(inputs["prefix_text_pos"]),
             ck_strict_parity=bool(args.ck_strict_parity),
+            llama_decode_mode=str(args.llama_decode_mode),
         )
     finally:
         _restore_prefix_decode_policy_env(old_env)
@@ -699,6 +722,28 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
         directory.mkdir(parents=True, exist_ok=True)
 
     capture_error: Exception | None = None
+    kv_comparison: dict[str, Any] | None = None
+
+    def export_kv(lib: Any, path: Path) -> dict[str, Any]:
+        if not hasattr(lib, "ck_model_debug_export_kv_f16"):
+            return {
+                "status": "unavailable",
+                "reason": "runtime lacks bounded ck_model_debug_export_kv_f16 X-ray ABI",
+                "path": str(path),
+            }
+        lib.ck_model_debug_export_kv_f16.argtypes = [ctypes.c_char_p, ctypes.c_int]
+        lib.ck_model_debug_export_kv_f16.restype = ctypes.c_int
+        rc = int(lib.ck_model_debug_export_kv_f16(str(path).encode("utf-8"), int(layer)))
+        if rc != 0:
+            return {
+                "status": "error",
+                "reason": f"FP16 KV export failed rc={rc} layer={layer}",
+                "path": str(path),
+            }
+        return {"status": "ok", "path": str(path)}
+
+    persistent_kv_export: dict[str, Any] | None = None
+    replay_kv_export: dict[str, Any] | None = None
     try:
         _restore_process_env({key: None for key in env_keys})
         lib, logits_buf, _vocab_size = _init_ck_state(
@@ -717,6 +762,7 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
                     raise RuntimeError(f"ck_model_decode failed rc={rc} while capturing persistent hidden state")
                 if i == last_i:
                     _restore_process_env({key: None for key in env_keys})
+            persistent_kv_export = export_kv(lib, persistent_dir / "kv_cache_f16.bin")
         finally:
             if hasattr(lib, "ck_model_free"):
                 try:
@@ -734,6 +780,7 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
         lib2, _logits2, _vocab2 = _init_ck_state(
             replay_inputs, bool(args.ck_strict_parity), getattr(args, "ck_engine_so", None)
         )
+        replay_kv_export = export_kv(lib2, full_dir / "kv_cache_f16.bin")
         if hasattr(lib2, "ck_model_free"):
             try:
                 lib2.ck_model_free()
@@ -757,6 +804,37 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
                 "full_replay_dir": str(full_dir),
             })
     else:
+        if (
+            persistent_kv_export is not None
+            and replay_kv_export is not None
+            and persistent_kv_export.get("status") == "ok"
+            and replay_kv_export.get("status") == "ok"
+        ):
+            persistent_kv = Path(str(persistent_kv_export["path"]))
+            replay_kv = Path(str(replay_kv_export["path"]))
+            persistent_bytes = persistent_kv.read_bytes()
+            replay_bytes = replay_kv.read_bytes()
+            first_byte = next(
+                (i for i, (a, b) in enumerate(zip(persistent_bytes, replay_bytes)) if a != b),
+                None,
+            )
+            kv_comparison = {
+                "status": "ok" if persistent_bytes == replay_bytes else "fail",
+                "persistent_path": str(persistent_kv),
+                "full_replay_path": str(replay_kv),
+                "persistent_bytes": len(persistent_bytes),
+                "full_replay_bytes": len(replay_bytes),
+                "first_differing_byte": first_byte,
+                "persistent_sha256": hashlib.sha256(persistent_bytes).hexdigest(),
+                "full_replay_sha256": hashlib.sha256(replay_bytes).hexdigest(),
+            }
+        else:
+            statuses = [item for item in (persistent_kv_export, replay_kv_export) if item is not None]
+            kv_comparison = {
+                "status": "error" if any(item.get("status") == "error" for item in statuses) else "unavailable",
+                "persistent": persistent_kv_export,
+                "full_replay": replay_kv_export,
+            }
         for name in names:
             replay_name = _hidden_full_replay_name(name)
             try:
@@ -817,6 +895,7 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
         "ck_execution_count": 2,
         "atol": float(args.hidden_state_atol),
         "first_issue": first_issue,
+        "kv_cache": kv_comparison,
         "results": results,
     }
 
@@ -1094,7 +1173,7 @@ def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]
         "append_on_divergence": str(args.append_on_divergence),
         "ck_runtime": _runtime_evidence(
             inputs["runtime"],
-            exact_reuse=bool(getattr(args, "reuse_bridge_decoder_runtime_exact", False)),
+            exact_reuse=bool(inputs.get("exact_runtime", False)),
             engine_so=getattr(args, "ck_engine_so", None),
         ),
         "stop_token_ids": sorted(stop_token_ids),

--- a/version/v8/scripts/decoder_first_token_parity_v8.py
+++ b/version/v8/scripts/decoder_first_token_parity_v8.py
@@ -535,20 +535,45 @@ def _augment_legacy_kqv_aliases(dumps: list[Any]) -> list[Any]:
 
 
 def _build_llama_row_specs(llama_dumps: list[Any]) -> dict[tuple[int, str], tuple[int, tuple[int, ...]]]:
-    specs: dict[tuple[int, str], tuple[int, tuple[int, ...]]] = {}
+    grouped: dict[tuple[int, str], list[Any]] = {}
     for dump in llama_dumps:
         op_name = _canonical_dump_op_name(str(dump.op_name))
         key = (int(dump.layer_id), op_name)
-        row_elems = int(np.asarray(dump.data).size)
-        row_shape = tuple(int(x) for x in np.asarray(dump.data).shape)
-        prev = specs.get(key)
-        choose = prev is None or row_elems < prev[0]
-        if not choose and prev is not None and row_elems == prev[0]:
+        grouped.setdefault(key, []).append(dump)
+
+    specs: dict[tuple[int, str], tuple[int, tuple[int, ...]]] = {}
+    for key, dumps in grouped.items():
+        sizes = [int(np.asarray(dump.data).size) for dump in dumps]
+        row_elems = sizes[0]
+        for size in sizes[1:]:
+            row_elems = math.gcd(row_elems, size)
+
+        shapes = [tuple(int(x) for x in np.asarray(dump.data).shape) for dump in dumps]
+        row_shape: tuple[int, ...] = (row_elems,)
+        if len(shapes) > 1 and len({len(shape) for shape in shapes}) == 1:
+            varying_axes = {
+                axis
+                for axis in range(len(shapes[0]))
+                if len({shape[axis] for shape in shapes}) > 1
+            }
+            candidate = tuple(
+                extent for axis, extent in enumerate(shapes[0]) if axis not in varying_axes
+            )
+            if candidate and int(np.prod(np.array(candidate, dtype=np.int64))) == row_elems:
+                row_shape = candidate
+        elif shapes:
             shaped_qk_ops = {"qcur_normed", "kcur_normed", "qcur_rope", "kcur_rope"}
-            if op_name in shaped_qk_ops and len(row_shape) > len(prev[1]):
-                choose = True
-        if choose:
-            specs[key] = (row_elems, row_shape)
+            ordered_shapes = sorted(
+                shapes,
+                key=lambda shape: len(shape) if key[1] in shaped_qk_ops else -len(shape),
+                reverse=True,
+            )
+            for shape in ordered_shapes:
+                if int(np.prod(np.array(shape, dtype=np.int64))) == row_elems:
+                    row_shape = shape
+                    break
+
+        specs[key] = (row_elems, row_shape)
     return specs
 
 
@@ -812,6 +837,72 @@ def _trim_llama_prefill_decode_dumps(
             )
     return trimmed
 
+
+def _expand_llama_prefill_decode_dumps(
+    llama_dumps: list[Any],
+    *,
+    prompt_token_count: int,
+    prompt_start_token: int = 0,
+) -> list[Any]:
+    """Expand the final batched llama segment into canonical logical rows.
+
+    Multimodal M-RoPE positions are not globally monotonic across the visual
+    and trailing-text segments. Selecting a batch by its final position can
+    therefore choose the visual batch instead of the last executed batch.
+    Batch extent and execution order are the stable contract here.
+    """
+    if prompt_token_count <= 0:
+        return list(llama_dumps)
+
+    row_specs = _build_llama_row_specs(llama_dumps)
+    grouped: dict[tuple[int, str], list[Any]] = {}
+    for dump in llama_dumps:
+        key = (int(dump.layer_id), _canonical_dump_op_name(str(dump.op_name)))
+        grouped.setdefault(key, []).append(dump)
+
+    expanded: list[Any] = []
+    for key, dumps in grouped.items():
+        row_spec = row_specs.get(key)
+        if row_spec is None:
+            expanded.extend(dumps)
+            continue
+        row_elems, row_shape = row_spec
+        exact = [
+            dump
+            for dump in dumps
+            if row_elems > 0
+            and int(np.asarray(dump.data).size) == row_elems * prompt_token_count
+        ]
+        selected = exact[-1] if exact else None
+        if selected is None:
+            expanded.extend(
+                _trim_llama_prefill_decode_dumps(
+                    dumps,
+                    prompt_start_token=prompt_start_token,
+                    prompt_token_count=prompt_token_count,
+                )
+            )
+            continue
+
+        flat = np.asarray(selected.data, dtype=np.float32).reshape(-1)
+        for prompt_idx in range(prompt_token_count):
+            start = prompt_idx * row_elems
+            row = flat[start : start + row_elems].copy()
+            if row_shape and int(np.prod(np.array(row_shape, dtype=np.int64))) == row.size:
+                row = row.reshape(row_shape)
+            expanded.append(
+                parity_test_v7.ParityDump(
+                    int(selected.layer_id),
+                    _canonical_dump_op_name(str(selected.op_name)),
+                    row,
+                    prompt_idx,
+                    str(selected.dtype),
+                    source_token_id=int(getattr(selected, "source_token_id", selected.token_id)),
+                    source_name=getattr(selected, "source_name", None),
+                )
+            )
+    return expanded
+
 def _compare_dump_sets(
     ck_dumps: list[Any],
     llama_dumps: list[Any],
@@ -1056,6 +1147,7 @@ def _capture_dump_compare(
     prefix_grid: tuple[int, int] | None = None,
     prefix_text_pos: int | None = None,
     ck_strict_parity: bool = True,
+    llama_decode_mode: str = "sequential",
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if prefix_tokens > 0:
         if str(dump_pass) != "decode":
@@ -1091,7 +1183,7 @@ def _capture_dump_compare(
         prefix_grid=prefix_grid,
         prefix_row_dim=int(prefix_row_dim),
         prefix_text_pos=prefix_text_pos,
-        decode_mode="sequential",
+        decode_mode=str(llama_decode_mode),
         dump_dir=llama_dump_dir,
         dump_names=dump_names,
     )
@@ -1153,10 +1245,10 @@ def _capture_dump_compare(
             prefix_text_pos=prefix_text_pos,
             llama_meta=dict(llama_capture.get("meta") or {}),
         )
-        llama_dumps = _trim_llama_prefill_decode_dumps(
+        llama_dumps = _expand_llama_prefill_decode_dumps(
             llama_dumps,
-            prompt_start_token=int(llama_prompt_start_token),
             prompt_token_count=len(token_ids),
+            prompt_start_token=int(llama_prompt_start_token),
         )
         ck_dumps = _expand_ck_prefill_decode_dumps(
             ck_dumps,

--- a/version/v8/scripts/numeric_parity_qwen3vl_mmproj_v8.py
+++ b/version/v8/scripts/numeric_parity_qwen3vl_mmproj_v8.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 from array import array
 import ctypes
+import hashlib
 import heapq
 import json
 import math
@@ -379,8 +380,41 @@ def _compile_generated_model(output_dir: Path) -> Path:
 def _compile_mtmd_shim(output_dir: Path) -> Path:
     shim_src = V8_TOOLS / "mtmd_clip_shim.cpp"
     shim_so = output_dir / "libmtmd_clip_shim.so"
-    if shim_so.exists() and shim_so.stat().st_mtime >= shim_src.stat().st_mtime:
-        return shim_so
+    stamp_path = output_dir / "libmtmd_clip_shim.so.build.json"
+
+    clip_header = (LLAMA_CPP_ROOT / "tools" / "mtmd" / "clip.h").read_text(
+        encoding="utf-8", errors="ignore"
+    )
+    clip_impl_header = (LLAMA_CPP_ROOT / "tools" / "mtmd" / "clip-impl.h").read_text(
+        encoding="utf-8", errors="ignore"
+    )
+    uses_object_api = "clip_embd_nbytes_by_img" not in clip_header
+    uses_value_api = uses_object_api and "clip_image_f32_ptr" not in (
+        clip_header + clip_impl_header
+    )
+    llama_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(LLAMA_CPP_ROOT),
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    build_fingerprint = {
+        "version": 1,
+        "llama_cpp_root": str(LLAMA_CPP_ROOT),
+        "llama_cpp_commit": llama_commit,
+        "shim_sha256": hashlib.sha256(shim_src.read_bytes()).hexdigest(),
+        "clip_header_sha256": hashlib.sha256(clip_header.encode()).hexdigest(),
+        "clip_impl_header_sha256": hashlib.sha256(clip_impl_header.encode()).hexdigest(),
+        "object_api": uses_object_api,
+        "value_api": uses_value_api,
+    }
+    if shim_so.is_file() and stamp_path.is_file():
+        try:
+            if json.loads(stamp_path.read_text(encoding="utf-8")) == build_fingerprint:
+                return shim_so
+        except (OSError, json.JSONDecodeError):
+            pass
 
     cmd = [
         "g++",
@@ -388,7 +422,8 @@ def _compile_mtmd_shim(output_dir: Path) -> Path:
         "-fPIC",
         "-O2",
         "-std=c++17",
-        *(["-DCK_MTMD_CLIP_OBJECT_API=1"] if "clip_embd_nbytes_by_img" not in (LLAMA_CPP_ROOT / "tools" / "mtmd" / "clip.h").read_text(encoding="utf-8", errors="ignore") else []),
+        *(["-DCK_MTMD_CLIP_OBJECT_API=1"] if uses_object_api else []),
+        *(["-DCK_MTMD_CLIP_VALUE_API=1"] if uses_value_api else []),
         f"-I{LLAMA_CPP_ROOT / 'tools' / 'mtmd'}",
         f"-I{LLAMA_CPP_ROOT / 'ggml' / 'include'}",
         f"-I{LLAMA_CPP_ROOT / 'include'}",
@@ -400,6 +435,7 @@ def _compile_mtmd_shim(output_dir: Path) -> Path:
         str(shim_so),
     ]
     _run(cmd)
+    stamp_path.write_text(json.dumps(build_fingerprint, indent=2) + "\n", encoding="utf-8")
     return shim_so
 
 

--- a/version/v8/scripts/resolve_attention_contracts_v8.py
+++ b/version/v8/scripts/resolve_attention_contracts_v8.py
@@ -237,6 +237,25 @@ def validate_contract_registry(doc: Dict[str, Any]) -> None:
         partition = contract.get("partition")
         if not isinstance(partition, dict) or not partition.get("kind"):
             raise ContractError(f"reduction contract {contract_id}.partition requires kind")
+        if partition.get("kind") == "query_tile_threshold":
+            for route in ("below_threshold", "at_or_above_threshold"):
+                referenced_id = partition[route]
+                referenced = contracts.get(referenced_id)
+                if not isinstance(referenced, dict):
+                    raise hard_contract_fault(
+                        f"reduction contract {contract_id!r} references missing {route} contract {referenced_id!r}",
+                        "A shape-dependent dispatch route has no registered arithmetic definition.",
+                        "Register and validate the exact arithmetic contract before selecting it.",
+                    )
+                if validate_state(
+                    referenced.get("status"),
+                    f"reduction contract {referenced_id}",
+                ) != "validated":
+                    raise hard_contract_fault(
+                        f"reduction contract {contract_id!r} references unvalidated {route} contract {referenced_id!r}",
+                        "A composite provider cannot be stronger than either selected arithmetic contract.",
+                        "Promote the referenced contract only after an independent numerical oracle passes.",
+                    )
 
 
 def validate_quantized_linear_contract_registry(doc: Dict[str, Any]) -> None:
@@ -274,6 +293,28 @@ def validate_quantized_linear_kernel_capability(
             "add and validate the complete contract before binding the kernel.",
         )
     production = kernel["production"]
+    reference = kernel["reference"]
+    if reference["kind"] == "scalar_contract_oracle":
+        if not reference["function"].endswith("_ref"):
+            raise hard_contract_fault(
+                f"kernel {kernel_id!r} scalar oracle is not a reference function",
+                f"reference.function={reference['function']!r}",
+                "bind a scalar _ref function or declare and validate a graph oracle.",
+            )
+    elif reference["kind"] == "llama_repacked_graph_oracle":
+        external = reference["validation"]["external_oracles"]
+        validated_llama = any(
+            item.get("backend") == "llama.cpp_ggml_cpu_graph"
+            and item.get("status") == "validated"
+            for item in external
+        )
+        comparison = production["reference_comparison"]
+        if not validated_llama or comparison["requirement"] != "bit_exact":
+            raise hard_contract_fault(
+                f"kernel {kernel_id!r} has an unproven loaded-model graph oracle",
+                "A repacked provider requires validated llama.cpp graph evidence and bit-exact comparison.",
+                "add a real production-provider oracle; do not substitute a leaf tolerance test.",
+            )
     impl_function = kernel["impl"]["function"]
     if production["function"] != impl_function:
         raise hard_contract_fault(

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -875,14 +875,16 @@ def _converter_fingerprint(gguf_path: Path) -> dict[str, Any]:
     }
 
 
-def _source_set_fingerprint(paths: list[Path]) -> dict[str, Any]:
+def _source_set_fingerprint(
+    paths: list[Path], *, suffixes: frozenset[str] = frozenset({".py", ".json"})
+) -> dict[str, Any]:
     files: list[Path] = []
     for path in paths:
         if path.is_dir():
             files.extend(
                 candidate
                 for candidate in path.rglob("*")
-                if candidate.is_file() and candidate.suffix in {".py", ".json"}
+                if candidate.is_file() and candidate.suffix in suffixes
             )
         elif path.is_file():
             files.append(path)
@@ -911,6 +913,14 @@ def _compiler_source_fingerprint() -> dict[str, Any]:
     )
 
 
+def _compiled_runtime_support_fingerprint() -> dict[str, Any]:
+    """Hash support code compiled or included directly by generated runtimes."""
+    return _source_set_fingerprint(
+        [REPO_ROOT / "version" / "v8" / "src", REPO_ROOT / "include"],
+        suffixes=frozenset({".c", ".h"}),
+    )
+
+
 def _runtime_fingerprint(
     *,
     manifest_path: Path,
@@ -920,7 +930,7 @@ def _runtime_fingerprint(
     profile: bool = False,
 ) -> dict[str, Any]:
     return {
-        "version": 2,
+        "version": 3,
         "mode": str(mode),
         "manifest": _path_identity(manifest_path, hash_content=True),
         "context_override": int(context_override) if context_override is not None else None,
@@ -1744,7 +1754,7 @@ def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = Fal
         else f"cc probe failed rc={compiler_probe.returncode}"
     )
     build_fingerprint = {
-        "version": 2,
+        "version": 3,
         "source_path": str(c_path.resolve()),
         "source_sha256": source_hash,
         "source_size": source_size,
@@ -1755,6 +1765,7 @@ def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = Fal
             "sha256": engine_hash,
             "runpath": "$ORIGIN",
         },
+        "compiled_support_source_set": _compiled_runtime_support_fingerprint(),
     }
     if so_path.exists():
         cached = _json_read(stamp_path)

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -2301,7 +2301,6 @@ def _resolved_symbol_library(lib: ctypes.CDLL, symbol: str) -> Path:
 def _load_decoder_lib(model_so: Path, *, engine_so: Path | None = None) -> ctypes.CDLL:
     requested_engine = (engine_so if engine_so is not None else BUILD_DIR / "libckernel_engine.so").resolve()
     adjacent_engine = model_so.resolve().parent / "libckernel_engine.so"
-    engine_path = requested_engine
     if adjacent_engine.is_file():
         requested_hash = hashlib.sha256(requested_engine.read_bytes()).hexdigest()
         adjacent_hash = hashlib.sha256(adjacent_engine.read_bytes()).hexdigest()
@@ -2310,8 +2309,10 @@ def _load_decoder_lib(model_so: Path, *, engine_so: Path | None = None) -> ctype
                 "generated decoder has a different adjacent CK engine than requested: "
                 f"requested={requested_engine} adjacent={adjacent_engine}"
             )
-        engine_path = adjacent_engine.resolve()
-    ctypes.CDLL(str(engine_path), mode=ctypes.RTLD_GLOBAL)
+    # Use one canonical engine object for the process. Generated runtimes keep
+    # a byte-identical $ORIGIN copy for standalone deployment; the engine
+    # SONAME makes their dependency resolve to this explicitly selected object.
+    ctypes.CDLL(str(requested_engine), mode=ctypes.RTLD_GLOBAL)
     tokenizer_candidates = [
         model_so.resolve().parent / "libckernel_tokenizer.so",
         BUILD_DIR / "libckernel_tokenizer.so",
@@ -2325,10 +2326,11 @@ def _load_decoder_lib(model_so: Path, *, engine_so: Path | None = None) -> ctype
     ctypes.CDLL(str(tokenizer_path), mode=ctypes.RTLD_GLOBAL)
     lib = ctypes.CDLL(str(model_so))
     resolved_engine = _resolved_symbol_library(lib, "ck_set_num_threads")
-    if resolved_engine != engine_path:
+    if resolved_engine != requested_engine:
         raise RuntimeError(
             "generated decoder resolved a different CK engine than the parity report requested: "
-            f"requested={engine_path} loaded={resolved_engine}; rebuild with $ORIGIN runtime linking"
+            f"requested={requested_engine} loaded={resolved_engine}; "
+            "rebuild libckernel_engine.so with its canonical SONAME"
         )
     lib.ck_model_init_with_manifest.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     lib.ck_model_init_with_manifest.restype = ctypes.c_int

--- a/version/v8/scripts/xray_execution_state_v8.py
+++ b/version/v8/scripts/xray_execution_state_v8.py
@@ -34,6 +34,7 @@ ROLE_STAGE = {
 
 REMEDIATIONS = {
     "EXECUTION_POLICY_MISMATCH": "Align prefill/decode segmentation and cache transitions in the circuit/runtime contract before tensor bisection.",
+    "KERNEL_CONTRACT_MISMATCH": "Align the exact resolved provider, declared numerical contract, and shape-selected effective contract before comparing tensors.",
     "KERNEL_BATCH_SHAPE_MISMATCH": "Make both backends invoke the same semantic kernel over equivalent M/N/K batches before comparing arithmetic.",
     "POSITION_STATE_MISMATCH": "Align text/M-RoPE position policy and runtime position values before attention diagnostics.",
     "CACHE_STATE_METADATA_MISMATCH": "Fix cache token count, append index, or physical strides before comparing cache bytes.",
@@ -171,6 +172,16 @@ def _kernel_batches(trace: dict[str, Any]) -> list[dict[str, Any]]:
     return [batch for call in trace["execution"]["calls"] for batch in call.get("kernel_batches", [])]
 
 
+def _kernel_contracts(batches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    fields = ("checkpoint_id", "kernel_id", "numerical_contract_id", "effective_contract_id")
+    return [{field: batch[field] for field in fields} for batch in batches]
+
+
+def _kernel_shapes(batches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    fields = ("checkpoint_id", "m", "n", "k")
+    return [{field: batch[field] for field in fields} for batch in batches]
+
+
 def _artifact_index(trace: dict[str, Any]) -> dict[str, dict[str, Any]]:
     indexed: dict[str, dict[str, Any]] = {}
     for entry in trace["artifacts"]:
@@ -259,8 +270,20 @@ def compare_traces(subject: dict[str, Any], oracle: dict[str, Any]) -> dict[str,
 
     subject_batches = _kernel_batches(subject)
     oracle_batches = _kernel_batches(oracle)
-    if subject_batches != oracle_batches:
-        checks.append(_fail("KERNEL_BATCH_SHAPE_MISMATCH", stage="kernel_batches", subject=subject_batches, oracle=oracle_batches))
+    subject_contracts = _kernel_contracts(subject_batches)
+    oracle_contracts = _kernel_contracts(oracle_batches)
+    if subject_contracts != oracle_contracts:
+        checks.append(_fail(
+            "KERNEL_CONTRACT_MISMATCH", stage="kernel_contracts",
+            subject=subject_contracts, oracle=oracle_contracts,
+        ))
+        return _report(subject, oracle, checks)
+    checks.append({"stage": "kernel_contracts", "status": "pass"})
+
+    subject_shapes = _kernel_shapes(subject_batches)
+    oracle_shapes = _kernel_shapes(oracle_batches)
+    if subject_shapes != oracle_shapes:
+        checks.append(_fail("KERNEL_BATCH_SHAPE_MISMATCH", stage="kernel_batches", subject=subject_shapes, oracle=oracle_shapes))
         return _report(subject, oracle, checks)
     checks.append({"stage": "kernel_batches", "status": "pass"})
 
@@ -342,7 +365,7 @@ def _report(subject: dict[str, Any], oracle: dict[str, Any], checks: list[dict[s
         "subject_backend": subject["backend"], "oracle_backend": oracle["backend"],
         "status": "fail" if first else "pass", "checks": checks, "first_divergence": first,
         "diagnostic_order": [
-            "execution_contract", "kernel_batches", "position_state", "cache_metadata",
+            "execution_contract", "kernel_contracts", "kernel_batches", "position_state", "cache_metadata",
             "cache_append_source", "cache_append_roundtrip", "all_valid_cache_rows",
             "attention_inputs", "attention_arithmetic", "ranking",
         ],

--- a/version/v8/src/ck_parallel_decode_v8.c
+++ b/version/v8/src/ck_parallel_decode_v8.c
@@ -182,17 +182,22 @@ static void work_gemv_q4_k_q8_k(int ith, int nth, void *args)
 #if defined(CK_TARGET_ARM)
     gemv_q4_k_q8_k_parallel(a->y, a->W, a->x_q8, a->M, a->K, ith, nth);
 #else
-#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
-    const char *fast_env = getenv("CK_ENABLE_Q4K_Q8K_VNNI_FAST");
-    const int fast_disabled = fast_env && fast_env[0] && fast_env[0] == '0';
-    if (!fast_disabled && !ck_strict_parity_enabled()) {
-        gemv_q4_k_q8_k_parallel_vnni(a->y, a->W, a->x_q8, a->M, a->K, ith, nth);
-    } else {
-        gemv_q4_k_q8_k_parallel_simd(a->y, a->W, a->x_q8, a->M, a->K, ith, nth);
+    const int rows_per_worker = (a->M + nth - 1) / nth;
+    const int row_begin = rows_per_worker * ith;
+    const int row_end = (row_begin + rows_per_worker < a->M)
+        ? row_begin + rows_per_worker
+        : a->M;
+    if (row_begin >= a->M) {
+        return;
     }
-#else
-    gemv_q4_k_q8_k_parallel_simd(a->y, a->W, a->x_q8, a->M, a->K, ith, nth);
-#endif
+
+    const size_t row_bytes = (size_t)(a->K / QK_K) * sizeof(block_q4_K);
+    gemv_q4_k_q8_k(
+        a->y + row_begin,
+        (const char *)a->W + (size_t)row_begin * row_bytes,
+        a->x_q8,
+        row_end - row_begin,
+        a->K);
 #endif
 }
 

--- a/version/v8/src/ck_parallel_decode_v8.h
+++ b/version/v8/src/ck_parallel_decode_v8.h
@@ -64,6 +64,9 @@ void gemv_q6_k_q8_k_parallel_dispatch(
 void gemv_q4_k_q8_k_parallel_dispatch(
     float *y, const void *W, const void *x_q8, int M, int K);
 
+void gemv_q4_k_q8_k_repacked_parallel_dispatch(
+    float *y, const void *W, const void *x_q8, int M, int K);
+
 /**
  * Parallel gemv_q8_0_q8_0: y[M] = W[M,K] @ x_q8[K]
  * Both W and x are Q8_0 quantized.
@@ -113,7 +116,6 @@ void gemv_fused_q5_0_bias_parallel_dispatch(
 
 #define gemv_q5_0_q8_0(y, W, x, M, K)   gemv_q5_0_q8_0_parallel_dispatch(y, W, x, M, K)
 #define gemv_q6_k_q8_k(y, W, x, M, K)   gemv_q6_k_q8_k_parallel_dispatch(y, W, x, M, K)
-#define gemv_q4_k_q8_k(y, W, x, M, K)   gemv_q4_k_q8_k_parallel_dispatch(y, W, x, M, K)
 #define gemv_q8_0_q8_0(y, W, x, M, K)   gemv_q8_0_q8_0_parallel_dispatch(y, W, x, M, K)
 #define gemv_q5_1_q8_1(y, W, x, M, K)   gemv_q5_1_q8_1_parallel_dispatch(y, W, x, M, K)
 #define gemv_q5_k(y, W, x, M, K)        gemv_q5_k_parallel_dispatch(y, W, x, M, K)

--- a/version/v8/src/ck_parallel_prefill_v8.c
+++ b/version/v8/src/ck_parallel_prefill_v8.c
@@ -90,6 +90,12 @@ extern void gemm_nt_q4_k_packed_meta_x8_q8_k_threaded_mreuse(const void *A_q8,
                                                              int M, int N, int K,
                                                              int tile_m,
                                                              int threads);
+extern void gemm_nt_q4_k_packed_meta_x8_q8_k_superblock_order(
+    const void *A_q8, const void *B_packed_x8, const float *bias, float *C,
+    int M, int N, int K);
+extern void gemm_nt_q4_k_packed_meta_x8_q8_k_gemv_order(
+    const void *A_q8, const void *B_packed_x8, const float *bias, float *C,
+    int M, int N, int K);
 extern void gemm_nt_q4_k_packed_meta_x16_q8_k_threaded_mreuse(const void *A_q8,
                                                               const void *B_packed_x16,
                                                               const float *bias,
@@ -143,13 +149,6 @@ void ck_parallel_prefill_init(void)
     }
 }
 
-void ck_parallel_prefill_shutdown(void)
-{
-    /* Pool is shared with decode — decode shutdown handles actual destroy.
-     * This is a no-op to avoid double-free. The global pool is destroyed
-     * once by whichever shutdown path runs last (or by ck_model_free). */
-}
-
 /* ============================================================================
  * Argument Packing Struct
  * ============================================================================ */
@@ -166,6 +165,15 @@ typedef struct {
     int          tile_m;      /* 2D scheduler token tile height */
     int          tile_n;      /* 2D scheduler output tile width */
 } gemm_args_t;
+
+typedef struct {
+    const void  *A;
+    const void  *B_packed_x8;
+    const float *bias;
+    float       *C;
+    int          N;
+    int          K;
+} q4k_repacked_gemv_args_t;
 
 static int ck_min_int(int a, int b) { return a < b ? a : b; }
 
@@ -236,6 +244,42 @@ typedef struct ck_q4k_packed_meta_x16_cache_entry {
 
 static pthread_mutex_t ck_q4k_packed_meta_x16_cache_mu = PTHREAD_MUTEX_INITIALIZER;
 static ck_q4k_packed_meta_x16_cache_entry_t *ck_q4k_packed_meta_x16_cache_head = NULL;
+
+void ck_q4k_packed_weight_cache_clear(void)
+{
+    pthread_mutex_lock(&ck_q4k_packed_meta_cache_mu);
+    while (ck_q4k_packed_meta_cache_head) {
+        ck_q4k_packed_meta_cache_entry_t *entry = ck_q4k_packed_meta_cache_head;
+        ck_q4k_packed_meta_cache_head = entry->next;
+        free(entry->packed);
+        free(entry);
+    }
+    pthread_mutex_unlock(&ck_q4k_packed_meta_cache_mu);
+
+    pthread_mutex_lock(&ck_q4k_packed_meta_x8_cache_mu);
+    while (ck_q4k_packed_meta_x8_cache_head) {
+        ck_q4k_packed_meta_x8_cache_entry_t *entry = ck_q4k_packed_meta_x8_cache_head;
+        ck_q4k_packed_meta_x8_cache_head = entry->next;
+        free(entry->packed);
+        free(entry);
+    }
+    pthread_mutex_unlock(&ck_q4k_packed_meta_x8_cache_mu);
+
+    pthread_mutex_lock(&ck_q4k_packed_meta_x16_cache_mu);
+    while (ck_q4k_packed_meta_x16_cache_head) {
+        ck_q4k_packed_meta_x16_cache_entry_t *entry = ck_q4k_packed_meta_x16_cache_head;
+        ck_q4k_packed_meta_x16_cache_head = entry->next;
+        free(entry->packed);
+        free(entry);
+    }
+    pthread_mutex_unlock(&ck_q4k_packed_meta_x16_cache_mu);
+}
+
+void ck_parallel_prefill_shutdown(void)
+{
+    /* Pool ownership remains with decode; prefill owns packed-weight caches. */
+    ck_q4k_packed_weight_cache_clear();
+}
 
 /* Q4_K packed-meta prefill experiment
  * -----------------------------------
@@ -668,6 +712,45 @@ static void work_gemm_nt_q4_k_q8_k(int ith, int nth, void *args)
     }
 }
 
+static void work_gemm_nt_q4_k_q8_k_pairwise_split_min(int ith, int nth, void *args)
+{
+    const gemm_args_t *a = (const gemm_args_t *)args;
+    const int dr = (a->M + nth - 1) / nth;
+    const int r0 = dr * ith;
+    const int r1 = (r0 + dr < a->M) ? (r0 + dr) : a->M;
+    if (r0 >= a->M) return;
+
+    gemm_nt_q4_k_packed_meta_x8_q8_k_superblock_order(
+        (const char *)a->A + (size_t)r0 * a->A_row_bytes,
+        a->B,
+        a->bias,
+        a->C + (size_t)r0 * (size_t)a->N,
+        r1 - r0, a->N, a->K
+    );
+}
+
+static void work_gemv_q4_k_q8_k_repacked(int ith, int nth, void *args)
+{
+    const q4k_repacked_gemv_args_t *a = (const q4k_repacked_gemv_args_t *)args;
+    const int groups = (a->N + 7) / 8;
+    const int dg = (groups + nth - 1) / nth;
+    const int g0 = dg * ith;
+    const int g1 = ck_min_int(g0 + dg, groups);
+    if (g0 >= groups) return;
+
+    const int n0 = g0 * 8;
+    const int n1 = ck_min_int(g1 * 8, a->N);
+    const size_t packed_group_bytes =
+            (size_t)(a->K / QK_K) * q4_k_packed_meta_x8_block_size();
+    gemm_nt_q4_k_packed_meta_x8_q8_k_gemv_order(
+        a->A,
+        (const char *)a->B_packed_x8 + (size_t)g0 * packed_group_bytes,
+        a->bias ? a->bias + n0 : NULL,
+        a->C + n0,
+        1, n1 - n0, a->K
+    );
+}
+
 static void work_gemm_nt_q6_k_q8_k(int ith, int nth, void *args)
 {
     const gemm_args_t *a = (const gemm_args_t *)args;
@@ -980,6 +1063,70 @@ void gemm_nt_q4_k_q8_k_parallel_dispatch(
     const int active = ck_select_gemm_active_threads(pool, M, N, K);
     ck_q4k_prefill_debug_dispatch("fallback_row_gemv", M, N, K, active);
     ck_threadpool_dispatch_n(pool, active, work_gemm_nt_q4_k_q8_k, &args);
+}
+
+void gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K)
+{
+    if (!A || !B || !C || M <= 0 || N <= 0 || K <= 0 || (K % QK_K) != 0) return;
+
+    void *packed_x8 = ck_get_q4k_packed_meta_x8_cached(B, N, K);
+    if (!packed_x8) return;
+
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const size_t row_bytes = (size_t)(K / QK_K) * sizeof(block_q8_K);
+    const int packed_rows = M - (M % 4);
+    if (packed_rows > 0 &&
+        (!pool || ck_threadpool_n_threads(pool) <= 1 ||
+         ck_should_run_gemm_serial(pool, packed_rows, N, K))) {
+        gemm_nt_q4_k_packed_meta_x8_q8_k_superblock_order(
+            A, packed_x8, bias, C, packed_rows, N, K);
+    } else if (packed_rows > 0) {
+        gemm_args_t args = {
+            .A = A, .B = packed_x8, .bias = bias, .C = C,
+            .M = packed_rows, .N = N, .K = K, .A_row_bytes = row_bytes
+        };
+        const int active = ck_select_gemm_active_threads(pool, packed_rows, N, K);
+        ck_threadpool_dispatch_n(
+            pool, active, work_gemm_nt_q4_k_q8_k_pairwise_split_min, &args);
+    }
+
+    /* The loaded CPU provider executes complete four-row groups through its
+     * repacked matrix kernel and routes residual rows through its repacked
+     * GEMV order. The two reduction boundaries are numerically distinct. */
+    if (packed_rows < M) {
+        gemm_nt_q4_k_packed_meta_x8_q8_k_gemv_order(
+            (const char *)A + (size_t)packed_rows * row_bytes,
+            packed_x8, bias, C + (size_t)packed_rows * (size_t)N,
+            M - packed_rows, N, K);
+    }
+}
+
+void gemv_q4_k_q8_k_repacked_parallel_dispatch(
+    float *y, const void *W, const void *x_q8, int N, int K)
+{
+    if (!y || !W || !x_q8 || N <= 0 || K <= 0 || (K % QK_K) != 0) return;
+
+    void *packed_x8 = ck_get_q4k_packed_meta_x8_cached(W, N, K);
+    if (!packed_x8) {
+        fprintf(stderr, "Q4_K repacked decode contract: weight packing failed\n");
+        abort();
+    }
+
+    q4k_repacked_gemv_args_t args = {
+        .A = x_q8, .B_packed_x8 = packed_x8, .bias = NULL,
+        .C = y, .N = N, .K = K
+    };
+    ck_threadpool_t *pool = ck_threadpool_global();
+    const int groups = (N + 7) / 8;
+    int active = pool ? ck_threadpool_n_threads(pool) : 1;
+    if (active > groups) active = groups;
+    if (active <= 1) {
+        work_gemv_q4_k_q8_k_repacked(0, 1, &args);
+        return;
+    }
+    ck_threadpool_dispatch_n(pool, active, work_gemv_q4_k_q8_k_repacked, &args);
 }
 
 void gemm_nt_q6_k_q8_k_parallel_dispatch(

--- a/version/v8/src/ck_parallel_prefill_v8.h
+++ b/version/v8/src/ck_parallel_prefill_v8.h
@@ -37,6 +37,9 @@ extern "C" {
 void ck_parallel_prefill_init(void);
 void ck_parallel_prefill_shutdown(void);
 
+/** Release lazily repacked Q4_K weights at model/test teardown. */
+void ck_q4k_packed_weight_cache_clear(void);
+
 /* Parallel GEMM Wrappers - same signatures as serial GEMM functions */
 void gemm_nt_q5_0_q8_0_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
@@ -49,6 +52,13 @@ void gemm_nt_q8_0_q8_0_parallel_dispatch(
 void gemm_nt_q4_k_q8_k_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,
     int M, int N, int K);
+
+void gemm_nt_q4_k_q8_k_pairwise_split_min_parallel_dispatch(
+    const void *A, const void *B, const float *bias, float *C,
+    int M, int N, int K);
+
+void gemv_q4_k_q8_k_repacked_parallel_dispatch(
+    float *y, const void *W, const void *x_q8, int N, int K);
 
 void gemm_nt_q4_k_q8_k_gateup_swiglu_x16_parallel_dispatch(
     const void *A, const void *B, const float *bias, float *C,

--- a/version/v8/tools/mtmd_clip_shim.cpp
+++ b/version/v8/tools/mtmd_clip_shim.cpp
@@ -367,9 +367,15 @@ size_t ck_mtmd_clip_embd_nbytes_by_img(void *handle_ptr, int img_w, int img_h) {
         return 0;
     }
 #ifdef CK_MTMD_CLIP_OBJECT_API
+#ifdef CK_MTMD_CLIP_VALUE_API
+    clip_image_f32 image;
+    image.set_size({img_w, img_h}, false, false);
+    const int tokens = clip_n_output_tokens(ctx, &image);
+#else
     clip_image_f32_ptr image(clip_image_f32_init());
     image->set_size({img_w, img_h}, false, false);
     const int tokens = clip_n_output_tokens(ctx, image.get());
+#endif
     const int embed_dim = clip_n_mmproj_embd(ctx);
     return tokens > 0 && embed_dim > 0
         ? (size_t) tokens * (size_t) embed_dim * sizeof(float)
@@ -386,16 +392,27 @@ int ck_mtmd_clip_encode_float_image(void *handle_ptr, int n_threads, float *img,
         return 0;
     }
 #ifdef CK_MTMD_CLIP_OBJECT_API
+#ifdef CK_MTMD_CLIP_VALUE_API
+    clip_image_f32 image;
+    image.set_size({w, h}, false, false);
+    image.cpy_buf(std::vector<float>(img, img + (size_t) h * (size_t) w * 3));
+    const int tokens = clip_n_output_tokens(ctx, &image);
+#else
     clip_image_f32_ptr image(clip_image_f32_init());
     image->set_size({w, h}, false, false);
     image->cpy_buf(std::vector<float>(img, img + (size_t) h * (size_t) w * 3));
     const int tokens = clip_n_output_tokens(ctx, image.get());
+#endif
     const int embed_dim = clip_n_mmproj_embd(ctx);
     if (tokens <= 0 || embed_dim <= 0) {
         return 0;
     }
     std::vector<float> output((size_t) tokens * (size_t) embed_dim, 0.0f);
+#ifdef CK_MTMD_CLIP_VALUE_API
+    if (!clip_image_encode(ctx, n_threads, &image, output)) {
+#else
     if (!clip_image_encode(ctx, n_threads, image.get(), output)) {
+#endif
         return 0;
     }
     std::memcpy(vec, output.data(), output.size() * sizeof(float));


### PR DESCRIPTION
## Why
Qwen3-VL mixed prefill uses query segments 5, 1008, and 14. Current llama.cpp selects FP16 online single-range attention below Q=64 and 64x64 FP32 tiled flash attention at or above Q=64. CK previously applied one arithmetic family to every segment. The investigation also exposed packed-provider ISA compile and generated-runtime provenance gaps.

## What changed
- Add the fail-closed `f16_flash_auto_qtile64` composite attention contract and map-owned provider.
- Select it from the Qwen3-VL circuit while preserving the existing decode contract.
- Match GGML SwiGLU order and harden packed Q4/Q8 production dispatch.
- Extend X-ray with declared and effective contract IDs and `KERNEL_CONTRACT_MISMATCH`.
- Give `libckernel_engine.so` a canonical SONAME and verify adjacent runtime copies by SHA-256.
- Compile packed Q4/Q8 for both AVX2 and AVX-512/VNNI in nightly.
- Keep current llama.cpp mtmd adapter compatibility explicit.

## Evidence
- Direct attention is byte-exact at Q=5, 14, 63, 64, and production Q=1008/KV=1013/H=32/Hkv=8/D=128.
- Canonical OCR image matches 384/384 steps with RMSE 0 and identical top-16 logits; EOS was not reached within that bound.
- Five OCR images match 64/64, including semantic prefix positions 41 and 45; two additional fake fixtures also match 64/64.
- Encoder and decoder generated libraries now resolve runtime symbols from the same canonical engine path.

## Validation
- Qwen3-VL circuit/codegen: 26/26.
- Attention resolver: 28/28.
- llama-backed FP16 attention: 27/27.
- X-ray execution: 7/7.
- Numerical contracts, DSL policy, call ABI, staged v7/v8 regressions, and pre-push gates pass.
- Forced AVX2 and AVX-512/VNNI packed-provider compilation passes.
- No tolerance was relaxed.

## Regression coverage
Nightly exercises both sides of Q=64, the production visual attention shape, packed Q4/Q8 production parity, AVX2 plus AVX-512/VNNI compilation, effective-contract X-ray classification, canonical engine SONAME, and stale adjacent-engine rejection.

## Documentation
Updated `docs/site/_pages/divergence-harness.html`, its published page, and `docs/site/assets/qwen3vl-q4-parity-investigation.txt` with confirmed defects, rejected hypotheses, measurements, limitations, and next gates.

## Content handoff
- Audience: CPU inference, runtime, compiler, and numerical-parity engineers.
- Angle: Exact leaf kernels still produced a wrong multimodal token because shape dispatch, reduction order, runtime identity, and harness semantics are part of numerical identity.
- Claims: Shape-selected attention, packed Q4/Q8 production routes, cache schedules, compiler ISA paths, hashes, SONAME, and stop metadata all require explicit contracts.
- Caveats: Seven distinct images pass 64 tokens and one image passes 384 tokens; 10/40 images and per-image EOS remain open. The current Fake 3 expansion is still running.
- Sources: Investigation text, divergence-harness page, llama oracle tests, contract maps, runtime identity tests, parity JSON artifacts, and CI logs.
