### PR TITLE
feat(v8): add optional LIKWID profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6293,6 +6293,7 @@ ADVISOR_ARTIFACTS_V7_SCRIPT := version/v7/scripts/advisor_artifacts_v7.py
 MEMORY_SIGNOFF_V7_SCRIPT := version/v7/scripts/memory_signoff_v7.py
 PERF_GATE_V7_SCRIPT := version/v7/scripts/perf_gate_v7.py
 PERF_GATE_V8_SCRIPT := version/v8/scripts/perf_gate_v8.py
+LIKWID_PROFILE_V8_SCRIPT := version/v8/scripts/likwid_profile_v8.py
 RESOLVE_MODEL_DIR_V7_SCRIPT := version/v7/scripts/resolve_model_dir_v7.py
 RESOLVE_MODEL_DIR_V8_SCRIPT := version/v8/scripts/resolve_model_dir_v8.py
 PROFILE_V7_SUMMARY_SCRIPT := version/v7/scripts/generate_profile_summary_v7.py
@@ -6329,6 +6330,10 @@ PROFILE_V8_ADVISOR_CSV ?= build/ck_v8_advisor_roofline.csv
 PROFILE_V8_ADVISOR_HTML ?= build/ck_v8_advisor_roofline.html
 PROFILE_V8_CACHEGRIND_OUT ?= build/cachegrind_v8.out
 PROFILE_V8_CACHEGRIND_ANNOTATE ?= build/cachegrind_v8_annotated.txt
+V8_LIKWID_GROUPS ?= auto
+V8_LIKWID_MAX_GROUPS ?= 2
+V8_LIKWID_CPUS ?= auto
+V8_LIKWID_THREADS ?= 1
 V8_PROFILE_V7_ARGS = \
 	V7_MODEL="$(V8_MODEL)" \
 	V7_PERF_RUNTIME="$(V8_PERF_RUNTIME)" \
@@ -7204,7 +7209,7 @@ profile-v7-full:
 
 .PHONY: profile-v8-prepare-runtime profile-v8-decode profile-v8-prefill profile-v8-flamegraph \
 	profile-v8-flamegraph-decode profile-v8-flamegraph-prefill profile-v8-perf-stat profile-v8-cachegrind \
-	profile-v8-vtune profile-v8-advisor profile-v8-full v8-perf-gate v8-perf-gate-evaluate
+	profile-v8-vtune profile-v8-advisor profile-v8-likwid profile-v8-full v8-perf-gate v8-perf-gate-evaluate
 
 profile-v8-prepare-runtime:
 	@CK_CACHE_DIR="$${CK_CACHE_DIR:-$$HOME/.cache/ck-engine-v8/models}" $(MAKE) --no-print-directory profile-v7-prepare-runtime $(V8_PROFILE_V7_ARGS)
@@ -7238,6 +7243,34 @@ profile-v8-vtune:
 profile-v8-advisor:
 	@CK_CACHE_DIR="$${CK_CACHE_DIR:-$$HOME/.cache/ck-engine-v8/models}" $(MAKE) --no-print-directory profile-v7-advisor $(V8_PROFILE_V7_ARGS)
 
+profile-v8-likwid:
+	@if ! command -v likwid-perfctr >/dev/null 2>&1; then \
+		echo "SKIP: profile-v8-likwid (likwid-perfctr not installed)"; \
+	elif [ "$(V8_PERF_RUNTIME)" != "cli" ]; then \
+		echo "SKIP: profile-v8-likwid currently requires V8_PERF_RUNTIME=cli"; \
+	else \
+		$(MAKE) --no-print-directory profile-v8-prepare-runtime; \
+		$(MAKE) --no-print-directory ck-cli-v8 CFLAGS="$(CFLAGS) $(PROFILE_V7_DEBUG_CFLAGS)"; \
+		model_dir="$$( CK_CACHE_DIR="$${CK_CACHE_DIR:-$$HOME/.cache/ck-engine-v8/models}" $(PYTHON) $(RESOLVE_MODEL_DIR_V8_SCRIPT) --model-input "$(V8_MODEL)" )"; \
+		runtime_dir="$$model_dir"; \
+		for candidate in "$$model_dir/.ck_build" "$$model_dir/.ck_build_v8"; do \
+			if [ -f "$$candidate/libmodel.so" ] && [ -f "$$candidate/weights.bump" ]; then runtime_dir="$$candidate"; break; fi; \
+		done; \
+		if [ ! -f "$$runtime_dir/libmodel.so" ] || [ ! -f "$$runtime_dir/weights.bump" ]; then \
+			echo "ERROR: LIKWID profile runtime is missing in $$model_dir"; \
+			exit 1; \
+		fi; \
+		CK_NUM_THREADS="$(V8_LIKWID_THREADS)" $(PYTHON) $(LIKWID_PROFILE_V8_SCRIPT) \
+			--output-dir "$$runtime_dir" \
+			--groups "$(V8_LIKWID_GROUPS)" \
+			--max-groups "$(V8_LIKWID_MAX_GROUPS)" \
+			--cpus "$(V8_LIKWID_CPUS)" \
+			--threads "$(V8_LIKWID_THREADS)" \
+			-- ./build/ck-cli-v8 "$$runtime_dir/libmodel.so" "$$runtime_dir/weights.bump" \
+				--prompt "The quick brown fox" --max-tokens 32 --timing --quiet-output \
+				$(V8_CLI_TEMPLATE_ARGS) $(V8_CLI_ARGS); \
+	fi
+
 profile-v8-full:
 	@$(MAKE) --no-print-directory profile-v8-prepare-runtime
 	@$(MAKE) --no-print-directory profile-v8-decode
@@ -7247,6 +7280,7 @@ profile-v8-full:
 	@$(MAKE) --no-print-directory profile-v8-flamegraph-prefill
 	@$(MAKE) --no-print-directory profile-v8-vtune
 	@$(MAKE) --no-print-directory profile-v8-advisor
+	@$(MAKE) --no-print-directory profile-v8-likwid || true
 	@echo "=== Open visualizer: version/v8/tools/ir_visualizer.html ==="
 	@echo "=== Load folder from model cache to see Profile tab ==="
 

--- a/tests/test_likwid_profile_v8.py
+++ b/tests/test_likwid_profile_v8.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "version/v8/scripts/likwid_profile_v8.py"
+VISUALIZER = ROOT / "version/v8/tools/open_ir_visualizer_v8.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("likwid_profile_v8_test", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class LikwidProfileV8Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = _load_module()
+
+    def test_available_groups_are_detected_and_preferred_dynamically(self) -> None:
+        available = self.module.parse_available_groups(
+            """
+            Group name      Description
+            FLOPS_DP        Double precision floating point
+            MEM             Main memory bandwidth
+            CLOCK           Clock frequency
+            """
+        )
+        self.assertEqual([row["name"] for row in available], ["FLOPS_DP", "MEM", "CLOCK"])
+        self.assertEqual(
+            self.module.choose_groups(available, "auto", 2),
+            ["MEM", "CLOCK"],
+        )
+        self.assertEqual(
+            self.module.choose_groups(available, "CACHE,MEM,NOPE", 4),
+            ["MEM"],
+        )
+
+    def test_csv_metrics_are_preserved_and_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mem.csv"
+            path.write_text(
+                "\n".join(
+                    [
+                        "TABLE,Region CKE,Core 0,Core 1",
+                        "Metric,Runtime (RDTSC) [s],1.0,1.2",
+                        "Metric,Memory bandwidth [MBytes/s],24000,26000",
+                        "Metric,CPI,0.80,1.00",
+                        "Event,UNC_M_CAS_COUNT_RD,100,120",
+                    ]
+                )
+            )
+            metrics, normalized = self.module.parse_likwid_csv(path)
+        self.assertEqual(len(metrics), 4)
+        self.assertAlmostEqual(normalized["runtime_seconds"], 1.1)
+        self.assertAlmostEqual(normalized["memory_bandwidth_mbytes_per_second"], 25000)
+        self.assertAlmostEqual(normalized["cpi"], 0.9)
+
+    def test_missing_likwid_is_a_recorded_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            with mock.patch.object(self.module.shutil, "which", return_value=None):
+                rc = self.module.main(
+                    ["--output-dir", str(output), "--", "/bin/true"]
+                )
+            summary = json.loads((output / "likwid_summary.json").read_text())
+        self.assertEqual(rc, 0)
+        self.assertEqual(summary["status"], "skip")
+        self.assertIn("not installed", summary["reason"])
+        self.assertEqual(summary["schema"], "cke.profile.likwid.v1")
+
+    def test_capture_runs_only_available_groups_with_cpu_pinning(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            if "-a" in command:
+                return self.module.subprocess.CompletedProcess(
+                    command, 0, "MEM Main memory bandwidth\nCLOCK CPU clock\n", ""
+                )
+            if "-v" in command:
+                return self.module.subprocess.CompletedProcess(
+                    command, 0, "likwid-perfctr 5.3\n", ""
+                )
+            if "-i" in command:
+                return self.module.subprocess.CompletedProcess(
+                    command, 0, "CPU type: test\n", ""
+                )
+            csv_path = Path(command[command.index("-o") + 1])
+            csv_path.write_text("Metric,Memory bandwidth [MBytes/s],12345\n")
+            return self.module.subprocess.CompletedProcess(
+                command, 0, "workload output\n", ""
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            with mock.patch.object(
+                self.module.shutil, "which", return_value="/usr/bin/likwid-perfctr"
+            ), mock.patch.object(
+                self.module.subprocess, "run", side_effect=fake_run
+            ):
+                rc = self.module.main(
+                    [
+                        "--output-dir",
+                        str(output),
+                        "--groups",
+                        "auto",
+                        "--max-groups",
+                        "1",
+                        "--cpus",
+                        "4,8",
+                        "--",
+                        "/bin/true",
+                    ]
+                )
+            summary = json.loads((output / "likwid_summary.json").read_text())
+        self.assertEqual(rc, 0)
+        self.assertEqual(summary["status"], "pass")
+        self.assertEqual(summary["selected_groups"], ["MEM"])
+        self.assertEqual(summary["cpu_ids"], [4, 8])
+        wrapped = next(command for command in calls if "-g" in command)
+        self.assertEqual(wrapped[wrapped.index("-C") + 1], "4,8")
+        self.assertEqual(
+            summary["normalized"]["MEM"]["memory_bandwidth_mbytes_per_second"],
+            12345,
+        )
+
+    def test_auto_cpu_selection_stays_inside_allowed_affinity(self) -> None:
+        with mock.patch.object(
+            self.module.os, "sched_getaffinity", return_value={4, 8, 12}
+        ):
+            self.assertEqual(self.module.default_cpu_ids(2), [4, 8])
+
+    def test_visualizer_loads_summary_and_resolves_raw_artifacts(self) -> None:
+        spec = importlib.util.spec_from_file_location(
+            "likwid_visualizer_v8_test", VISUALIZER
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"cannot load {VISUALIZER}")
+        visualizer = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(visualizer)
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            raw = run_dir / "likwid" / "mem.csv"
+            raw.parent.mkdir()
+            raw.write_text("Metric,CPI,1.0\n")
+            (run_dir / "likwid_summary.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "cke.profile.likwid.v1",
+                        "status": "pass",
+                        "artifacts": [{"kind": "MEM csv", "path": str(raw)}],
+                        "runs": [{"group": "MEM", "csv_path": str(raw)}],
+                    }
+                )
+            )
+            data = visualizer.load_model_data(
+                run_dir, run_dir=run_dir, strict_run_artifacts=True
+            )
+        summary = data["files"]["likwid_summary"]
+        self.assertEqual(summary["status"], "pass")
+        self.assertEqual(summary["artifacts"][0]["resolved_path"], str(raw))
+        self.assertEqual(summary["runs"][0]["csv_path_resolved"], str(raw))
+
+    def test_visualizer_discovers_v8_build_directory(self) -> None:
+        spec = importlib.util.spec_from_file_location(
+            "likwid_visualizer_v8_build_test", VISUALIZER
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"cannot load {VISUALIZER}")
+        visualizer = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(visualizer)
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            build_dir = model_dir / ".ck_build_v8"
+            build_dir.mkdir()
+            (build_dir / "likwid_summary.json").write_text(
+                json.dumps({"schema": "cke.profile.likwid.v1", "status": "pass"})
+            )
+            resolved_build, _ = visualizer.resolve_model_target(str(model_dir))
+            data = visualizer.load_model_data(resolved_build)
+        self.assertEqual(resolved_build, build_dir)
+        self.assertEqual(data["files"]["likwid_summary"]["status"], "pass")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -66,4 +66,28 @@ Notes:
 - The `.ppm` regression image is a Portable Pixmap file. CK uses it in CI because the format is simple enough to parse directly: a short header plus raw RGB pixels. That removes PNG/JPEG decoder dependency differences from the vision smoke. It is a test-fixture format, not a requirement for normal use; user-facing runs can still use PNG/JPEG when the local image stack is available.
 - Qwen3-VL is an 8B multimodal lane. `make v8-regression-fast` stays text-family focused, while `make test-v8-qwen3vl-e2e-smoke` runs the cached vision E2E path when the decoder and mmproj artifacts are present.
 
+Optional LIKWID profiling:
+
+```text
+make profile-v8-likwid \
+  V8_MODEL="/path/to/model-or-run-dir" \
+  V8_PERF_RUNTIME=cli \
+  V8_LIKWID_GROUPS=auto \
+  V8_LIKWID_THREADS=1
+```
+
+The target detects the counter groups supported by the current processor,
+selects up to two portable groups by default, pins the workload to CPUs from the
+current affinity set, preserves LIKWID CSV/stdout/stderr, and writes
+`likwid_summary.json` for the IR visualizer Profile section. Override
+`V8_LIKWID_GROUPS` with a comma-separated list, `V8_LIKWID_MAX_GROUPS` to run
+more groups, or `V8_LIKWID_CPUS` with an explicit CPU list. Each group reruns the
+workload, so keep the default small when profiling large models.
+
+LIKWID is optional. If `likwid-perfctr` is unavailable, the Make target reports
+`SKIP` and the normal build, runtime, and visualizer paths remain unchanged.
+Wrapper measurements include all activity on the pinned CPUs; avoid noisy
+neighboring workloads when collecting evidence. Marker API regions can be added
+later without changing this artifact contract.
+
 That keeps `v8` small and honest: the version split now includes the inference runner, local kernel registry/maps, multimodal bridge entrypoint, and the `v8`-named operator tooling surface used by the visualizer, hub, and regression entrypoints.

--- a/version/v8/scripts/likwid_profile_v8.py
+++ b/version/v8/scripts/likwid_profile_v8.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Capture optional LIKWID wrapper profiles and emit a stable v8 artifact."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA = "cke.profile.likwid.v1"
+AUTO_GROUP_PREFERENCE = (
+    "MEM",
+    "CACHE",
+    "L3",
+    "L2",
+    "CLOCK",
+    "BRANCH",
+    "FLOPS_DP",
+    "FLOPS_SP",
+)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_number(value: str) -> float | None:
+    text = value.strip().replace(",", "")
+    if not text or text.lower() in {"nan", "inf", "-inf", "n/a", "-"}:
+        return None
+    try:
+        number = float(text)
+    except ValueError:
+        return None
+    return number if math.isfinite(number) else None
+
+
+def parse_available_groups(text: str) -> list[dict[str, str]]:
+    """Parse `likwid-perfctr -a` across old and new LIKWID table formats."""
+    groups: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("-", "Group name", "Groups")):
+            continue
+        match = re.match(r"^([A-Za-z][A-Za-z0-9_]*)\s+(.*)$", line)
+        if not match:
+            continue
+        name, description = match.groups()
+        upper = name.upper()
+        if upper in {"AVAILABLE", "GROUP", "EVENT"} or upper in seen:
+            continue
+        seen.add(upper)
+        groups.append({"name": upper, "description": description.strip()})
+    return groups
+
+
+def choose_groups(
+    available: Iterable[dict[str, str]], requested: str, max_groups: int
+) -> list[str]:
+    available_names = {
+        str(item.get("name", "")).upper()
+        for item in available
+        if item.get("name")
+    }
+    if requested.strip().lower() == "auto":
+        selected = [name for name in AUTO_GROUP_PREFERENCE if name in available_names]
+    else:
+        wanted = [part.strip().upper() for part in requested.split(",") if part.strip()]
+        selected = [name for name in wanted if name in available_names]
+    return selected[:max_groups] if max_groups > 0 else selected
+
+
+def default_cpu_ids(thread_count: int) -> list[int]:
+    try:
+        allowed = sorted(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        allowed = list(range(os.cpu_count() or 1))
+    return allowed[: max(1, min(thread_count, len(allowed)))]
+
+
+def parse_cpu_ids(value: str, thread_count: int) -> list[int]:
+    if value.strip().lower() == "auto":
+        return default_cpu_ids(thread_count)
+    cpus: list[int] = []
+    for part in value.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if "-" in token:
+            start_text, end_text = token.split("-", 1)
+            start, end = int(start_text), int(end_text)
+            if end < start:
+                raise ValueError(f"invalid descending CPU range: {token}")
+            cpus.extend(range(start, end + 1))
+        else:
+            cpus.append(int(token))
+    if not cpus:
+        raise ValueError("CPU selection is empty")
+    return list(dict.fromkeys(cpus))
+
+
+def _metric_key(name: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", name.strip()).lower()
+    mappings = (
+        ("runtime (rdtsc)", "runtime_seconds"),
+        ("runtime unhalted", "runtime_unhalted_seconds"),
+        ("memory bandwidth", "memory_bandwidth_mbytes_per_second"),
+        ("memory data volume", "memory_data_volume_gbytes"),
+        ("cpi", "cpi"),
+        ("ipc", "ipc"),
+        ("branch misprediction rate", "branch_misprediction_rate"),
+        ("l2 bandwidth", "l2_bandwidth_mbytes_per_second"),
+        ("l3 bandwidth", "l3_bandwidth_mbytes_per_second"),
+        ("mflop/s", "mflops"),
+    )
+    for needle, key in mappings:
+        if needle in normalized:
+            return key
+    return None
+
+
+def parse_likwid_csv(path: Path) -> tuple[list[dict[str, Any]], dict[str, float]]:
+    """Extract LIKWID metric rows without depending on a processor's group set."""
+    if not path.exists():
+        return [], {}
+    rows: list[dict[str, Any]] = []
+    normalized_values: dict[str, list[float]] = {}
+    with path.open("r", errors="ignore", newline="") as handle:
+        for row in csv.reader(handle):
+            cells = [cell.strip() for cell in row]
+            if len(cells) < 2:
+                continue
+            label_index = 1 if cells[0].upper() in {"METRIC", "EVENT"} else 0
+            label = cells[label_index]
+            values = [
+                value
+                for value in (parse_number(cell) for cell in cells[label_index + 1 :])
+                if value is not None
+            ]
+            if not label or not values:
+                continue
+            entry = {
+                "name": label,
+                "values": values,
+                "average": sum(values) / len(values),
+            }
+            rows.append(entry)
+            key = _metric_key(label)
+            if key:
+                normalized_values.setdefault(key, []).extend(values)
+    normalized = {
+        key: sum(values) / len(values)
+        for key, values in normalized_values.items()
+        if values
+    }
+    return rows, normalized
+
+
+def run_metadata_command(command: list[str], output: Path) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(command, text=True, capture_output=True, check=False)
+    output.write_text(completed.stdout + completed.stderr)
+    return completed
+
+
+def write_summary(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--groups", default="auto")
+    parser.add_argument("--max-groups", type=int, default=2)
+    parser.add_argument("--cpus", default="auto")
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=max(1, int(os.environ.get("CK_NUM_THREADS", "1"))),
+    )
+    parser.add_argument("--summary-name", default="likwid_summary.json")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise SystemExit("a workload command is required after --")
+
+    output_dir = args.output_dir.resolve()
+    artifact_dir = output_dir / "likwid"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / args.summary_name
+    executable = shutil.which("likwid-perfctr")
+    summary: dict[str, Any] = {
+        "schema": SCHEMA,
+        "generated_at": utc_now_iso(),
+        "status": "skip",
+        "reason": "",
+        "tool": {
+            "name": "likwid-perfctr",
+            "path": executable,
+        },
+        "requested_groups": args.groups,
+        "available_groups": [],
+        "selected_groups": [],
+        "cpu_ids": [],
+        "command": command,
+        "runs": [],
+        "normalized": {},
+        "artifacts": [],
+        "limitations": [
+            "Wrapper mode measures activity on the pinned CPUs, not only the CKE process.",
+            "Counter groups and metric names vary by processor and LIKWID version.",
+        ],
+    }
+    if not executable:
+        summary["reason"] = "likwid-perfctr is not installed"
+        write_summary(summary_path, summary)
+        print(f"SKIP: {summary['reason']} ({summary_path})")
+        return 0
+
+    try:
+        cpu_ids = parse_cpu_ids(args.cpus, args.threads)
+    except ValueError as exc:
+        summary.update(status="fail", reason=str(exc))
+        write_summary(summary_path, summary)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    cpu_spec = ",".join(str(cpu) for cpu in cpu_ids)
+    summary["cpu_ids"] = cpu_ids
+
+    info_path = artifact_dir / "likwid_info.txt"
+    groups_path = artifact_dir / "available_groups.txt"
+    version_path = artifact_dir / "version.txt"
+    version_run = run_metadata_command([executable, "-v"], version_path)
+    info_run = run_metadata_command([executable, "-i"], info_path)
+    groups_run = run_metadata_command([executable, "-a"], groups_path)
+    summary["tool"]["version"] = version_run.stdout.strip().splitlines()[:1]
+    summary["tool"]["info_returncode"] = info_run.returncode
+    for kind, path in (
+        ("version", version_path),
+        ("cpu_info", info_path),
+        ("available_groups", groups_path),
+    ):
+        summary["artifacts"].append({"kind": kind, "path": str(path)})
+
+    available = parse_available_groups(groups_run.stdout)
+    selected = choose_groups(available, args.groups, args.max_groups)
+    summary["available_groups"] = available
+    summary["selected_groups"] = selected
+    if groups_run.returncode != 0:
+        summary["reason"] = "LIKWID could not enumerate counter groups"
+        write_summary(summary_path, summary)
+        print(f"SKIP: {summary['reason']} ({summary_path})")
+        return 0
+    if not selected:
+        summary["reason"] = "none of the requested LIKWID groups are available"
+        write_summary(summary_path, summary)
+        print(f"SKIP: {summary['reason']} ({summary_path})")
+        return 0
+
+    normalized_by_group: dict[str, dict[str, float]] = {}
+    for group in selected:
+        slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", group.lower())
+        csv_path = artifact_dir / f"{slug}.csv"
+        stdout_path = artifact_dir / f"{slug}.stdout.txt"
+        stderr_path = artifact_dir / f"{slug}.stderr.txt"
+        wrapped = [
+            executable,
+            "-C",
+            cpu_spec,
+            "-g",
+            group,
+            "-o",
+            str(csv_path),
+            "--",
+            *command,
+        ]
+        completed = subprocess.run(wrapped, text=True, capture_output=True, check=False)
+        stdout_path.write_text(completed.stdout)
+        stderr_path.write_text(completed.stderr)
+        metrics, normalized = parse_likwid_csv(csv_path)
+        normalized_by_group[group] = normalized
+        run = {
+            "group": group,
+            "returncode": completed.returncode,
+            "command": wrapped,
+            "csv_path": str(csv_path),
+            "stdout_path": str(stdout_path),
+            "stderr_path": str(stderr_path),
+            "metrics": metrics,
+            "normalized": normalized,
+        }
+        summary["runs"].append(run)
+        summary["artifacts"].extend(
+            [
+                {"kind": f"{group} csv", "path": str(csv_path)},
+                {"kind": f"{group} stdout", "path": str(stdout_path)},
+                {"kind": f"{group} stderr", "path": str(stderr_path)},
+            ]
+        )
+
+    failed = [run for run in summary["runs"] if run["returncode"] != 0]
+    if failed:
+        summary["status"] = "fail"
+        summary["reason"] = "one or more LIKWID group runs failed"
+    else:
+        summary["status"] = "pass"
+    summary["normalized"] = normalized_by_group
+    write_summary(summary_path, summary)
+    print(f"LIKWID profile: {summary['status']} ({summary_path})")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version/v8/tools/ir_visualizer.html
+++ b/version/v8/tools/ir_visualizer.html
@@ -3670,6 +3670,7 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
         let asanSummaryData = null;
         let vtuneSummaryData = null;
         let advisorSummaryData = null;
+        let likwidSummaryData = null;
         let memorySignoffData = null;
         let perfGateData = null;
         let kernelRegistryData = null;
@@ -4432,6 +4433,7 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
                 { key: 'cachegrind_summary', label: 'cachegrind_summary.json', ready: Boolean(cachegrindSummaryData) },
                 { key: 'vtune_summary', label: 'vtune_summary.json', ready: Boolean(vtuneSummaryData) },
                 { key: 'advisor_summary', label: 'advisor_summary.json', ready: Boolean(advisorSummaryData) },
+                { key: 'likwid_summary', label: 'likwid_summary.json', ready: Boolean(likwidSummaryData) },
                 { key: 'memory_signoff', label: 'memory_signoff.json', ready: Boolean(memorySignoffData) },
                 { key: 'perf_gate_report', label: 'perf_gate_report.json', ready: Boolean(perfGateData) },
                 { key: 'multimodal_bridge_report', label: 'multimodal_bridge/bridge_report.json', ready: Boolean(bridgeView) },
@@ -4885,6 +4887,7 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
                             { label: 'cachegrind', ready: Boolean(cachegrindSummaryData) },
                             { label: 'vtune', ready: Boolean(vtuneSummaryData) },
                             { label: 'advisor', ready: Boolean(advisorSummaryData) },
+                            { label: 'likwid', ready: Boolean(likwidSummaryData) },
                         ])}
                     </div>`;
                 }
@@ -5164,6 +5167,11 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
                     await tryFetchJson('.ck_build/advisor_summary.json') ||
                     await tryFetchJson('ck_build/advisor_summary.json');
             }
+            if (!likwidSummaryData) {
+                likwidSummaryData = await tryFetchJson('likwid_summary.json') ||
+                    await tryFetchJson('.ck_build/likwid_summary.json') ||
+                    await tryFetchJson('ck_build/likwid_summary.json');
+            }
             if (!memorySignoffData) {
                 memorySignoffData = await tryFetchJson('memory_signoff.json') ||
                     await tryFetchJson('.ck_build/memory_signoff.json') ||
@@ -5397,6 +5405,7 @@ python3 trace_divergence.py --model "$MODEL_DIR" --token 25 --threads 1 --contex
             asanSummaryData = files.asan_summary || asanSummaryData;
             vtuneSummaryData = files.vtune_summary || vtuneSummaryData;
             advisorSummaryData = files.advisor_summary || advisorSummaryData;
+            likwidSummaryData = files.likwid_summary || likwidSummaryData;
             memorySignoffData = files.memory_signoff || memorySignoffData;
             perfGateData = files.perf_gate_report || perfGateData;
             kernelRegistryData = files.kernel_registry || kernelRegistryData;
@@ -10364,7 +10373,7 @@ function renderTraining() {
         function getFileType(filename) {
             const name = filename.toLowerCase();
             if (name.includes('profile')) return 'profile';
-            if (name.includes('perf_stat') || name.includes('flamegraph_manifest') || name.includes('cachegrind_summary') || name.includes('vtune_summary') || name.includes('advisor_summary')) return 'profile';
+            if (name.includes('perf_stat') || name.includes('flamegraph_manifest') || name.includes('cachegrind_summary') || name.includes('vtune_summary') || name.includes('advisor_summary') || name.includes('likwid_summary')) return 'profile';
             if (name.includes('memory_signoff') || name.includes('perf_gate_report') || name.includes('asan_summary') || name.includes('memory_verification')) return 'validation';
             if (name.includes('ir_train_invariants') || name.includes('ir2_train_summary')) return 'training';
             if (name.includes('ir1_train') || name.includes('ir2_train')) return 'training';
@@ -10452,6 +10461,8 @@ function renderTraining() {
                         console.log('Auto-loaded: vtune summary');
                     } else if (name.includes('advisor_summary')) {
                         advisorSummaryData = info.data;
+                    } else if (name.includes('likwid_summary')) {
+                        likwidSummaryData = info.data;
                         console.log('Auto-loaded: advisor summary');
                     } else if (name.includes('memory_signoff')) {
                         memorySignoffData = info.data;
@@ -12064,6 +12075,7 @@ function renderProfileHowTo() {
         { name: 'perf_gate_report.json', ok: Boolean(perfGateData) },
         { name: 'vtune_summary.json', ok: Boolean(vtuneSummaryData) },
         { name: 'advisor_summary.json', ok: Boolean(advisorSummaryData) },
+        { name: 'likwid_summary.json', ok: Boolean(likwidSummaryData) },
     ];
     const optionalDepChips = [];
     if (hasTrainRuntimeContext || Boolean(asanSummaryData)) {
@@ -12091,6 +12103,7 @@ function renderProfileHowTo() {
     const cachegrindInstalled = Boolean(profileToolStatus.valgrind) && Boolean(profileToolStatus.cg_annotate);
     const vtuneInstalled = Boolean(profileToolStatus.vtune);
     const advisorInstalled = Boolean(profileToolStatus.advisor);
+    const likwidInstalled = Boolean(profileToolStatus.likwid);
     const coreHostReady = linuxHost && perfInstalled && flamegraphInstalled && cachegrindInstalled;
     const hostOsPretty = embeddedHostContext.os_pretty_name || '';
     const hostKernel = embeddedHostContext.kernel_release || '';
@@ -12154,6 +12167,7 @@ function renderProfileHowTo() {
         { name: 'cachegrind', ok: cachegrindInstalled, label: cachegrindInstalled ? 'installed' : 'missing' },
         { name: 'VTune', ok: vtuneInstalled, label: vtuneInstalled ? 'installed' : 'optional' },
         { name: 'Advisor', ok: advisorInstalled, label: advisorInstalled ? 'installed' : 'optional' },
+        { name: 'LIKWID', ok: likwidInstalled, label: likwidInstalled ? 'installed' : 'optional' },
     ];
     const hostToolWarnings = [];
     if (!linuxHost) {
@@ -12290,6 +12304,12 @@ function renderProfileHowTo() {
         'python3 version/v8/tools/open_ir_visualizer_v8.py --generate --run "$REPORT_MODEL_DIR" --html-only --output "$REPORT_MODEL_DIR/ir_report.html"',
     ].join('\n');
 
+    const likwidCmd = [
+        explicitModelDirCmd,
+        `make profile-v8-likwid V8_MODEL="$REPORT_MODEL_DIR" V8_PERF_RUNTIME=cli V8_PREP_WITH_PYTHON=0 V8_LIKWID_GROUPS=auto V8_LIKWID_THREADS=1${makeChatArg}${makeCliArg}`,
+        'python3 version/v8/tools/open_ir_visualizer_v8.py --generate --run "$REPORT_MODEL_DIR" --html-only --output "$REPORT_MODEL_DIR/ir_report.html"',
+    ].join('\n');
+
     const cachegrindNativeCmd = [
         explicitModelDirCmd,
         `make profile-v8-cachegrind V8_MODEL="$REPORT_MODEL_DIR"${makeChatArg}${makeCliArg}`,
@@ -12371,6 +12391,12 @@ function renderProfileHowTo() {
                 : 'Advisor summary requires Intel Advisor (oneAPI). It is not installed on this host.',
             cmd: advisorCmd,
         },
+        'likwid_summary.json': {
+            why: likwidInstalled
+                ? 'Cross-vendor pinned CPU, cache, and memory-counter measurements from groups available on this processor.'
+                : 'LIKWID is optional. Install likwid-perfctr to capture processor-specific counter groups; CKE runs normally without it.',
+            cmd: likwidCmd,
+        },
     };
 
     const missingHelpHtml = missingDeps.length
@@ -12422,6 +12448,7 @@ function renderProfileHowTo() {
         { label: 'Gate',      filled: Boolean(perfGateData) },
         { label: 'VTune',     filled: Boolean(vtuneSummaryData) },
         { label: 'Advisor',   filled: Boolean(advisorSummaryData) },
+        { label: 'LIKWID',    filled: Boolean(likwidSummaryData) },
     ];
     const storyArcHtml = storySteps.map((s, i) => {
         const dot = `<div class="profile-story-arc-step"><div class="profile-story-arc-dot ${s.filled ? 'filled' : ''}"></div><div class="profile-story-arc-label">${escapeHtml(s.label)}</div></div>`;
@@ -13787,6 +13814,7 @@ function renderProfileHowTo() {
             let tlbPanelHtml = '';
             let cachePanelHtml = '';
             let advisorPanelHtml = '';
+            let likwidPanelHtml = '';
             let safetyPanelHtml = '';
 
             const cyc = getPerfCounterByMatcher(['cycles', 'cpu-cycles', /cycles/i, /cpu_core\/cycles/i]);
@@ -14528,6 +14556,64 @@ function renderProfileHowTo() {
                 `;
             }
 
+            if (likwidSummaryData) {
+                const status = String(likwidSummaryData?.status || 'unknown');
+                const cpuIds = Array.isArray(likwidSummaryData?.cpu_ids)
+                    ? likwidSummaryData.cpu_ids.join(', ')
+                    : '-';
+                const groups = Array.isArray(likwidSummaryData?.selected_groups)
+                    ? likwidSummaryData.selected_groups
+                    : [];
+                const normalized = (likwidSummaryData?.normalized && typeof likwidSummaryData.normalized === 'object')
+                    ? likwidSummaryData.normalized
+                    : {};
+                const metricRows = [];
+                Object.entries(normalized).forEach(([group, metrics]) => {
+                    if (!metrics || typeof metrics !== 'object') return;
+                    Object.entries(metrics).forEach(([name, rawValue]) => {
+                        const value = Number(rawValue);
+                        metricRows.push(`
+                            <tr>
+                                <td>${escapeHtml(String(group))}</td>
+                                <td>${escapeHtml(String(name))}</td>
+                                <td>${Number.isFinite(value) ? value.toFixed(3) : escapeHtml(String(rawValue))}</td>
+                            </tr>
+                        `);
+                    });
+                });
+                if (Array.isArray(likwidSummaryData?.artifacts)) {
+                    likwidSummaryData.artifacts.forEach((artifact) => {
+                        if (!artifact || typeof artifact !== 'object') return;
+                        const path = artifact.resolved_path || artifact.path;
+                        if (!path) return;
+                        links.push(`<a href="${escapeHtml(String(path))}" target="_blank" style="color:var(--blue);font-family:'JetBrains Mono',monospace;">LIKWID ${escapeHtml(String(artifact.kind || 'artifact'))}</a>`);
+                    });
+                }
+                likwidPanelHtml = `
+                    <div class="profile-artifact-panel" style="margin-top:0.8rem;">
+                        <h3><span class="badge badge-blue">LIKWID</span> Pinned Cross-Vendor Counters</h3>
+                        <table class="profile-hotspot-table">
+                            <tbody>
+                                <tr><td>Status</td><td>${escapeHtml(status.toUpperCase())}</td></tr>
+                                <tr><td>Pinned CPUs</td><td><code>${escapeHtml(cpuIds)}</code></td></tr>
+                                <tr><td>Groups</td><td>${escapeHtml(groups.join(', ') || '-')}</td></tr>
+                                ${likwidSummaryData?.reason ? `<tr><td>Reason</td><td>${escapeHtml(String(likwidSummaryData.reason))}</td></tr>` : ''}
+                            </tbody>
+                        </table>
+                        ${metricRows.length ? `
+                        <div style="margin-top:0.7rem;">
+                            <table class="profile-hotspot-table">
+                                <thead><tr><th>Group</th><th>Normalized Metric</th><th>Average</th></tr></thead>
+                                <tbody>${metricRows.join('')}</tbody>
+                            </table>
+                        </div>` : ''}
+                        <div style="margin-top:0.55rem;color:var(--text-muted);font-size:0.78rem;">
+                            Wrapper mode counts activity on the selected CPUs. Keep the workload pinned and the neighboring CPUs quiet.
+                        </div>
+                    </div>
+                `;
+            }
+
             if (vtuneSummaryData) {
                 links.push('VTune summary loaded');
 
@@ -14712,10 +14798,11 @@ function renderProfileHowTo() {
                         </div>
                     </div>
                 ${advisorPanelHtml}
+                ${likwidPanelHtml}
                 ${safetyPanelHtml}
                 `;
             } else {
-                vtuneEl.innerHTML = `${advisorPanelHtml}${safetyPanelHtml}` || '';
+                vtuneEl.innerHTML = `${advisorPanelHtml}${likwidPanelHtml}${safetyPanelHtml}` || '';
             }
 
             summaryEl.innerHTML = cards.length > 0
@@ -15408,8 +15495,8 @@ function renderProfileHowTo() {
                 },
                 {
                     label: 'Microarchitecture',
-                    state: (perfStatData || files.perf_stat_summary || flamegraphManifestData || files.flamegraph_manifest || cachegrindSummaryData || files.cachegrind_summary || vtuneSummaryData || files.vtune_summary || advisorSummaryData || files.advisor_summary) ? 'ready' : 'missing',
-                    detail: 'Perf counters, flamegraph, cache, VTune/Advisor',
+                    state: (perfStatData || files.perf_stat_summary || flamegraphManifestData || files.flamegraph_manifest || cachegrindSummaryData || files.cachegrind_summary || vtuneSummaryData || files.vtune_summary || advisorSummaryData || files.advisor_summary || likwidSummaryData || files.likwid_summary) ? 'ready' : 'missing',
+                    detail: 'Perf counters, flamegraph, cache, VTune/Advisor/LIKWID',
                 },
                 {
                     label: 'Safety + Gates',

--- a/version/v8/tools/open_ir_visualizer_v8.py
+++ b/version/v8/tools/open_ir_visualizer_v8.py
@@ -294,6 +294,7 @@ def collect_profile_tool_status() -> dict[str, object]:
         "cg_annotate": shutil.which("cg_annotate") is not None,
         "vtune": shutil.which("vtune") is not None,
         "advisor": shutil.which("advisor") is not None,
+        "likwid": shutil.which("likwid-perfctr") is not None,
         "xdg_open": shutil.which("xdg-open") is not None,
         "flamegraph": (
             (flamegraph_dir / "stackcollapse-perf.pl").exists()
@@ -309,7 +310,7 @@ def resolve_model_target(model_arg: str) -> tuple[Path, Path]:
     if candidate.exists():
         if not candidate.is_dir():
             raise ValueError(f"Model path is not a directory: {candidate}")
-        if candidate.name in {"ck_build", ".ck_build"}:
+        if candidate.name in {"ck_build", ".ck_build", ".ck_build_v8"}:
             ck_build = candidate
             model_root = candidate.parent
         else:
@@ -317,6 +318,8 @@ def resolve_model_target(model_arg: str) -> tuple[Path, Path]:
                 ck_build = candidate / "ck_build"
             elif (candidate / ".ck_build").exists():
                 ck_build = candidate / ".ck_build"
+            elif (candidate / ".ck_build_v8").exists():
+                ck_build = candidate / ".ck_build_v8"
             else:
                 ck_build = candidate
             model_root = candidate
@@ -329,6 +332,10 @@ def resolve_model_target(model_arg: str) -> tuple[Path, Path]:
     dot_ck_build = CACHE_PATH / model_arg / ".ck_build"
     if dot_ck_build.exists():
         return dot_ck_build, CACHE_PATH / model_arg
+
+    dot_ck_build_v8 = CACHE_PATH / model_arg / ".ck_build_v8"
+    if dot_ck_build_v8.exists():
+        return dot_ck_build_v8, CACHE_PATH / model_arg
 
     model_dir = CACHE_PATH / model_arg
     if model_dir.exists():
@@ -551,6 +558,7 @@ def copy_artifacts_if_needed(src_model_dir: Path, dst_model_dir: Path) -> None:
         "asan_summary.json",
         "vtune_summary.json",
         "advisor_summary.json",
+        "likwid_summary.json",
         "memory_signoff.json",
         "memory_verification_latest.json",
         "perf_gate_report.json",
@@ -3483,8 +3491,8 @@ def load_model_data(
         model_root = run_dir
         model_name = run_dir.name
     else:
-        model_name = ck_build_path.parent.name if ck_build_path.name in {"ck_build", ".ck_build"} else ck_build_path.name
-        model_root = ck_build_path.parent if ck_build_path.name in {"ck_build", ".ck_build"} else ck_build_path
+        model_name = ck_build_path.parent.name if ck_build_path.name in {"ck_build", ".ck_build", ".ck_build_v8"} else ck_build_path.name
+        model_root = ck_build_path.parent if ck_build_path.name in {"ck_build", ".ck_build", ".ck_build_v8"} else ck_build_path
     train_runtime_available = has_train_runtime_artifacts(run_dir if run_dir is not None else model_root)
     inference_runtime_available = has_inference_runtime_artifacts(run_dir if run_dir is not None else model_root)
     bridge_dirs = _resolve_multimodal_bridge_dirs(run_dir, model_root)
@@ -3496,8 +3504,8 @@ def load_model_data(
     if bridge_decoder_root is not None:
         search_roots.append(bridge_decoder_root)
     if run_dir is not None:
-        search_roots.extend([run_dir, run_dir / "ck_build", run_dir / ".ck_build"])
-    search_roots.extend([ck_build_path, model_root, model_root / ".ck_build"])
+        search_roots.extend([run_dir, run_dir / "ck_build", run_dir / ".ck_build", run_dir / ".ck_build_v8"])
+    search_roots.extend([ck_build_path, model_root, model_root / ".ck_build", model_root / ".ck_build_v8"])
     if bridge_root is not None:
         search_roots.append(bridge_root)
     if bridge_encoder_root is not None:
@@ -3605,6 +3613,7 @@ def load_model_data(
         "asan_summary",
         "vtune_summary",
         "advisor_summary",
+        "likwid_summary",
         "memory_signoff",
         "perf_gate_report",
         "regression_ledger",
@@ -3706,6 +3715,7 @@ def load_model_data(
         "asan_summary": model_candidates("asan_summary.json") + [V8_REPORT_PATH / "asan_summary.json", V8_REPORT_PATH_LEGACY / "asan_summary.json"],
         "vtune_summary": model_candidates("vtune_summary.json") + [V8_REPORT_PATH / "vtune_summary.json", V8_REPORT_PATH_LEGACY / "vtune_summary.json"],
         "advisor_summary": model_candidates("advisor_summary.json") + [V8_REPORT_PATH / "advisor_summary.json", V8_REPORT_PATH_LEGACY / "advisor_summary.json"],
+        "likwid_summary": model_candidates("likwid_summary.json") + [V8_REPORT_PATH / "likwid_summary.json", V8_REPORT_PATH_LEGACY / "likwid_summary.json"],
         "memory_signoff": model_candidates("memory_signoff.json") + [V8_REPORT_PATH / "memory_signoff.json", V8_REPORT_PATH_LEGACY / "memory_signoff.json"],
         "perf_gate_report": model_candidates("perf_gate_report.json") + [V8_REPORT_PATH / "perf_gate_report.json", V8_REPORT_PATH_LEGACY / "perf_gate_report.json"],
         "embedding_dump": model_candidates("embedding_dump.json") + model_candidates("embedding_dump_latest.json"),
@@ -4501,6 +4511,39 @@ def load_model_data(
                 enriched.append(item2)
             advisor["artifacts"] = enriched
 
+    likwid = data["files"].get("likwid_summary")
+    if isinstance(likwid, dict):
+        artifacts = likwid.get("artifacts")
+        if isinstance(artifacts, list):
+            enriched = []
+            for item in artifacts:
+                if not isinstance(item, dict):
+                    continue
+                item2 = dict(item)
+                raw = item2.get("path")
+                if isinstance(raw, str):
+                    resolved = _resolve_asset_path(raw, ck_build_path, model_root)
+                    if resolved:
+                        item2["resolved_path"] = str(resolved)
+                enriched.append(item2)
+            likwid["artifacts"] = enriched
+        runs = likwid.get("runs")
+        if isinstance(runs, list):
+            enriched_runs = []
+            for run in runs:
+                if not isinstance(run, dict):
+                    continue
+                run2 = dict(run)
+                for key in ("csv_path", "stdout_path", "stderr_path"):
+                    raw = run2.get(key)
+                    if not isinstance(raw, str):
+                        continue
+                    resolved = _resolve_asset_path(raw, ck_build_path, model_root)
+                    if resolved:
+                        run2[f"{key}_resolved"] = str(resolved)
+                enriched_runs.append(run2)
+            likwid["runs"] = enriched_runs
+
     cachegrind = data["files"].get("cachegrind_summary")
     if isinstance(cachegrind, dict):
         for key in ("cachegrind_out", "annotate_path"):
@@ -4604,7 +4647,7 @@ def generate_html_report(
     """Generate standalone HTML report."""
     from datetime import datetime
 
-    model_name = ck_build_path.parent.name if ck_build_path.name in {"ck_build", ".ck_build"} else ck_build_path.name
+    model_name = ck_build_path.parent.name if ck_build_path.name in {"ck_build", ".ck_build", ".ck_build_v8"} else ck_build_path.name
     print(f"Generating report for: {model_name}")
 
     # Load data


### PR DESCRIPTION
## Why

CKE currently relies on `perf`, VTune, and Advisor for most CPU profiling evidence. It needs an optional cross-vendor counter path that works across supported Intel and AMD processors without making any profiler a runtime dependency.

## What changed

- Added `make profile-v8-likwid`.
- Added processor-specific group discovery through `likwid-perfctr -a`; only groups available on the current CPU are selected.
- Added CPU pinning based on the process affinity set, with explicit CPU/thread overrides.
- Preserved LIKWID version, CPU info, available groups, per-group CSV, workload stdout, and stderr.
- Added the stable `cke.profile.likwid.v1` JSON artifact with normalized common metrics.
- Integrated `likwid_summary.json` into the v8 IR visualizer Profile section and external-artifact links.
- Added `.ck_build_v8` discovery to the v8 visualizer so native v8 profile artifacts are found.
- Kept LIKWID optional: normal CKE builds and runs are unchanged when `likwid-perfctr` is unavailable.

Marker API regions are deliberately deferred to a later PR; this change establishes the wrapper-mode artifact contract first.

## Evidence

- The capture regression fixture exposed `MEM` and `CLOCK`; auto-selection chose only `MEM` with `V8_LIKWID_MAX_GROUPS=1`.
- The wrapper command pinned the workload to fixture CPUs `4,8`.
- The fixture CSV normalized `Memory bandwidth [MBytes/s]` to `12345`.
- A missing `likwid-perfctr` produced a successful explicit `skip` artifact rather than a runtime/build failure.
- No physical-counter performance claim is made because LIKWID is not installed on the current validation host.

## Validation

- `python3 -m unittest tests.test_likwid_profile_v8 tests.test_profile_install_hints -v` — 8 tests passed.
- `python3 version/v8/scripts/test_visualizer_js_units_v8.py` — 109 tests passed.
- `python3 version/v8/scripts/test_visualizer_health_v8.py` — 180 checks passed with 10 pre-existing dynamic-DOM warnings.
- `python3 version/v8/scripts/test_visualizer_generated_e2e_v8.py` — passed as `no_cached_runs` on this host.
- `make -n profile-v8-likwid V8_MODEL=/tmp/fake-model V8_PERF_RUNTIME=cli` — Make recipe expanded successfully and the unavailable-tool path skipped cleanly.
- `git diff --check` and Python byte-compilation passed.
- `python3 scripts/validate_change_metadata.py commits --base origin/main --head HEAD` — passed.

The broader `tests.test_run_regression_v8` module has one baseline failure unrelated to this PR: the test expects `qwen3vl`, while `origin/main:version/v8/regression/families.json` does not contain that family.

## Regression coverage

`tests/test_likwid_profile_v8.py` covers:

- available-group parsing and dynamic preference ordering;
- explicit group filtering;
- LIKWID CSV preservation and common-metric normalization;
- CPU selection within the allowed affinity set;
- wrapper command CPU pinning;
- missing-tool skip behavior;
- visualizer artifact loading and raw-path resolution;
- `.ck_build_v8` discovery.

The existing visualizer JS and health suites exercise the modified Profile-section source and bootstrap paths. Hardware-specific counter access remains a contributor/maintainer validation step on a host with LIKWID installed.

## Documentation

Updated `version/v8/README.md` with the `profile-v8-likwid` command, configuration overrides, optional behavior, repeated-workload cost, raw artifact contract, and wrapper-mode measurement limitation.

## Content handoff

- Audience: CKE contributors profiling CPU inference on Intel or AMD systems.
- Angle: CKE gains an optional, processor-aware profiling path that complements perf, VTune, and Advisor instead of depending on one vendor tool.
- Claims: The patch dynamically selects available LIKWID groups, pins wrapper workloads, preserves raw outputs, normalizes common metrics, and renders the resulting artifact in the v8 IR visualizer.
- Caveats: No physical LIKWID counter run was available on the authoring host; wrapper mode includes all activity on selected CPUs; group and metric availability varies by processor; Marker API regions are future work.
- Sources: Commit `2e3c15c7`, `version/v8/scripts/likwid_profile_v8.py`, `tests/test_likwid_profile_v8.py`, `version/v8/tools/open_ir_visualizer_v8.py`, `version/v8/tools/ir_visualizer.html`, and `version/v8/README.md`.
