### PR TITLE
feat(v8): surface and visualize LIKWID profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6334,6 +6334,7 @@ V8_LIKWID_GROUPS ?= auto
 V8_LIKWID_MAX_GROUPS ?= 2
 V8_LIKWID_CPUS ?= auto
 V8_LIKWID_THREADS ?= 1
+V8_LIKWID_PLOT ?=
 V8_PROFILE_V7_ARGS = \
 	V7_MODEL="$(V8_MODEL)" \
 	V7_PERF_RUNTIME="$(V8_PERF_RUNTIME)" \
@@ -7266,6 +7267,7 @@ profile-v8-likwid:
 			--max-groups "$(V8_LIKWID_MAX_GROUPS)" \
 			--cpus "$(V8_LIKWID_CPUS)" \
 			--threads "$(V8_LIKWID_THREADS)" \
+			$(if $(strip $(V8_LIKWID_PLOT)),--plot-artifact "$(V8_LIKWID_PLOT)",) \
 			-- ./build/ck-cli-v8 "$$runtime_dir/libmodel.so" "$$runtime_dir/weights.bump" \
 				--prompt "The quick brown fox" --max-tokens 32 --timing --quiet-output \
 				$(V8_CLI_TEMPLATE_ARGS) $(V8_CLI_ARGS); \

--- a/tests/test_likwid_profile_v8.py
+++ b/tests/test_likwid_profile_v8.py
@@ -140,6 +140,20 @@ class LikwidProfileV8Tests(unittest.TestCase):
         ):
             self.assertEqual(self.module.default_cpu_ids(2), [4, 8])
 
+    def test_exported_plot_is_preserved_as_an_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "memory.svg"
+            source.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+            artifact_dir = root / "run" / "likwid"
+            artifact_dir.mkdir(parents=True)
+            summary = {"artifacts": []}
+            self.module.register_plot_artifacts([source], artifact_dir, summary)
+        artifact = summary["artifacts"][0]
+        self.assertEqual(artifact["kind"], "plot")
+        self.assertEqual(artifact["media_type"], "image/svg+xml")
+        self.assertTrue(artifact["path"].endswith("plot_memory.svg"))
+
     def test_visualizer_loads_summary_and_resolves_raw_artifacts(self) -> None:
         spec = importlib.util.spec_from_file_location(
             "likwid_visualizer_v8_test", VISUALIZER
@@ -153,12 +167,17 @@ class LikwidProfileV8Tests(unittest.TestCase):
             raw = run_dir / "likwid" / "mem.csv"
             raw.parent.mkdir()
             raw.write_text("Metric,CPI,1.0\n")
+            plot = run_dir / "likwid" / "memory.svg"
+            plot.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
             (run_dir / "likwid_summary.json").write_text(
                 json.dumps(
                     {
                         "schema": "cke.profile.likwid.v1",
                         "status": "pass",
-                        "artifacts": [{"kind": "MEM csv", "path": str(raw)}],
+                        "artifacts": [
+                            {"kind": "MEM csv", "path": str(raw)},
+                            {"kind": "plot", "path": str(plot)},
+                        ],
                         "runs": [{"group": "MEM", "csv_path": str(raw)}],
                     }
                 )
@@ -169,6 +188,11 @@ class LikwidProfileV8Tests(unittest.TestCase):
         summary = data["files"]["likwid_summary"]
         self.assertEqual(summary["status"], "pass")
         self.assertEqual(summary["artifacts"][0]["resolved_path"], str(raw))
+        self.assertTrue(
+            summary["artifacts"][1]["image_data_uri"].startswith(
+                "data:image/svg+xml;base64,"
+            )
+        )
         self.assertEqual(summary["runs"][0]["csv_path_resolved"], str(raw))
 
     def test_visualizer_discovers_v8_build_directory(self) -> None:

--- a/tests/test_profile_install_hints.py
+++ b/tests/test_profile_install_hints.py
@@ -44,6 +44,28 @@ class ProfileInstallHintsTests(unittest.TestCase):
                     with patch.object(module, "_read_os_release", return_value=os_release):
                         self.assertEqual(module._profile_install_hints(), ARCH_HINTS)
 
+    def test_v8_likwid_hints_cover_ubuntu_source_and_cachyos_aur(self):
+        module = _load_module(VISUALIZERS[1])
+        with patch.object(
+            module, "_read_os_release", return_value={"ID": "ubuntu", "ID_LIKE": "debian"}
+        ):
+            hints = module._likwid_install_hints()
+        self.assertEqual(hints["distro_family"], "ubuntu")
+        self.assertEqual(hints["recommended"], "ubuntu_source")
+        self.assertIn("sudo apt-get install -y likwid", hints["commands"]["ubuntu_package"])
+        self.assertTrue(
+            any("--branch v5.5.1" in command for command in hints["commands"]["ubuntu_source"])
+        )
+
+        with patch.object(
+            module, "_read_os_release", return_value={"ID": "cachyos", "ID_LIKE": "arch"}
+        ):
+            hints = module._likwid_install_hints()
+        self.assertEqual(hints["distro_family"], "arch")
+        self.assertEqual(hints["recommended"], "arch_aur")
+        self.assertIn("makepkg -si", hints["commands"]["arch_aur"])
+        self.assertIn("likwid-perfctr -a", hints["commands"]["verify"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_v8_ir_hub_likwid.py
+++ b/tests/test_v8_ir_hub_likwid.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HUB_SCRIPT = ROOT / "version/v8/tools/open_ir_hub_v8.py"
+
+
+def _load_hub():
+    spec = importlib.util.spec_from_file_location("v8_ir_hub_likwid_test", HUB_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {HUB_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class V8IrHubLikwidTests(unittest.TestCase):
+    def test_hub_indexes_likwid_status_metrics_and_raw_links(self) -> None:
+        hub = _load_hub()
+        with tempfile.TemporaryDirectory() as tmp:
+            models_root = Path(tmp)
+            run_dir = models_root / "demo"
+            build_dir = run_dir / ".ck_build_v8"
+            raw_dir = build_dir / "likwid"
+            raw_dir.mkdir(parents=True)
+            (run_dir / "ir_report.html").write_text("<html></html>")
+            raw_csv = raw_dir / "mem.csv"
+            raw_csv.write_text("Metric,Memory bandwidth [MBytes/s],12345\n")
+            (build_dir / "likwid_summary.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "cke.profile.likwid.v1",
+                        "status": "pass",
+                        "selected_groups": ["MEM"],
+                        "cpu_ids": [4, 8],
+                        "normalized": {
+                            "MEM": {"memory_bandwidth_mbytes_per_second": 12345.0}
+                        },
+                        "artifacts": [{"kind": "MEM csv", "path": str(raw_csv)}],
+                    }
+                )
+            )
+
+            payload = hub.build_index(models_root)
+            rendered = hub.render_html(payload)
+
+        self.assertEqual(payload["summary"]["runs_with_likwid"], 1)
+        self.assertEqual(len(payload["runs"]), 1)
+        summary = payload["runs"][0]["likwid_summary"]
+        self.assertEqual(summary["status"], "pass")
+        self.assertEqual(summary["selected_groups"], ["MEM"])
+        self.assertEqual(summary["cpu_ids"], [4, 8])
+        self.assertEqual(summary["metrics"][0]["value"], 12345.0)
+        self.assertTrue(summary["summary_uri"].startswith("file://"))
+        self.assertTrue(summary["artifacts"][0]["uri"].startswith("file://"))
+        deep = next(
+            section
+            for section in payload["runs"][0]["artifact_sections"]
+            if section["key"] == "deep_profiling"
+        )
+        self.assertIn({"label": "likwid", "ready": True}, deep["items"])
+        self.assertIn("renderLikwidSummary", rendered)
+        self.assertIn("LIKWID Profiles", rendered)
+
+    def test_rendered_hub_javascript_is_valid(self) -> None:
+        node = shutil.which("node")
+        if node is None:
+            self.skipTest("node is not installed")
+        hub = _load_hub()
+        html = hub.render_html({"schema": "ck.ir.hub.v2", "runs": [], "summary": {}})
+        script = html.rsplit("<script>", 1)[1].split("</script>", 1)[0]
+        with tempfile.TemporaryDirectory() as tmp:
+            script_path = Path(tmp) / "hub.js"
+            script_path.write_text(script)
+            completed = subprocess.run(
+                [node, "--check", str(script_path)], text=True, capture_output=True
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_hub_surfaces_skip_reason_without_metrics(self) -> None:
+        hub = _load_hub()
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            (run_dir / "likwid_summary.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "cke.profile.likwid.v1",
+                        "status": "skip",
+                        "reason": "counter access denied",
+                    }
+                )
+            )
+            summary = hub._extract_likwid_summary(run_dir)
+
+        self.assertEqual(summary["status"], "skip")
+        self.assertEqual(summary["reason"], "counter access denied")
+        self.assertEqual(summary["metrics"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -94,4 +94,54 @@ Wrapper measurements include all activity on the pinned CPUs; avoid noisy
 neighboring workloads when collecting evidence. Marker API regions can be added
 later without changing this artifact contract.
 
+Install the current stable release on Ubuntu (recommended for Xeon 6, Zen 5,
+and other recent processors):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential git perl
+git clone --depth 1 --branch v5.5.1 https://github.com/RRZE-HPC/likwid.git
+cd likwid
+make -j"$(nproc)"
+sudo make install
+sudo ldconfig
+```
+
+For a quick setup on an older supported processor, Ubuntu also packages LIKWID:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y likwid
+```
+
+Ubuntu LTS repositories may contain an older LIKWID release. If LIKWID does not
+recognize the processor or exposes few useful groups, install the current source
+release above. On CachyOS, Arch, EndeavourOS, or Manjaro, build the current AUR
+package:
+
+```bash
+sudo pacman -S --needed base-devel git perl
+git clone https://aur.archlinux.org/likwid.git
+cd likwid
+makepkg -si
+```
+
+Verify access and discover the groups supported by the actual processor instead
+of assuming that an event name exists:
+
+```bash
+likwid-perfctr -v
+sudo modprobe msr
+likwid-perfctr -i
+likwid-perfctr -a
+likwid-topology -c
+```
+
+The Profile page visualizes the evidence flow from the CKE workload through its
+pinned CPUs and dynamically selected groups to normalized metric cards. The
+audit table and raw CSV/stdout/stderr links remain available beneath it. Metrics
+with different units are deliberately not placed on one comparative bar chart.
+LIKWID's live `likwid-perfscope` plotting can be added later as a separate
+time-series artifact without changing the normalized summary contract.
+
 That keeps `v8` small and honest: the version split now includes the inference runner, local kernel registry/maps, multimodal bridge entrypoint, and the `v8`-named operator tooling surface used by the visualizer, hub, and regression entrypoints.

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -84,6 +84,10 @@ current affinity set, preserves LIKWID CSV/stdout/stderr, and writes
 more groups, or `V8_LIKWID_CPUS` with an explicit CPU list. Each group reruns the
 workload, so keep the default small when profiling large models.
 
+The v8 IR Hub indexes the same summary and exposes its pass/skip/fail status,
+selected groups, pinned CPUs, common normalized metrics, and links to the JSON
+and preserved raw artifacts directly on each run card.
+
 LIKWID is optional. If `likwid-perfctr` is unavailable, the Make target reports
 `SKIP` and the normal build, runtime, and visualizer paths remain unchanged.
 Wrapper measurements include all activity on the pinned CPUs; avoid noisy

--- a/version/v8/README.md
+++ b/version/v8/README.md
@@ -99,13 +99,17 @@ and other recent processors):
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential git perl
+sudo apt-get install -y build-essential git perl gnuplot-nox
 git clone --depth 1 --branch v5.5.1 https://github.com/RRZE-HPC/likwid.git
 cd likwid
 make -j"$(nproc)"
 sudo make install
 sudo ldconfig
 ```
+
+The `gnuplot-nox` dependency enables headless SVG/PNG generation. The regular
+`gnuplot` desktop package can be used instead when interactive windows are
+wanted.
 
 For a quick setup on an older supported processor, Ubuntu also packages LIKWID:
 
@@ -120,7 +124,7 @@ release above. On CachyOS, Arch, EndeavourOS, or Manjaro, build the current AUR
 package:
 
 ```bash
-sudo pacman -S --needed base-devel git perl
+sudo pacman -S --needed base-devel git perl gnuplot
 git clone https://aur.archlinux.org/likwid.git
 cd likwid
 makepkg -si
@@ -137,11 +141,26 @@ likwid-perfctr -a
 likwid-topology -c
 ```
 
+`likwid-perfscope` is a live plotting frontend and does not automatically leave
+a durable image for every run. Gnuplot/feedgnuplot can export SVG or PNG. Once a
+plot has been exported, preserve and embed it in the generated IR report with:
+
+```bash
+make profile-v8-likwid \
+  V8_MODEL="/path/to/model-or-run-dir" \
+  V8_LIKWID_PLOT="/path/to/exported-likwid-plot.svg"
+```
+
+The profiling script also accepts repeatable `--plot-artifact` arguments when
+called directly. SVG, PNG, JPEG, and WebP files are copied under the run's
+`likwid/` directory, recorded in `likwid_summary.json`, and embedded in the
+Profile page so the standalone report does not depend on the original path.
+
 The Profile page visualizes the evidence flow from the CKE workload through its
 pinned CPUs and dynamically selected groups to normalized metric cards. The
 audit table and raw CSV/stdout/stderr links remain available beneath it. Metrics
 with different units are deliberately not placed on one comparative bar chart.
-LIKWID's live `likwid-perfscope` plotting can be added later as a separate
-time-series artifact without changing the normalized summary contract.
+Automated headless perfscope timeline export can be added later without changing
+the normalized summary or plot-artifact contract.
 
 That keeps `v8` small and honest: the version split now includes the inference runner, local kernel registry/maps, multimodal bridge entrypoint, and the `v8`-named operator tooling surface used by the visualizer, hub, and regression entrypoints.

--- a/version/v8/scripts/likwid_profile_v8.py
+++ b/version/v8/scripts/likwid_profile_v8.py
@@ -177,6 +177,40 @@ def write_summary(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
+def register_plot_artifacts(
+    paths: Iterable[Path], artifact_dir: Path, summary: dict[str, Any]
+) -> None:
+    """Preserve user-exported LIKWID/perfscope plots beside counter evidence."""
+    supported = {".svg", ".png", ".jpg", ".jpeg", ".webp"}
+    for source in paths:
+        resolved = source.expanduser().resolve()
+        if not resolved.is_file():
+            raise ValueError(f"LIKWID plot artifact does not exist: {source}")
+        if resolved.suffix.lower() not in supported:
+            raise ValueError(
+                f"unsupported LIKWID plot format {resolved.suffix!r}; "
+                "use SVG, PNG, JPEG, or WebP"
+            )
+        destination = artifact_dir / f"plot_{resolved.name}"
+        if resolved != destination.resolve():
+            shutil.copy2(resolved, destination)
+        suffix = destination.suffix.lower()
+        media_type = {
+            ".svg": "image/svg+xml",
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".webp": "image/webp",
+        }[suffix]
+        summary["artifacts"].append(
+            {
+                "kind": "plot",
+                "path": str(destination),
+                "media_type": media_type,
+            }
+        )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", type=Path, required=True)
@@ -189,6 +223,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=max(1, int(os.environ.get("CK_NUM_THREADS", "1"))),
     )
     parser.add_argument("--summary-name", default="likwid_summary.json")
+    parser.add_argument(
+        "--plot-artifact",
+        type=Path,
+        action="append",
+        default=[],
+        help="preserve an exported LIKWID/perfscope SVG or raster plot (repeatable)",
+    )
     parser.add_argument("command", nargs=argparse.REMAINDER)
     return parser
 
@@ -228,6 +269,13 @@ def main(argv: list[str] | None = None) -> int:
             "Counter groups and metric names vary by processor and LIKWID version.",
         ],
     }
+    try:
+        register_plot_artifacts(args.plot_artifact, artifact_dir, summary)
+    except ValueError as exc:
+        summary.update(status="fail", reason=str(exc))
+        write_summary(summary_path, summary)
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
     if not executable:
         summary["reason"] = "likwid-perfctr is not installed"
         write_summary(summary_path, summary)

--- a/version/v8/tools/ir_visualizer.html
+++ b/version/v8/tools/ir_visualizer.html
@@ -12335,6 +12335,12 @@ function renderProfileHowTo() {
         `make profile-v8-likwid V8_MODEL="$REPORT_MODEL_DIR" V8_PERF_RUNTIME=cli V8_PREP_WITH_PYTHON=0 V8_LIKWID_GROUPS=auto V8_LIKWID_THREADS=1${makeChatArg}${makeCliArg}`,
         'python3 version/v8/tools/open_ir_visualizer_v8.py --generate --run "$REPORT_MODEL_DIR" --html-only --output "$REPORT_MODEL_DIR/ir_report.html"',
     ].join('\n');
+    const likwidPlotCmd = [
+        explicitModelDirCmd,
+        'LIKWID_PLOT=/absolute/path/to/exported-likwid-plot.svg',
+        `make profile-v8-likwid V8_MODEL="$REPORT_MODEL_DIR" V8_PERF_RUNTIME=cli V8_PREP_WITH_PYTHON=0 V8_LIKWID_GROUPS=auto V8_LIKWID_THREADS=1 V8_LIKWID_PLOT="$LIKWID_PLOT"${makeChatArg}${makeCliArg}`,
+        'python3 version/v8/tools/open_ir_visualizer_v8.py --generate --run "$REPORT_MODEL_DIR" --html-only --output "$REPORT_MODEL_DIR/ir_report.html"',
+    ].join('\n');
 
     const cachegrindNativeCmd = [
         explicitModelDirCmd,
@@ -12635,6 +12641,16 @@ function renderProfileHowTo() {
                                 'Verify counters and topology',
                                 likwidVerifyCmd,
                                 'Loads the MSR module, prints LIKWID access information, lists processor-supported groups, and shows the CPU topology used for pinning.'
+                            )}
+                            ${renderHowToBlock(
+                                'Run LIKWID and refresh this report',
+                                likwidCmd,
+                                'Profiles the current run with supported groups, pins the workload, writes likwid_summary.json and raw evidence, then regenerates this report.'
+                            )}
+                            ${renderHowToBlock(
+                                'Import an exported SVG or PNG plot',
+                                likwidPlotCmd,
+                                'Copies a gnuplot/perfscope export into the run and embeds it in the LIKWID Profile panel. SVG, PNG, JPEG, and WebP are supported.'
                             )}
                         </div>
                     </details>

--- a/version/v8/tools/ir_visualizer.html
+++ b/version/v8/tools/ir_visualizer.html
@@ -14623,6 +14623,7 @@ function renderProfileHowTo() {
                     : {};
                 const metricRows = [];
                 const metricCards = [];
+                const plotArtifacts = [];
                 Object.entries(normalized).forEach(([group, metrics]) => {
                     if (!metrics || typeof metrics !== 'object') return;
                     Object.entries(metrics).forEach(([name, rawValue]) => {
@@ -14656,6 +14657,13 @@ function renderProfileHowTo() {
                         const path = artifact.resolved_path || artifact.path;
                         if (!path) return;
                         links.push(`<a href="${escapeHtml(String(path))}" target="_blank" style="color:var(--blue);font-family:'JetBrains Mono',monospace;">LIKWID ${escapeHtml(String(artifact.kind || 'artifact'))}</a>`);
+                        if (artifact.image_data_uri) {
+                            plotArtifacts.push({
+                                label: String(artifact.label || artifact.kind || 'LIKWID plot'),
+                                source: String(artifact.image_data_uri),
+                                path: String(path),
+                            });
+                        }
                     });
                 }
                 likwidPanelHtml = `
@@ -14689,6 +14697,17 @@ function renderProfileHowTo() {
                                 ${likwidSummaryData?.reason ? `<tr><td>Reason</td><td>${escapeHtml(String(likwidSummaryData.reason))}</td></tr>` : ''}
                             </tbody>
                         </table>
+                        ${plotArtifacts.length ? `
+                        <div style="margin-top:0.8rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:0.7rem;">
+                            ${plotArtifacts.map((plot) => `
+                                <figure style="margin:0;padding:0.65rem;border:1px solid var(--grey);border-radius:10px;background:rgba(0,0,0,0.12);">
+                                    <img src="${escapeHtml(plot.source)}" alt="${escapeHtml(plot.label)}" style="display:block;width:100%;height:auto;max-height:520px;object-fit:contain;border-radius:6px;background:white;">
+                                    <figcaption style="margin-top:0.45rem;color:var(--text-muted);font-size:0.72rem;overflow-wrap:anywhere;">
+                                        ${escapeHtml(plot.label)} · <a href="${escapeHtml(plot.path)}" target="_blank" style="color:var(--blue);">open original</a>
+                                    </figcaption>
+                                </figure>
+                            `).join('')}
+                        </div>` : ''}
                         ${metricCards.length ? `
                         <div style="margin-top:0.7rem;">
                             <div style="margin-bottom:0.4rem;color:var(--text-secondary);font-size:0.78rem;font-weight:700;">Normalized metric cards</div>

--- a/version/v8/tools/ir_visualizer.html
+++ b/version/v8/tools/ir_visualizer.html
@@ -12182,6 +12182,9 @@ function renderProfileHowTo() {
     if (!cachegrindInstalled) {
         hostToolWarnings.push('valgrind/cg_annotate are missing, so cachegrind attribution will be skipped by the one-command flow.');
     }
+    if (!likwidInstalled) {
+        hostToolWarnings.push('LIKWID is optional and missing. Use the distro-aware install block to enable pinned cross-vendor counters.');
+    }
 
     const profileIssueHtml = profileDataIssue
         ? `<div style="margin-top:0.65rem;padding:0.55rem 0.7rem;border:1px solid #7a5f1a;border-radius:8px;background:rgba(243,156,18,0.10);color:#f6d48f;font-size:0.84rem;">${escapeHtml(profileDataIssue)}</div>`
@@ -12196,6 +12199,29 @@ function renderProfileHowTo() {
             '# Install perf, valgrind, and FlameGraph for this host, then retry.',
         ];
     const depsCmd = depsCmdLines.join('\n');
+
+    const likwidInstall = (profileToolStatus.likwid_install_hints && typeof profileToolStatus.likwid_install_hints === 'object')
+        ? profileToolStatus.likwid_install_hints
+        : {};
+    const likwidInstallCommands = (likwidInstall.commands && typeof likwidInstall.commands === 'object')
+        ? likwidInstall.commands
+        : {};
+    const likwidRecommendedKey = String(likwidInstall.recommended || 'ubuntu_source');
+    const likwidRecommendedCmd = Array.isArray(likwidInstallCommands[likwidRecommendedKey])
+        ? likwidInstallCommands[likwidRecommendedKey].join('\n')
+        : '';
+    const likwidPackageCmd = Array.isArray(likwidInstallCommands.ubuntu_package)
+        ? likwidInstallCommands.ubuntu_package.join('\n')
+        : '';
+    const likwidVerifyCmd = Array.isArray(likwidInstallCommands.verify)
+        ? likwidInstallCommands.verify.join('\n')
+        : 'likwid-perfctr -v\nlikwid-perfctr -a\nlikwid-topology -c';
+    const likwidDistroFamily = String(likwidInstall.distro_family || 'other');
+    const likwidDistroLabel = likwidDistroFamily === 'arch'
+        ? 'CachyOS / Arch AUR install'
+        : likwidDistroFamily === 'ubuntu'
+            ? 'Ubuntu source install (recommended)'
+            : 'Current LIKWID source install';
 
     const explicitModelDirCmd = [
         `REPORT_MODEL_DIR=${quoteShell(reportModelDir)}`,
@@ -12585,6 +12611,33 @@ function renderProfileHowTo() {
                                 )}
                             </div>
                         `}
+                    <details style="margin-top:0.7rem;" ${!likwidInstalled ? 'open' : ''}>
+                        <summary style="cursor:pointer;font-size:0.8rem;color:var(--text-secondary);font-weight:600;">Optional LIKWID setup (${escapeHtml(likwidDistroFamily)})</summary>
+                        <p class="profile-phase-desc" style="margin-top:0.65rem;">
+                            LIKWID adds CPU-pinned, cross-vendor hardware counters. It remains optional. For Xeon 6,
+                            Zen 5, and other recent CPUs, use LIKWID 5.5.x or newer and trust
+                            <code>likwid-perfctr -a</code> for the groups actually exposed by this machine.
+                        </p>
+                        <div class="profile-howto-grid">
+                            ${renderHowToBlock(
+                                likwidDistroLabel,
+                                likwidRecommendedCmd,
+                                likwidDistroFamily === 'arch'
+                                    ? 'Builds the current AUR package on CachyOS, Arch, EndeavourOS, or Manjaro.'
+                                    : 'Builds the current stable LIKWID release. This is preferred over older Ubuntu repository packages on recent processors.'
+                            )}
+                            ${likwidDistroFamily === 'ubuntu' && likwidPackageCmd ? renderHowToBlock(
+                                'Ubuntu package (quick, may be older)',
+                                likwidPackageCmd,
+                                'Fastest setup for older supported processors. Use the source install above when the package lacks your CPU or counter groups.'
+                            ) : ''}
+                            ${renderHowToBlock(
+                                'Verify counters and topology',
+                                likwidVerifyCmd,
+                                'Loads the MSR module, prints LIKWID access information, lists processor-supported groups, and shows the CPU topology used for pinning.'
+                            )}
+                        </div>
+                    </details>
                 </div>
             </details>
 
@@ -14558,9 +14611,10 @@ function renderProfileHowTo() {
 
             if (likwidSummaryData) {
                 const status = String(likwidSummaryData?.status || 'unknown');
-                const cpuIds = Array.isArray(likwidSummaryData?.cpu_ids)
-                    ? likwidSummaryData.cpu_ids.join(', ')
-                    : '-';
+                const cpuIdList = Array.isArray(likwidSummaryData?.cpu_ids)
+                    ? likwidSummaryData.cpu_ids
+                    : [];
+                const cpuIds = cpuIdList.length ? cpuIdList.join(', ') : '-';
                 const groups = Array.isArray(likwidSummaryData?.selected_groups)
                     ? likwidSummaryData.selected_groups
                     : [];
@@ -14568,19 +14622,34 @@ function renderProfileHowTo() {
                     ? likwidSummaryData.normalized
                     : {};
                 const metricRows = [];
+                const metricCards = [];
                 Object.entries(normalized).forEach(([group, metrics]) => {
                     if (!metrics || typeof metrics !== 'object') return;
                     Object.entries(metrics).forEach(([name, rawValue]) => {
                         const value = Number(rawValue);
+                        const displayValue = Number.isFinite(value) ? value.toFixed(3) : String(rawValue);
                         metricRows.push(`
                             <tr>
                                 <td>${escapeHtml(String(group))}</td>
                                 <td>${escapeHtml(String(name))}</td>
-                                <td>${Number.isFinite(value) ? value.toFixed(3) : escapeHtml(String(rawValue))}</td>
+                                <td>${escapeHtml(displayValue)}</td>
                             </tr>
+                        `);
+                        metricCards.push(`
+                            <div style="padding:0.65rem 0.7rem;border:1px solid rgba(69,143,255,0.3);border-radius:9px;background:rgba(69,143,255,0.07);min-width:0;">
+                                <div style="color:var(--text-muted);font-size:0.66rem;text-transform:uppercase;letter-spacing:0.05em;">${escapeHtml(String(group))}</div>
+                                <div style="margin-top:0.2rem;color:var(--text-secondary);font-size:0.72rem;overflow-wrap:anywhere;">${escapeHtml(String(name).replaceAll('_', ' '))}</div>
+                                <div style="margin-top:0.3rem;color:var(--text-primary);font-family:'JetBrains Mono',monospace;font-size:1rem;font-weight:700;">${escapeHtml(displayValue)}</div>
+                            </div>
                         `);
                     });
                 });
+                const cpuChips = cpuIdList.length
+                    ? cpuIdList.map((cpu) => `<span style="padding:0.12rem 0.38rem;border:1px solid rgba(36,179,113,0.42);border-radius:999px;color:#a7f4cc;font-family:'JetBrains Mono',monospace;font-size:0.68rem;">CPU ${escapeHtml(String(cpu))}</span>`).join('')
+                    : '<span style="color:var(--text-muted);">No CPU selection recorded</span>';
+                const groupChips = groups.length
+                    ? groups.map((group) => `<span style="padding:0.12rem 0.38rem;border:1px solid rgba(69,143,255,0.42);border-radius:999px;color:#a9caff;font-family:'JetBrains Mono',monospace;font-size:0.68rem;">${escapeHtml(String(group))}</span>`).join('')
+                    : '<span style="color:var(--text-muted);">No supported groups selected</span>';
                 if (Array.isArray(likwidSummaryData?.artifacts)) {
                     likwidSummaryData.artifacts.forEach((artifact) => {
                         if (!artifact || typeof artifact !== 'object') return;
@@ -14592,6 +14661,26 @@ function renderProfileHowTo() {
                 likwidPanelHtml = `
                     <div class="profile-artifact-panel" style="margin-top:0.8rem;">
                         <h3><span class="badge badge-blue">LIKWID</span> Pinned Cross-Vendor Counters</h3>
+                        <div aria-label="LIKWID evidence flow" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(145px,1fr));gap:0.55rem;margin:0.65rem 0 0.8rem;">
+                            <div style="padding:0.7rem;border:1px solid var(--grey);border-radius:9px;background:rgba(255,255,255,0.025);">
+                                <div style="color:var(--text-muted);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;">1 · Workload</div>
+                                <strong style="display:block;margin-top:0.25rem;">CKE v8 run</strong>
+                                <span style="color:var(--text-muted);font-size:0.72rem;">Repeated once per selected group</span>
+                            </div>
+                            <div style="padding:0.7rem;border:1px solid rgba(36,179,113,0.35);border-radius:9px;background:rgba(36,179,113,0.06);">
+                                <div style="color:var(--text-muted);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;">2 · Pinned CPUs</div>
+                                <div style="display:flex;gap:0.28rem;flex-wrap:wrap;margin-top:0.35rem;">${cpuChips}</div>
+                            </div>
+                            <div style="padding:0.7rem;border:1px solid rgba(69,143,255,0.35);border-radius:9px;background:rgba(69,143,255,0.06);">
+                                <div style="color:var(--text-muted);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;">3 · Detected groups</div>
+                                <div style="display:flex;gap:0.28rem;flex-wrap:wrap;margin-top:0.35rem;">${groupChips}</div>
+                            </div>
+                            <div style="padding:0.7rem;border:1px solid rgba(169,104,255,0.35);border-radius:9px;background:rgba(169,104,255,0.06);">
+                                <div style="color:var(--text-muted);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.06em;">4 · Evidence</div>
+                                <strong style="display:block;margin-top:0.25rem;">${metricCards.length} normalized metrics</strong>
+                                <span style="color:var(--text-muted);font-size:0.72rem;">JSON plus preserved CSV/stdout/stderr</span>
+                            </div>
+                        </div>
                         <table class="profile-hotspot-table">
                             <tbody>
                                 <tr><td>Status</td><td>${escapeHtml(status.toUpperCase())}</td></tr>
@@ -14600,13 +14689,21 @@ function renderProfileHowTo() {
                                 ${likwidSummaryData?.reason ? `<tr><td>Reason</td><td>${escapeHtml(String(likwidSummaryData.reason))}</td></tr>` : ''}
                             </tbody>
                         </table>
-                        ${metricRows.length ? `
+                        ${metricCards.length ? `
                         <div style="margin-top:0.7rem;">
+                            <div style="margin-bottom:0.4rem;color:var(--text-secondary);font-size:0.78rem;font-weight:700;">Normalized metric cards</div>
+                            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(155px,1fr));gap:0.5rem;">
+                                ${metricCards.slice(0, 16).join('')}
+                            </div>
+                        </div>` : ''}
+                        ${metricRows.length ? `
+                        <details style="margin-top:0.7rem;">
+                            <summary style="cursor:pointer;color:var(--text-secondary);font-size:0.78rem;font-weight:700;">Metric audit table (${metricRows.length})</summary>
                             <table class="profile-hotspot-table">
                                 <thead><tr><th>Group</th><th>Normalized Metric</th><th>Average</th></tr></thead>
                                 <tbody>${metricRows.join('')}</tbody>
                             </table>
-                        </div>` : ''}
+                        </details>` : ''}
                         <div style="margin-top:0.55rem;color:var(--text-muted);font-size:0.78rem;">
                             Wrapper mode counts activity on the selected CPUs. Keep the workload pinned and the neighboring CPUs quiet.
                         </div>

--- a/version/v8/tools/open_ir_hub_v8.py
+++ b/version/v8/tools/open_ir_hub_v8.py
@@ -281,6 +281,7 @@ def _artifact_search_bases(run_dir: Path) -> list[Path]:
     bases = [
         run_dir,
         run_dir / ".ck_build",
+        run_dir / ".ck_build_v8",
         run_dir / "multimodal_bridge",
         run_dir / "multimodal_bridge" / "decoder",
         run_dir / "multimodal_bridge" / "encoder",
@@ -298,6 +299,76 @@ def _artifact_search_bases(run_dir: Path) -> list[Path]:
 
 def _find_bridge_report_path(run_dir: Path) -> Path | None:
     return _find_run_artifact(run_dir, "multimodal_bridge/bridge_report.json")
+
+
+def _resolve_likwid_artifact(run_dir: Path, raw_path: Any) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    raw = Path(raw_path).expanduser()
+    candidates = [raw] if raw.is_absolute() else []
+    for base in _artifact_search_bases(run_dir):
+        candidates.extend([base / raw, base / "likwid" / raw.name])
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+    return None
+
+
+def _extract_likwid_summary(run_dir: Path) -> dict[str, Any]:
+    summary_path = _find_run_artifact(run_dir, "likwid_summary.json")
+    if summary_path is None:
+        return {}
+    payload = _safe_read_json(summary_path)
+    if not isinstance(payload, dict):
+        return {
+            "status": "fail",
+            "reason": "likwid_summary.json is not valid JSON",
+            "summary_path": str(summary_path),
+            "summary_uri": summary_path.resolve().as_uri(),
+        }
+
+    metrics: list[dict[str, Any]] = []
+    normalized = payload.get("normalized")
+    if isinstance(normalized, dict):
+        for group, group_metrics in normalized.items():
+            if not isinstance(group_metrics, dict):
+                continue
+            for name, value in group_metrics.items():
+                if not isinstance(value, (int, float)):
+                    continue
+                metrics.append({"group": str(group), "name": str(name), "value": float(value)})
+
+    artifacts: list[dict[str, str]] = []
+    raw_artifacts = payload.get("artifacts")
+    if isinstance(raw_artifacts, list):
+        for item in raw_artifacts:
+            if not isinstance(item, dict):
+                continue
+            resolved = _resolve_likwid_artifact(run_dir, item.get("path"))
+            if resolved is None:
+                continue
+            artifacts.append(
+                {
+                    "kind": str(item.get("kind") or "artifact"),
+                    "path": str(resolved),
+                    "uri": resolved.as_uri(),
+                }
+            )
+
+    return {
+        "status": str(payload.get("status") or "unknown").lower(),
+        "reason": str(payload.get("reason") or ""),
+        "selected_groups": [str(value) for value in payload.get("selected_groups", [])]
+        if isinstance(payload.get("selected_groups"), list)
+        else [],
+        "cpu_ids": [int(value) for value in payload.get("cpu_ids", []) if isinstance(value, int)]
+        if isinstance(payload.get("cpu_ids"), list)
+        else [],
+        "metrics": metrics[:8],
+        "summary_path": str(summary_path),
+        "summary_uri": summary_path.resolve().as_uri(),
+        "artifacts": artifacts,
+    }
 
 
 def _extract_bridge_summary(path: Path | None) -> dict[str, Any]:
@@ -968,6 +1039,7 @@ class RunRecord:
     artifact_index_path: Path | None
     bridge_report_path: Path | None
     bridge_summary: dict[str, Any]
+    likwid_summary: dict[str, Any]
     dataset_workspace: str | None
     dataset_type: str | None
     dataset_stage_mode: str | None
@@ -1048,6 +1120,7 @@ class RunRecord:
             "bridge_report_path": str(self.bridge_report_path) if self.bridge_report_path else None,
             "bridge_report_uri": self.bridge_report_path.resolve().as_uri() if self.bridge_report_path else None,
             "bridge_summary": self.bridge_summary,
+            "likwid_summary": self.likwid_summary,
             "dataset_workspace": self.dataset_workspace,
             "dataset_type": self.dataset_type,
             "dataset_stage_mode": self.dataset_stage_mode,
@@ -1286,6 +1359,7 @@ def _build_run_coverage(
                     ("cachegrind", _has_run_artifact(run_dir, "cachegrind_summary.json")),
                     ("vtune", _has_run_artifact(run_dir, "vtune_summary.json")),
                     ("advisor", _has_run_artifact(run_dir, "advisor_summary.json")),
+                    ("likwid", _has_run_artifact(run_dir, "likwid_summary.json")),
                 ],
                 core=False,
             ),
@@ -1339,7 +1413,7 @@ def discover_run_dirs(models_root: Path) -> list[Path]:
             continue
         p = current
         # If marker sits in .ck_build, map to parent run dir.
-        if p.name == ".ck_build":
+        if p.name in {".ck_build", ".ck_build_v8"}:
             p = p.parent
         if p.name in {"encoder", "decoder"} and p.parent.name == "multimodal_bridge":
             p = p.parent.parent
@@ -1357,6 +1431,7 @@ def collect_run_record(run_dir: Path, models_root: Path) -> RunRecord:
     report = _find_report_path(run_dir)
     bridge_report_path = _find_bridge_report_path(run_dir)
     bridge_summary = _extract_bridge_summary(bridge_report_path)
+    likwid_summary = _extract_likwid_summary(run_dir)
     dataset_viewer = _find_dataset_viewer_path(run_dir)
     embeddings = _find_embeddings_path(run_dir)
     attention = _find_attention_path(run_dir)
@@ -1386,7 +1461,8 @@ def collect_run_record(run_dir: Path, models_root: Path) -> RunRecord:
     latest_ckpt_step, latest_ckpt_bump, latest_ckpt_manifest, ckpt_count = _latest_checkpoint(run_dir)
 
     mtimes = []
-    for p in (report, bridge_report_path, wm, parity, loss, post_eval, run_index):
+    likwid_summary_path = _find_run_artifact(run_dir, "likwid_summary.json")
+    for p in (report, bridge_report_path, likwid_summary_path, wm, parity, loss, post_eval, run_index):
         m = _file_mtime(p)
         if m is not None:
             mtimes.append(m)
@@ -1454,6 +1530,7 @@ def collect_run_record(run_dir: Path, models_root: Path) -> RunRecord:
         artifact_index_path=artifact_index_path,
         bridge_report_path=bridge_report_path,
         bridge_summary=bridge_summary,
+        likwid_summary=likwid_summary,
         dataset_workspace=dataset_workspace,
         dataset_type=dataset_type,
         dataset_stage_mode=dataset_stage_mode,
@@ -1516,6 +1593,7 @@ def build_index(models_root: Path) -> dict[str, Any]:
     weight_health_count = sum(1 for r in payload_runs if r.get("weight_health_path"))
     bridge_report_count = sum(1 for r in payload_runs if r.get("bridge_report_path"))
     probe_report_html_count = sum(1 for r in payload_runs if r.get("probe_report_html_path"))
+    likwid_count = sum(1 for r in payload_runs if (r.get("likwid_summary") or {}).get("status"))
     pass_count = sum(1 for r in payload_runs if (r.get("parity_regimen") or {}).get("status") in ("PASS", "PASS_REUSED"))
 
     global_viewer = REPO_ROOT / "dataset_viewer.html"
@@ -1536,6 +1614,7 @@ def build_index(models_root: Path) -> dict[str, Any]:
             "runs_with_weight_health": weight_health_count,
             "runs_with_bridge_report": bridge_report_count,
             "runs_with_probe_report_html": probe_report_html_count,
+            "runs_with_likwid": likwid_count,
             "runs_parity_pass": pass_count,
         },
         "runs": payload_runs,
@@ -3448,6 +3527,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
         scope.objective,
         run.agentBriefExcerpt,
         run.trainingBriefExcerpt,
+        (run.likwidSummary?.selected_groups || []).join(' '),
       ]
         .filter(Boolean)
         .join(' ')
@@ -3458,6 +3538,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
       const dims = run.dims || {};
       const parity = run.parity_regimen || {};
       const bridgeSummary = (run.bridge_summary && typeof run.bridge_summary === 'object') ? run.bridge_summary : {};
+      const likwidSummary = (run.likwid_summary && typeof run.likwid_summary === 'object') ? run.likwid_summary : {};
       const parityStatus = String(parity.status || 'MISSING').toUpperCase();
       const normalized = {
         ...run,
@@ -3481,6 +3562,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
         regressionFastCmd: run.regression_fast_cmd || '',
         bridgeReportReady: Boolean(run.bridge_report_path),
         bridgeSummary,
+        likwidSummary,
         bridgeMode: bridgeSummary.bridge_mode || 'decoder_only',
         datasetViewerReady: Boolean(run.dataset_viewer_path),
         galleryReady: Boolean(run.gallery_path),
@@ -4316,6 +4398,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
       const weightHealthCount = summary.runs_with_weight_health || runs.filter((run) => run.weight_health_path).length;
       const bridgeReportCount = summary.runs_with_bridge_report || runs.filter((run) => run.bridgeReportReady).length;
       const probeReportCount = runs.filter((run) => run.probeReportHtmlReady).length;
+      const likwidCount = summary.runs_with_likwid || runs.filter((run) => run.likwidSummary && run.likwidSummary.status).length;
       const parityPass = summary.runs_parity_pass || runs.filter((run) => run.parityStatus === 'PASS' || run.parityStatus === 'PASS_REUSED').length;
       const trainCount = summary.runs_train || runs.filter((run) => run.kind === 'train').length;
       const inferCount = runs.filter((run) => run.kind === 'inference').length;
@@ -4347,6 +4430,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
         { label: '🔭 Attention', value: fmtInt(attentionCount), note: 'Runs with exported attention.json.' },
         { label: '🩺 Weight Health', value: fmtInt(weightHealthCount), note: 'Runs with weight_health_latest.json probe results.' },
         { label: '🔬 DSL Probes', value: fmtInt(probeReportCount), note: 'Runs with probe_report.html DSL output viewers.' },
+        { label: '📈 LIKWID Profiles', value: fmtInt(likwidCount), note: 'Runs with pinned cross-vendor counter artifacts.' },
         { label: 'Parity Pass', value: fmtInt(parityPass), note: 'PASS plus PASS_REUSED regimen states.' },
         { label: 'Best Loss / Checkpoints', value: `${fmtLoss(bestLoss)} / ${fmtInt(totalCheckpoints)}`, note: 'Lowest loss and total checkpoint volume.' },
       ];
@@ -4372,6 +4456,49 @@ def render_html(index_payload: dict[str, Any]) -> str:
             const state = section.present === section.total ? 'pass' : (section.present > 0 ? 'skip' : 'missing');
             return `<span class="badge ${state}">${escapeHtml(section.title)} ${escapeHtml(String(section.present))}/${escapeHtml(String(section.total))}</span>`;
           }).join('')}
+        </div>
+      `;
+    }
+
+    function likwidTone(status) {
+      if (status === 'pass') return 'pass';
+      if (status === 'fail') return 'fail';
+      if (status === 'skip') return 'skip';
+      return 'missing';
+    }
+
+    function renderLikwidSummary(run) {
+      const summary = run.likwidSummary || {};
+      const status = String(summary.status || '').toLowerCase();
+      if (!status) return '';
+      const groups = Array.isArray(summary.selected_groups) ? summary.selected_groups : [];
+      const cpus = Array.isArray(summary.cpu_ids) ? summary.cpu_ids : [];
+      const metrics = Array.isArray(summary.metrics) ? summary.metrics.slice(0, 6) : [];
+      const artifacts = Array.isArray(summary.artifacts) ? summary.artifacts.slice(0, 5) : [];
+      const metricHtml = metrics.map((metric) => {
+        const value = Number(metric.value);
+        const rendered = Number.isFinite(value)
+          ? (Math.abs(value) >= 100 ? value.toFixed(1) : value.toFixed(3))
+          : String(metric.value || '-');
+        const label = String(metric.name || 'metric').replaceAll('_', ' ');
+        return `<span class="tag"><strong>${escapeHtml(String(metric.group || '-'))}</strong> ${escapeHtml(label)}: ${escapeHtml(rendered)}</span>`;
+      }).join('');
+      const links = [
+        summary.summary_uri ? `<a class="btn" target="_blank" rel="noopener" href="${escapeHtml(summary.summary_uri)}">LIKWID JSON</a>` : '',
+        ...artifacts.map((artifact) => artifact.uri
+          ? `<a class="btn" target="_blank" rel="noopener" href="${escapeHtml(artifact.uri)}">${escapeHtml(String(artifact.kind || 'raw'))}</a>`
+          : ''),
+      ].filter(Boolean).join('');
+      return `
+        <div class="health-note" style="margin-top:10px;padding:10px;border:1px solid var(--line);border-radius:12px;background:rgba(7,173,248,0.05);">
+          <div class="run-badges" style="margin-bottom:7px;">
+            <span class="badge ${likwidTone(status)}">LIKWID ${escapeHtml(status.toUpperCase())}</span>
+            ${groups.length ? `<span class="badge">groups ${escapeHtml(groups.join(', '))}</span>` : ''}
+            ${cpus.length ? `<span class="badge mono">CPUs ${escapeHtml(cpus.join(', '))}</span>` : ''}
+          </div>
+          ${summary.reason ? `<div style="margin-bottom:7px;">${escapeHtml(String(summary.reason))}</div>` : ''}
+          ${metricHtml ? `<div class="spotlight-tags" style="margin-bottom:7px;">${metricHtml}</div>` : ''}
+          ${links ? `<div class="run-actions">${links}</div>` : ''}
         </div>
       `;
     }
@@ -4458,6 +4585,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
             ${run.reportReady ? '<span class="badge report">report ready</span>' : ''}
             ${run.bridgeReportReady ? `<span class="badge pass">${escapeHtml(run.bridgeMode === 'encoder_decoder' ? 'vision bridge' : 'bridge')}</span>` : ''}
             ${run.datasetViewerReady ? '<span class="badge report">dataset viewer</span>' : ''}
+            ${run.likwidSummary?.status ? `<span class="badge ${likwidTone(run.likwidSummary.status)}">LIKWID ${escapeHtml(String(run.likwidSummary.status).toUpperCase())}</span>` : ''}
           </div>
         </div>
         <div class="spotlight-body">
@@ -4496,6 +4624,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
               </div>
               ${renderSectionSummary(run, true)}
               <div class="health-note">Core dashboard coverage. Advanced correctness and deep profiling are tracked separately below.</div>
+              ${renderLikwidSummary(run)}
               ${renderDatasetPrepChecklist(run)}
               ${renderCommandsPanel(run)}
               <details class="detail-toggle">
@@ -4741,6 +4870,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
                   ${run.bridgeReportReady ? `<span class="badge pass">${escapeHtml(run.bridgeMode === 'encoder_decoder' ? 'vl' : 'bridge')}</span>` : ''}
                   ${run.probeReportHtmlReady ? '<span class="badge pass">probe</span>' : (run.probeReportCmd ? '<span class="badge warn">probe pending</span>' : '')}
                   ${run.datasetViewerReady ? '<span class="badge report">dataset</span>' : ''}
+                  ${run.likwidSummary?.status ? `<span class="badge ${likwidTone(run.likwidSummary.status)}">LIKWID ${escapeHtml(String(run.likwidSummary.status).toUpperCase())}</span>` : ''}
                   ${(() => {
                     const tg = run.tokenizerGate || {};
                     if (tg.verdict === 'FAIL') return '<span class="badge fail" title="Tokenizer has degenerate content-embedded tokens">tok ❌</span>';
@@ -4757,6 +4887,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
                 <div class="health-bar"><span style="width:${Math.max(0, Math.min(100, run.healthScore))}%"></span></div>
                 ${renderSectionSummary(run, true)}
                 <div class="health-note">Measures core dashboard completeness, not model quality.</div>
+                ${renderLikwidSummary(run)}
               </div>
 
               <div class="run-stats">
@@ -4858,6 +4989,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
                         ${showParityBadge(run) ? `<span class="badge ${tone}">${escapeHtml(run.parityStatus)}</span>` : ''}
                         ${run.reportReady ? '<span class="badge report">report</span>' : ''}
                         ${run.datasetViewerReady ? '<span class="badge report">dataset</span>' : ''}
+                        ${run.likwidSummary?.status ? `<span class="badge ${likwidTone(run.likwidSummary.status)}">LIKWID ${escapeHtml(String(run.likwidSummary.status).toUpperCase())}</span>` : ''}
                       </div>
                       <div class="table-secondary tight">${escapeHtml(run.healthReason || 'coverage unavailable')}</div>
                     </td>
@@ -4882,6 +5014,7 @@ def render_html(index_payload: dict[str, Any]) -> str:
                       <div class="table-actions">
                         ${run.report_uri ? `<a class="btn primary" target="_blank" rel="noopener" href="${escapeHtml(run.report_uri)}">Report</a>` : ''}
                         ${run.dataset_viewer_uri ? `<a class="btn dataset" target="_blank" rel="noopener" href="${escapeHtml(run.dataset_viewer_uri)}">Dataset</a>` : ''}
+                        ${run.likwidSummary?.summary_uri ? `<a class="btn" target="_blank" rel="noopener" href="${escapeHtml(run.likwidSummary.summary_uri)}">LIKWID</a>` : ''}
                         ${embViewerLink(run, '🧬')}
                         ${attnViewerLink(run, '🔭')}
                         ${run.gallery_uri ? `<a class="btn" target="_blank" rel="noopener" href="${escapeHtml(run.gallery_uri)}">Gallery</a>` : ''}

--- a/version/v8/tools/open_ir_visualizer_v8.py
+++ b/version/v8/tools/open_ir_visualizer_v8.py
@@ -149,7 +149,7 @@ def _likwid_install_hints() -> dict[str, object]:
         ],
         "ubuntu_source": [
             "sudo apt-get update",
-            "sudo apt-get install -y build-essential git perl",
+            "sudo apt-get install -y build-essential git perl gnuplot-nox",
             "git clone --depth 1 --branch v5.5.1 https://github.com/RRZE-HPC/likwid.git",
             "cd likwid",
             'make -j"$(nproc)"',
@@ -157,7 +157,7 @@ def _likwid_install_hints() -> dict[str, object]:
             "sudo ldconfig",
         ],
         "arch_aur": [
-            "sudo pacman -S --needed base-devel git perl",
+            "sudo pacman -S --needed base-devel git perl gnuplot",
             "git clone https://aur.archlinux.org/likwid.git",
             "cd likwid",
             "makepkg -si",
@@ -794,6 +794,7 @@ def _encode_image_data_uri(path: Path) -> str | None:
         ".jpeg": "image/jpeg",
         ".webp": "image/webp",
         ".gif": "image/gif",
+        ".svg": "image/svg+xml",
     }.get(suffix)
     if mime is None:
         return None
@@ -4585,6 +4586,9 @@ def load_model_data(
                     resolved = _resolve_asset_path(raw, ck_build_path, model_root)
                     if resolved:
                         item2["resolved_path"] = str(resolved)
+                        image_data_uri = _encode_image_data_uri(resolved)
+                        if image_data_uri:
+                            item2["image_data_uri"] = image_data_uri
                 enriched.append(item2)
             likwid["artifacts"] = enriched
         runs = likwid.get("runs")

--- a/version/v8/tools/open_ir_visualizer_v8.py
+++ b/version/v8/tools/open_ir_visualizer_v8.py
@@ -126,6 +126,65 @@ def _profile_install_hints() -> list[str]:
     ]
 
 
+def _likwid_install_hints() -> dict[str, object]:
+    """Return copyable LIKWID install paths without making it mandatory."""
+    os_release = _read_os_release() if sys.platform.startswith("linux") else {}
+    distro_id = (os_release.get("ID") or "").lower()
+    distro_like = (os_release.get("ID_LIKE") or "").lower()
+    family = "other"
+    if distro_id in {"ubuntu", "debian", "linuxmint", "pop"} or any(
+        value in distro_like for value in ("debian", "ubuntu")
+    ):
+        family = "ubuntu"
+    elif (
+        distro_id in {"arch", "manjaro", "endeavouros", "cachyos"}
+        or "arch" in distro_like
+    ):
+        family = "arch"
+
+    commands: dict[str, list[str]] = {
+        "ubuntu_package": [
+            "sudo apt-get update",
+            "sudo apt-get install -y likwid",
+        ],
+        "ubuntu_source": [
+            "sudo apt-get update",
+            "sudo apt-get install -y build-essential git perl",
+            "git clone --depth 1 --branch v5.5.1 https://github.com/RRZE-HPC/likwid.git",
+            "cd likwid",
+            'make -j"$(nproc)"',
+            "sudo make install",
+            "sudo ldconfig",
+        ],
+        "arch_aur": [
+            "sudo pacman -S --needed base-devel git perl",
+            "git clone https://aur.archlinux.org/likwid.git",
+            "cd likwid",
+            "makepkg -si",
+        ],
+        "verify": [
+            "likwid-perfctr -v",
+            "sudo modprobe msr",
+            "likwid-perfctr -i",
+            "likwid-perfctr -a",
+            "likwid-topology -c",
+        ],
+    }
+    return {
+        "distro_family": family,
+        "recommended": (
+            "arch_aur" if family == "arch" else "ubuntu_source"
+        ),
+        "commands": commands,
+        "minimum_modern_version": "5.5.0",
+        "stable_source_version": "5.5.1",
+        "note": (
+            "Ubuntu repository packages can be older than current LIKWID. "
+            "Use the source path for Xeon 6, Zen 5, or other recent processors."
+        ),
+    }
+
+
 def _format_mem_gib(kb: int | None) -> str | None:
     if not isinstance(kb, int) or kb <= 0:
         return None
@@ -289,6 +348,7 @@ def collect_profile_tool_status() -> dict[str, object]:
     return {
         "host_platform": sys.platform,
         "install_hints": _profile_install_hints(),
+        "likwid_install_hints": _likwid_install_hints(),
         "perf": shutil.which("perf") is not None,
         "valgrind": shutil.which("valgrind") is not None,
         "cg_annotate": shutil.which("cg_annotate") is not None,


### PR DESCRIPTION
## Why

PR #185 made LIKWID results available to each generated v8 IR report, but the Hub did not expose them directly, operators lacked distro-aware setup guidance, and exported perfscope/gnuplot images were not portable report artifacts.

## What changed

- Index `likwid_summary.json` from run roots, `.ck_build`, and `.ck_build_v8`.
- Add LIKWID to deep-profiling coverage and the Hub-wide profile count.
- Show pass/skip/fail, selected groups, pinned CPUs, skip/failure reason, and up to six normalized metrics on spotlight and run cards.
- Add direct links to the normalized JSON and preserved raw LIKWID artifacts.
- Add LIKWID badges and links to table view.
- Include selected LIKWID groups in Hub search text.
- Add Ubuntu source/package and CachyOS/Arch AUR installation and verification blocks to the generated Profile page and v8 README.
- Visualize the evidence path from workload to pinned CPUs to dynamically detected groups to normalized metrics, with independent metric cards and an audit table.
- Accept `V8_LIKWID_PLOT` / repeatable `--plot-artifact`, preserve exported SVG/PNG/JPEG/WebP files, and embed them into the standalone IR report.

## Evidence

- A Hub fixture indexed `MEM`, pinned CPUs `4,8`, and normalized memory bandwidth `12345 MB/s` from `.ck_build_v8`.
- The fixture exposed working `file://` links for `likwid_summary.json` and raw `MEM` CSV.
- A separate skip fixture retained `counter access denied` without inventing metrics.
- Rendered Hub JavaScript passed `node --check`.
- Ubuntu selects the LIKWID 5.5.1 source path and warns that repository packages may be older; CachyOS selects the current AUR path.
- An exported SVG fixture was copied into the run, recorded as `image/svg+xml`, converted to a self-contained data URI, and exposed to the Profile renderer.

## Validation

- `python3 -m unittest tests.test_v8_ir_hub_likwid tests.test_likwid_profile_v8 tests.test_profile_install_hints -v` — 13 tests passed.
- `python3 version/v8/scripts/test_visualizer_js_units_v8.py` — 109 JavaScript unit tests passed.
- `python3 version/v8/scripts/test_visualizer_health_v8.py` — 180 checks passed with 10 pre-existing dynamic-DOM warnings.
- Python byte-compilation, `make -n profile-v8-likwid V8_LIKWID_PLOT=/tmp/likwid.svg`, and `git diff --check` passed.
- Commit and PR metadata validation passed.

## Regression coverage

`tests/test_v8_ir_hub_likwid.py` covers Hub indexing from `.ck_build_v8`, aggregate counts, deep-profile coverage, status and reason preservation, normalized metrics, JSON/raw links, and rendered JavaScript syntax.

`tests/test_likwid_profile_v8.py` also covers plot preservation, SVG embedding, dynamic groups, pinned wrapper execution, CSV normalization, skip behavior, and report artifact resolution. `tests/test_profile_install_hints.py` covers Ubuntu and CachyOS selection.

## Documentation

Updated `version/v8/README.md` with Hub behavior, Ubuntu and CachyOS/Arch installation, gnuplot dependencies, processor-aware group discovery, exported plot import, and wrapper-mode limitations.

## Content handoff

- Audience: CKE contributors comparing CPU profiling evidence across v8 runs.
- Angle: LIKWID evidence is installable, understandable, and portable from an individual report through the fleet-level Hub.
- Claims: The report and Hub expose status, CPU placement, selected groups, normalized metrics, raw evidence, and optional exported plots.
- Caveats: Tests use deterministic fixtures; physical counters vary by CPU and access mode; perfscope is live by default, so an SVG/raster must be exported before CKE imports it; automated headless timeline export is future work.
- Sources: Commits `880790f5`, `532fa792`, and `a6cd62f9`; `version/v8/tools/open_ir_hub_v8.py`; `version/v8/tools/ir_visualizer.html`; `version/v8/scripts/likwid_profile_v8.py`; focused tests; v8 README; and merged foundation PR #185.
