### PR TITLE
fix(v8): close grouped Q8 and split-KV parity gaps

### DIFF
--- a/src/kernels/attention_kernels.c
+++ b/src/kernels/attention_kernels.c
@@ -5076,17 +5076,6 @@ static inline float ck_attention_f16_reduce_expf(float value)
 #endif
 }
 
-static CK_NOINLINE CK_OPTNONE float ck_attention_f16_reduce_sum(
-    float old_sum,
-    float old_scale,
-    float chunk_sum,
-    float chunk_scale)
-{
-    volatile float old_term = old_sum * old_scale;
-    volatile float chunk_term = chunk_sum * chunk_scale;
-    return old_term + chunk_term;
-}
-
 static inline float ck_attention_dot_f16_llama(const uint16_t *x,
                                                 const uint16_t *y,
                                                 int n)
@@ -5379,11 +5368,8 @@ void attention_forward_decode_head_major_gqa_flash_f16cache_split(const float *q
     const size_t resolved_count = (size_t) num_heads * (size_t) split_chunks * (size_t) partial_stride;
     float *partials = (float *) alloca(resolved_count * sizeof(float));
     /*
-     * llama.cpp keeps decode graphs reusable by padding the KV scheduling
-     * extent to at least 256 rows. Masked rows do not contribute values, but
-     * the padded extent still determines worker chunk boundaries and therefore
-     * the FP16 partial-reduction order. Keep valid storage separate from that
-     * scheduling contract: this kernel never reads rows >= kv_tokens.
+     * llama.cpp reuses a padded decode graph. Masked rows do not contribute,
+     * but the physical K tensor extent still determines worker boundaries.
      */
     const int partition_alignment = 256;
     const int partition_tokens = kv_tokens >= 512
@@ -5442,8 +5428,10 @@ void attention_forward_decode_head_major_gqa_flash_f16cache_split(const float *q
                 const float chunk_term = partial[2 + d] * chunk_scale;
                 out_head[d] = fmaf(out_head[d], old_scale, chunk_term);
             }
-            final_sum = ck_attention_f16_reduce_sum(
-                final_sum, old_scale, chunk_sum, chunk_scale);
+            /* llama.cpp's production build contracts the old partial into the
+             * new chunk contribution. Keep this explicit: one FP32 ULP in the
+             * denominator crosses downstream Q8 quantization boundaries. */
+            final_sum = fmaf(final_sum, old_scale, chunk_sum * chunk_scale);
             final_max = new_max;
         }
 

--- a/src/kernels/gemm_kernels_q4k_q8k.c
+++ b/src/kernels/gemm_kernels_q4k_q8k.c
@@ -53,6 +53,11 @@ static inline int ck_nearest_int(float fval) {
     return (i & 0x007fffff) - 0x00400000;
 }
 
+#if defined(__clang__)
+#pragma clang fp contract(off)
+#elif defined(__GNUC__)
+__attribute__((optimize("fp-contract=off")))
+#endif
 void quantize_row_q8_k_ref(const float *x, void *vy, int k) {
     if (!x || !vy || k <= 0) {
         return;
@@ -81,9 +86,8 @@ void quantize_row_q8_k_ref(const float *x, void *vy, int k) {
 
         const float iscale = -127.0f / max;
         for (int j = 0; j < QK_K; ++j) {
-            /* Keep the active llama.cpp oracle expression intact. In
-             * particular, do not insert a store/load rounding barrier between
-             * the multiply and nearest_int: that changes tie cases on AVX2. */
+            /* llama.cpp rounds the multiply before adding nearest_int's magic
+             * constant. Contracting both operations changes Q8_K tie cases. */
             float scaled = iscale * x[j];
             int v = ck_nearest_int(scaled);
             if (v > 127) {
@@ -142,121 +146,16 @@ void quantize_batch_q8_k_4row_nearest_even(const float *x, void *vy,
 
     block_q8_K *y = (block_q8_K *)vy;
     const int blocks_per_row = k / QK_K;
-    int row0 = 0;
 
-#if defined(__AVX2__)
-    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
-    for (; row0 + 3 < num_rows; row0 += 4) {
-        for (int block = 0; block < blocks_per_row; ++block) {
-            for (int lane = 0; lane < 4; ++lane) {
-                const float *src =
-                        x + (size_t)(row0 + lane) * (size_t)k +
-                        (size_t)block * QK_K;
-                block_q8_K *dst =
-                        y + (size_t)(row0 + lane) * (size_t)blocks_per_row +
-                        (size_t)block;
-                __m256 source[QK_K / 8];
-                __m256 values0 = _mm256_loadu_ps(src);
-                __m256 values1 = _mm256_loadu_ps(src + 8);
-                __m256 values2 = _mm256_loadu_ps(src + 16);
-                __m256 values3 = _mm256_loadu_ps(src + 24);
-                __m256 max_abs = _mm256_max_ps(
-                        _mm256_andnot_ps(sign_bit, values0),
-                        _mm256_andnot_ps(sign_bit, values1));
-                max_abs = _mm256_max_ps(
-                        max_abs, _mm256_andnot_ps(sign_bit, values2));
-                max_abs = _mm256_max_ps(
-                        max_abs, _mm256_andnot_ps(sign_bit, values3));
-                __m256 signed_max_mask = _mm256_or_ps(
-                        _mm256_or_ps(
-                                _mm256_cmp_ps(max_abs, values0, _CMP_EQ_OQ),
-                                _mm256_cmp_ps(max_abs, values1, _CMP_EQ_OQ)),
-                        _mm256_or_ps(
-                                _mm256_cmp_ps(max_abs, values2, _CMP_EQ_OQ),
-                                _mm256_cmp_ps(max_abs, values3, _CMP_EQ_OQ)));
-                source[0] = values0;
-                source[1] = values1;
-                source[2] = values2;
-                source[3] = values3;
-
-                for (int subblock = 1; subblock < QK_K / 32; ++subblock) {
-                    const int vector = subblock * 4;
-                    values0 = _mm256_loadu_ps(src + subblock * 32);
-                    values1 = _mm256_loadu_ps(src + subblock * 32 + 8);
-                    values2 = _mm256_loadu_ps(src + subblock * 32 + 16);
-                    values3 = _mm256_loadu_ps(src + subblock * 32 + 24);
-                    const __m256 previous_max = max_abs;
-                    max_abs = _mm256_max_ps(
-                            max_abs, _mm256_andnot_ps(sign_bit, values0));
-                    max_abs = _mm256_max_ps(
-                            max_abs, _mm256_andnot_ps(sign_bit, values1));
-                    max_abs = _mm256_max_ps(
-                            max_abs, _mm256_andnot_ps(sign_bit, values2));
-                    max_abs = _mm256_max_ps(
-                            max_abs, _mm256_andnot_ps(sign_bit, values3));
-                    signed_max_mask = _mm256_and_ps(
-                            signed_max_mask,
-                            _mm256_cmp_ps(previous_max, max_abs, _CMP_EQ_OQ));
-                    const __m256 current_mask = _mm256_or_ps(
-                            _mm256_or_ps(
-                                    _mm256_cmp_ps(max_abs, values0, _CMP_EQ_OQ),
-                                    _mm256_cmp_ps(max_abs, values1, _CMP_EQ_OQ)),
-                            _mm256_or_ps(
-                                    _mm256_cmp_ps(max_abs, values2, _CMP_EQ_OQ),
-                                    _mm256_cmp_ps(max_abs, values3, _CMP_EQ_OQ)));
-                    signed_max_mask =
-                            _mm256_or_ps(signed_max_mask, current_mask);
-                    source[vector] = values0;
-                    source[vector + 1] = values1;
-                    source[vector + 2] = values2;
-                    source[vector + 3] = values3;
-                }
-
-                __m128 max4 = _mm_max_ps(
-                        _mm256_extractf128_ps(max_abs, 1),
-                        _mm256_castps256_ps128(max_abs));
-                max4 = _mm_max_ps(max4, _mm_movehl_ps(max4, max4));
-                max4 = _mm_max_ss(max4, _mm_movehdup_ps(max4));
-                const float max_scalar = _mm_cvtss_f32(max4);
-                const __m256 winning_lane = _mm256_cmp_ps(
-                        _mm256_set1_ps(max_scalar), max_abs, _CMP_EQ_OQ);
-                const int signed_winner = _mm256_movemask_ps(
-                        _mm256_and_ps(signed_max_mask, winning_lane));
-                volatile float inverse_max =
-                        max_scalar == 0.0f ? 0.0f : 1.0f / max_scalar;
-                volatile float iscale =
-                        inverse_max * (signed_winner ? -127.0f : 127.0f);
-                const __m256 iscale_vec = _mm256_set1_ps(iscale);
-
-                for (int vector = 0; vector < QK_K / 8; ++vector) {
-                    const __m256 rounded = _mm256_round_ps(
-                            _mm256_mul_ps(source[vector], iscale_vec),
-                            _MM_ROUND_NEAREST);
-                    const __m256i integers = _mm256_cvtps_epi32(rounded);
-                    int32_t values[8];
-                    _mm256_storeu_si256((__m256i *)values, integers);
-                    for (int i = 0; i < 8; ++i) {
-                        dst->qs[vector * 8 + i] = (int8_t)values[i];
-                    }
-                }
-
-                for (int group = 0; group < QK_K / 16; ++group) {
-                    int sum = 0;
-                    for (int i = 0; i < 16; ++i) {
-                        sum += dst->qs[group * 16 + i];
-                    }
-                    dst->bsums[group] = (int16_t)sum;
-                }
-                dst->d = max_scalar == 0.0f ? 0.0f : 1.0f / iscale;
-            }
-        }
-    }
-#endif
-
-    for (; row0 < num_rows; ++row0) {
+    /* Q8_K bytes are a numerical ABI. The previous four-row AVX2 path used
+     * a different max/scale evaluation order and changed real Qwen3-VL
+     * visual-prefix scales by one FP32 ULP. Keep this public grouped ABI on
+     * the canonical row provider until an optimized implementation is
+     * byte-exact against llama.cpp on both synthetic and production inputs. */
+    for (int row = 0; row < num_rows; ++row) {
         quantize_row_q8_k(
-                x + (size_t)row0 * (size_t)k,
-                y + (size_t)row0 * (size_t)blocks_per_row,
+                x + (size_t)row * (size_t)k,
+                y + (size_t)row * (size_t)blocks_per_row,
                 k);
     }
 }

--- a/tests/test_v8_multitoken_eos_contract.py
+++ b/tests/test_v8_multitoken_eos_contract.py
@@ -27,6 +27,58 @@ def load_module():
 
 
 class MultitokenEOSContractTests(unittest.TestCase):
+    def test_llama_persistent_dump_targets_decode_call_before_logits_step(self) -> None:
+        observed = {}
+
+        def run_helper(command, **kwargs):
+            observed["command"] = command
+            seq_path = Path(command[command.index("--logits-seq-out") + 1])
+            logits_path = Path(command[command.index("--logits-out") + 1])
+            np.zeros((2, 3), dtype=np.float32).tofile(seq_path)
+            np.zeros(3, dtype=np.float32).tofile(logits_path)
+            payload = {"ok": True, "n_vocab": 3, "greedy_steps": 2, "greedy_generated": [1, 2]}
+            return mock.Mock(returncode=0, stdout=json.dumps(payload) + "\n", stderr="")
+
+        args = Namespace(
+            top_k=3,
+            llama_decode_mode="batched",
+            max_new_tokens=2,
+            threads=4,
+            llama_no_repack=False,
+            llama_persistent_dump_step=5,
+            llama_persistent_dump_dir=Path("persistent-dump"),
+            llama_persistent_dump_names="l_out-0",
+            llama_persistent_dump_flash_inputs=True,
+            workdir=Path("work"),
+        )
+        inputs = {
+            "gguf_path": Path("model.gguf"),
+            "ctx_len": 4096,
+            "tokens_before": [1],
+            "tokens_after": [2],
+            "llama_prefix_path": None,
+            "prefix_grid": None,
+            "prefix_row_dim": 0,
+            "prefix_text_pos": 0,
+        }
+        with mock.patch.object(
+            self.runner.first_token.compare_first_token_logits_v7,
+            "ensure_llama_helper",
+            return_value=Path("llama-helper"),
+        ), mock.patch.object(
+            self.runner,
+            "_llama_oracle_evidence",
+            return_value={"commit": "a" * 40},
+        ), mock.patch.object(self.runner.subprocess, "run", side_effect=run_helper):
+            result = self.runner._run_llama_greedy_sequence(inputs, args)
+
+        command = observed["command"]
+        index = command.index("--dump-greedy-decode-step")
+        self.assertEqual(command[index + 1], "4")
+        self.assertEqual(command[command.index("--dump-names") + 1], "l_out-0")
+        self.assertIn("--dump-flash-inputs", command)
+        self.assertEqual(result["oracle_evidence"]["commit"], "a" * 40)
+
     def test_kv_first_difference_decodes_semantic_location(self) -> None:
         header = struct.pack("<8I", 0x564B5843, 1, 3, 5, 2, 4096, 4, 0)
         values = [0] * (2 * 2 * 5 * 4)
@@ -48,6 +100,45 @@ class MultitokenEOSContractTests(unittest.TestCase):
         self.assertEqual(row["token"], 2)
         self.assertEqual(row["channel"], 3)
         self.assertEqual(row["fp16_bit_distance"], 1)
+
+    def test_compiler_provenance_accepts_matching_runtime(self) -> None:
+        evidence = {
+            "shared_library": {
+                "build": {"compiler": {"command": ["gcc"], "version": "gcc 15"}},
+                "elf_compiler_comments": ["GCC: 15"],
+            },
+            "engine_library": {
+                "build": {"compiler": {"command": ["gcc"], "version": "gcc 15"}},
+                "elf_compiler_comments": ["GCC: 15"],
+            },
+        }
+        result = self.runner._validate_runtime_compiler_provenance(evidence)
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["decoder_family"], "gcc")
+
+    def test_compiler_provenance_rejects_gcc_decoder_with_icx_engine(self) -> None:
+        evidence = {
+            "shared_library": {
+                "build": {"compiler": {"command": "cc", "version": "gcc 15"}},
+                "elf_compiler_comments": ["GCC: 15"],
+            },
+            "engine_library": {
+                "elf_compiler_comments": [
+                    "GCC: 15",
+                    "Intel(R) oneAPI DPC++/C++ Compiler 2026.0.0",
+                ],
+            },
+        }
+        with self.assertRaisesRegex(RuntimeError, "compiler provenance"):
+            self.runner._validate_runtime_compiler_provenance(evidence)
+
+    def test_compiler_provenance_rejects_unknown_family(self) -> None:
+        evidence = {
+            "shared_library": {"elf_compiler_comments": []},
+            "engine_library": {"elf_compiler_comments": []},
+        }
+        with self.assertRaisesRegex(RuntimeError, "unknown_compiler_family"):
+            self.runner._validate_runtime_compiler_provenance(evidence)
 
     def test_dump_first_divergence_resolves_observed_step(self) -> None:
         report = {"first_divergence": {"step": 60}}
@@ -370,6 +461,75 @@ class MultitokenEOSContractTests(unittest.TestCase):
             self.assertEqual([row["status"] for row in result["results"]], ["ok", "error", "ok"])
             self.assertIn("missing rope_k", result["results"][1]["error"])
 
+    def test_hidden_capture_exports_bounded_kv_for_every_requested_layer(self) -> None:
+        class ExportKV:
+            argtypes = None
+            restype = None
+
+            def __call__(self, path, layer):
+                Path(path.decode("utf-8")).write_bytes(bytes([int(layer), 0, 1, 2]))
+                return 0
+
+        class Library:
+            def __init__(self):
+                self.ck_model_debug_export_kv_f16 = ExportKV()
+
+            def ck_model_decode(self, token, logits):
+                return 0
+
+            def ck_model_free(self):
+                return None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "decoder_v8.c"
+            source.write_text(
+                "\n".join(
+                    f'ck_debug_export_hidden(model, {layer}, "{name}", data, 128);'
+                    for layer in (0, 1)
+                    for name in ("rope_q", "rope_q_last", "attn_out", "attn_out_last")
+                ),
+                encoding="utf-8",
+            )
+            inputs = {
+                "runtime": {"workdir": root, "c_path": source},
+                "tokens_after": [1, 2],
+            }
+            report = {
+                "steps": [
+                    {},
+                    {"generated_prefix": [10, 11], "ck_next": 12, "llama_next": 12},
+                ]
+            }
+            args = Namespace(
+                hidden_state_step=1,
+                hidden_state_layer=-1,
+                hidden_state_names="rope_q,attn_out",
+                hidden_state_dir=root / "capture",
+                hidden_state_atol=1.0e-5,
+                workdir=root,
+                ck_strict_parity=False,
+            )
+            init = mock.Mock(side_effect=[(Library(), object(), 3), (Library(), object(), 3)])
+            compared = [
+                {"layer": 0, "status": "ok", "max_abs_diff": 0.0},
+                {"layer": 1, "status": "ok", "max_abs_diff": 0.0},
+            ]
+
+            with mock.patch.object(self.runner, "_prepare_inputs", return_value=inputs), \
+                 mock.patch.object(self.runner, "_init_ck_state", init), \
+                 mock.patch.object(self.runner, "_hidden_compare_many", return_value=compared):
+                result = self.runner._capture_hidden_state_step(report, args)
+
+            self.assertEqual(result["preflight"]["capture_layers"], [0, 1])
+            self.assertEqual(len(result["kv_cache"]["layers"]), 2)
+            self.assertEqual(result["kv_cache"]["status"], "ok")
+            for phase in ("persistent", "full_replay"):
+                for layer in (0, 1):
+                    self.assertTrue(
+                        (root / "capture" / phase / f"kv_cache_f16_layer_{layer:03d}.bin").is_file()
+                    )
+
     def test_granular_capture_rejects_uninstrumented_runtime_before_execution(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -392,6 +552,58 @@ class MultitokenEOSContractTests(unittest.TestCase):
                     self.runner._capture_step_dump(report, args)
 
             capture.assert_not_called()
+
+    def test_multimodal_prefill_segments_use_extent_and_execution_order(self) -> None:
+        dump_type = self.runner.first_token.parity_test_v7.ParityDump
+        dumps = [
+            dump_type(0, "q_proj", np.zeros(rows * 4, dtype=np.float32), 0, "fp32")
+            for rows in (5, 1008, 14)
+        ]
+        specs = {(0, "q_proj"): (4, (4,))}
+        segments = [
+            ("text_before", 5, 0),
+            ("visual", 1008, 5),
+            ("text_after", 14, 1013),
+        ]
+
+        labeled = self.runner.first_token._label_multimodal_prefill_segments(
+            dumps, specs, segments
+        )
+
+        self.assertEqual(
+            [(row.op_name, row.token_id, row.data.size) for row in labeled],
+            [
+                ("q_proj@text_before", 0, 20),
+                ("q_proj@visual", 5, 4032),
+                ("q_proj@text_after", 1013, 56),
+            ],
+        )
+
+    def test_llama_qk_middle_occurrence_is_not_guessed_as_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rows = []
+            for occurrence, values in enumerate(([1.0, 2.0], [3.0, 4.0], [5.0, 6.0])):
+                name = f"Qcur-0-token-000000-occ-{occurrence:03d}"
+                np.asarray(values, dtype=np.float32).tofile(root / f"{name}.bin")
+                rows.append({
+                    "name": name,
+                    "base_name": "Qcur-0",
+                    "token_id": 0,
+                    "occurrence": occurrence,
+                    "elem_count": 2,
+                    "nbytes": 8,
+                    "rank": 1,
+                    "shape": [2],
+                })
+            (root / "index.json").write_text(
+                "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+            )
+
+            dumps = self.runner.first_token._load_llama_dump_dir(root)
+
+        self.assertEqual([dump.op_name for dump in dumps], ["q_proj", "qcur_rope"])
+        self.assertNotIn("qcur_normed", [dump.op_name for dump in dumps])
 
     def test_prepare_inputs_preserves_explicit_engine_for_nested_dumps(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -496,12 +708,25 @@ class MultitokenEOSContractTests(unittest.TestCase):
         llama_sequence = {
             "meta": {"greedy_generated": [151645, 7]},
             "logits": np.zeros((2, 3), dtype=np.float32),
+            "oracle_evidence": {
+                "root": "/oracle/llama.cpp",
+                "commit": "a" * 40,
+                "helper": {"sha256": "b" * 64},
+                "libraries": [{"sha256": "c" * 64}],
+            },
         }
         with mock.patch.object(self.runner, "_prepare_inputs", return_value=inputs), \
              mock.patch.object(self.runner, "_run_llama_greedy_sequence", return_value=llama_sequence), \
              mock.patch.object(self.runner, "_init_ck_state", return_value=(library, object(), 3)), \
              mock.patch.object(self.runner, "_ck_logits_from_buffer", return_value=np.zeros(3, dtype=np.float32)), \
-             mock.patch.object(self.runner, "_runtime_evidence", return_value={}), \
+             mock.patch.object(
+                 self.runner,
+                 "_runtime_evidence",
+                 return_value={
+                     "shared_library": {"elf_compiler_comments": ["GCC: 15"]},
+                     "engine_library": {"elf_compiler_comments": ["GCC: 15"]},
+                 },
+             ), \
              mock.patch.object(self.runner.first_token.compare_first_token_logits_v7, "compare_logits", return_value=comparison), \
              mock.patch.object(self.runner, "_decode_topk", return_value=[]):
             report = self.runner.run_multimodal_multitoken_parity(args)
@@ -513,6 +738,7 @@ class MultitokenEOSContractTests(unittest.TestCase):
         self.assertFalse(report["execution_modes"]["diagnostic_tensor_dump"])
         self.assertIsInstance(report["execution_modes"]["ck_environment"], dict)
         self.assertEqual(report["stop_reason"], "matched_stop_token")
+        self.assertEqual(report["llama_oracle"]["commit"], "a" * 40)
         self.assertEqual(len(report["steps"]), 1)
         self.assertEqual(report["steps"][0]["ck_next"], 151645)
         self.assertEqual(library.decode_calls, 0)

--- a/tests/test_v8_native_bridge_host.py
+++ b/tests/test_v8_native_bridge_host.py
@@ -257,6 +257,59 @@ def _build_tiny_decoder_runtime(workdir: Path) -> tuple[Path, Path, Path]:
 
 
 class V8NativeBridgeHostTests(unittest.TestCase):
+    def test_generated_model_compiler_comes_from_engine_build_stamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stamp = Path(tmpdir) / ".ck_build_flags"
+            stamp.write_text(
+                "CC=ccache gcc\nCFLAGS=-O3 -mavx2\nLDFLAGS=\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                bridge_runner_v8._engine_compiler_argv(stamp),
+                ["ccache", "gcc"],
+            )
+
+    def test_runtime_engine_copy_records_compiler_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            build = root / "build"
+            runtime = root / "runtime"
+            build.mkdir()
+            runtime.mkdir()
+            engine = build / "libckernel_engine.so"
+            engine.write_bytes(b"engine")
+            (build / ".ck_build_flags").write_text(
+                "CC=gcc\nCFLAGS=-O3\nLDFLAGS=\n",
+                encoding="utf-8",
+            )
+            model = runtime / "libdecoder_v8.so"
+            model.touch()
+            probe = subprocess.CompletedProcess(
+                ["gcc", "--version"], 0, "gcc test compiler\n", ""
+            )
+            with mock.patch.object(bridge_runner_v8, "BUILD_DIR", build), \
+                 mock.patch.object(bridge_runner_v8.subprocess, "run", return_value=probe):
+                copied = bridge_runner_v8._sync_runtime_engine(engine, model)
+
+            metadata = json.loads(
+                copied.with_suffix(copied.suffix + ".build.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(metadata["compiler"]["command"], ["gcc"])
+            self.assertEqual(metadata["compiler"]["version"], "gcc test compiler")
+            self.assertEqual(copied.read_bytes(), b"engine")
+
+    def test_runtime_preflight_builds_engine_and_tokenizer_together(self) -> None:
+        with mock.patch.object(bridge_runner_v8, "_run") as run:
+            bridge_runner_v8._ensure_engine_lib(openmp=True)
+        run.assert_called_once_with(
+            [
+                "make",
+                "CK_ENABLE_OPENMP=1",
+                "build/libckernel_engine.so",
+                "build/libckernel_tokenizer.so",
+            ]
+        )
+
     def test_engine_has_canonical_soname(self) -> None:
         dynamic = subprocess.run(
             ["readelf", "-d", str(LIBCK)],

--- a/tests/test_v8_stitched_parity_modes.py
+++ b/tests/test_v8_stitched_parity_modes.py
@@ -27,6 +27,7 @@ def args_for(mode: str) -> argparse.Namespace:
         image_min_tokens=None,
         image_max_tokens=1024,
         threads=20,
+        compiler="gcc",
         execution_mode=mode,
         granular_dump_names="kqv_out",
         granular_ck_stop=True,
@@ -34,6 +35,13 @@ def args_for(mode: str) -> argparse.Namespace:
 
 
 class StitchedParityModeTests(unittest.TestCase):
+    def test_parity_runtime_uses_one_explicit_compiler_family(self) -> None:
+        args = args_for("production")
+        env = stitched._runtime_environment(args)
+        self.assertEqual(env["CC"], "gcc")
+        args.compiler = "icx"
+        self.assertEqual(stitched._runtime_environment(args)["CC"], "icx")
+
     def test_strict_mode_is_consistent_across_phases(self) -> None:
         args = args_for("strict")
         bridge = stitched._bridge_command(args, Path("bridge"), Path("prefix.f32"))
@@ -55,6 +63,16 @@ class StitchedParityModeTests(unittest.TestCase):
         self.assertNotIn("--strict-parity", granular)
         self.assertEqual(numeric[numeric.index("--llama-flash-attn") + 1], "enabled")
         self.assertEqual(granular[granular.index("--llama-flash-attn") + 1], "enabled")
+
+    def test_encoder_numeric_observe_policy_is_exposed(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('choices=("require", "observe", "skip")', source)
+        self.assertIn('"non_causal_for_observed_token_window"', source)
+
+    def test_failed_runtime_is_retained_by_default(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('"--prune-failed-weights"', source)
+        self.assertIn('"failed_weight_bumps_retained"', source)
 
 
 if __name__ == "__main__":

--- a/unittest/test_attention_f16_split_kv.py
+++ b/unittest/test_attention_f16_split_kv.py
@@ -304,7 +304,7 @@ def _llama_prefill_output(q, k_bits, v_bits, head_dim, past_tokens, threads):
 
 
 def _llama_kv_partition_extent(kv_tokens):
-    """Match llama.cpp's reusable decode-graph KV scheduling extent."""
+    """Model llama.cpp's padded physical decode-graph K tensor extent."""
     kv_tokens = int(kv_tokens)
     return ((kv_tokens + 255) // 256) * 256 if kv_tokens >= 512 else kv_tokens
 
@@ -661,6 +661,11 @@ def main():
         "f16_split_threshold(KV=512,C=4)", 512, 8, 2, 512, 64, 64, 4, 0.0,
     )
     results.append(threshold)
+    merge_rounding, _ = _case(
+        "f16_split_merge_rounding(KV=512,H=1,D=32,C=20)",
+        2, 1, 1, 512, 32, 32, 20, 0.0,
+    )
+    results.append(merge_rounding)
     qwen, qwen_data = _case(
         "f16_split_qwen3vl(KV=1058,H=32,D=128,C=20)",
         1058, 32, 8, 1058, 128, 128, 20, 0.0,

--- a/unittest/test_q6k_q8k_llama_production.cpp
+++ b/unittest/test_q6k_q8k_llama_production.cpp
@@ -8,9 +8,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <vector>
 
 extern "C" {
@@ -76,6 +78,36 @@ static bool compare_f32(const char *label, const float *a, const float *b, size_
                 "ck=%.9g llama=%.9g [FAIL]\n",
             label, different, count, first, worst, max_abs, a[worst], b[worst]);
     return false;
+}
+
+static float f32_from_bits(uint32_t bits) {
+    float value;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+static bool run_q8_rounding_boundary_case() {
+    std::printf("\nq8_rounding_boundary K=%d\n", QK_K);
+    std::vector<float> input(QK_K, 0.0f);
+    input[119] = f32_from_bits(0x3e9ade7bU);
+    input[204] = f32_from_bits(0xbe508645U);
+
+    block_q8_K ck = {};
+    block_q8_K llama = {};
+    quantize_row_q8_k(input.data(), &ck, QK_K);
+    quantize_row_q8_K_ref(input.data(), &llama, QK_K);
+    return compare_bytes("Q8_K non-contracted rounding", &ck, &llama, sizeof(ck));
+}
+
+static std::vector<unsigned char> read_bytes(const char *path) {
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input) return {};
+    const std::streamsize size = input.tellg();
+    if (size < 0) return {};
+    std::vector<unsigned char> data(static_cast<size_t>(size));
+    input.seekg(0);
+    input.read(reinterpret_cast<char *>(data.data()), size);
+    return input ? data : std::vector<unsigned char>{};
 }
 
 static bool llama_graph(const std::vector<unsigned char> &weights,
@@ -177,6 +209,49 @@ static bool run_case(const case_spec &spec) {
     return pass;
 }
 
+static bool run_xray_artifact_case() {
+    const char *input_path = std::getenv("CK_Q6_XRAY_INPUT_F32");
+    const char *weights_path = std::getenv("CK_Q6_XRAY_WEIGHTS_Q6_K");
+    const char *output_path = std::getenv("CK_Q6_XRAY_LLAMA_OUTPUT_F32");
+    if (!input_path && !weights_path && !output_path) return true;
+    if (!input_path || !weights_path || !output_path) {
+        std::fprintf(stderr, "all CK_Q6_XRAY_* paths are required together\n");
+        return false;
+    }
+
+    const int k = std::atoi(std::getenv("CK_Q6_XRAY_K") ? std::getenv("CK_Q6_XRAY_K") : "4096");
+    const int n = std::atoi(std::getenv("CK_Q6_XRAY_N") ? std::getenv("CK_Q6_XRAY_N") : "1024");
+    const auto input_bytes = read_bytes(input_path);
+    const auto weights = read_bytes(weights_path);
+    const auto output_bytes = read_bytes(output_path);
+    const size_t q6_row = static_cast<size_t>(k / QK_K) * sizeof(block_q6_K);
+    if (input_bytes.size() != static_cast<size_t>(k) * sizeof(float)
+            || weights.size() != static_cast<size_t>(n) * q6_row
+            || output_bytes.size() != static_cast<size_t>(n) * sizeof(float)) {
+        std::fprintf(stderr, "invalid Q6 X-ray artifact extents: input=%zu weights=%zu output=%zu\n",
+                input_bytes.size(), weights.size(), output_bytes.size());
+        return false;
+    }
+
+    std::vector<float> input(k), expected(n), leaf(n), graph(n), ck(n);
+    std::memcpy(input.data(), input_bytes.data(), input_bytes.size());
+    std::memcpy(expected.data(), output_bytes.data(), output_bytes.size());
+    std::vector<block_q8_K> q8(static_cast<size_t>(k / QK_K));
+    quantize_row_q8_k(input.data(), q8.data(), k);
+    for (int row = 0; row < n; ++row) {
+        ggml_vec_dot_q6_K_q8_K(k, &leaf[row], 0,
+                weights.data() + static_cast<size_t>(row) * q6_row, 0, q8.data(), 0, 1);
+    }
+    gemv_q6_k_q8_k_parallel_dispatch(ck.data(), weights.data(), q8.data(), n, k);
+    if (!llama_graph(weights, input, graph, 1, n, k, false)) return false;
+
+    std::printf("\nxray_artifact M=1 N=%d K=%d\n", n, k);
+    bool pass = compare_f32("llama leaf vs graph", leaf.data(), graph.data(), n);
+    pass &= compare_f32("CK vs llama graph", ck.data(), graph.data(), n);
+    pass &= compare_f32("llama graph vs captured V", graph.data(), expected.data(), n);
+    return pass;
+}
+
 } // namespace
 
 int main(int argc, char **argv) {
@@ -211,7 +286,9 @@ int main(int argc, char **argv) {
     const size_t count = quick ? sizeof(quick_cases) / sizeof(quick_cases[0])
                                : sizeof(full_cases) / sizeof(full_cases[0]);
     int failed = 0;
+    if (!run_q8_rounding_boundary_case()) ++failed;
     for (size_t i = 0; i < count; ++i) if (!run_case(cases[i])) ++failed;
+    if (!run_xray_artifact_case()) ++failed;
     ck_threadpool_global_destroy();
     std::printf("\nQ6_K x Q8_K llama.cpp production parity: %s (%zu cases, %d failed)\n",
             failed ? "FAIL" : "PASS", count, failed);

--- a/version/v8/contracts/attention_reductions.json
+++ b/version/v8/contracts/attention_reductions.json
@@ -133,7 +133,7 @@
         "below_threshold_chunks": 1,
         "at_or_above_threshold_chunks": "runtime_worker_count"
       },
-      "description": "FP16-rounded online-softmax partials with a 256-row padded scheduling extent and deterministic FP32 chunk-order merge.",
+      "description": "FP16-rounded online-softmax partials over the padded physical K tensor extent with deterministic FP32 chunk-order merge.",
       "validation": {
         "test": "unittest/test_attention_f16_split_kv.py",
         "cases": ["KV=511", "KV=512", "Qwen3-VL KV=1047->1280", "KV=1058->1280", "KV=1609->1792", "padded GQA"],

--- a/version/v8/kernel_maps/KERNEL_REGISTRY.json
+++ b/version/v8/kernel_maps/KERNEL_REGISTRY.json
@@ -2975,7 +2975,7 @@
           "function": "attention_forward_decode_head_major_gqa_flash_f16cache_contract",
           "explicit_selector": true,
           "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
-          "notes": "FP16 Q/K and partial-value storage with a 256-row padded KV scheduling extent, worker-chunk online softmax, and ordered FP32 merge."
+          "notes": "FP16 Q/K and partial-value storage partitioned by the padded physical K tensor extent, online softmax, and ordered FP32 merge."
         }
       },
       "implementation": {

--- a/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_f16cache_contract.json
+++ b/version/v8/kernel_maps/attention_forward_decode_head_major_gqa_flash_f16cache_contract.json
@@ -17,7 +17,7 @@
       "function": "attention_forward_decode_head_major_gqa_flash_f16cache_contract",
       "explicit_selector": true,
       "selector": "CK_ATTN_REDUCTION_F16_ONLINE_FP32_MERGE",
-      "notes": "FP16 Q/K and partial-value storage with a 256-row padded KV scheduling extent, worker-chunk online softmax, and ordered FP32 merge."
+      "notes": "FP16 Q/K and partial-value storage partitioned by the padded physical K tensor extent, online softmax, and ordered FP32 merge."
     }
   },
   "implementation": {

--- a/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
+++ b/version/v8/scripts/compare_multimodal_multitoken_logits_v8.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import struct
 import subprocess
 import sys
@@ -248,6 +249,7 @@ def _validate_hidden_capture_request(
 
 def _run_llama_greedy_sequence(inputs: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
     helper = first_token.compare_first_token_logits_v7.ensure_llama_helper()
+    oracle_evidence = _llama_oracle_evidence(helper)
     with tempfile.TemporaryDirectory(prefix="llama_token_replay_v8_seq_") as td:
         tmp = Path(td)
         logits_out = tmp / "llama_final.f32"
@@ -287,6 +289,27 @@ def _run_llama_greedy_sequence(inputs: dict[str, Any], args: argparse.Namespace)
             cmd.extend(["--threads", str(int(args.threads))])
         if bool(args.llama_no_repack):
             cmd.append("--no-repack")
+        persistent_dump_step = getattr(args, "llama_persistent_dump_step", None)
+        if persistent_dump_step is not None:
+            persistent_dump_step = int(persistent_dump_step)
+            if persistent_dump_step <= 0:
+                raise ValueError(
+                    "--llama-persistent-dump-step must be >= 1; step 0 is produced by prefill"
+                )
+            dump_dir = getattr(args, "llama_persistent_dump_dir", None)
+            if dump_dir is None:
+                dump_dir = args.workdir / f"llama_persistent_step_{persistent_dump_step:04d}"
+            dump_names = str(getattr(args, "llama_persistent_dump_names", "") or "").strip()
+            if not dump_names:
+                raise ValueError("--llama-persistent-dump-step requires --llama-persistent-dump-names")
+            cmd.extend([
+                "--dump-dir", str(Path(dump_dir).resolve()),
+                "--dump-names", dump_names,
+                # Logits row N is produced by decoding the token selected at N-1.
+                "--dump-greedy-decode-step", str(persistent_dump_step - 1),
+            ])
+            if bool(getattr(args, "llama_persistent_dump_flash_inputs", False)):
+                cmd.append("--dump-flash-inputs")
         proc = subprocess.run(cmd, cwd=str(REPO_ROOT), text=True, capture_output=True, check=False)
         if proc.returncode != 0:
             raise RuntimeError(
@@ -306,6 +329,7 @@ def _run_llama_greedy_sequence(inputs: dict[str, Any], args: argparse.Namespace)
         return {
             "meta": meta,
             "logits": logits.reshape((steps, n_vocab)),
+            "oracle_evidence": oracle_evidence,
         }
 
 def _load_exact_decoder_runtime(
@@ -402,6 +426,80 @@ def _runtime_evidence(
         "weights_bump_path": str(Path(runtime["weights_bump"]).resolve()),
         "context_length": int(runtime.get("context_length", 0) or 0),
     }
+
+
+def _llama_oracle_evidence(helper: Path) -> dict[str, Any]:
+    module = first_token.compare_first_token_logits_v7
+    llama_root, _lib_dir, libraries = module._llama_helper_paths()
+
+    def describe(path: Path) -> dict[str, Any]:
+        resolved = path.resolve()
+        return {
+            "path": str(resolved),
+            "sha256": hashlib.sha256(resolved.read_bytes()).hexdigest(),
+        }
+
+    commit_probe = subprocess.run(
+        ["git", "-C", str(llama_root), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if commit_probe.returncode != 0:
+        raise RuntimeError(
+            "cannot establish llama.cpp oracle commit provenance: "
+            + (commit_probe.stderr.strip() or f"git rc={commit_probe.returncode}")
+        )
+    return {
+        "root": str(llama_root.resolve()),
+        "commit": commit_probe.stdout.strip(),
+        "helper": describe(helper),
+        "helper_source": describe(module.HELPER_SRC),
+        "libraries": [describe(path) for path in libraries],
+    }
+
+
+def _compiler_family(description: dict[str, Any]) -> str | None:
+    compiler = description.get("build", {}).get("compiler", {})
+    values = [compiler.get("command"), compiler.get("version")]
+    values.extend(description.get("elf_compiler_comments", []))
+    text = " ".join(
+        " ".join(str(part) for part in value)
+        if isinstance(value, list)
+        else str(value or "")
+        for value in values
+    ).lower()
+    if "intel(r) oneapi" in text or re.search(r"\bicx\b", text):
+        return "intel-icx"
+    if "clang" in text:
+        return "clang"
+    if "gcc" in text or "gnu compiler" in text:
+        return "gcc"
+    return None
+
+
+def _validate_runtime_compiler_provenance(evidence: dict[str, Any]) -> dict[str, Any]:
+    decoder_family = _compiler_family(evidence["shared_library"])
+    engine_family = _compiler_family(evidence["engine_library"])
+    result = {
+        "status": "pass",
+        "decoder_family": decoder_family,
+        "engine_family": engine_family,
+    }
+    if decoder_family is None or engine_family is None:
+        result["status"] = "fail"
+        result["reason"] = "unknown_compiler_family"
+    elif decoder_family != engine_family:
+        result["status"] = "fail"
+        result["reason"] = "compiler_family_mismatch"
+    if result["status"] != "pass":
+        raise RuntimeError(
+            "HARD PARITY CONTRACT FAULT: generated decoder and core engine compiler "
+            "provenance must be known and identical; "
+            f"decoder={decoder_family!r} engine={engine_family!r} "
+            f"reason={result['reason']}"
+        )
+    return result
 
 
 def _ck_environment_evidence() -> dict[str, str]:
@@ -621,7 +719,32 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
     if dump_dir is None:
         dump_dir = args.workdir / f"dump_step_{step_index:04d}"
 
-    inputs = _prepare_inputs(args, parity_dump=True)
+    dump_dir = Path(dump_dir).resolve()
+    if dump_dir.exists():
+        shutil.rmtree(dump_dir)
+    ck_dump_dir = dump_dir / "ck"
+    ck_dump_dir.mkdir(parents=True, exist_ok=True)
+    # The generated parity library may initialize its writer while it is
+    # loaded. Publish an existing absolute directory before preparing/loading
+    # that runtime; setting CK_PARITY_DIR afterward leaves a permanently
+    # disabled writer and used to produce a misleading skipped diagnostic.
+    old_parity_dir = os.environ.get("CK_PARITY_DIR")
+    old_op_filter = os.environ.get("CK_PARITY_OP_FILTER")
+    os.environ["CK_PARITY_DIR"] = str(ck_dump_dir)
+    ck_dump_names = first_token._ck_dump_filter_names(str(getattr(args, "dump_names", "")))
+    if ck_dump_names:
+        os.environ["CK_PARITY_OP_FILTER"] = ck_dump_names
+    try:
+        inputs = _prepare_inputs(args, parity_dump=True)
+    finally:
+        if old_parity_dir is None:
+            os.environ.pop("CK_PARITY_DIR", None)
+        else:
+            os.environ["CK_PARITY_DIR"] = old_parity_dir
+        if old_op_filter is None:
+            os.environ.pop("CK_PARITY_OP_FILTER", None)
+        else:
+            os.environ["CK_PARITY_OP_FILTER"] = old_op_filter
     dump_source = Path(inputs["runtime"].get("c_path") or "")
     if not dump_source.is_file() or "#define CK_PARITY_DUMP 1" not in dump_source.read_text(encoding="utf-8"):
         raise RuntimeError(
@@ -644,7 +767,7 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
             ctx_len=int(inputs["ctx_len"]),
             top_k=int(args.top_k),
             threads=_ck_threads(args),
-            dump_root=dump_dir.resolve(),
+            dump_root=dump_dir,
             dump_names=str(args.dump_names),
             dump_pass=str(args.dump_pass),
             dump_atol=float(args.dump_atol),
@@ -656,10 +779,15 @@ def _capture_step_dump(report: dict[str, Any], args: argparse.Namespace) -> dict
         )
     finally:
         _restore_prefix_decode_policy_env(old_env)
+    if str(dump_report.get("status", "")).lower() in {"error", "skipped"}:
+        raise RuntimeError(
+            "granular capture did not produce a comparable CK/llama tensor set; "
+            f"status={dump_report.get('status')} reason={dump_report.get('reason', '')}"
+        )
     return {
         "step": int(step_index),
         "step_row": row,
-        "dump_dir": str(dump_dir.resolve()),
+        "dump_dir": str(dump_dir),
         "replay_tokens_after_count": int(len(replay_tokens_after)),
         "generated_prefix": generated_prefix,
         "ck_top1": int((ck.get("comparison") or {}).get("top1_ck", ck.get("ck_top1", -1))),
@@ -777,23 +905,55 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
     capture_error: Exception | None = None
     kv_comparison: dict[str, Any] | None = None
 
-    def export_kv(lib: Any, path: Path) -> dict[str, Any]:
+    capture_layers = (
+        [layer]
+        if layer >= 0
+        else sorted(set.intersection(*(set(catalog[name]) for name in names)))
+    )
+
+    def export_kv(lib: Any, directory: Path) -> dict[str, Any]:
         if not hasattr(lib, "ck_model_debug_export_kv_f16"):
             return {
                 "status": "unavailable",
                 "reason": "runtime lacks bounded ck_model_debug_export_kv_f16 X-ray ABI",
-                "path": str(path),
+                "directory": str(directory),
             }
         lib.ck_model_debug_export_kv_f16.argtypes = [ctypes.c_char_p, ctypes.c_int]
         lib.ck_model_debug_export_kv_f16.restype = ctypes.c_int
-        rc = int(lib.ck_model_debug_export_kv_f16(str(path).encode("utf-8"), int(layer)))
-        if rc != 0:
-            return {
-                "status": "error",
-                "reason": f"FP16 KV export failed rc={rc} layer={layer}",
+        rows: list[dict[str, Any]] = []
+        for capture_layer in capture_layers:
+            path = (
+                directory / "kv_cache_f16.bin"
+                if layer >= 0
+                else directory / f"kv_cache_f16_layer_{capture_layer:03d}.bin"
+            )
+            rc = int(
+                lib.ck_model_debug_export_kv_f16(
+                    str(path).encode("utf-8"), int(capture_layer)
+                )
+            )
+            rows.append({
+                "layer": int(capture_layer),
+                "status": "ok" if rc == 0 else "error",
                 "path": str(path),
-            }
-        return {"status": "ok", "path": str(path)}
+                "rc": int(rc),
+            })
+            if rc != 0:
+                break
+        status = "ok" if rows and all(row["status"] == "ok" for row in rows) else "error"
+        result: dict[str, Any] = {
+            "status": status,
+            "directory": str(directory),
+            "layers": rows,
+        }
+        if len(rows) == 1:
+            result["path"] = rows[0]["path"]
+        if status != "ok":
+            failed = next(row for row in rows if row["status"] != "ok")
+            result["reason"] = (
+                f"FP16 KV export failed rc={failed['rc']} layer={failed['layer']}"
+            )
+        return result
 
     persistent_kv_export: dict[str, Any] | None = None
     replay_kv_export: dict[str, Any] | None = None
@@ -815,7 +975,7 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
                     raise RuntimeError(f"ck_model_decode failed rc={rc} while capturing persistent hidden state")
                 if i == last_i:
                     _restore_process_env({key: None for key in env_keys})
-            persistent_kv_export = export_kv(lib, persistent_dir / "kv_cache_f16.bin")
+            persistent_kv_export = export_kv(lib, persistent_dir)
         finally:
             if hasattr(lib, "ck_model_free"):
                 try:
@@ -833,7 +993,7 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
         lib2, _logits2, _vocab2 = _init_ck_state(
             replay_inputs, bool(args.ck_strict_parity), getattr(args, "ck_engine_so", None)
         )
-        replay_kv_export = export_kv(lib2, full_dir / "kv_cache_f16.bin")
+        replay_kv_export = export_kv(lib2, full_dir)
         if hasattr(lib2, "ck_model_free"):
             try:
                 lib2.ck_model_free()
@@ -863,27 +1023,58 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
             and persistent_kv_export.get("status") == "ok"
             and replay_kv_export.get("status") == "ok"
         ):
-            persistent_kv = Path(str(persistent_kv_export["path"]))
-            replay_kv = Path(str(replay_kv_export["path"]))
-            persistent_bytes = persistent_kv.read_bytes()
-            replay_bytes = replay_kv.read_bytes()
-            first_byte = next(
-                (i for i, (a, b) in enumerate(zip(persistent_bytes, replay_bytes)) if a != b),
-                None,
-            )
-            kv_comparison = {
-                "status": "ok" if persistent_bytes == replay_bytes else "fail",
-                "persistent_path": str(persistent_kv),
-                "full_replay_path": str(replay_kv),
-                "persistent_bytes": len(persistent_bytes),
-                "full_replay_bytes": len(replay_bytes),
-                "first_differing_byte": first_byte,
-                "first_difference": _describe_kv_f16_difference(
-                    persistent_bytes, replay_bytes, first_byte
-                ),
-                "persistent_sha256": hashlib.sha256(persistent_bytes).hexdigest(),
-                "full_replay_sha256": hashlib.sha256(replay_bytes).hexdigest(),
+            persistent_by_layer = {
+                int(row["layer"]): Path(str(row["path"]))
+                for row in persistent_kv_export["layers"]
             }
+            replay_by_layer = {
+                int(row["layer"]): Path(str(row["path"]))
+                for row in replay_kv_export["layers"]
+            }
+            kv_rows: list[dict[str, Any]] = []
+            for capture_layer in sorted(set(persistent_by_layer) | set(replay_by_layer)):
+                persistent_kv = persistent_by_layer.get(capture_layer)
+                replay_kv = replay_by_layer.get(capture_layer)
+                if persistent_kv is None or replay_kv is None:
+                    kv_rows.append({
+                        "layer": int(capture_layer),
+                        "status": "missing",
+                        "persistent_path": None if persistent_kv is None else str(persistent_kv),
+                        "full_replay_path": None if replay_kv is None else str(replay_kv),
+                    })
+                    continue
+                persistent_bytes = persistent_kv.read_bytes()
+                replay_bytes = replay_kv.read_bytes()
+                first_byte = next(
+                    (i for i, (a, b) in enumerate(zip(persistent_bytes, replay_bytes)) if a != b),
+                    None,
+                )
+                kv_rows.append({
+                    "layer": int(capture_layer),
+                    "status": "ok" if persistent_bytes == replay_bytes else "fail",
+                    "persistent_path": str(persistent_kv),
+                    "full_replay_path": str(replay_kv),
+                    "persistent_bytes": len(persistent_bytes),
+                    "full_replay_bytes": len(replay_bytes),
+                    "first_differing_byte": first_byte,
+                    "first_difference": _describe_kv_f16_difference(
+                        persistent_bytes, replay_bytes, first_byte
+                    ),
+                    "persistent_sha256": hashlib.sha256(persistent_bytes).hexdigest(),
+                    "full_replay_sha256": hashlib.sha256(replay_bytes).hexdigest(),
+                })
+            first_kv_issue = next((row for row in kv_rows if row["status"] != "ok"), None)
+            kv_comparison = {
+                "status": "ok" if first_kv_issue is None else "fail",
+                "first_layer_issue": first_kv_issue,
+                "layers": kv_rows,
+            }
+            if len(kv_rows) == 1:
+                kv_comparison.update({
+                    key: value
+                    for key, value in kv_rows[0].items()
+                    if key != "status"
+                })
         else:
             statuses = [item for item in (persistent_kv_export, replay_kv_export) if item is not None]
             kv_comparison = {
@@ -946,6 +1137,7 @@ def _capture_hidden_state_step(report: dict[str, Any], args: argparse.Namespace)
         "preflight": {
             "status": "pass",
             "requested_names": names,
+            "capture_layers": capture_layers,
             "available_exporter_count": len(catalog),
         },
         "ck_execution_count": 2,
@@ -1121,6 +1313,12 @@ def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]
             inputs["bridge_report"],
             allow_diagnostic_mismatch=True,
         )
+    runtime_evidence = _runtime_evidence(
+        inputs["runtime"],
+        exact_reuse=bool(inputs.get("exact_runtime", False)),
+        engine_so=getattr(args, "ck_engine_so", None),
+    )
+    compiler_provenance = _validate_runtime_compiler_provenance(runtime_evidence)
     tokenizer: GGUFTokenizer = inputs["tokenizer"]
     llama_seq = _run_llama_greedy_sequence(inputs, args)
     lib, logits_buf, vocab_size = _init_ck_state(
@@ -1226,12 +1424,10 @@ def run_multimodal_multitoken_parity(args: argparse.Namespace) -> dict[str, Any]
             "prefill_mode_contract": mode_contract,
         },
         "llama_greedy_generated": llama_generated,
+        "llama_oracle": llama_seq["oracle_evidence"],
         "append_on_divergence": str(args.append_on_divergence),
-        "ck_runtime": _runtime_evidence(
-            inputs["runtime"],
-            exact_reuse=bool(inputs.get("exact_runtime", False)),
-            engine_so=getattr(args, "ck_engine_so", None),
-        ),
+        "ck_runtime": runtime_evidence,
+        "compiler_provenance": compiler_provenance,
         "stop_token_ids": sorted(stop_token_ids),
         "stop_reason": stop_reason,
         "prompt_tokens_before_image": inputs["tokens_before"],
@@ -1393,6 +1589,23 @@ def main() -> int:
     ap.add_argument("--json-out", type=Path, default=None)
     ap.add_argument("--dump-step", type=int, default=None, help="Capture CK-vs-llama tensor dumps at this generated step")
     ap.add_argument(
+        "--llama-persistent-dump-step",
+        type=int,
+        default=None,
+        help="Bound llama.cpp tensor capture to the persistent decode call that produced generated logits step N",
+    )
+    ap.add_argument("--llama-persistent-dump-dir", type=Path, default=None)
+    ap.add_argument(
+        "--llama-persistent-dump-flash-inputs",
+        action="store_true",
+        help="Boundedly capture the production flash node's Q/K/V/mask inputs",
+    )
+    ap.add_argument(
+        "--llama-persistent-dump-names",
+        default="",
+        help="Comma-separated llama.cpp graph tensor names for bounded persistent capture",
+    )
+    ap.add_argument(
         "--dump-first-divergence",
         action="store_true",
         help="Capture CK-vs-llama tensors at the first observed pre-EOS divergence",
@@ -1415,6 +1628,17 @@ def main() -> int:
     ap.add_argument("--hidden-state-atol", type=float, default=1.0e-5)
     ap.add_argument("--summary", action="store_true")
     args = ap.parse_args()
+    if args.dump_step is not None or args.dump_first_divergence:
+        early_dump_dir = args.dump_dir
+        if early_dump_dir is None:
+            requested = 0 if args.dump_step is None else int(args.dump_step)
+            early_dump_dir = args.workdir / f"dump_step_{requested:04d}"
+        early_dump_dir = Path(early_dump_dir).resolve() / "ck"
+        early_dump_dir.mkdir(parents=True, exist_ok=True)
+        # Set this before any generated parity library can be loaded. Its dump
+        # writer initializes once; a later environment change cannot recover
+        # from an initial open failure.
+        os.environ["CK_PARITY_DIR"] = str(early_dump_dir)
     if args.ck_engine_so is not None:
         args.ck_engine_so = args.ck_engine_so.resolve()
         if not args.ck_engine_so.is_file():

--- a/version/v8/scripts/decoder_first_token_parity_v8.py
+++ b/version/v8/scripts/decoder_first_token_parity_v8.py
@@ -396,10 +396,15 @@ def _load_llama_dump_dir(dump_dir: Path) -> list[Any]:
         final_occurrence = max_occurrence.get((base_name, token_id), occurrence)
         if norm_op in {"q_proj", "k_proj"} and occurrence > 0:
             stem = "qcur" if norm_op == "q_proj" else "kcur"
-            if final_occurrence >= 2 and occurrence < final_occurrence:
-                norm_op = f"{stem}_normed"
-            else:
-                norm_op = f"{stem}_rope"
+            if occurrence < final_occurrence:
+                # llama.cpp reuses Qcur/Kcur for graph aliases that are not a
+                # stable semantic boundary. In the Qwen3-VL prefill graph the
+                # middle occurrence is the pre-normalization projection alias,
+                # not CK's qcur_normed/kcur_normed checkpoint. Do not guess a
+                # semantic identity from occurrence number; the final reuse is
+                # the only occurrence established as post-RoPE by the graph.
+                continue
+            norm_op = f"{stem}_rope"
         dumps.append(
             parity_test_v7.ParityDump(
                 norm_layer,
@@ -1053,6 +1058,62 @@ def _compare_dump_sets(
     }
 
 
+def _label_multimodal_prefill_segments(
+    dumps: list[Any],
+    row_specs: dict[tuple[int, str], tuple[int, tuple[int, ...]]],
+    segments: list[tuple[str, int, int]],
+) -> list[Any]:
+    """Give batched prefill captures stable execution-segment identities.
+
+    The legacy CK dump header carries a decode token id, not a prefill pass or
+    segment id. Segmented multimodal prefill can consequently emit text-before,
+    visual, and text-after tensors with the same token id. Tensor extent plus
+    execution order is the unambiguous contract for those captures.
+    """
+    grouped: dict[tuple[int, str], list[Any]] = {}
+    key_order: list[tuple[int, str]] = []
+    for dump in dumps:
+        key = (int(dump.layer_id), _canonical_dump_op_name(str(dump.op_name)))
+        if key not in grouped:
+            key_order.append(key)
+        grouped.setdefault(key, []).append(dump)
+
+    labeled: list[Any] = []
+    for key in key_order:
+        row_spec = row_specs.get(key)
+        if row_spec is None:
+            continue
+        row_elems, _ = row_spec
+        if row_elems <= 0:
+            continue
+
+        remaining = list(segments)
+        for dump in grouped[key]:
+            flat = np.asarray(dump.data).reshape(-1)
+            if flat.size % row_elems != 0:
+                continue
+            batch_rows = int(flat.size // row_elems)
+            match_idx = next(
+                (idx for idx, (_, count, _) in enumerate(remaining) if int(count) == batch_rows),
+                None,
+            )
+            if match_idx is None:
+                continue
+            segment_name, _, segment_start = remaining.pop(match_idx)
+            labeled.append(
+                parity_test_v7.ParityDump(
+                    int(dump.layer_id),
+                    f"{key[1]}@{segment_name}",
+                    np.array(dump.data, copy=False),
+                    int(segment_start),
+                    str(dump.dtype),
+                    source_token_id=int(getattr(dump, "source_token_id", dump.token_id)),
+                    source_name=getattr(dump, "source_name", None),
+                )
+            )
+    return labeled
+
+
 def _capture_ck_dump(
     runtime: dict[str, Any],
     prefix_embeddings: array,
@@ -1066,7 +1127,9 @@ def _capture_ck_dump(
     prefix_text_pos: int | None = None,
     ck_strict_parity: bool = True,
 ) -> dict[str, Any]:
-    if dump_dir.exists():
+    target = dump_dir / "dump.bin"
+    writer_preinitialized = target.exists()
+    if dump_dir.exists() and not writer_preinitialized:
         shutil.rmtree(dump_dir)
     dump_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1100,7 +1163,6 @@ def _capture_ck_dump(
             prefix_text_pos=prefix_text_pos,
             strict_parity=ck_strict_parity,
         )
-        target = dump_dir / "dump.bin"
         fallback = fallback_dir / "dump.bin"
         if not target.exists() and fallback.exists():
             shutil.move(str(fallback), str(target))
@@ -1150,20 +1212,6 @@ def _capture_dump_compare(
     llama_decode_mode: str = "sequential",
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if prefix_tokens > 0:
-        if str(dump_pass) != "decode":
-            ck = bridge_runner_v8._run_decoder(
-                runtime,
-                prefix_embeddings,
-                prefix_tokens,
-                token_ids,
-                tokens_before=tokens_before,
-                prefix_embed_dim=prefix_row_dim,
-                strict_parity=ck_strict_parity,
-            )
-            return ck, {
-                "status": "skipped",
-                "reason": "multimodal dump alignment is only implemented for decode-mode comparisons; use --dump-pass decode",
-            }
         prefix_path = dump_root / "prefix.f32"
         prefix_path.parent.mkdir(parents=True, exist_ok=True)
         prefix_path.write_bytes(prefix_embeddings.tobytes())
@@ -1238,7 +1286,9 @@ def _capture_dump_compare(
     tokens_before_count = len(list(tokens_before or []))
     ck_prompt_start_token = None
     llama_prompt_start_token = None
-    if str(dump_pass) == "decode":
+    compare_pass = str(dump_pass)
+    prefill_segments: list[dict[str, Any]] | None = None
+    if compare_pass == "decode":
         ck_prompt_start_token, llama_prompt_start_token = _resolve_decode_prompt_start_tokens(
             tokens_before_count=tokens_before_count,
             prefix_tokens=int(prefix_tokens),
@@ -1256,12 +1306,31 @@ def _capture_dump_compare(
             prompt_start_token=int(ck_prompt_start_token),
             prompt_token_count=len(token_ids),
         )
+    elif compare_pass == "prefill" and prefix_tokens > 0:
+        segment_specs = [
+            ("text_before", len(list(tokens_before or [])), 0),
+            ("visual", int(prefix_tokens), len(list(tokens_before or []))),
+            (
+                "text_after",
+                len(token_ids),
+                len(list(tokens_before or [])) + int(prefix_tokens),
+            ),
+        ]
+        segment_specs = [segment for segment in segment_specs if segment[1] > 0]
+        row_specs = _build_llama_row_specs(llama_dumps)
+        ck_dumps = _label_multimodal_prefill_segments(ck_dumps, row_specs, segment_specs)
+        llama_dumps = _label_multimodal_prefill_segments(llama_dumps, row_specs, segment_specs)
+        compare_pass = "all"
+        prefill_segments = [
+            {"name": name, "rows": int(rows), "physical_start": int(start)}
+            for name, rows, start in segment_specs
+        ]
     compare = _compare_dump_sets(
         ck_dumps,
         llama_dumps,
         atol=float(dump_atol),
         rtol=float(dump_rtol),
-        pass_filter=str(dump_pass),
+        pass_filter=compare_pass,
     )
 
     status = "ok"
@@ -1275,6 +1344,8 @@ def _capture_dump_compare(
         "dump_names": [item.strip() for item in str(dump_names).split(",") if item.strip()],
         "ck_dump_names": [item.strip() for item in ck_dump_names.split(",") if item.strip()],
         "pass_filter": str(dump_pass),
+        "comparison_pass_filter": compare_pass,
+        "prefill_segments": prefill_segments,
         "atol": float(dump_atol),
         "rtol": float(dump_rtol),
         "ck_dump_path": str(ck_dump_path),

--- a/version/v8/scripts/llama_token_replay_v8.cpp
+++ b/version/v8/scripts/llama_token_replay_v8.cpp
@@ -37,8 +37,10 @@ struct Args {
     int prefix_row_dim = 0;
     int prefix_text_pos = -1;
     int greedy_steps = 0;
+    int dump_greedy_decode_step = -1;
     bool no_repack = false;
     bool dump_list_only = false;
+    bool dump_flash_inputs = false;
 };
 
 struct DumpState {
@@ -49,6 +51,9 @@ struct DumpState {
     int dumped = 0;
     bool list_only = false;
     int32_t current_token_id = 0;
+    int current_greedy_decode_step = -1;
+    int requested_greedy_decode_step = -1;
+    bool dump_flash_inputs = false;
     std::unordered_map<std::string, int> occurrences;
 };
 
@@ -201,6 +206,12 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
             args.greedy_steps = std::max(0, std::atoi(v));
             continue;
         }
+        if (a == "--dump-greedy-decode-step") {
+            const char * v = need_value("--dump-greedy-decode-step");
+            if (!v) return false;
+            args.dump_greedy_decode_step = std::atoi(v);
+            continue;
+        }
         if (a == "--embeddings-out") {
             const char * v = need_value("--embeddings-out");
             if (!v) return false;
@@ -221,6 +232,10 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
         }
         if (a == "--dump-list-only") {
             args.dump_list_only = true;
+            continue;
+        }
+        if (a == "--dump-flash-inputs") {
+            args.dump_flash_inputs = true;
             continue;
         }
         if (a == "--decode-mode") {
@@ -254,7 +269,8 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
                 << "--logits-out <path.bin> [--logits-seq-out <path.bin> --greedy-steps N] [--embeddings-out <path.f32>] [--prefix-f32 <path.f32>] "
                 << "[--prefix-grid-x N --prefix-grid-y N] [--prefix-row-dim N] [--prefix-text-pos N] [--ctx N] [--top-k K] [--threads N] "
                 << "[--decode-mode batched|sequential] [--prefix-decode-mode batched|sequential] "
-                << "[--dump-dir dir --dump-names a,b,c] [--dump-list-only] [--no-repack]\n";
+                << "[--dump-dir dir --dump-names a,b,c] [--dump-greedy-decode-step N] "
+                << "[--dump-list-only] [--no-repack]\n";
             std::exit(0);
         }
         err = "unknown arg: " + a;
@@ -290,6 +306,18 @@ static bool parse_args(int argc, char ** argv, Args & args, std::string & err) {
     }
     if (args.prefix_text_pos < -1) {
         err = "prefix text position must be >= -1";
+        return false;
+    }
+    if (args.dump_greedy_decode_step < -1) {
+        err = "dump-greedy-decode-step must be >= -1";
+        return false;
+    }
+    if (args.dump_greedy_decode_step >= args.greedy_steps) {
+        err = "dump-greedy-decode-step must be less than greedy-steps";
+        return false;
+    }
+    if (args.dump_greedy_decode_step >= 0 && args.dump_dir.empty()) {
+        err = "dump-greedy-decode-step requires --dump-dir";
         return false;
     }
     return true;
@@ -393,6 +421,10 @@ static bool should_dump_tensor(const DumpState * state, const ggml_tensor * t) {
     if (!state || state->dump_dir.empty() || !t) {
         return false;
     }
+    if (state->requested_greedy_decode_step >= 0 &&
+        state->current_greedy_decode_step != state->requested_greedy_decode_step) {
+        return false;
+    }
     const char * raw_name = ggml_get_name(t);
     if (!raw_name || !raw_name[0]) {
         return false;
@@ -464,6 +496,93 @@ static bool append_index_entry(
     return index.good();
 }
 
+static const ggml_tensor * find_flash_attention_ancestor(
+    const ggml_tensor * tensor,
+    int remaining_depth
+) {
+    if (!tensor || remaining_depth < 0) {
+        return nullptr;
+    }
+    if (tensor->op == GGML_OP_FLASH_ATTN_EXT) {
+        return tensor;
+    }
+    for (const ggml_tensor * source : tensor->src) {
+        if (const ggml_tensor * flash =
+                find_flash_attention_ancestor(source, remaining_depth - 1)) {
+            return flash;
+        }
+    }
+    return nullptr;
+}
+
+static void append_tensor_shape(std::ostream & out, const ggml_tensor * tensor) {
+    if (!tensor) {
+        out << "null";
+        return;
+    }
+    out << "[" << tensor->ne[0] << "," << tensor->ne[1] << ","
+        << tensor->ne[2] << "," << tensor->ne[3] << "]";
+}
+
+static void append_tensor_strides(std::ostream & out, const ggml_tensor * tensor) {
+    if (!tensor) {
+        out << "null";
+        return;
+    }
+    out << "[" << tensor->nb[0] << "," << tensor->nb[1] << ","
+        << tensor->nb[2] << "," << tensor->nb[3] << "]";
+}
+
+static bool dump_tensor_bytes(
+    const std::filesystem::path & path,
+    const ggml_tensor * tensor
+) {
+    if (!tensor) {
+        return true;
+    }
+    const size_t nbytes = ggml_nbytes(tensor);
+    std::vector<uint8_t> raw(nbytes);
+    ggml_backend_tensor_get(tensor, raw.data(), 0, nbytes);
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output.write(reinterpret_cast<const char *>(raw.data()),
+                 static_cast<std::streamsize>(raw.size()));
+    return output.good();
+}
+
+static void append_flash_attention_metadata(std::ostream & out, const ggml_tensor * tensor) {
+    // kqv_out is usually a view/permute above FLASH_ATTN_EXT. Walk only the
+    // local producer chain so diagnostics can report the production graph's
+    // physical K extent without requesting QK tensors and disabling flash.
+    const ggml_tensor * flash = find_flash_attention_ancestor(tensor, 12);
+    if (!flash) {
+        return;
+    }
+    int32_t precision = 0;
+    std::memcpy(&precision, flash->op_params + 3 * sizeof(int32_t), sizeof(precision));
+    out << ",\"flash_attention\":{";
+    out << "\"op\":\"" << json_escape(ggml_op_name(flash->op)) << "\",";
+    out << "\"precision\":" << precision << ",";
+    out << "\"q_shape\":";
+    append_tensor_shape(out, flash->src[0]);
+    out << ",\"k_shape\":";
+    append_tensor_shape(out, flash->src[1]);
+    out << ",\"v_shape\":";
+    append_tensor_shape(out, flash->src[2]);
+    out << ",\"mask_shape\":";
+    append_tensor_shape(out, flash->src[3]);
+    static const char * source_names[] = {"q", "k", "v", "mask"};
+    for (int source = 0; source < 4; ++source) {
+        if (!flash->src[source]) {
+            continue;
+        }
+        out << ",\"" << source_names[source] << "_type\":"
+            << static_cast<int>(flash->src[source]->type);
+        out << ",\"" << source_names[source] << "_strides\":";
+        append_tensor_strides(out, flash->src[source]);
+    }
+    out << "}";
+}
+
 static bool dump_eval_callback(struct ggml_tensor * t, bool ask, void * user_data) {
     const DumpState * state = static_cast<const DumpState *>(user_data);
     if (!should_dump_tensor(state, t)) {
@@ -516,7 +635,30 @@ static bool dump_eval_callback(struct ggml_tensor * t, bool ask, void * user_dat
         meta << "\"elem_count\":" << ggml_nelements(t) << ",";
         meta << "\"ne\":[" << t->ne[0] << "," << t->ne[1] << "," << t->ne[2] << "," << t->ne[3] << "],";
         meta << "\"nb\":[" << t->nb[0] << "," << t->nb[1] << "," << t->nb[2] << "," << t->nb[3] << "]";
+        append_flash_attention_metadata(meta, t);
         meta << "}\n";
+    }
+
+    if (mut->dump_flash_inputs) {
+        const ggml_tensor * flash = find_flash_attention_ancestor(t, 12);
+        constexpr size_t max_flash_input_bytes = 64u * 1024u * 1024u;
+        size_t total_bytes = 0;
+        if (flash) {
+            for (int source = 0; source < 4 && flash->src[source]; ++source) {
+                total_bytes += ggml_nbytes(flash->src[source]);
+            }
+        }
+        if (!flash || total_bytes > max_flash_input_bytes) {
+            return false;
+        }
+        static const char * suffixes[] = {"q", "k", "v", "mask"};
+        for (int source = 0; source < 4 && flash->src[source]; ++source) {
+            if (!dump_tensor_bytes(
+                    mut->dump_dir / (dump_name + ".flash_" + suffixes[source] + ".bin"),
+                    flash->src[source])) {
+                return false;
+            }
+        }
     }
 
     if (!append_index_entry(mut, dump_name, base_name, t, occurrence)) {
@@ -803,6 +945,8 @@ int main(int argc, char ** argv) {
         cparams.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
     }
     DumpState dump_state;
+    dump_state.requested_greedy_decode_step = args.dump_greedy_decode_step;
+    dump_state.dump_flash_inputs = args.dump_flash_inputs;
     if (!args.dump_dir.empty()) {
         dump_state.dump_dir = args.dump_dir;
         dump_state.index_path = dump_state.dump_dir / "index.json";
@@ -982,6 +1126,7 @@ int main(int argc, char ** argv) {
             if (step + 1 >= args.greedy_steps) {
                 break;
             }
+            dump_state.current_greedy_decode_step = step;
             begin_dump_batch(dump_state.dump_dir.empty() ? nullptr : &dump_state, prefix_text_pos + static_cast<int32_t>(tokens_after.size()) + step);
             llama_batch batch = llama_batch_init(1, 0, 1);
             batch.n_tokens = 1;
@@ -1082,6 +1227,7 @@ int main(int argc, char ** argv) {
               << (dump_attention_internals ? "disabled_for_internal_dump" : "auto")
               << "\",";
     std::cout << "\"greedy_steps\":" << args.greedy_steps << ",";
+    std::cout << "\"dump_greedy_decode_step\":" << args.dump_greedy_decode_step << ",";
     std::cout << "\"greedy_generated\":[";
     for (size_t i = 0; i < greedy_generated.size(); ++i) {
         if (i) std::cout << ",";

--- a/version/v8/scripts/run_multimodal_bridge_v8.py
+++ b/version/v8/scripts/run_multimodal_bridge_v8.py
@@ -12,6 +12,7 @@ import json
 import math
 import os
 import random
+import shlex
 import shutil
 import subprocess
 import sys
@@ -1333,7 +1334,10 @@ def _ensure_engine_lib(openmp: bool = False) -> None:
         # BUILD_STAMP tracks compiler flags, so toggling CK_ENABLE_OPENMP only
         # rebuilds when the cached engine library was built for the wrong mode.
         cmd.append("CK_ENABLE_OPENMP=1")
-    cmd.append("build/libckernel_engine.so")
+    # Decoder runtimes link both shared libraries. Build them together before
+    # any expensive model conversion/encoder execution so a clean checkout
+    # cannot fail only when the decoder is finally loaded.
+    cmd.extend(("build/libckernel_engine.so", "build/libckernel_tokenizer.so"))
     _run(cmd)
 
 
@@ -1726,15 +1730,59 @@ def _sync_runtime_engine(engine_path: Path, model_so: Path) -> Path:
     if not source.is_file():
         raise FileNotFoundError(f"CK engine library is missing: {source}")
     destination = model_so.resolve().parent / "libckernel_engine.so"
-    if destination == source:
-        return destination
     source_hash = hashlib.sha256(source.read_bytes()).hexdigest()
-    if destination.is_file() and hashlib.sha256(destination.read_bytes()).hexdigest() == source_hash:
-        return destination
-    temporary = destination.with_suffix(destination.suffix + ".tmp")
-    shutil.copy2(source, temporary)
-    os.replace(temporary, destination)
+    if destination != source and (
+        not destination.is_file()
+        or hashlib.sha256(destination.read_bytes()).hexdigest() != source_hash
+    ):
+        temporary = destination.with_suffix(destination.suffix + ".tmp")
+        shutil.copy2(source, temporary)
+        os.replace(temporary, destination)
+    source_metadata = _json_load(source.with_suffix(source.suffix + ".build.json"))
+    compiler = (
+        source_metadata.get("compiler")
+        if isinstance(source_metadata, dict) and isinstance(source_metadata.get("compiler"), dict)
+        else _engine_compiler_descriptor()
+        if source == (BUILD_DIR / "libckernel_engine.so").resolve()
+        else {"command": [], "version": "unknown; use ELF compiler evidence"}
+    )
+    _json_write(
+        destination.with_suffix(destination.suffix + ".build.json"),
+        {
+            "version": 1,
+            "compiler": compiler,
+            "source_path": str(source),
+            "sha256": source_hash,
+        },
+    )
     return destination
+
+
+def _engine_compiler_argv(stamp_path: Path | None = None) -> list[str]:
+    stamp = stamp_path or (BUILD_DIR / ".ck_build_flags")
+    if not stamp.is_file():
+        raise FileNotFoundError(
+            f"CK engine build stamp is missing: {stamp}; build libckernel_engine.so first"
+        )
+    for line in stamp.read_text(encoding="utf-8").splitlines():
+        if line.startswith("CC="):
+            argv = shlex.split(line[3:].strip())
+            if argv:
+                return argv
+    raise RuntimeError(f"CK engine build stamp does not declare CC: {stamp}")
+
+
+def _engine_compiler_descriptor(stamp_path: Path | None = None) -> dict[str, Any]:
+    argv = _engine_compiler_argv(stamp_path)
+    probe = subprocess.run(
+        [*argv, "--version"], text=True, capture_output=True, check=False
+    )
+    version = (
+        probe.stdout.splitlines()[0]
+        if probe.returncode == 0 and probe.stdout
+        else f"compiler probe failed rc={probe.returncode}"
+    )
+    return {"command": argv, "version": version}
 
 
 def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = False) -> Path:
@@ -1745,22 +1793,15 @@ def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = Fal
     engine_hash = hashlib.sha256(engine_path.read_bytes()).hexdigest()
     source_hash = hashlib.sha256(c_path.read_bytes()).hexdigest()
     source_size = int(c_path.stat().st_size)
-    compiler = os.environ.get("CC", "").strip() or "cc"
-    compiler_probe = subprocess.run(
-        [compiler, "--version"], text=True, capture_output=True, check=False
-    )
-    compiler_version = (
-        compiler_probe.stdout.splitlines()[0]
-        if compiler_probe.returncode == 0 and compiler_probe.stdout
-        else f"{compiler} probe failed rc={compiler_probe.returncode}"
-    )
+    compiler_argv = _engine_compiler_argv()
+    compiler = _engine_compiler_descriptor()
     build_fingerprint = {
         "version": 3,
         "source_path": str(c_path.resolve()),
         "source_sha256": source_hash,
         "source_size": source_size,
         "profile": bool(profile),
-        "compiler": {"command": compiler, "version": compiler_version},
+        "compiler": compiler,
         "runtime_dependency": {
             "name": "libckernel_engine.so",
             "sha256": engine_hash,
@@ -1774,7 +1815,7 @@ def _compile_generated_model(c_path: Path, so_path: Path, *, profile: bool = Fal
             _sync_runtime_engine(engine_path, so_path)
             return so_path
     cmd = [
-        compiler,
+        *compiler_argv,
         "-shared",
         "-fPIC",
         "-O3",

--- a/version/v8/scripts/stitched_parity_v8.py
+++ b/version/v8/scripts/stitched_parity_v8.py
@@ -92,6 +92,18 @@ def _reader_thread(pipe: Any, capture: _BoundedCapture) -> None:
         pipe.close()
 
 
+def _runtime_environment(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["CK_NUM_THREADS"] = str(int(args.threads))
+    env["OMP_NUM_THREADS"] = str(int(args.threads))
+    compiler = str(getattr(args, "compiler", "gcc"))
+    if compiler == "auto":
+        env.pop("CC", None)
+    else:
+        env["CC"] = compiler
+    return env
+
+
 def _run_logged(
     cmd: list[str],
     *,
@@ -414,11 +426,33 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--workdir", type=Path, default=REPO_ROOT / "build" / "stitched_parity" / "qwen3vl")
     ap.add_argument("--ctx-len", type=int, default=4096)
     ap.add_argument("--threads", type=int, default=20)
+    ap.add_argument(
+        "--compiler",
+        choices=("gcc", "icx", "auto"),
+        default="gcc",
+        help=(
+            "Compiler family for both the core engine and generated C. "
+            "Parity certification defaults to GCC; auto retains Makefile selection."
+        ),
+    )
     ap.add_argument("--top-k", type=int, default=16)
     ap.add_argument("--max-new-tokens", type=int, default=64)
     ap.add_argument("--image-min-tokens", type=int, default=None)
     ap.add_argument("--image-max-tokens", type=int, default=1024)
-    ap.add_argument("--skip-encoder-numeric", action="store_true", help="Skip final vision prefix numeric parity against llama.cpp")
+    ap.add_argument(
+        "--encoder-numeric-policy",
+        choices=("require", "observe", "skip"),
+        default="require",
+        help=(
+            "require final-prefix thresholds before token replay, observe and record "
+            "them without suppressing token replay, or skip the numeric phase"
+        ),
+    )
+    ap.add_argument(
+        "--skip-encoder-numeric",
+        action="store_true",
+        help="Deprecated alias for --encoder-numeric-policy skip",
+    )
     ap.add_argument("--encoder-cosine-min", type=float, default=0.9999)
     ap.add_argument("--encoder-rmse-max", type=float, default=1.0e-3)
     ap.add_argument("--encoder-max-abs-max", type=float, default=1.0e-1)
@@ -428,6 +462,14 @@ def main(argv: list[str] | None = None) -> int:
         "--keep-generated-weights",
         action="store_true",
         help="Keep generated weights.bump files from bridge/multitoken/granular phases; default prunes them to control scratch usage",
+    )
+    ap.add_argument(
+        "--prune-failed-weights",
+        action="store_true",
+        help=(
+            "Delete generated weights after a numerical/token failure. By default the "
+            "first failing runtime is retained for exact artifact replay."
+        ),
     )
     ap.add_argument("--granular-layers", type=str, default=None, help="Comma-separated activation layers to inspect after coarse mismatch")
     ap.add_argument(
@@ -450,6 +492,8 @@ def main(argv: list[str] | None = None) -> int:
     args.image_path = args.image_path.resolve()
     args.workdir = args.workdir.resolve()
 
+    encoder_numeric_policy = "skip" if args.skip_encoder_numeric else args.encoder_numeric_policy
+
     missing = [str(p) for p in (args.decoder_gguf, args.mmproj_gguf, args.image_path) if not p.exists()]
     if missing:
         print("missing required artifact(s): " + ", ".join(missing), file=sys.stderr)
@@ -459,9 +503,7 @@ def main(argv: list[str] | None = None) -> int:
         shutil.rmtree(args.workdir)
     args.workdir.mkdir(parents=True, exist_ok=True)
 
-    env = os.environ.copy()
-    env["CK_NUM_THREADS"] = str(int(args.threads))
-    env["OMP_NUM_THREADS"] = str(int(args.threads))
+    env = _runtime_environment(args)
 
     command_log = args.workdir / "commands.log"
     bridge_dir = args.workdir / "bridge"
@@ -485,14 +527,17 @@ def main(argv: list[str] | None = None) -> int:
         "prompt": args.prompt,
         "ctx_len": int(args.ctx_len),
         "threads": int(args.threads),
+        "compiler": str(args.compiler),
         "image_min_tokens": args.image_min_tokens,
         "image_max_tokens": args.image_max_tokens,
         "command_log": str(command_log),
         "log_byte_limit": int(args.log_byte_limit),
         "keep_generated_weights": bool(args.keep_generated_weights),
+        "prune_failed_weights": bool(args.prune_failed_weights),
         "bridge_report": str(bridge_report),
         "prefix_f32": str(prefix_f32),
         "encoder_numeric_report": str(encoder_numeric_report),
+        "encoder_numeric_policy": encoder_numeric_policy,
         "multitoken_report": str(multitoken_report),
         "granular_ck_stop": bool(args.granular_ck_stop),
     }
@@ -516,7 +561,7 @@ def main(argv: list[str] | None = None) -> int:
         report["bridge_pruned_weight_bumps"] = _prune_weight_bumps(bridge_dir)
 
     encoder_ok = True
-    if not args.skip_encoder_numeric:
+    if encoder_numeric_policy != "skip":
         encoder_dir = args.workdir / "encoder_numeric"
         encoder_proc = _run_logged(
             _encoder_numeric_command(args, encoder_dir, encoder_numeric_report),
@@ -530,7 +575,7 @@ def main(argv: list[str] | None = None) -> int:
         report["encoder_numeric_exit_code"] = int(encoder_proc.returncode)
         report["encoder_numeric_metrics"] = encoder_numeric.get("metrics")
         report["encoder_numeric_pass"] = bool(encoder_ok)
-        if not encoder_ok:
+        if not encoder_ok and encoder_numeric_policy == "require":
             report["status"] = "fail"
             report["failure_stage"] = "encoder_numeric"
             if not args.no_granular:
@@ -559,8 +604,14 @@ def main(argv: list[str] | None = None) -> int:
                     {k: v for k, v in row.items() if k != "report"} for row in granular_reports
                 ]
                 report["first_granular_issue"] = _first_granular_issue(granular_reports)
-            if not args.keep_generated_weights:
+            if not args.keep_generated_weights and args.prune_failed_weights:
                 report["final_pruned_weight_bumps"] = _prune_weight_bumps(args.workdir)
+            elif not args.keep_generated_weights:
+                report["failed_weight_bumps_retained"] = [
+                    {"path": str(path), "bytes": int(path.stat().st_size)}
+                    for path in sorted(args.workdir.rglob("weights.bump"))
+                    if path.is_file()
+                ]
             _write_json(final_json, report)
             _write_markdown(report, final_md)
             issue = report.get("first_granular_issue") or {}
@@ -584,6 +635,14 @@ def main(argv: list[str] | None = None) -> int:
     report["multitoken_exit_code"] = int(multi_proc.returncode)
     report["multitoken_status"] = multitoken.get("status")
     report["first_divergence"] = multitoken.get("first_divergence")
+
+    if encoder_numeric_policy == "observe" and not encoder_ok:
+        if multitoken.get("pass") is True:
+            report["encoder_numeric_ranking_classification"] = (
+                "non_causal_for_observed_token_window"
+            )
+        else:
+            report["encoder_numeric_ranking_classification"] = "causality_unresolved"
 
     if multitoken.get("pass") is True:
         report["status"] = "pass"
@@ -622,8 +681,14 @@ def main(argv: list[str] | None = None) -> int:
         ]
         report["first_granular_issue"] = _first_granular_issue(granular_reports)
 
-    if not args.keep_generated_weights:
+    if not args.keep_generated_weights and args.prune_failed_weights:
         report["final_pruned_weight_bumps"] = _prune_weight_bumps(args.workdir)
+    elif not args.keep_generated_weights:
+        report["failed_weight_bumps_retained"] = [
+            {"path": str(path), "bytes": int(path.stat().st_size)}
+            for path in sorted(args.workdir.rglob("weights.bump"))
+            if path.is_file()
+        ]
     _write_json(final_json, report)
     _write_markdown(report, final_md)
     first = report.get("first_divergence") or {}


### PR DESCRIPTION
## Why

Qwen3-VL Fake 6 exposed two independent one-ULP numerical defects after segmented mixed prefill, cache state, and compiler provenance were already correct. The differences crossed Q8_K boundaries and eventually changed greedy tokens.

## What changed

- Match llama.cpp split-KV chunk merging with explicit FMA for both the output vector and final denominator.
- Route the grouped Q8_K activation ABI through the canonical byte-exact row quantizer until an optimized grouped provider satisfies the same contract.
- Add bounded persistent-decode and production-flash capture with runtime, compiler, oracle, and submodule provenance.
- Compare segmented multimodal prefill by semantic segment extent and execution order.
- Stop treating llama.cpp middle Qcur/Kcur aliases as normalized CK checkpoints.
- Advance the llama.cpp submodule to f3e182816421c648188b5eab269853bf1531d950.

## Evidence

- Old grouped Q8 producer: 3,365 differing bytes out of 4,709,376 on a real visual-prefix activation; first changed scale was one FP32 ULP.
- Canonical Q8 producer: 4,709,376/4,709,376 bytes exact.
- Q4_K projection with canonical Q8: 4,128,768/4,128,768 outputs exact.
- Fake 6: 64/64 and 128/128 pre-EOS tokens exact.
- Staged corpus: 10/10 distinct visual prefixes at 128/128 tokens with one GCC decoder/engine and production llama.cpp attention.
- Machine-readable local summary: build/qwen3vl_fixed_ten_128/summary.json.

## Validation

- FP16 split-KV oracle: 34/34 exact at CK threads 1, 16, 20, and 24.
- Q4/Q6 llama.cpp production matrix: PASS at threads 1, 16, 20, and 24.
- Qwen3-VL circuit/codegen gate: PASS.
- X-ray/EOS unit suite: 28/28 PASS.
- Mandatory commit hook: v7 kernel-map contracts, v7-regression-fast, v8-regression-fast PASS.
- Mandatory pre-push hook: submodule pins, ICX build, v8 E2E text, inference contracts, v7 training smoke, v7/v8 fast regressions, and v7 training-kernel parity PASS.

## Regression coverage

The existing nightly attention, numerical-contract, Q4/Q6 production-oracle, Qwen3-VL circuit/codegen, and X-ray lanes exercise these changes without relaxed tolerances. Production artifact inputs remain resource-gated; deterministic synthetic boundary cases always run.

## Documentation

No documentation page changed in this focused correctness PR. The structured commit and PR evidence preserve the investigation; a full case-study update should follow the 40-image certification.

## Content handoff

- Audience: CPU inference engineers, runtime maintainers, and teams debugging quantized multimodal models.
- Angle: A one-ULP reduction difference and a grouped activation producer can pass leaf tests yet flip long-form OCR tokens.
- Claims: Zero-tolerance 34-case attention matrix; exact production Q8 and Q4 boundaries; Fake 6 at 128 tokens; staged 10/10 image parity.
- Caveats: Full 40-image certification and native Xeon validation remain pending; canonical grouped quantization may trade performance for correctness.
- Sources: Commit 3ccc0ec0, attention/Q8 kernel diffs, llama.cpp production oracle tests, X-ray scripts, and build/qwen3vl_fixed_ten_128/summary.json.