### PR TITLE
fix(ci): make optional llama patch drift advisory

### DIFF
--- a/.github/workflows/llamacpp-rolling-compat.yml
+++ b/.github/workflows/llamacpp-rolling-compat.yml
@@ -53,6 +53,8 @@ jobs:
               raise SystemExit(0)
           data = json.loads(path.read_text())
           llama = data["llama_cpp"]
+          patch_phase = data.get("phases", {}).get("patch_compatibility", {})
+          patch_status = patch_phase.get("status", "unknown").upper()
           lines = [
               "## llama.cpp rolling compatibility",
               "",
@@ -61,8 +63,11 @@ jobs:
               f"- Pinned oracle: `{llama['pinned_commit'][:12]}`",
               f"- Rolling upstream: `{llama['rolling_commit'][:12]}`",
               f"- Upstream commits since pin: {llama.get('commits_ahead_of_pin', 'unknown')}",
+              f"- Optional patch drift: **{patch_status}** (non-blocking)",
               "- Authoritative oracle changed: **no**",
           ]
+          for patch in patch_phase.get("patches", []):
+              lines.append(f"  - `{patch['path']}`: {patch['status']}")
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as stream:
               stream.write("\n".join(lines) + "\n")
           PY

--- a/scripts/run_llamacpp_rolling_compat.py
+++ b/scripts/run_llamacpp_rolling_compat.py
@@ -87,6 +87,15 @@ def patch_status(probe: pathlib.Path, relative_path: str) -> dict[str, Any]:
     }
 
 
+def compatibility_status(phases: dict[str, Any]) -> str:
+    """Treat executable compatibility as authoritative and patch drift as advisory."""
+    for phase_name in ("ck_build", "quick_parity"):
+        status = phases.get(phase_name, {}).get("status")
+        if status in {"fail", "error"}:
+            return "fail"
+    return "pass"
+
+
 def upstream_delta(probe: pathlib.Path, pinned: str, rolling: str, limit: int) -> tuple[int, list[dict[str, str]]]:
     count = int(git_output(["rev-list", "--count", f"{pinned}..{rolling}"], cwd=probe))
     lines = git_output(
@@ -163,17 +172,25 @@ def main() -> int:
             patch_status(probe, "patches/llama.patch"),
             patch_status(probe, "patches/ck-engine-parity-bench.patch"),
         ]
+        patch_drift = any(item["status"] != "applies" for item in patches)
         report["phases"]["patch_compatibility"] = {
-            "status": "pass" if all(item["status"] == "applies" for item in patches) else "fail",
+            "status": "warn" if patch_drift else "pass",
+            "blocking": False,
+            "reason": (
+                "Optional tensor-dump and benchmark patches drifted; rolling build and "
+                "quick parity determine compatibility."
+                if patch_drift
+                else "Optional patches still apply cleanly."
+            ),
             "patches": patches,
         }
 
         if args.resolve_only:
             report["phases"]["quick_parity"] = {"status": "skip", "reason": "resolve-only"}
-            report["status"] = report["phases"]["patch_compatibility"]["status"]
+            report["status"] = "pass"
             write_report(report_path, report)
             print(report_path)
-            return 0 if report["status"] == "pass" else 1
+            return 0
 
         log_path = output_dir / "quick-parity.log"
         build_log_path = output_dir / "ck-build.log"
@@ -214,12 +231,7 @@ def main() -> int:
             "log": str(log_path),
             "summary": parse_quick_log(log_path),
         }
-        report["status"] = (
-            "pass"
-            if report["phases"]["quick_parity"]["status"] == "pass"
-            and report["phases"]["patch_compatibility"]["status"] == "pass"
-            else "fail"
-        )
+        report["status"] = compatibility_status(report["phases"])
     except Exception as exc:  # Preserve diagnostics even when upstream changes break setup.
         report["status"] = "error"
         report["error"] = f"{type(exc).__name__}: {exc}"

--- a/tests/test_llamacpp_rolling_compat.py
+++ b/tests/test_llamacpp_rolling_compat.py
@@ -36,6 +36,25 @@ PARITY SMOKETEST SUMMARY
             [{"ck_over_llama_speedup": 0.9, "ck_gflops": 7.26, "llama_gflops": 9.77}],
         )
 
+    def test_optional_patch_drift_does_not_fail_runtime_compatibility(self) -> None:
+        phases = {
+            "patch_compatibility": {"status": "warn", "blocking": False},
+            "ck_build": {"status": "pass"},
+            "quick_parity": {"status": "pass"},
+        }
+        self.assertEqual(MODULE.compatibility_status(phases), "pass")
+
+    def test_build_or_parity_failure_remains_blocking(self) -> None:
+        for phase_name in ("ck_build", "quick_parity"):
+            with self.subTest(phase=phase_name):
+                phases = {
+                    "patch_compatibility": {"status": "pass", "blocking": False},
+                    "ck_build": {"status": "pass"},
+                    "quick_parity": {"status": "pass"},
+                }
+                phases[phase_name]["status"] = "fail"
+                self.assertEqual(MODULE.compatibility_status(phases), "fail")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

The scheduled rolling-compatibility workflow failed even though current llama.cpp built successfully and quick parity passed with 6 passed, 0 failed, and 1 skipped. The failure came only from two legacy optional patches that no longer apply to upstream source locations.

## What changed

- Keep the CK build and quick parity phases authoritative for rolling compatibility.
- Report tensor-dump and optional benchmark patch drift as a non-blocking warning.
- Include each optional patch status in the GitHub Actions summary.
- Add regression tests proving patch drift is advisory while build or parity failures remain blocking.

## Evidence

- Failed run `29232970340` recorded `ck_build=pass` and `quick_parity=pass`, but set the overall result to failure because both optional patches drifted.
- A current upstream HEAD probe now reports `status=pass`, `ck_build=pass`, `quick_parity=pass`, and `patch_compatibility=warn`.
- Current quick parity result: 6 passed, 0 failed, 1 skipped.

## Validation

- PASS: `python3 -m unittest tests.test_llamacpp_rolling_compat` — 3 tests passed.
- PASS: Python compilation for the rolling probe and tests.
- PASS: workflow YAML parsing.
- PASS: `git diff --check`.
- PASS: full current llama.cpp HEAD build and quick-parity probe.
- PASS: change-metadata commit validation.

## Regression coverage

`tests/test_llamacpp_rolling_compat.py` now verifies that optional patch drift does not fail an otherwise successful runtime probe, while either CK build failure or quick-parity failure still produces a blocking result.

## Documentation

No standalone documentation is required. The workflow summary now explicitly labels optional patch drift as non-blocking and lists each patch status.

## Content handoff

Not publishable: this is an internal CI policy correction with no runtime, numerical, or performance claim.
